### PR TITLE
feat(admin): improve batch token dialog and add access token group filters

### DIFF
--- a/web/src/AdminDashboard.tsx
+++ b/web/src/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import LanguageSwitcher from './components/LanguageSwitcher'
 import TokenDetail from './pages/TokenDetail'
 import { useTranslate, type AdminTranslations } from './i18n'
-  import {
+import {
   fetchApiKeys,
   fetchApiKeySecret,
   addApiKey,
@@ -32,6 +32,8 @@ import { useTranslate, type AdminTranslations } from './i18n'
   fetchApiKeyDetail,
   syncApiKeyUsage,
   fetchJobs,
+  fetchTokenGroups,
+  type TokenGroup,
 } from './api'
 
 function parseHashForKeyId(): string | null {
@@ -185,6 +187,11 @@ function AdminDashboard(): JSX.Element {
   const [tokensPage, setTokensPage] = useState(1)
   const tokensPerPage = 10
   const [tokensTotal, setTokensTotal] = useState(0)
+  const [tokenGroups, setTokenGroups] = useState<TokenGroup[]>([])
+  const [selectedTokenGroupName, setSelectedTokenGroupName] = useState<string | null>(null)
+  const [selectedTokenUngrouped, setSelectedTokenUngrouped] = useState(false)
+  const [tokenGroupsExpanded, setTokenGroupsExpanded] = useState(false)
+  const [tokenGroupsCollapsedOverflowing, setTokenGroupsCollapsedOverflowing] = useState(false)
   const [logs, setLogs] = useState<RequestLog[]>([])
   const [jobs, setJobs] = useState<import('./api').JobLogView[]>([])
   const [loading, setLoading] = useState(true)
@@ -195,6 +202,7 @@ function AdminDashboard(): JSX.Element {
   const [profile, setProfile] = useState<Profile | null>(null)
   const secretCacheRef = useRef<Map<string, string>>(new Map())
   const tokenSecretCacheRef = useRef<Map<string, string>>(new Map())
+  const tokenGroupsListRef = useRef<HTMLDivElement | null>(null)
   const [copyState, setCopyState] = useState<Map<string, 'loading' | 'copied'>>(() => new Map())
   const [expandedLogs, setExpandedLogs] = useState<Set<number>>(() => new Set())
   const [newKey, setNewKey] = useState('')
@@ -291,13 +299,27 @@ function AdminDashboard(): JSX.Element {
   const loadData = useCallback(
     async (signal?: AbortSignal) => {
       try {
-        const [summaryData, keyData, logData, ver, profileData, tokenData, jobsData] = await Promise.all([
+        const [summaryData, keyData, logData, ver, profileData, tokenData, tokenGroupsData, jobsData] = await Promise.all([
           fetchSummary(signal),
           fetchApiKeys(signal),
           fetchRequestLogs(50, signal),
           fetchVersion(signal).catch(() => null),
           fetchProfile(signal).catch(() => null),
-          fetchTokens(tokensPage, tokensPerPage, signal).catch(() => ({ items: [], total: 0, page: tokensPage, perPage: tokensPerPage } as Paginated<AuthToken>)),
+          fetchTokens(
+            tokensPage,
+            tokensPerPage,
+            { group: selectedTokenGroupName, ungrouped: selectedTokenUngrouped },
+            signal,
+          ).catch(
+            () =>
+              ({
+                items: [],
+                total: 0,
+                page: tokensPage,
+                perPage: tokensPerPage,
+              }) as Paginated<AuthToken>,
+          ),
+          fetchTokenGroups(signal).catch(() => [] as TokenGroup[]),
           fetchJobs(50, signal).catch(() => []),
         ])
 
@@ -311,6 +333,7 @@ function AdminDashboard(): JSX.Element {
         setLogs(logData)
         setTokens(tokenData.items)
         setTokensTotal(tokenData.total)
+        setTokenGroups(tokenGroupsData)
         setJobs(jobsData)
         setExpandedLogs((previous) => {
           if (previous.size === 0) {
@@ -339,7 +362,7 @@ function AdminDashboard(): JSX.Element {
         }
       }
   },
-    [tokensPage],
+    [tokensPage, selectedTokenGroupName, selectedTokenUngrouped],
   )
 
   useEffect(() => {
@@ -373,6 +396,26 @@ function AdminDashboard(): JSX.Element {
       }
     }
   }, [sseConnected, loadData])
+
+  // Detect whether the collapsed token groups row overflows horizontally.
+  // If everything fits in a single line, we hide the "more" toggle button.
+  useEffect(() => {
+    if (!Array.isArray(tokenGroups) || tokenGroups.length === 0 || tokenGroupsExpanded) {
+      setTokenGroupsCollapsedOverflowing(false)
+      return
+    }
+    const el = tokenGroupsListRef.current
+    if (!el) return
+
+    const measure = () => {
+      const overflowing = el.scrollWidth > el.clientWidth
+      setTokenGroupsCollapsedOverflowing(overflowing)
+    }
+
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [tokenGroups, tokenGroupsExpanded, selectedTokenGroupName, selectedTokenUngrouped])
 
   // Establish SSE connection to receive live dashboard updates
   useEffect(() => {
@@ -594,6 +637,28 @@ function AdminDashboard(): JSX.Element {
     setTokensPage((p) => Math.min(totalPages, p + 1))
   }
 
+  const handleSelectTokenGroupAll = () => {
+    setSelectedTokenGroupName(null)
+    setSelectedTokenUngrouped(false)
+    setTokensPage(1)
+  }
+
+  const handleSelectTokenGroupUngrouped = () => {
+    setSelectedTokenGroupName(null)
+    setSelectedTokenUngrouped(true)
+    setTokensPage(1)
+  }
+
+  const handleSelectTokenGroupNamed = (group: string) => {
+    setSelectedTokenGroupName(group)
+    setSelectedTokenUngrouped(false)
+    setTokensPage(1)
+  }
+
+  const toggleTokenGroupsExpanded = () => {
+    setTokenGroupsExpanded((previous) => !previous)
+  }
+
   const openBatchDialog = () => {
     setBatchGroup('')
     setBatchCount(10)
@@ -809,6 +874,10 @@ function AdminDashboard(): JSX.Element {
   }
 
   const tokenList = Array.isArray(tokens) ? tokens : []
+  const tokenGroupList = Array.isArray(tokenGroups) ? tokenGroups : []
+  const ungroupedGroup = tokenGroupList.find((group) => !group.name || group.name.trim().length === 0)
+  const namedTokenGroups = tokenGroupList.filter((group) => group.name && group.name.trim().length > 0)
+  const hasTokenGroups = tokenGroupList.length > 0
   return (
     <>
     <main className="app-shell">
@@ -870,6 +939,70 @@ function AdminDashboard(): JSX.Element {
             </div>
           )}
         </div>
+        {hasTokenGroups && (
+          <div className="token-groups-container">
+            <div className="token-groups-label">
+              <span>{tokenStrings.groups.label}</span>
+            </div>
+            <div className="token-groups-row">
+              <div
+                ref={tokenGroupsListRef}
+                className={`token-groups-list${tokenGroupsExpanded ? ' token-groups-list-expanded' : ''}`}
+              >
+                <button
+                  type="button"
+                  className={`token-group-chip${
+                    !selectedTokenUngrouped && selectedTokenGroupName == null ? ' token-group-chip-active' : ''
+                  }`}
+                  onClick={handleSelectTokenGroupAll}
+                >
+                  <span className="token-group-name">{tokenStrings.groups.all}</span>
+                </button>
+                {ungroupedGroup && (
+                  <button
+                    type="button"
+                    className={`token-group-chip${selectedTokenUngrouped ? ' token-group-chip-active' : ''}`}
+                    onClick={handleSelectTokenGroupUngrouped}
+                  >
+                    <span className="token-group-name">{tokenStrings.groups.ungrouped}</span>
+                    {tokenGroupsExpanded && (
+                      <span className="token-group-count">
+                        {ungroupedGroup.tokenCount}
+                      </span>
+                    )}
+                  </button>
+                )}
+                {namedTokenGroups.map((group) => (
+                  <button
+                    key={group.name}
+                    type="button"
+                    className={`token-group-chip${
+                      !selectedTokenUngrouped && selectedTokenGroupName === group.name ? ' token-group-chip-active' : ''
+                    }`}
+                    onClick={() => handleSelectTokenGroupNamed(group.name)}
+                  >
+                    <span className="token-group-name">{group.name}</span>
+                    {tokenGroupsExpanded && (
+                      <span className="token-group-count">
+                        {group.tokenCount}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+              {(tokenGroupsCollapsedOverflowing || tokenGroupsExpanded) && (
+                <button
+                  type="button"
+                  className={`token-group-chip token-group-toggle${tokenGroupsExpanded ? ' token-group-toggle-active' : ''}`}
+                  onClick={toggleTokenGroupsExpanded}
+                  aria-label={tokenGroupsExpanded ? tokenStrings.groups.moreHide : tokenStrings.groups.moreShow}
+                >
+                  <Icon icon={tokenGroupsExpanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width={18} height={18} />
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         <div className="table-wrapper">
           {tokenList.length === 0 ? (
             <div className="empty-state">{loading ? tokenStrings.empty.loading : tokenStrings.empty.none}</div>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -280,8 +280,24 @@ export interface Paginated<T> {
   perPage: number
 }
 
-export function fetchTokens(page = 1, perPage = 10, signal?: AbortSignal): Promise<Paginated<AuthToken>> {
+export interface TokenGroup {
+  name: string
+  tokenCount: number
+  latestCreatedAt: number
+}
+
+export function fetchTokens(
+  page = 1,
+  perPage = 10,
+  options?: { group?: string | null; ungrouped?: boolean },
+  signal?: AbortSignal,
+): Promise<Paginated<AuthToken>> {
   const params = new URLSearchParams({ page: String(page), per_page: String(perPage) })
+  if (options?.ungrouped) {
+    params.set('no_group', 'true')
+  } else if (options?.group && options.group.trim().length > 0) {
+    params.set('group', options.group.trim())
+  }
   return requestJson(`/api/tokens?${params.toString()}`, { signal })
 }
 
@@ -339,4 +355,8 @@ export async function createTokensBatch(group: string, count: number, note?: str
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ group, count, note }),
   })
+}
+
+export function fetchTokenGroups(signal?: AbortSignal): Promise<TokenGroup[]> {
+  return requestJson('/api/tokens/groups', { signal })
 }

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -150,6 +150,13 @@ interface AdminTranslationsShape {
       createdN: string
       copyAll: string
     }
+    groups: {
+      label: string
+      all: string
+      ungrouped: string
+      moreShow: string
+      moreHide: string
+    }
   }
     metrics: {
       labels: {
@@ -492,6 +499,13 @@ export const translations: Record<Language, TranslationShape> = {
           createdN: 'Created {n} tokens',
           copyAll: 'Copy all links',
         },
+        groups: {
+          label: 'Groups',
+          all: 'All',
+          ungrouped: 'Ungrouped',
+          moreShow: 'Show all groups',
+          moreHide: 'Collapse groups',
+        },
       },
       metrics: {
         labels: {
@@ -816,6 +830,13 @@ export const translations: Record<Language, TranslationShape> = {
           done: '完成',
           createdN: '已创建 {n} 个令牌',
           copyAll: '复制全部链接',
+        },
+        groups: {
+          label: '分组',
+          all: '全部',
+          ungrouped: '未分组',
+          moreShow: '展开全部分组',
+          moreHide: '收起分组',
         },
       },
       metrics: {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1010,6 +1010,87 @@ button:disabled {
   line-height: 1.2;
 }
 
+.token-groups-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.token-groups-label {
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  color: #64748b;
+  padding-top: 4px;
+  white-space: nowrap;
+}
+
+.token-groups-row {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: flex-start; /* 展开为多行时，保持展开按钮与第一行对齐，不随高度居中漂移 */
+  gap: 8px;
+  min-width: 0;
+}
+
+.token-groups-list {
+  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: hidden; /* 保持单行但不出现横向滚动条 */
+}
+
+.token-groups-list-expanded {
+  flex-wrap: wrap;
+  overflow-x: visible;
+}
+
+.token-group-chip {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(248, 250, 252, 0.9);
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.token-group-chip-active {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border-color: transparent;
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.25);
+}
+
+.token-group-toggle {
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.token-group-toggle-active {
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.token-group-name {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.token-group-count {
+  font-weight: 600;
+  font-size: 0.8rem;
+  opacity: 0.85;
+}
+
 /* 小屏优化（< 752px）：将筛选控件放到标题下一行并左对齐，避免被推挤 */
 @media (max-width: 752px) {
   .token-panel-header {
@@ -1031,6 +1112,16 @@ button:disabled {
   .token-panel-header .panel-description {
     text-align: left;
     margin: 0;
+  }
+  .token-groups-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .token-groups-label {
+    padding-top: 0;
+  }
+  .token-groups-row {
+    width: 100%;
   }
 }
 .token-metrics-grid {


### PR DESCRIPTION
## Summary

This PR refines the admin Access Tokens UX in two areas:

1. Batch token creation result dialog
2. Token group filtering and layout for the Access Tokens table

## Changes

### Backend

- Add `GET /api/tokens/groups` endpoint to aggregate access token groups:
  - Returns `{ name, tokenCount, latestCreatedAt }` per group.
  - Groups are derived from the `auth_tokens` table and ordered by `latestCreatedAt DESC`, then name ASC.
  - Includes an entry with `name: ""` to represent ungrouped tokens.
- Extend `GET /api/tokens` to support filtering:
  - `group=<name>`: returns only tokens with matching `group_name`, with in-memory pagination.
  - `no_group=true`: returns only tokens with `NULL` or empty `group_name`, with in-memory pagination.
  - Falls back to existing paginated query when no filter is provided.

### Frontend API

- Update `fetchTokens` signature to accept filter options:
  - `fetchTokens(page, perPage, { group?: string | null; ungrouped?: boolean }, signal?)`.
  - Emits `group` or `no_group` query parameters accordingly.
- Add `TokenGroup` model and `fetchTokenGroups()` client for `/api/tokens/groups`.

### Admin Dashboard UI

**Batch create dialog (existing branch work)**

- Monospace textarea for batch-created token links.
- One share link per line, with `wrap="off"` and `white-space: 'pre'` to avoid wrapping.
- Only the textarea scrolls; the DaisyUI `modal-box` is kept within the viewport and does not scroll.
- Add a "Copy all links" button that copies the full list of share URLs.

**Access Tokens panel: group chips and filtering**

- Add a group chip row above the Access Tokens table:
  - `All` — default view, no group filtering.
  - `Ungrouped` — shows only tokens without a group (`group_name` null/empty).
  - One chip per named group (e.g. `playwright-group`, `teamA`), ordered by latest token creation time.
- Selecting a chip:
  - Updates `selectedTokenGroupName` / `selectedTokenUngrouped` state.
  - Resets token pagination to page 1.
  - Reloads tokens via `fetchTokens` with the appropriate filter.
- The chip row is strictly ordered as: `All`, `Ungrouped` (if present), then named groups.

### Layout & Styling

- New styles in `web/src/index.css` for the group row:
  - `.token-groups-container` / `.token-groups-row` to align label + chips.
  - `.token-groups-list` keeps chips in a single line when collapsed.
  - `.token-groups-list-expanded` wraps chips into multiple lines when expanded.
  - `.token-group-chip` / `-active` / `-toggle` define chip appearance and the round expand/collapse button.
- Horizontal scrollbar removal:
  - Collapsed state uses `overflow-x: hidden` on the chip list to avoid a horizontal scrollbar.
- Expand/collapse toggle behavior:
  - The toggle button is rendered only when the collapsed row actually overflows (`scrollWidth > clientWidth`), or when the row is currently expanded.
  - A small effect watches `tokenGroups`, the selected group, and window resizes to recompute overflow.
  - Toggle is top-aligned so it does not "float" vertically when chips wrap.

### i18n

- Extend admin translations for the new group UI:
  - `tokens.groups.label` — "Groups" / "分组".
  - `tokens.groups.all` — "All" / "全部".
  - `tokens.groups.ungrouped` — "Ungrouped" / "未分组".
  - `tokens.groups.moreShow` — "Show all groups" / "展开全部分组".
  - `tokens.groups.moreHide` — "Collapse groups" / "收起分组".

## Screenshots (from current dev)

- `tmp/admin-tokens-groups-desktop-no-toggle.png` — All + Ungrouped + all groups fit on one line, no expand button.
- `tmp/admin-tokens-groups-ungrouped-desktop.png` — Desktop view with All, Ungrouped, and group chips.
- `tmp/admin-tokens-groups-narrow.png` — Narrow viewport with expanded multi-line chips (expand toggle visible).
- `tmp/admin-batch-dialog-*.png` (from earlier work on this branch) — batch result dialog with monospace textarea and copy-all button.

## Notes

- Pre-commit hooks (fmt + clippy + commitlint) pass locally.
- Backend dev server verified via `scripts/start-backend-dev.sh` with `DEV_OPEN_ADMIN=1`.
- Frontend tested via Vite dev server and Playwright snapshots at multiple viewport sizes (desktop and narrow)."}