### PR TITLE
feat(core+web): update banner via SSE and version event

### DIFF
--- a/web/src/hooks/useUpdateAvailable.ts
+++ b/web/src/hooks/useUpdateAvailable.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { fetchVersion } from '../api'
+import { subscribeToSseOpen } from '../sse'
+
+const DISMISS_KEY = 'update-dismissed-version'
+
+export interface UpdateAvailableState {
+  currentVersion: string | null
+  availableVersion: string | null
+  visible: boolean
+  dismiss: () => void
+  reload: () => void
+}
+
+export default function useUpdateAvailable(): UpdateAvailableState {
+  const [currentVersion, setCurrentVersion] = useState<string | null>(null)
+  const [availableVersion, setAvailableVersion] = useState<string | null>(null)
+  const [visible, setVisible] = useState(false)
+  const initialVersionRef = useRef<string | null>(null)
+
+  const dismissed = useMemo(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY)
+    } catch {
+      return null
+    }
+  }, [])
+
+  const loadVersion = useCallback(async () => {
+    try {
+      const v = await fetchVersion()
+      return v.backend
+    } catch {
+      return null
+    }
+  }, [])
+
+  // Fetch initial version
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const v = await loadVersion()
+      if (cancelled) return
+      setCurrentVersion(v)
+      initialVersionRef.current = v
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [loadVersion])
+
+  // When SSE connects (or reconnects), re-check version
+  useEffect(() => {
+    const unsubscribe = subscribeToSseOpen(async () => {
+      const next = await loadVersion()
+      if (!next) return
+      const initial = initialVersionRef.current
+      if (!initial) {
+        initialVersionRef.current = next
+        setCurrentVersion(next)
+        return
+      }
+      if (next !== initial && next !== dismissed) {
+        setAvailableVersion(next)
+        setVisible(true)
+      }
+    })
+    return unsubscribe
+  }, [dismissed, loadVersion])
+
+  const dismiss = useCallback(() => {
+    if (availableVersion) {
+      try {
+        localStorage.setItem(DISMISS_KEY, availableVersion)
+      } catch {
+        /* noop */
+      }
+    }
+    setVisible(false)
+  }, [availableVersion])
+
+  const reload = useCallback(() => {
+    window.location.reload()
+  }, [])
+
+  // Provide a manual trigger for validation/testing
+  useEffect(() => {
+    ;(window as unknown as { __FORCE_UPDATE_BANNER__?: () => void }).__FORCE_UPDATE_BANNER__ = () => {
+      setAvailableVersion((v) => v ?? (currentVersion ? `${currentVersion}-next` : 'next'))
+      setVisible(true)
+    }
+  }, [currentVersion])
+
+  return { currentVersion, availableVersion, visible, dismiss, reload }
+}


### PR DESCRIPTION
Summary
- Add backend /events SSE endpoint that seeds an initial version event on connect and keeps the connection alive.
- Add frontend SSE open subscription + useUpdateAvailable hook, and render a dismissible "Update available" banner.
- Map version from /api/version (backend/frontend) and compare on reconnect.

Backend
- src/server.rs: add events_sse() returning Sse, send {type:"version", version} on connect.
- Register route GET /events. Keep-alive every 15s.
- Cargo.toml: add futures-util.

Frontend
- web/src/sse.ts: introduce subscribeToSseOpen() for EventSource 'open'.
- web/src/hooks/useUpdateAvailable.ts: fetch initial version, on SSE open fetch again, compare with initial, persist dismissal in localStorage, expose reload/dismiss. Add window.__FORCE_UPDATE_BANNER__() for validation only.
- web/src/App.tsx: inject sticky banner using the hook. web/src/index.css: styles for .update-banner.

Why
- Users often keep the dashboard open during deploys. Surfacing an unobtrusive refresh prompt improves UX and avoids running with stale assets.

How to run locally (no production Tavily)
1) Build SPA: cd web && npm run build
2) Start backend (use a dummy key and stub upstream):
   RUST_LOG=info cargo run -- --bind 127.0.0.1 --port 58087 --db-path tavily_proxy.db --static-dir web/dist --keys tv-local-dummy --upstream http://127.0.0.1:59999/mcp
3) Open http://127.0.0.1:58087/ and run in DevTools console to validate banner:
   window.__FORCE_UPDATE_BANNER__()

Notes
- Does not hit production Tavily upstream. Aligns with testing restriction to use local/mock upstream only.
- Keeps SSE session open; only seeds version on connect.

Validation
- Verified backend responds: /health, /api/version, /events (text/event-stream + initial version).
- Verified UI banner appears and actions work (Refresh/Not now).