### PR TITLE
feat: enhance admin recent request view

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1270,6 +1270,7 @@ impl KeyStore {
             sqlx::query_as::<_, (
                 i64,
                 String,
+                Option<String>,
                 String,
                 String,
                 Option<String>,
@@ -1284,7 +1285,7 @@ impl KeyStore {
                 String,
             )>(
                 r#"
-                SELECT id, api_key_id, method, path, query, status_code, tavily_status_code, error_message,
+                SELECT id, api_key_id, auth_token_id, method, path, query, status_code, tavily_status_code, error_message,
                        result_status, request_body, response_body, created_at, forwarded_headers, dropped_headers
                 FROM request_logs
                 WHERE api_key_id = ? AND created_at >= ?
@@ -1301,6 +1302,7 @@ impl KeyStore {
             sqlx::query_as::<_, (
                 i64,
                 String,
+                Option<String>,
                 String,
                 String,
                 Option<String>,
@@ -1315,7 +1317,7 @@ impl KeyStore {
                 String,
             )>(
                 r#"
-                SELECT id, api_key_id, method, path, query, status_code, tavily_status_code, error_message,
+                SELECT id, api_key_id, auth_token_id, method, path, query, status_code, tavily_status_code, error_message,
                        result_status, request_body, response_body, created_at, forwarded_headers, dropped_headers
                 FROM request_logs
                 WHERE api_key_id = ?
@@ -1335,6 +1337,7 @@ impl KeyStore {
                 |(
                     id,
                     key_id,
+                    auth_token_id,
                     method,
                     path,
                     query,
@@ -1350,6 +1353,7 @@ impl KeyStore {
                 )| RequestLogRecord {
                     id,
                     key_id,
+                    auth_token_id,
                     method,
                     path,
                     query,
@@ -2379,6 +2383,7 @@ impl KeyStore {
             SELECT
                 id,
                 api_key_id,
+                auth_token_id,
                 method,
                 path,
                 query,
@@ -2412,6 +2417,7 @@ impl KeyStore {
                 Ok(RequestLogRecord {
                     id: row.try_get("id")?,
                     key_id: row.try_get("api_key_id")?,
+                    auth_token_id: row.try_get("auth_token_id")?,
                     method: row.try_get("method")?,
                     path: row.try_get("path")?,
                     query: row.try_get("query")?,
@@ -2736,6 +2742,7 @@ pub struct ApiKeyMetrics {
 pub struct RequestLogRecord {
     pub id: i64,
     pub key_id: String,
+    pub auth_token_id: Option<String>,
     pub method: String,
     pub path: String,
     pub query: Option<String>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1952,6 +1952,7 @@ struct ApiKeySecretView {
 struct RequestLogView {
     id: i64,
     key_id: String,
+    auth_token_id: Option<String>,
     method: String,
     path: String,
     query: Option<String>,
@@ -2637,6 +2638,7 @@ impl From<RequestLogRecord> for RequestLogView {
         Self {
             id: record.id,
             key_id: record.key_id,
+            auth_token_id: record.auth_token_id,
             method: record.method,
             path: record.path,
             query: record.query,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -65,6 +65,7 @@ export interface ApiKeyStats {
 export interface RequestLog {
   id: number
   key_id: string
+  auth_token_id: string | null
   method: string
   path: string
   query: string | null

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -230,6 +230,7 @@ interface AdminTranslationsShape {
     table: {
       time: string
       key: string
+      token: string
       httpStatus: string
       mcpStatus: string
       result: string
@@ -577,8 +578,9 @@ export const translations: Record<Language, TranslationShape> = {
           none: 'No request logs captured yet.',
         },
         table: {
-          time: 'Time',
           key: 'Key',
+          token: 'Token',
+          time: 'Time',
           httpStatus: 'HTTP Status',
           mcpStatus: 'MCP Status',
           result: 'Result',
@@ -909,8 +911,9 @@ export const translations: Record<Language, TranslationShape> = {
           none: '尚未捕获请求日志。',
         },
         table: {
-          time: '时间',
           key: 'Key',
+          token: 'Token',
+          time: '时间',
           httpStatus: 'HTTP 状态码',
           mcpStatus: 'MCP 状态码',
           result: '结果',

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1312,15 +1312,87 @@ table {
   color: #475569;
 }
 /* 确保“结果”列徽章不换行并右对齐（兼容 4/5 列位置） */
+.admin-logs-table td:nth-child(6) .status-badge,
 .admin-logs-table td:nth-child(5) .status-badge,
 .admin-logs-table td:nth-child(4) .status-badge {
   white-space: nowrap;
   display: inline-flex;
 }
+.admin-logs-table td:nth-child(6) .log-result-button,
 .admin-logs-table td:nth-child(5) .log-result-button,
 .admin-logs-table td:nth-child(4) .log-result-button {
   width: 100%;
   justify-content: flex-end;
+}
+
+.admin-logs-table .log-key-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 12px;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0f172a;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.95rem;
+}
+
+.admin-logs-table .log-key-pill code {
+  color: inherit;
+}
+
+.log-time-cell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+  overflow: visible;
+}
+
+.log-time-trigger {
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.log-time-trigger:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.log-time-main {
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.log-time-bubble {
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.95);
+  background: #0f172a;
+  color: #fff;
+  padding: 4px 12px;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-size: 0.85rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 5;
+}
+
+.log-time-cell:hover .log-time-bubble,
+.log-time-cell:focus-within .log-time-bubble {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+
+.log-token-link code {
+  color: #0f172a;
 }
 
 .table-pagination {


### PR DESCRIPTION
## Summary
- show API key and token in separate columns for the admin recent requests table
- add inline tooltip bubble with precise timestamp (including milliseconds) plus relative time
- propagate `auth_token_id` through backend + API, update translations and styles

## Testing
- `npm run build`
- manual QA on http://127.0.0.1:58087/admin