### PR TITLE
fix: unblock docker build on rust 1.91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
-RUN cargo fetch
+RUN mkdir src \
+    && printf 'fn main() {}\n' > src/main.rs \
+    && printf 'pub fn noop() {}\n' > src/lib.rs \
+    && cargo fetch
 
 COPY src ./src
 RUN cargo build --release --locked


### PR DESCRIPTION
## Summary
- create minimal placeholder `src/main.rs` and `src/lib.rs` in the Docker builder stage before running `cargo fetch`
- keep the caching-friendly layering while satisfying Cargo's manifest checks on Rust 1.91+

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

> ℹ️ Local Docker daemon is unavailable in this environment, so the image build could not be re-run here.