### PR TITLE
fix(web): add missing SSE helper for useUpdateAvailable

### DIFF
--- a/web/src/sse.ts
+++ b/web/src/sse.ts
@@ -1,0 +1,30 @@
+// Minimal SSE helper for dashboard
+// Subscribes to EventSource '/api/events' and invokes the provided callback
+// whenever the connection opens (including reconnects). Returns an unsubscribe
+// function that closes the EventSource.
+
+export function subscribeToSseOpen(onOpen: () => void): () => void {
+  const es = new EventSource('/api/events');
+
+  const handleOpen = () => {
+    try {
+      onOpen();
+    } catch {
+      // swallow callback errors to avoid tearing down the SSE session
+    }
+  };
+
+  es.addEventListener('open', handleOpen);
+
+  // noop error handler to avoid noisy console in case of transient disconnects
+  const handleError = () => {
+    // EventSource will auto-reconnect; keep silent here
+  };
+  es.addEventListener('error', handleError);
+
+  return () => {
+    es.removeEventListener('open', handleOpen as EventListener);
+    es.removeEventListener('error', handleError as EventListener);
+    es.close();
+  };
+}


### PR DESCRIPTION
Summary
- Add `web/src/sse.ts` implementing `subscribeToSseOpen()` used by `web/src/hooks/useUpdateAvailable.ts`.
- This file was missing at commit 726cd344 (run 19102741906), causing TS2307 in the Docker build step.

Why
- CI run 19102741906 failed at "TypeScript compile" with:
  TS2307: Cannot find module '../sse' or its corresponding type declarations.
- Adding the missing helper unblocks the front-end typecheck/build path.

Scope
- Single file addition; no behavior change beyond wiring EventSource open callback.
- No workflow changes included in this PR.

Validation
- In a fresh worktree based on 726cd344, ran `npm ci` then `npx tsc -b` under `web/` — passed.
- This aligns with the CI step that failed previously.

Notes
- Keeps version-locking flow intact (tag+release first, then build image).
- Follow-up builds on main will proceed to image push for the next patch release.
