### PR TITLE
feat: add admin shortcut in user console

### DIFF
--- a/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
+++ b/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
@@ -1,0 +1,101 @@
+# 用户控制台管理员入口（#2uv3g）
+
+## 状态
+
+- Status: 已完成
+- Created: 2026-03-07
+- Last: 2026-03-07
+
+## 背景 / 问题陈述
+
+- 现状：首页 `/` 已有管理员入口；LinuxDo 登录成功后默认落到 `/console`；管理员若要进入后台，仍需手工改地址到 `/admin`。
+- 问题：Forward Auth 管理员账号落到用户控制台后，没有明确后台入口，导致“已是管理员但看起来像普通用户”的体验割裂。
+
+## 目标 / 非目标
+
+### Goals
+
+- 在用户控制台 `/console` 的共享页头增加管理员专属入口。
+- 入口只对 `GET /api/profile` 返回 `isAdmin=true` 的会话展示。
+- 点击入口后直接进入 `/admin`，不改变现有 `/console` hash 路由和控制台主体交互。
+
+### Non-goals
+
+- 不改变 LinuxDo 登录成功后的默认落点（仍为 `/console`）。
+- 不调整 Rust 鉴权、Forward Auth、`/api/profile` 契约或管理员权限口径。
+- 不为非管理员新增后台入口提示或引导。
+
+## 范围（Scope）
+
+### In scope
+
+- `web/src/UserConsole.tsx`：在共享页头 actions 区域增加管理员入口。
+- `web/src/UserConsole.stories.tsx`：补充管理员显示态，覆盖入口可见性。
+- `docs/specs/README.md`：登记该工作项并同步状态。
+
+### Out of scope
+
+- `/` 首页 Hero 的管理员入口逻辑。
+- `/auth/linuxdo/callback`、`/console`、`/admin` 的服务端重定向逻辑。
+- 新增后端 capability API 或角色模型。
+
+## 需求（Requirements）
+
+### MUST
+
+- 管理员进入 `/console` 后，页头出现单一、明确的“打开管理员面板” CTA。
+- 非管理员进入 `/console` 时，该 CTA 不显示。
+- CTA 文案优先复用现有国际化键 `public.adminButton`。
+- CTA 点击目标固定为 `/admin`。
+
+### SHOULD
+
+- CTA 与现有页头按钮视觉层级一致，不挤压主题/语言切换控件。
+- Storybook 提供可直接验证管理员显示态的页面级 story。
+
+## 接口契约（Interfaces & Contracts）
+
+- None
+
+## 验收标准（Acceptance Criteria）
+
+- Given 管理员会话访问 `/console`
+  When 用户进入 dashboard、tokens 或 token detail 任一视图
+  Then 页头都能看到管理员入口，且点击后进入 `/admin`。
+
+- Given 非管理员会话访问 `/console`
+  When 页面加载完成
+  Then 不展示管理员入口，其余控制台内容与现有行为保持一致。
+
+- Given 现有 LinuxDo 登录链路
+  When 用户登录成功或已登录用户访问 `/`
+  Then 默认落点仍为 `/console`，不改为 `/admin`。
+
+## 非功能性验收 / 质量门槛（Quality Gates）
+
+### Testing
+
+- Frontend build: `cd web && bun run build`
+
+### UI / Storybook
+
+- Update `web/src/UserConsole.stories.tsx` with an admin-visible console scenario.
+
+### Quality checks
+
+- 浏览器实测 `/console` 管理员态可见、非管理员态隐藏。
+
+## 实现里程碑（Milestones / Delivery checklist）
+
+- [x] M1: 用户控制台页头增加管理员专属入口
+- [x] M2: Storybook 覆盖管理员可见态与默认隐藏态
+- [x] M3: 本地构建与浏览器验证完成
+
+## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
+
+- 风险：页头空间在窄屏下较紧，需要保持按钮不破坏现有换行与控件布局。
+- 假设：`/api/profile.isAdmin` 已足够代表“允许进入 `/admin` 的管理员态”，无需新增更细粒度 capability。
+
+## 变更记录（Change log）
+
+- 2026-03-07: 完成 `/console` 管理员入口、Storybook 管理员态覆盖与本地构建/浏览器验证。

