### PR TITLE
fix(web): flatten empty state in table wrapper

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1742,6 +1742,15 @@ tbody .log-details-row:hover {
   color: #64748b;
 }
 
+/* Inside table wrappers, keep empty states flat (avoid double border/rounded "alert" card). */
+.table-wrapper .empty-state.alert {
+  display: block;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 /* Reserve a stable slot after token ID to avoid layout shift when toggling status icon */
 .token-status-slot {
   display: inline-block;


### PR DESCRIPTION
## What
Fix a UI glitch where empty states inside `.table-wrapper` showed a second rounded "alert" card (double border / misaligned radii).

## How
Add a scoped CSS override for `.table-wrapper .empty-state.alert` to remove background/border/radius/shadow so the wrapper remains the only container outline.

## Verify
- Open `/admin` with empty lists and confirm the empty-state is flat (no inner rounded rectangle).
- `cd web && npm run build`