### PR TITLE
fix(admin): keep user search focused until submit

### DIFF
--- a/web/src/AdminDashboard.tsx
+++ b/web/src/AdminDashboard.tsx
@@ -3336,18 +3336,6 @@ function AdminDashboard(): JSX.Element {
   ])
 
   useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const normalized = usersQueryInput.trim()
-      setUsersQuery((previous) => {
-        if (previous === normalized) return previous
-        setUsersPage(1)
-        return normalized
-      })
-    }, 250)
-    return () => window.clearTimeout(timer)
-  }, [usersQueryInput])
-
-  useEffect(() => {
     const usersRouteActive =
       isUsersCollectionRoute || route.name === 'user'
     if (!usersRouteActive) return

--- a/web/src/admin/AdminPages.stories.tsx
+++ b/web/src/admin/AdminPages.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { addons } from 'storybook/preview-api'
 import { SELECT_STORY } from 'storybook/internal/core-events'
 import { ArrowDown, ArrowUp, ArrowUpDown, ChartColumnIncreasing } from 'lucide-react'
-import { Fragment, type ReactNode, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import { Fragment, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import type {
   ApiKeyBulkAction,
@@ -2134,6 +2134,53 @@ function compareAdminUserSummaryRows(
   return compareUserId(left.userId, right.userId)
 }
 
+function normalizeStorySearchQuery(query: string): string {
+  return query.trim()
+}
+
+function useStorySearchController(initialQuery = ''): {
+  queryInput: string
+  query: string
+  applySearch: () => void
+  resetSearch: () => void
+  handleQueryInputChange: (value: string) => void
+  handleQueryInputKeyDown: (event: ReactKeyboardEvent<HTMLInputElement>) => void
+} {
+  const [queryInput, setQueryInput] = useState(initialQuery)
+  const [query, setQuery] = useState(initialQuery)
+
+  const applySearch = () => {
+    const normalized = normalizeStorySearchQuery(queryInput)
+    setQueryInput(normalized)
+    setQuery(normalized)
+  }
+
+  const resetSearch = () => {
+    setQueryInput('')
+    setQuery('')
+  }
+
+  const handleQueryInputChange = (value: string) => {
+    setQueryInput(value)
+  }
+
+  const handleQueryInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      applySearch()
+    }
+  }
+
+  return {
+    queryInput,
+    query,
+    applySearch,
+    resetSearch,
+    handleQueryInputChange,
+    handleQueryInputKeyDown,
+  }
+}
+
 function compareAdminUnboundTokenUsageRows(
   left: AdminUnboundTokenUsageSummary,
   right: AdminUnboundTokenUsageSummary,
@@ -4162,10 +4209,17 @@ function UsersPageCanvas(): JSX.Element {
   const admin = useTranslate().admin
   const { language } = useLanguage()
   const users = admin.users
-  const [query, setQuery] = useState('')
   const [allowRegistration, setAllowRegistration] = useState(true)
   const [sortField, setSortField] = useState<AdminUsersSortField | null>(null)
   const [sortOrder, setSortOrder] = useState<SortDirection | null>(null)
+  const {
+    queryInput,
+    query,
+    applySearch,
+    resetSearch,
+    handleQueryInputChange,
+    handleQueryInputKeyDown,
+  } = useStorySearchController()
   const normalizedQuery = query.trim().toLowerCase()
   const effectiveSortField = sortField ?? ADMIN_USERS_DEFAULT_SORT_FIELD
   const effectiveSortOrder = sortOrder ?? ADMIN_USERS_DEFAULT_SORT_ORDER
@@ -4271,16 +4325,23 @@ function UsersPageCanvas(): JSX.Element {
             />
           </div>
           <div className="users-search-controls">
-            <input
+            <Input
               type="text"
-              className="input input-bordered users-search-input"
+              name="users-search"
+              className="users-search-input"
               placeholder={users.searchPlaceholder}
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              value={queryInput}
+              onChange={(event) => handleQueryInputChange(event.target.value)}
+              onKeyDown={handleQueryInputKeyDown}
             />
-            <button type="button" className="btn btn-outline">
+            <Button type="button" variant="outline" onClick={applySearch}>
               {users.search}
-            </button>
+            </Button>
+            {(queryInput.length > 0 || query.length > 0) && (
+              <Button type="button" variant="ghost" onClick={resetSearch}>
+                {users.clear}
+              </Button>
+            )}
           </div>
         </div>
 
@@ -4403,9 +4464,16 @@ function UsersUsagePageCanvas({
   const users = admin.users
   const usageDailyRateLabel = language === 'zh' ? users.usage.table.dailySuccessRate : 'Daily'
   const usageMonthlyRateLabel = language === 'zh' ? users.usage.table.monthlySuccessRate : 'Monthly'
-  const [query, setQuery] = useState('')
   const [sortField, setSortField] = useState<AdminUsersSortField | null>(null)
   const [sortOrder, setSortOrder] = useState<SortDirection | null>(null)
+  const {
+    queryInput,
+    query,
+    applySearch,
+    resetSearch,
+    handleQueryInputChange,
+    handleQueryInputKeyDown,
+  } = useStorySearchController()
   const [monthlyBrokenDrawer, setMonthlyBrokenDrawer] = useState<{
     label: string
     items: MonthlyBrokenKeyDetail[]
@@ -4523,25 +4591,27 @@ function UsersUsagePageCanvas({
           </div>
           <div className="admin-inline-actions" style={{ flexWrap: 'wrap', justifyContent: 'flex-end' }}>
             <div className="admin-stacked-only">
-              <button type="button" className="btn btn-outline" onClick={() => openAdminStory('admin-pages--users')}>
+              <Button type="button" variant="outline" onClick={() => openAdminStory('admin-pages--users')}>
                 {users.usage.back}
-              </button>
+              </Button>
             </div>
             <div className="users-search-controls">
-              <input
+              <Input
                 type="text"
-                className="input input-bordered users-search-input"
+                name="user-usage-search"
+                className="users-search-input"
                 placeholder={users.searchPlaceholder}
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
+                value={queryInput}
+                onChange={(event) => handleQueryInputChange(event.target.value)}
+                onKeyDown={handleQueryInputKeyDown}
               />
-              <button type="button" className="btn btn-outline">
+              <Button type="button" variant="outline" onClick={applySearch}>
                 {users.search}
-              </button>
-              {query.length > 0 && (
-                <button type="button" className="btn btn-ghost" onClick={() => setQuery('')}>
+              </Button>
+              {(queryInput.length > 0 || query.length > 0) && (
+                <Button type="button" variant="ghost" onClick={resetSearch}>
                   {users.clear}
-                </button>
+                </Button>
               )}
             </div>
           </div>
@@ -6012,10 +6082,64 @@ export const Jobs: Story = {
   },
 }
 
+async function waitForStoryUi(ms = 80): Promise<void> {
+  await new Promise((resolve) => window.setTimeout(resolve, ms))
+}
+
+function updateStorySearchInput(input: HTMLInputElement, value: string): void {
+  input.focus()
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
+}
+
+function submitStorySearchInput(input: HTMLInputElement): void {
+  input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+}
+
+function getFirstRenderedUserLabel(root: ParentNode): string | null {
+  return root.querySelector<HTMLElement>('tbody tr strong')?.textContent?.trim() ?? null
+}
+
 export const Users: Story = {
   render: () => <UsersPageCanvas />,
   parameters: {
     viewport: { defaultViewport: '1440-device-desktop' },
+  },
+  play: async ({ canvasElement }) => {
+    await waitForStoryUi()
+    const searchInput = canvasElement.querySelector<HTMLInputElement>('input[name="users-search"]')
+    if (!searchInput) {
+      throw new Error('Expected users story to render the users search input.')
+    }
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Alice Wang') {
+      throw new Error('Expected users story to start with Alice Wang as the first rendered row.')
+    }
+
+    updateStorySearchInput(searchInput, 'bob')
+    await waitForStoryUi(320)
+
+    if (canvasElement.ownerDocument.activeElement !== searchInput) {
+      throw new Error('Expected users search input to keep focus while typing before submitting.')
+    }
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Alice Wang') {
+      throw new Error('Expected users story to keep the unfiltered order before the search is submitted.')
+    }
+
+    submitStorySearchInput(searchInput)
+    await waitForStoryUi()
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Bob Chen') {
+      throw new Error('Expected users story to filter rows only after pressing Enter.')
+    }
+
+    const clearButton = canvasElement.querySelector<HTMLButtonElement>('.users-search-controls button:last-of-type')
+    clearButton?.click()
+    await waitForStoryUi()
+    if (searchInput.value !== '') {
+      throw new Error('Expected users story clear action to reset the search draft.')
+    }
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Alice Wang') {
+      throw new Error('Expected users story clear action to restore the full list.')
+    }
   },
 }
 
@@ -6025,7 +6149,7 @@ export const UsersUsage: Story = {
     viewport: { defaultViewport: '1440-device-desktop' },
   },
   play: async ({ canvasElement }) => {
-    await new Promise((resolve) => window.setTimeout(resolve, 80))
+    await waitForStoryUi()
     const utility = canvasElement.querySelector<HTMLElement>('.admin-sidebar-utility')
     const intro = canvasElement.querySelector<HTMLElement>('.admin-compact-intro')
     if (!utility) {
@@ -6033,6 +6157,40 @@ export const UsersUsage: Story = {
     }
     if (!intro || !intro.textContent?.includes('用量')) {
       throw new Error('Expected user usage page to render a compact intro with the page title.')
+    }
+
+    const searchInput = canvasElement.querySelector<HTMLInputElement>('input[name="user-usage-search"]')
+    if (!searchInput) {
+      throw new Error('Expected users usage story to render the usage search input.')
+    }
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Alice Wang') {
+      throw new Error('Expected users usage story to start with Alice Wang as the first rendered row.')
+    }
+
+    updateStorySearchInput(searchInput, 'charlie')
+    await waitForStoryUi(320)
+
+    if (canvasElement.ownerDocument.activeElement !== searchInput) {
+      throw new Error('Expected users usage search input to keep focus while typing before submitting.')
+    }
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Alice Wang') {
+      throw new Error('Expected users usage story to keep the unfiltered order before the search is submitted.')
+    }
+
+    submitStorySearchInput(searchInput)
+    await waitForStoryUi()
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Charlie Li') {
+      throw new Error('Expected users usage story to filter rows only after pressing Enter.')
+    }
+
+    const clearButton = canvasElement.querySelector<HTMLButtonElement>('.users-search-controls button:last-of-type')
+    clearButton?.click()
+    await waitForStoryUi()
+    if (searchInput.value !== '') {
+      throw new Error('Expected users usage story clear action to reset the search draft.')
+    }
+    if (getFirstRenderedUserLabel(canvasElement) !== 'Alice Wang') {
+      throw new Error('Expected users usage story clear action to restore the full list.')
     }
   },
 }

--- a/web/src/admin/AdminPages.stories.tsx
+++ b/web/src/admin/AdminPages.stories.tsx
@@ -6088,7 +6088,12 @@ async function waitForStoryUi(ms = 80): Promise<void> {
 
 function updateStorySearchInput(input: HTMLInputElement, value: string): void {
   input.focus()
-  input.value = value
+  const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+  if (valueSetter) {
+    valueSetter.call(input, value)
+  } else {
+    input.value = value
+  }
   input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
 }
 

--- a/web/src/components/ConnectivityChecksPanel.test.tsx
+++ b/web/src/components/ConnectivityChecksPanel.test.tsx
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'bun:test'
-import { renderToStaticMarkup } from 'react-dom/server'
+import '../../test/happydom'
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
 
 import ConnectivityChecksPanel, { type ProbeButtonModel, type ProbeStepStatus } from './ConnectivityChecksPanel'
 import { TooltipProvider } from './ui/tooltip'
@@ -18,9 +21,13 @@ const idleProbe: ProbeButtonModel = {
   total: 0,
 }
 
-describe('ConnectivityChecksPanel', () => {
-  it('renders MCP tool-call rows with a separate monospace tool chip', () => {
-    const html = renderToStaticMarkup(
+async function mountPanel(label: string): Promise<{ container: HTMLDivElement; root: Root }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(
       <TooltipProvider>
         <ConnectivityChecksPanel
           title="连通性检测"
@@ -36,48 +43,48 @@ describe('ConnectivityChecksPanel', () => {
             anchor: 'mcp',
             items: [{
               id: 'mcp-tool-call:tavily_search',
-              label: '调用 tavily_search 工具',
+              label,
               status: 'success',
-              detail: 'mock upstream replied in 42ms',
+              detail: label === '调用 tavily_search 工具' ? 'mock upstream replied in 42ms' : undefined,
             }],
           }}
         />
       </TooltipProvider>,
     )
+  })
+
+  return { container, root }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('ConnectivityChecksPanel', () => {
+  it('renders MCP tool-call rows with a separate monospace tool chip', async () => {
+    const { root } = await mountPanel('调用 tavily_search 工具')
+    const html = document.body.innerHTML
 
     expect(html).toContain('user-console-probe-bubble-item-label-structured')
     expect(html).toContain('<span class="user-console-probe-bubble-item-label-text">调用</span>')
     expect(html).toContain('<code class="user-console-probe-bubble-item-tool">tavily_search</code>')
     expect(html).toContain('<span class="user-console-probe-bubble-item-label-text">工具</span>')
     expect(html).toContain('mock upstream replied in 42ms')
+
+    await act(async () => {
+      root.unmount()
+    })
   })
 
-  it('falls back to the plain label when the rendered copy cannot be split around the tool name', () => {
-    const html = renderToStaticMarkup(
-      <TooltipProvider>
-        <ConnectivityChecksPanel
-          title="连通性检测"
-          costHint="Runs probe checks."
-          costHintAria="Probe cost hint"
-          stepStatusText={stepStatusText}
-          mcpButtonLabel="检测 MCP"
-          apiButtonLabel="检测 API"
-          mcpProbe={idleProbe}
-          apiProbe={idleProbe}
-          probeBubble={{
-            visible: true,
-            anchor: 'mcp',
-            items: [{
-              id: 'mcp-tool-call:tavily_search',
-              label: '自定义调用文案',
-              status: 'success',
-            }],
-          }}
-        />
-      </TooltipProvider>,
-    )
+  it('falls back to the plain label when the rendered copy cannot be split around the tool name', async () => {
+    const { root } = await mountPanel('自定义调用文案')
+    const html = document.body.innerHTML
 
     expect(html).not.toContain('user-console-probe-bubble-item-label-structured')
     expect(html).toContain('<strong class="user-console-probe-bubble-item-label">自定义调用文案</strong>')
+
+    await act(async () => {
+      root.unmount()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- remove the debounced auto-submit path from the admin user search flow so `/admin/users` and `/admin/users/usage` keep a local draft until explicit submit
- update the `Admin/Pages` Storybook stories to match the real submit semantics and add interaction coverage for focus retention, no auto-filter after the old debounce window, Enter submit, and clear reset
- adjust the connectivity checks panel test harness to use client rendering so the existing `bun test` suite still passes with portal-based UI

## Validation
- `cd web && bun test`
- `cd web && bun run build`
- `cd web && bun run build-storybook`
- browser-verified the updated search behavior on the local admin page and Storybook canvas

## Notes
- Spec: -
- Spec Sync: n/a(no spec)
- Spec Drift: none
- PR screenshots are intentionally not included; visual evidence was prepared locally and shared owner-side only