### PR TITLE
feat(web): refine public overview token stats

### DIFF
--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -32,6 +32,9 @@ interface PublicTranslations {
       dailySuccess: string
       dailyFailure: string
       monthlySuccess: string
+      hourlyLimit: string
+      dailyLimit: string
+      monthlyLimit: string
     }
   }
   accessToken: {
@@ -393,6 +396,9 @@ export const translations: Record<Language, TranslationShape> = {
           dailySuccess: 'Daily Success',
           dailyFailure: 'Daily Failure',
           monthlySuccess: 'Monthly Success',
+          hourlyLimit: 'Hourly Limit',
+          dailyLimit: 'Daily Limit',
+          monthlyLimit: 'Monthly Limit',
         },
       },
       accessToken: {
@@ -733,6 +739,9 @@ export const translations: Record<Language, TranslationShape> = {
           dailySuccess: '今日成功',
           dailyFailure: '今日失败',
           monthlySuccess: '本月成功',
+          hourlyLimit: '1 小时限额',
+          dailyLimit: '24 小时限额',
+          monthlyLimit: '月度限额',
         },
       },
       accessToken: {

--- a/web/src/pages/TokenDetail.tsx
+++ b/web/src/pages/TokenDetail.tsx
@@ -698,7 +698,7 @@ export default function TokenDetail({ id, onBack }: { id: string; onBack?: () =>
                 used={info.quota_monthly_used}
                 limit={info.quota_monthly_limit}
                 resetAt={info.quota_monthly_reset_at}
-                description="Calendar month (server time)"
+                description="Calendar month"
               />
             </>
           ) : (


### PR DESCRIPTION
## Summary

This PR refines the public overview (user landing) page token stats and aligns them with the admin views.

- Reorders the public overview panels so that **Token Usage** comes directly before **Recent Requests (last 20)**.
- Splits the access-token stats into two logical groups: usage counts and quota limits.
- Adds explicit 1 hour / 24 hours / monthly quota stats using a `used / limit` presentation similar to the admin token detail "Quick Stats".
- Keeps the quota limits in sync with backend constants (`TOKEN_HOURLY_LIMIT`, `TOKEN_DAILY_LIMIT`, `TOKEN_MONTHLY_LIMIT`).
- Removes the "(server time)" suffix from the calendar-month description to save vertical space.

## Changes

### Public overview (`/`)

- `web/src/PublicHome.tsx`
  - Introduce `recentTokenUsage` state, populated via:
    - initial `fetchTokenMetrics` when a valid token is present (from hash or last-used token),
    - SSE updates from `/api/public/events`, and
    - fallback polling `fetchTokenMetrics`.
  - Add a new **Token Usage** panel with two groups:
    1. **Usage group**: Daily success, daily failure, monthly success (same metrics as before).
    2. **Quota group**: three cards showing `used / limit` for 1 hour, 24 hours, and calendar month, styled with `quota-stat-card` classes to match the admin "Quick Stats".
  - Ensure that `Recent Requests (last 20)` remains immediately below the token usage panel.

- `web/src/i18n.tsx`
  - Extend `PublicTranslations.accessPanel.stats` with three new labels: `hourlyLimit`, `dailyLimit`, `monthlyLimit` for both EN and ZH locales.

### Admin token detail

- `web/src/pages/TokenDetail.tsx`
  - Tidy the monthly quota card description from `Calendar month (server time)` to `Calendar month` to match the new public view wording.

## Notes

- Public quota cards currently use the token-scoped success metrics from `/api/token/metrics` as the "used" counts. If we later expose window-specific counters (hour/day/month) from the backend, the UI can be wired to those without changing layout.

## Testing

- `npm run build` in `web/`.
- Local manual verification (with mock Tavily upstream and generated access token):
  - `Token Usage` panel shows two groups of stats as described above.
  - Quota cards render `0 / 100`, `0 / 500`, `0 / 3,000` initially and share the same visual style as admin `QuotaStatCard`.
  - `Recent Requests` panel appears directly under the token usage panel and shows the latest 20 requests for the active token when provided.