### PR TITLE
fix: satisfy clippy under rust 1.91

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env.*
 *.db
 node_modules
+.serena

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,7 @@ pre-commit:
       run: cargo fmt
       stage_fixed: true
     clippy:
-      glob: "**/*.rs"
+      files: git diff --cached --name-only --diff-filter=ACMR -- '*.rs' 'Cargo.toml' 'Cargo.lock' 'rust-toolchain.toml'
       run: cargo clippy -- -D warnings
 
 commit-msg:


### PR DESCRIPTION
## Summary
- introduce a `LogAttempt` helper so `KeyStore::log_attempt` no longer trips the rust 1.91 clippy parameter count lint
- fold the nested conditional branches clippy::collapsible_if now highlights while keeping the existing behaviour
- ignore `.serena` artefacts and ensure the lefthook clippy task reruns whenever toolchain or manifest files change

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test