### PR TITLE
fix(public): align token overview quotas with detail view

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,6 +727,16 @@ impl TavilyProxy {
         self.token_quota.check(token_id).await
     }
 
+    /// Read-only snapshot of current token quota usage (hour / day / month).
+    pub async fn token_quota_snapshot(
+        &self,
+        token_id: &str,
+    ) -> Result<Option<TokenQuotaVerdict>, ProxyError> {
+        let ids = vec![token_id.to_string()];
+        let verdicts = self.token_quota.snapshot_many(&ids).await?;
+        Ok(verdicts.get(token_id).cloned())
+    }
+
     /// Token logs (page-based pagination)
     pub async fn token_logs_page(
         &self,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -19,6 +19,12 @@ export interface TokenMetrics {
   monthlySuccess: number
   dailySuccess: number
   dailyFailure: number
+  quotaHourlyUsed: number
+  quotaHourlyLimit: number
+  quotaDailyUsed: number
+  quotaDailyLimit: number
+  quotaMonthlyUsed: number
+  quotaMonthlyLimit: number
 }
 
 export interface TokenHourlyBucket {


### PR DESCRIPTION
Fix public overview token usage stats so that rolling quota cards use the same quota snapshot data as the admin token detail view, while keeping daily/monthly success counters based on request logs.

- Extend `TokenMetricsView` and `/api/token/metrics` to include quota snapshot fields.
- Reuse `TokenQuota::snapshot_many` via a new `token_quota_snapshot` helper on `TavilyProxy`.
- Update `/api/public/events` SSE payload to stream quota fields.
- Wire `PublicHome` to consume the new fields and use them for the "hourly/daily/monthly limit" cards instead of daily/monthly success counts.

Backend still relies on `request_logs` as the source of truth for success/failure counts; quota buckets remain approximate but consistent across overview and detail views.