### PR TITLE
feat(admin,backend): quota usage sync, scheduler, jobs UI, and responsive quick-stats

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,14 @@ struct Cli {
     /// 开发模式：放开管理接口权限（仅本地验证使用）
     #[arg(long, env = "DEV_OPEN_ADMIN", default_value_t = false)]
     dev_open_admin: bool,
+
+    /// Tavily Usage API base (for quota/usage sync)
+    #[arg(
+        long,
+        env = "TAVILY_USAGE_BASE",
+        default_value = "https://api.tavily.com"
+    )]
+    usage_base: String,
 }
 
 #[tokio::main]
@@ -107,7 +115,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    server::serve(addr, proxy, static_dir, forward_auth, cli.dev_open_admin).await?;
+    server::serve(
+        addr,
+        proxy,
+        static_dir,
+        forward_auth,
+        cli.dev_open_admin,
+        cli.usage_base,
+    )
+    .await?;
 
     Ok(())
 }

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -115,18 +115,19 @@ interface AdminTranslationsShape {
       }
     }
   }
-  metrics: {
-    labels: {
-      total: string
-      success: string
-      errors: string
-      quota: string
-      keys: string
-    }
-    subtitles: {
-      keysAll: string
-      keysExhausted: string
-    }
+    metrics: {
+      labels: {
+        total: string
+        success: string
+        errors: string
+        quota: string
+        keys: string
+        remaining: string
+      }
+      subtitles: {
+        keysAll: string
+        keysExhausted: string
+      }
     loading: string
   }
   keys: {
@@ -143,6 +144,9 @@ interface AdminTranslationsShape {
       errors: string
       quota: string
       successRate: string
+      remainingPct: string
+      quotaLeft: string
+      syncedAt: string
       lastUsed: string
       statusChanged: string
       actions: string
@@ -420,6 +424,7 @@ export const translations: Record<Language, TranslationShape> = {
           errors: 'Errors',
           quota: 'Quota Exhausted',
           keys: 'Active Keys',
+          remaining: 'Remaining',
         },
         subtitles: {
           keysAll: 'All keys available',
@@ -433,18 +438,21 @@ export const translations: Record<Language, TranslationShape> = {
         placeholder: 'New Tavily API Key',
         addButton: 'Add Key',
         adding: 'Adding…',
-        table: {
-          keyId: 'Key ID',
-          status: 'Status',
-          total: 'Total',
-          success: 'Success',
-          errors: 'Errors',
-          quota: 'Quota Exhausted',
-          successRate: 'Success Rate',
-          lastUsed: 'Last Used',
-          statusChanged: 'Status Changed',
-          actions: 'Actions',
-        },
+      table: {
+        keyId: 'Key ID',
+        status: 'Status',
+        total: 'Total',
+        success: 'Success',
+        errors: 'Errors',
+        quota: 'Quota Exhausted',
+        successRate: 'Success Rate',
+        remainingPct: 'Remaining %',
+        quotaLeft: 'Remaining',
+        syncedAt: 'Synced',
+        lastUsed: 'Last Used',
+        statusChanged: 'Status Changed',
+        actions: 'Actions',
+      },
         empty: {
           loading: 'Loading key statistics…',
           none: 'No key data recorded yet.',
@@ -701,6 +709,7 @@ export const translations: Record<Language, TranslationShape> = {
           errors: '错误',
           quota: '额度耗尽',
           keys: '活跃密钥',
+          remaining: '剩余可用',
         },
         subtitles: {
           keysAll: '全部可用',
@@ -722,6 +731,9 @@ export const translations: Record<Language, TranslationShape> = {
           errors: '错误',
           quota: '额度耗尽',
           successRate: '成功率',
+          remainingPct: '剩余比例',
+          quotaLeft: '剩余',
+          syncedAt: '同步时间',
           lastUsed: '最近使用',
           statusChanged: '状态更新',
           actions: '操作',

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -716,6 +716,12 @@ button:disabled {
   gap: 16px;
   padding: 20px 24px 28px;
 }
+/* 中等屏幕增加 2 列级别（避免 1 -> 3 的跳变） */
+@media (min-width: 700px) {
+  .quick-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
 /* 900px 左右希望一行放下 3 个：提前到 860px 起三列，并适当收紧间距与内边距 */
 @media (min-width: 860px) {
   .quick-stats-grid {


### PR DESCRIPTION
This PR implements quota usage synchronization and visibility across backend and admin UI.

Key changes

Backend
- DB: add `api_keys.quota_limit`, `quota_remaining`, `quota_synced_at` (with auto migrations)
- DB: add `scheduled_jobs` (id, job_type, key_id, status, attempt, message, started_at, finished_at)
- Scheduler: hourly scan for keys with `quota_synced_at` older than 24h (or never), serial execution per key, 0–5 min random jitter; first cycle starts on boot (not mass sync)
- API: `POST /api/keys/:id/sync-usage` (manual), `GET /api/jobs` (latest jobs), `GET /api/keys/:id`
- Summary: adds `total_quota_limit`, `total_quota_remaining`
- Config: `TAVILY_USAGE_BASE` (CLI/env). A local `/usage` mock is included for safe testing without hitting production.

Admin UI
- Overview: adds "Remaining" card (remaining / total + percentage)
- Keys table: new columns for remaining absolute/percentage and last sync time
- Key detail: new Quota block (used / total / remaining% / synced at) + "Sync Usage" button
- Jobs: new "Scheduled Jobs" panel shows recent runs
- CSS: quick-stats grid layout with responsive 1/2/3 columns (>=700px → 2 cols, >=860px → 3 cols)

Notes
- By default, development uses the local `/usage` mock when `TAVILY_USAGE_BASE` points to the backend, keeping us away from the production Tavily endpoint per project policy.
- Dev scripts are unchanged; start as usual with `scripts/start-backend-dev.sh` and `scripts/start-frontend-dev.sh`.

Validation
- Manual sync from Key Details updates quota metrics and logs a job row
- Overview Remaining card and Keys table reflect the synced values
- Jobs panel displays recent scheduler and manual runs

Let me know if you'd like different breakpoints or grouping for the overview cards.