--- a/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
+++ b/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
@@ -79,7 +79,7 @@
 
 ### UI / Storybook
 
-- Update `web/src/UserConsole.stories.tsx` with admin-visible dashboard, compact/mobile dashboard, and tokens scenarios.
+- Update `web/src/UserConsole.stories.tsx` with admin-visible dashboard, compact/mobile dashboard, tokens, and token-detail scenarios.
 
 ### Quality checks
 
@@ -98,4 +98,4 @@
 
 ## 变更记录（Change log）
 
-- 2026-03-07: 完成 `/console` 管理员入口，并在 review-loop 中补齐链接语义与 dashboard/tokens/mobile Storybook 覆盖。
+- 2026-03-07: 完成 `/console` 管理员入口，并在 review-loop 中补齐链接语义与 dashboard/tokens/token-detail/mobile Storybook 覆盖。

--- a/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
+++ b/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
@@ -76,6 +76,7 @@
 ### Testing
 
 - Frontend build: `cd web && bun run build`
+- Frontend unit tests: `cd web && bun test`
 
 ### UI / Storybook
 
@@ -89,7 +90,7 @@
 
 - [x] M1: 用户控制台页头增加管理员专属入口
 - [x] M2: Storybook 覆盖管理员可见态与默认隐藏态
-- [x] M3: 本地构建与浏览器验证完成
+- [x] M3: 本地构建、自动化断言与浏览器验证完成
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 
@@ -98,4 +99,4 @@
 
 ## 变更记录（Change log）
 
-- 2026-03-07: 完成 `/console` 管理员入口，并在 review-loop 中补齐链接语义与 dashboard/tokens/token-detail/mobile Storybook 覆盖。
+- 2026-03-07: 完成 `/console` 管理员入口，并在 review-loop 中补齐链接语义、dashboard/tokens/token-detail/mobile Storybook 覆盖，以及管理员入口 gating/href 自动化断言。

--- a/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
+++ b/docs/specs/2uv3g-user-console-admin-entry/SPEC.md
@@ -79,7 +79,7 @@
 
 ### UI / Storybook
 
-- Update `web/src/UserConsole.stories.tsx` with an admin-visible console scenario.
+- Update `web/src/UserConsole.stories.tsx` with admin-visible dashboard, compact/mobile dashboard, and tokens scenarios.
 
 ### Quality checks
 
@@ -98,4 +98,4 @@
 
 ## 变更记录（Change log）
 
-- 2026-03-07: 完成 `/console` 管理员入口、Storybook 管理员态覆盖与本地构建/浏览器验证。
+- 2026-03-07: 完成 `/console` 管理员入口，并在 review-loop 中补齐链接语义与 dashboard/tokens/mobile Storybook 覆盖。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 
 |    ID | Title                                                  | Status           | Spec                                                  | Last       | Notes                                                                                                       |
 | ----: | ------------------------------------------------------ | ---------------- | ----------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
-| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | PR #101；admin-only `/console` entry + dashboard/tokens/mobile Storybook coverage + local validation        |
+| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | PR #101；admin-only `/console` entry + dashboard/tokens/token-detail/mobile Storybook coverage + validation |
 | bcpru | Web 响应式双设备与 Storybook 断点验收收敛              | 已完成（6/6）    | `bcpru-web-responsive-breakpoint-convergence/SPEC.md` | 2026-03-04 | fast-track: responsive convergence, Storybook coverage, and boundary validation completed                   |
 | vr67d | LinuxDo 登录复用既有 Token + 强制重登录 + 历史误建自愈 | 已完成（快车道） | `vr67d-linuxdo-token-rebind-relogin/SPEC.md`          | 2026-03-05 | hotfix: `/auth/linuxdo` use 303 to avoid POST body leak + fix upstream 405                                  |
 | 6xeyh | 多 Token 绑定保留已分配 token（不做历史回补）          | 进行中（快车道） | `6xeyh-multi-token-binding-preserve/SPEC.md`          | 2026-03-06 | PR #95；共享测试机 E2E 回归通过；review-loop 已完成并按契约保留“最新绑定优先”语义                           |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,6 +9,7 @@
 
 |    ID | Title                                                  | Status           | Spec                                                  | Last       | Notes                                                                                                       |
 | ----: | ------------------------------------------------------ | ---------------- | ----------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
+| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | admin-only `/console` entry + Storybook coverage + local validation                                         |
 | bcpru | Web 响应式双设备与 Storybook 断点验收收敛              | 已完成（6/6）    | `bcpru-web-responsive-breakpoint-convergence/SPEC.md` | 2026-03-04 | fast-track: responsive convergence, Storybook coverage, and boundary validation completed                   |
 | vr67d | LinuxDo 登录复用既有 Token + 强制重登录 + 历史误建自愈 | 已完成（快车道） | `vr67d-linuxdo-token-rebind-relogin/SPEC.md`          | 2026-03-05 | hotfix: `/auth/linuxdo` use 303 to avoid POST body leak + fix upstream 405                                  |
 | 6xeyh | 多 Token 绑定保留已分配 token（不做历史回补）          | 进行中（快车道） | `6xeyh-multi-token-binding-preserve/SPEC.md`          | 2026-03-06 | PR #95；共享测试机 E2E 回归通过；review-loop 已完成并按契约保留“最新绑定优先”语义                           |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 
 |    ID | Title                                                  | Status           | Spec                                                  | Last       | Notes                                                                                                       |
 | ----: | ------------------------------------------------------ | ---------------- | ----------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
-| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | PR #101；admin-only `/console` entry + dashboard/tokens/token-detail/mobile Storybook coverage + validation |
+| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | PR #101；admin-only `/console` entry + dashboard/tokens/token-detail/mobile Storybook coverage + unit test  |
 | bcpru | Web 响应式双设备与 Storybook 断点验收收敛              | 已完成（6/6）    | `bcpru-web-responsive-breakpoint-convergence/SPEC.md` | 2026-03-04 | fast-track: responsive convergence, Storybook coverage, and boundary validation completed                   |
 | vr67d | LinuxDo 登录复用既有 Token + 强制重登录 + 历史误建自愈 | 已完成（快车道） | `vr67d-linuxdo-token-rebind-relogin/SPEC.md`          | 2026-03-05 | hotfix: `/auth/linuxdo` use 303 to avoid POST body leak + fix upstream 405                                  |
 | 6xeyh | 多 Token 绑定保留已分配 token（不做历史回补）          | 进行中（快车道） | `6xeyh-multi-token-binding-preserve/SPEC.md`          | 2026-03-06 | PR #95；共享测试机 E2E 回归通过；review-loop 已完成并按契约保留“最新绑定优先”语义                           |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@
 
 |    ID | Title                                                  | Status           | Spec                                                  | Last       | Notes                                                                                                       |
 | ----: | ------------------------------------------------------ | ---------------- | ----------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
-| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | admin-only `/console` entry + Storybook coverage + local validation                                         |
+| 2uv3g | 用户控制台管理员入口                                   | 已完成           | `2uv3g-user-console-admin-entry/SPEC.md`              | 2026-03-07 | PR #101；admin-only `/console` entry + dashboard/tokens/mobile Storybook coverage + local validation        |
 | bcpru | Web 响应式双设备与 Storybook 断点验收收敛              | 已完成（6/6）    | `bcpru-web-responsive-breakpoint-convergence/SPEC.md` | 2026-03-04 | fast-track: responsive convergence, Storybook coverage, and boundary validation completed                   |
 | vr67d | LinuxDo 登录复用既有 Token + 强制重登录 + 历史误建自愈 | 已完成（快车道） | `vr67d-linuxdo-token-rebind-relogin/SPEC.md`          | 2026-03-05 | hotfix: `/auth/linuxdo` use 303 to avoid POST body leak + fix upstream 405                                  |
 | 6xeyh | 多 Token 绑定保留已分配 token（不做历史回补）          | 进行中（快车道） | `6xeyh-multi-token-binding-preserve/SPEC.md`          | 2026-03-06 | PR #95；共享测试机 E2E 回归通过；review-loop 已完成并按契约保留“最新绑定优先”语义                           |

