### PR TITLE
feat(admin): batch token creation, pagination, and sorting

### DIFF
--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -97,6 +97,12 @@ interface AdminTranslationsShape {
     notePlaceholder: string
     newToken: string
     creating: string
+    batchCreate: string
+    pagination: {
+      prev: string
+      next: string
+      page: string
+    }
     table: {
       id: string
       note: string
@@ -133,6 +139,15 @@ interface AdminTranslationsShape {
         confirm: string
         saving: string
       }
+    }
+    batchDialog: {
+      title: string
+      groupPlaceholder: string
+      confirm: string
+      creating: string
+      cancel: string
+      done: string
+      createdN: string
     }
   }
     metrics: {
@@ -423,6 +438,12 @@ export const translations: Record<Language, TranslationShape> = {
         notePlaceholder: 'Note (optional)',
         newToken: 'New Token',
         creating: 'Creating…',
+        batchCreate: 'Batch Create',
+        pagination: {
+          prev: 'Prev',
+          next: 'Next',
+          page: 'Page {page} of {total}',
+        },
         table: {
           id: 'ID',
           note: 'Note',
@@ -459,6 +480,15 @@ export const translations: Record<Language, TranslationShape> = {
             confirm: 'Save',
             saving: 'Saving…',
           },
+        },
+        batchDialog: {
+          title: 'Batch Create Tokens',
+          groupPlaceholder: 'Group (required)',
+          confirm: 'Create',
+          creating: 'Creating…',
+          cancel: 'Cancel',
+          done: 'Done',
+          createdN: 'Created {n} tokens',
         },
       },
       metrics: {
@@ -732,6 +762,12 @@ export const translations: Record<Language, TranslationShape> = {
         notePlaceholder: '备注（可选）',
         newToken: '新建令牌',
         creating: '创建中…',
+        batchCreate: '批量创建',
+        pagination: {
+          prev: '上一页',
+          next: '下一页',
+          page: '第 {page}/{total} 页',
+        },
         table: {
           id: 'ID',
           note: '备注',
@@ -768,6 +804,15 @@ export const translations: Record<Language, TranslationShape> = {
             confirm: '保存',
             saving: '保存中…',
           },
+        },
+        batchDialog: {
+          title: '批量创建令牌',
+          groupPlaceholder: '分组名（必填）',
+          confirm: '创建',
+          creating: '创建中…',
+          cancel: '取消',
+          done: '完成',
+          createdN: '已创建 {n} 个令牌',
         },
       },
       metrics: {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1214,12 +1214,13 @@ table {
 }
 
 .table-pagination {
-  padding: 16px 24px 20px;
+  padding: 12px 16px 14px;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
 }
 .table-pagination span {
   font-size: 0.92rem;


### PR DESCRIPTION
Summary
- Add batch token creation with group name: POST /api/tokens/batch
- Add group_name column to auth_tokens (nullable) with auto-migration
- List tokens sorted by created_at DESC and add pagination (items,total,page,perPage)
- Admin UI: Batch Create dialog (daisyUI) and share links textarea
- Admin UI: Tokens table pagination (default 10 / page)
- UI: Improve pagination layout (.table-pagination)

Backend
- src/lib.rs: add group_name, batch create, paginated list
- src/server.rs: list tokens with pagination; /api/tokens/batch route and handlers

Frontend
- web/src/api.ts: AuthToken.group, fetchTokens(page, perPage), createTokensBatch
- web/src/AdminDashboard.tsx: Batch Create dialog + pagination UI
- web/src/i18n.tsx: strings for pagination and batch dialog (en/zh)
- web/src/index.css: .table-pagination styling

Validation
- Build backend: cargo build
- Build frontend: (cd web && npm run build) or start dev scripts
- Start dev: scripts/start-backend-dev.sh (DEV_OPEN_ADMIN=1) & scripts/start-frontend-dev.sh
- Visit /admin: verify tokens table sorted by createdAt desc, pagination (10/page), and Batch Create dialog shows share links after creating tokens.
