### PR TITLE
feat(dashboard): SSE live updates + fallback; UI polish (Updated HH:mm:ss)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
+    outputs:
+      app_version: ${{ steps.export_version.outputs.version }}
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@v4
@@ -141,6 +143,12 @@ jobs:
       - name: Compute effective version
         shell: bash
         run: ./.github/scripts/compute-version.sh
+
+      - name: Export effective version
+        id: export_version
+        shell: bash
+        run: |
+          echo "version=${APP_EFFECTIVE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git user
         run: |
@@ -181,16 +189,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      APP_EFFECTIVE_VERSION: ${{ needs.release-tag.outputs.app_version }}
     timeout-minutes: 45
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Compute effective version
-        shell: bash
-        run: ./.github/scripts/compute-version.sh
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -275,9 +281,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Compute effective version
+      - name: Derive version from tag
+        id: derive_version
         shell: bash
-        run: ./.github/scripts/compute-version.sh
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.release.tag_name }}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_REF_NAME:-}"
+          fi
+          version="${tag#v}"
+          echo "APP_EFFECTIVE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,12 +2135,14 @@ dependencies = [
 name = "tavily-hikari"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "axum",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
  "dotenvy",
+ "futures-util",
  "html-escape",
  "nanoid",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ bytes = "1"
 chrono = { version = "0.4", features = ["clock"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"
-reqwest = { version = "0.12", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream", "json"] }
 base64 = "0.22"
 sha2 = "0.10"
 sqlx = { version = "0.7", features = ["runtime-tokio", "sqlite", "macros"] }
@@ -24,3 +24,5 @@ nanoid = "0.4"
 urlencoding = "2.1"
 html-escape = "0.2"
 rand = { version = "0.8", features = ["std", "std_rng"] }
+async-stream = "0.3"
+futures-util = "0.3"

--- a/src/bin/mock_upstream.rs
+++ b/src/bin/mock_upstream.rs
@@ -1,0 +1,148 @@
+use axum::{Json, Router, extract::Query, http::StatusCode, response::IntoResponse, routing::any};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::SocketAddr, time::Duration};
+use tokio::task::JoinHandle;
+
+#[derive(Serialize)]
+struct StructuredContent {
+    status: i64,
+}
+
+#[derive(Serialize)]
+struct ResultBody {
+    #[serde(rename = "structuredContent")]
+    structured_content: StructuredContent,
+}
+
+#[derive(Serialize)]
+struct ResponseBody {
+    result: ResultBody,
+}
+
+async fn handle(Query(q): Query<HashMap<String, String>>) -> impl IntoResponse {
+    // Accept optional `status` query; default to 200
+    let status: i64 = q
+        .get("status")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(200);
+
+    let body = Json(ResponseBody {
+        result: ResultBody {
+            structured_content: StructuredContent { status },
+        },
+    });
+
+    (StatusCode::OK, body)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Start upstream mock server
+    let app = Router::new()
+        .route("/mcp", any(handle))
+        .route("/mcp/*path", any(handle));
+    let bind_addr =
+        std::env::var("MOCK_UPSTREAM_ADDR").unwrap_or_else(|_| "127.0.0.1:58088".to_string());
+    let addr: SocketAddr = bind_addr.parse()?;
+    println!("Mock upstream on http://{addr}");
+
+    // Kick off background traffic generator
+    let generator = spawn_generator();
+
+    axum::serve(tokio::net::TcpListener::bind(addr).await?, app).await?;
+
+    // Ensure generator is awaited if server exits
+    if let Some(h) = generator {
+        let _ = h.await;
+    }
+    Ok(())
+}
+
+fn spawn_generator() -> Option<JoinHandle<()>> {
+    let proxy_base =
+        std::env::var("PROXY_BASE").unwrap_or_else(|_| "http://127.0.0.1:58087".to_string());
+    let admin_header_name = std::env::var("ADMIN_HEADER_NAME").ok();
+    let admin_header_value = std::env::var("ADMIN_HEADER_VALUE").ok();
+    let provided_token = std::env::var("ACCESS_TOKEN").ok();
+    let interval_ms: u64 = std::env::var("GEN_INTERVAL_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5000);
+
+    Some(tokio::spawn(async move {
+        let client = Client::new();
+
+        // Try to obtain token once
+        let mut token = provided_token;
+        if token.is_none()
+            && let (Some(hname), Some(hval)) =
+                (admin_header_name.as_deref(), admin_header_value.as_deref())
+        {
+            match create_token(&client, &proxy_base, hname, hval).await {
+                Ok(t) => {
+                    println!("[mock-gen] created token: {}", t);
+                    token = Some(t);
+                }
+                Err(e) => {
+                    eprintln!("[mock-gen] create token failed: {e}");
+                }
+            }
+        }
+
+        let Some(token) = token else {
+            eprintln!("[mock-gen] no ACCESS_TOKEN and admin creation failed; generator idle");
+            return;
+        };
+
+        let mut i = 0u64;
+        loop {
+            let statuses = [200, 500, 432];
+            let code = statuses[(i as usize) % statuses.len()];
+            let url = format!("{}/mcp?status={}", proxy_base, code);
+            match client
+                .get(&url)
+                .header("Authorization", format!("Bearer {}", token))
+                .send()
+                .await
+            {
+                Ok(resp) => {
+                    let sc = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    println!("[mock-gen] {} -> {}", url, sc);
+                    if !sc.is_success() {
+                        eprintln!("[mock-gen] response body: {}", body);
+                    }
+                }
+                Err(err) => eprintln!("[mock-gen] request error: {}", err),
+            }
+
+            i = i.wrapping_add(1);
+            tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+        }
+    }))
+}
+
+#[derive(Deserialize)]
+struct TokenSecret {
+    token: String,
+}
+
+async fn create_token(
+    client: &Client,
+    base: &str,
+    admin_header_name: &str,
+    admin_header_value: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let url = format!("{}/api/tokens", base);
+    let resp = client
+        .post(url)
+        .header("content-type", "application/json")
+        .header(admin_header_name, admin_header_value)
+        .body("{}")
+        .send()
+        .await?;
+    let resp = resp.error_for_status()?;
+    let ts: TokenSecret = resp.json().await?;
+    Ok(ts.token)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,10 @@ struct Cli {
     /// 管理员模式昵称（覆盖前端显示）
     #[arg(long, env = "ADMIN_MODE_NAME")]
     admin_mode_name: Option<String>,
+
+    /// 开发模式：放开管理接口权限（仅本地验证使用）
+    #[arg(long, env = "DEV_OPEN_ADMIN", default_value_t = false)]
+    dev_open_admin: bool,
 }
 
 #[tokio::main]
@@ -104,7 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    server::serve(addr, proxy, static_dir, forward_auth).await?;
+    server::serve(addr, proxy, static_dir, forward_auth, cli.dev_open_admin).await?;
 
     Ok(())
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -269,6 +269,12 @@ button:disabled {
   font-size: 0.92rem;
 }
 
+/* Subtle, lighter time text for header updated time */
+.updated-time {
+  font-weight: 500;
+  color: #94a3b8;
+}
+
 .table-wrapper {
   overflow-x: auto;
   border-radius: 14px;


### PR DESCRIPTION
This PR introduces server-sent events (SSE) to drive the dashboard with real-time updates, removes the manual auto-refresh toggle, and adds a resilient polling fallback when SSE is unavailable. It also polishes the header to show a compact 24-hour time-only "Updated HH:mm:ss" and removes the redundant "Last activity" subtitle on the Total card.

Highlights
- Backend
  - New GET /api/events SSE endpoint that streams `snapshot` events when data changes and `ping` heartbeats.
  - Change detection via compact signature to avoid redundant pushes.
  - Forward-auth helpers: improved header matching and debug endpoints.
  - Added mock upstream binary with background traffic generator for local E2E verification.
- Frontend
  - Wire `EventSource` to consume snapshots; auto fallback to polling when SSE drops; removed auto-refresh toggle; keep "Refresh Now".
  - Header now shows `Updated HH:mm:ss` (24h) on the right; lighter style.
  - Total card no longer shows "Last activity".

Verification
- Local mock upstream + generator creates a token via admin header and sends /mcp?status=200/500/432 cyclic requests.
- Dashboard updates in real time via SSE; table appends continuously.

Notes
- Commit messages follow Conventional Commits; clippy and commitlint are clean.

Please review. Screenshots or a short video can be attached if needed.