--- a/web/src/UserConsole.stories.tsx
+++ b/web/src/UserConsole.stories.tsx
@@ -8,6 +8,7 @@ type Scenario =
   | 'dashboard'
   | 'dashboard-admin'
   | 'tokens-admin'
+  | 'token-detail-admin'
   | 'tokens'
   | 'tokens-empty'
   | 'token-detail'
@@ -177,7 +178,8 @@ function scenarioHash(scenario: Scenario): string {
   if (scenario === 'tokens' || scenario === 'tokens-admin') return '#/tokens'
   if (scenario === 'tokens-empty') return '#/tokens'
   if (
-    scenario === 'token-detail'
+    scenario === 'token-detail-admin'
+    || scenario === 'token-detail'
     || scenario === 'token-detail-probe-running'
     || scenario === 'token-detail-probe-success'
     || scenario === 'token-detail-probe-partial'
@@ -193,7 +195,8 @@ function installUserConsoleFetchMock(scenario: Scenario): () => void {
   const originalFetch = window.fetch.bind(window)
   const probeMode = probeModeFromScenario(scenario)
   const researchRequestId = 'rq-story-001'
-  const isAdminScenario = scenario === 'dashboard-admin' || scenario === 'tokens-admin'
+  const isAdminScenario =
+    scenario === 'dashboard-admin' || scenario === 'tokens-admin' || scenario === 'token-detail-admin'
 
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const request = input instanceof Request
@@ -420,6 +423,15 @@ export const DashboardAdminMobile: Story = {
 export const TokensAdmin: Story = {
   args: {
     scenario: 'tokens-admin',
+  },
+  parameters: {
+    viewport: { defaultViewport: '1440-device-desktop' },
+  },
+}
+
+export const TokenDetailAdmin: Story = {
+  args: {
+    scenario: 'token-detail-admin',
   },
   parameters: {
     viewport: { defaultViewport: '1440-device-desktop' },

--- a/web/src/UserConsole.stories.tsx
+++ b/web/src/UserConsole.stories.tsx
@@ -6,6 +6,7 @@ import UserConsole from './UserConsole'
 
 type Scenario =
   | 'dashboard'
+  | 'dashboard-admin'
   | 'tokens'
   | 'tokens-empty'
   | 'token-detail'
@@ -133,6 +134,11 @@ const profileSample: Profile = {
   userDisplayName: 'Ivan',
 }
 
+const adminProfileSample: Profile = {
+  ...profileSample,
+  isAdmin: true,
+}
+
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -194,7 +200,7 @@ function installUserConsoleFetchMock(scenario: Scenario): () => void {
     const url = new URL(request.url, window.location.origin)
 
     if (url.pathname === '/api/profile') {
-      return jsonResponse(profileSample)
+      return jsonResponse(scenario === 'dashboard-admin' ? adminProfileSample : profileSample)
     }
 
     if (url.pathname === '/api/user/dashboard') {
@@ -385,6 +391,15 @@ type Story = StoryObj<typeof meta>
 export const Dashboard: Story = {
   args: {
     scenario: 'dashboard',
+  },
+  parameters: {
+    viewport: { defaultViewport: '1440-device-desktop' },
+  },
+}
+
+export const DashboardAdmin: Story = {
+  args: {
+    scenario: 'dashboard-admin',
   },
   parameters: {
     viewport: { defaultViewport: '1440-device-desktop' },

--- a/web/src/UserConsole.stories.tsx
+++ b/web/src/UserConsole.stories.tsx
@@ -7,6 +7,7 @@ import UserConsole from './UserConsole'
 type Scenario =
   | 'dashboard'
   | 'dashboard-admin'
+  | 'tokens-admin'
   | 'tokens'
   | 'tokens-empty'
   | 'token-detail'
@@ -173,7 +174,7 @@ function autoProbeTargetFromScenario(scenario: Scenario): 'mcp' | 'api' | null {
 }
 
 function scenarioHash(scenario: Scenario): string {
-  if (scenario === 'tokens') return '#/tokens'
+  if (scenario === 'tokens' || scenario === 'tokens-admin') return '#/tokens'
   if (scenario === 'tokens-empty') return '#/tokens'
   if (
     scenario === 'token-detail'
@@ -192,6 +193,7 @@ function installUserConsoleFetchMock(scenario: Scenario): () => void {
   const originalFetch = window.fetch.bind(window)
   const probeMode = probeModeFromScenario(scenario)
   const researchRequestId = 'rq-story-001'
+  const isAdminScenario = scenario === 'dashboard-admin' || scenario === 'tokens-admin'
 
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const request = input instanceof Request
@@ -200,7 +202,7 @@ function installUserConsoleFetchMock(scenario: Scenario): () => void {
     const url = new URL(request.url, window.location.origin)
 
     if (url.pathname === '/api/profile') {
-      return jsonResponse(scenario === 'dashboard-admin' ? adminProfileSample : profileSample)
+      return jsonResponse(isAdminScenario ? adminProfileSample : profileSample)
     }
 
     if (url.pathname === '/api/user/dashboard') {
@@ -400,6 +402,24 @@ export const Dashboard: Story = {
 export const DashboardAdmin: Story = {
   args: {
     scenario: 'dashboard-admin',
+  },
+  parameters: {
+    viewport: { defaultViewport: '1440-device-desktop' },
+  },
+}
+
+export const DashboardAdminMobile: Story = {
+  args: {
+    scenario: 'dashboard-admin',
+  },
+  parameters: {
+    viewport: { defaultViewport: '0390-device-iphone-14' },
+  },
+}
+
+export const TokensAdmin: Story = {
+  args: {
+    scenario: 'tokens-admin',
   },
   parameters: {
     viewport: { defaultViewport: '1440-device-desktop' },

--- a/web/src/UserConsole.tsx
+++ b/web/src/UserConsole.tsx
@@ -26,6 +26,7 @@ import LanguageSwitcher from './components/LanguageSwitcher'
 import RollingNumber from './components/RollingNumber'
 import { StatusBadge, type StatusTone } from './components/StatusBadge'
 import ThemeToggle from './components/ThemeToggle'
+import { Button } from './components/ui/button'
 import { useLanguage, useTranslate, type Language } from './i18n'
 import {
   type McpProbeStepState,
@@ -404,6 +405,11 @@ export default function UserConsole(): JSX.Element {
   )
 
   const anyProbeRunning = mcpProbe.state === 'running' || apiProbe.state === 'running'
+  const isAdmin = profile?.isAdmin ?? false
+
+  const goAdmin = useCallback(() => {
+    window.location.href = '/admin'
+  }, [])
 
   const runMcpProbe = useCallback(async () => {
     if (route.name !== 'token' || anyProbeRunning) return
@@ -918,6 +924,20 @@ export default function UserConsole(): JSX.Element {
               <LanguageSwitcher />
             </div>
           </div>
+          {isAdmin && (
+            <div className="admin-panel-header-actions">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="user-console-admin-entry"
+                onClick={goAdmin}
+              >
+                <Icon icon="mdi:crown-outline" width={16} height={16} aria-hidden="true" />
+                <span>{publicStrings.adminButton}</span>
+              </Button>
+            </div>
+          )}
         </div>
       </section>
 

--- a/web/src/UserConsole.tsx
+++ b/web/src/UserConsole.tsx
@@ -39,6 +39,7 @@ import {
   resolveMcpProbeButtonState,
 } from './lib/mcpProbe'
 import { useResponsiveModes } from './lib/responsive'
+import { getUserConsoleAdminHref } from './lib/userConsoleAdminEntry'
 
 const REPO_URL = 'https://github.com/IvanLi-CN/tavily-hikari'
 const CODEX_DOC_URL = 'https://github.com/openai/codex/blob/main/docs/config.md'
@@ -405,8 +406,7 @@ export default function UserConsole(): JSX.Element {
   )
 
   const anyProbeRunning = mcpProbe.state === 'running' || apiProbe.state === 'running'
-  const isAdmin = profile?.isAdmin ?? false
-
+  const adminHref = getUserConsoleAdminHref(profile)
 
   const runMcpProbe = useCallback(async () => {
     if (route.name !== 'token' || anyProbeRunning) return
@@ -921,10 +921,10 @@ export default function UserConsole(): JSX.Element {
               <LanguageSwitcher />
             </div>
           </div>
-          {isAdmin && (
+          {adminHref && (
             <div className="admin-panel-header-actions">
               <Button asChild variant="outline" size="sm" className="user-console-admin-entry">
-                <a href="/admin">
+                <a href={adminHref}>
                   <Icon icon="mdi:crown-outline" width={16} height={16} aria-hidden="true" />
                   <span>{publicStrings.adminButton}</span>
                 </a>

--- a/web/src/UserConsole.tsx
+++ b/web/src/UserConsole.tsx
@@ -407,9 +407,6 @@ export default function UserConsole(): JSX.Element {
   const anyProbeRunning = mcpProbe.state === 'running' || apiProbe.state === 'running'
   const isAdmin = profile?.isAdmin ?? false
 
-  const goAdmin = useCallback(() => {
-    window.location.href = '/admin'
-  }, [])
 
   const runMcpProbe = useCallback(async () => {
     if (route.name !== 'token' || anyProbeRunning) return
@@ -926,15 +923,11 @@ export default function UserConsole(): JSX.Element {
           </div>
           {isAdmin && (
             <div className="admin-panel-header-actions">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="user-console-admin-entry"
-                onClick={goAdmin}
-              >
-                <Icon icon="mdi:crown-outline" width={16} height={16} aria-hidden="true" />
-                <span>{publicStrings.adminButton}</span>
+              <Button asChild variant="outline" size="sm" className="user-console-admin-entry">
+                <a href="/admin">
+                  <Icon icon="mdi:crown-outline" width={16} height={16} aria-hidden="true" />
+                  <span>{publicStrings.adminButton}</span>
+                </a>
               </Button>
             </div>
           )}

--- a/web/src/lib/userConsoleAdminEntry.test.js
+++ b/web/src/lib/userConsoleAdminEntry.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getUserConsoleAdminHref, USER_CONSOLE_ADMIN_HREF } from './userConsoleAdminEntry'
+
+describe('getUserConsoleAdminHref', () => {
+  it('hides the admin entry when the session is not an admin', () => {
+    expect(getUserConsoleAdminHref(undefined)).toBeNull()
+    expect(getUserConsoleAdminHref(null)).toBeNull()
+    expect(getUserConsoleAdminHref({ isAdmin: false })).toBeNull()
+  })
+
+  it('routes admin sessions to the admin dashboard', () => {
+    expect(getUserConsoleAdminHref({ isAdmin: true })).toBe(USER_CONSOLE_ADMIN_HREF)
+  })
+})

--- a/web/src/lib/userConsoleAdminEntry.ts
+++ b/web/src/lib/userConsoleAdminEntry.ts
@@ -1,0 +1,9 @@
+import type { Profile } from '../api'
+
+export const USER_CONSOLE_ADMIN_HREF = '/admin' as const
+
+export function getUserConsoleAdminHref(
+  profile: Pick<Profile, 'isAdmin'> | null | undefined,
+): typeof USER_CONSOLE_ADMIN_HREF | null {
+  return profile?.isAdmin ? USER_CONSOLE_ADMIN_HREF : null
+}


### PR DESCRIPTION
## What
- add an admin-only CTA to the `/console` header that links to `/admin`
- keep the CTA hidden for non-admin console sessions by reusing `profile.isAdmin`
- add Storybook coverage for the admin-visible console state and record the change in `docs/specs/2uv3g-user-console-admin-entry/SPEC.md`
- add a small frontend unit test that locks the admin CTA gating and `/admin` target

## Validation
- `cd web && bun test`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- browser check via Storybook: `Dashboard Admin` shows `Open Admin Dashboard`, while `Dashboard` keeps the CTA hidden
- smoke check: `curl -s http://127.0.0.1:58087/health` -> `200`
