### PR TITLE
feat: respect browser default language

### DIFF
--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -331,6 +331,22 @@ function readStoredLanguage(): Language | null {
   return null
 }
 
+function detectBrowserLanguage(): Language | null {
+  if (typeof navigator === 'undefined') return null
+  const preferred = Array.isArray(navigator.languages) ? navigator.languages : []
+  const fallbacks = typeof navigator.language === 'string' ? [navigator.language] : []
+  const candidates = [...preferred, ...fallbacks]
+
+  for (const locale of candidates) {
+    const normalized = locale?.toLowerCase()
+    if (!normalized) continue
+    if (normalized.startsWith('zh')) return 'zh'
+    if (normalized.startsWith('en')) return 'en'
+  }
+
+  return null
+}
+
 function persistLanguage(language: Language): void {
   if (typeof window === 'undefined') return
   window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
@@ -1016,7 +1032,9 @@ export type Translations = TranslationShape
 export type AdminTranslations = TranslationShape['admin']
 
 export function LanguageProvider({ children }: { children: ReactNode }): JSX.Element {
-  const [language, setLanguageState] = useState<Language>(() => readStoredLanguage() ?? DEFAULT_LANGUAGE)
+  const [language, setLanguageState] = useState<Language>(
+    () => readStoredLanguage() ?? detectBrowserLanguage() ?? DEFAULT_LANGUAGE,
+  )
 
   const setLanguage = (next: Language) => {
     setLanguageState(next)


### PR DESCRIPTION
## Summary
- add a `detectBrowserLanguage()` helper that checks the browser locale and returns zh/en when possible
- initialize `LanguageProvider` with stored language, then browser preference, and finally fall back to the existing default
- keep the existing storage semantics so manual toggles still persist

## Testing
- npm ci --prefix web
- npm run build --prefix web
- scripts/start-backend-dev.sh
- scripts/start-frontend-dev.sh
- curl -s http://127.0.0.1:58087/health
- curl -s http://127.0.0.1:58087/api/summary | jq .
