### PR TITLE
fix(admin): prevent key detail hook crash

### DIFF
--- a/web/src/AdminDashboard.tsx
+++ b/web/src/AdminDashboard.tsx
@@ -1136,16 +1136,17 @@ function AdminDashboard(): JSX.Element {
     setPendingDisableId(null)
   }
 
+  const tokenLeaderboardView = useMemo(() => {
+    if (!tokenLeaderboard || tokenLeaderboard.length === 0) return []
+    return sortLeaderboard(tokenLeaderboard, tokenLeaderboardPeriod, tokenLeaderboardFocus).slice(0, 50)
+  }, [tokenLeaderboard, tokenLeaderboardPeriod, tokenLeaderboardFocus])
+
   if (route.name === 'key') {
     return <KeyDetails id={route.id} onBack={navigateHome} />
   }
   if (route.name === 'token') {
     return <TokenDetail id={route.id} onBack={navigateHome} />
   }
-  const tokenLeaderboardView = useMemo(() => {
-    if (!tokenLeaderboard || tokenLeaderboard.length === 0) return []
-    return sortLeaderboard(tokenLeaderboard, tokenLeaderboardPeriod, tokenLeaderboardFocus).slice(0, 50)
-  }, [tokenLeaderboard, tokenLeaderboardPeriod, tokenLeaderboardFocus])
 
   if (route.name === 'token-usage') {
     const primaryMetric: MetricKey = tokenLeaderboardFocus


### PR DESCRIPTION
## Summary
- ensure token leaderboard hook is declared before route branching to keep React hook order stable
- avoid React invariant #300 that caused API key detail page to white-screen when navigating
- verified via built frontend + backend static serving; key detail navigation and back now render correctly

## Testing
- npm run build (web)
- DEV_OPEN_ADMIN=true cargo run -- --static-dir web/dist
- manual: add test key, open /admin#/keys/<id>, back to /admin# (no console errors, no white screen)