### PR TITLE
fix(mcp): align rebalance protocol handling

### DIFF
--- a/docs/specs/xm3dh-rebalance-mcp-gateway/SPEC.md
+++ b/docs/specs/xm3dh-rebalance-mcp-gateway/SPEC.md
@@ -100,9 +100,17 @@
   - `tavily_research`
 - `tools/call` 同时接受 underscore 与 hyphen 工具名别名。
 - `initialize / ping / tools/list / prompts/list / resources/list / resources/templates/list / notifications/*` 本地处理。
+- Rebalance `tools/call` 返回的 MCP `CallToolResult` 必须始终携带顶层 `content` 数组；工具执行失败使用顶层 `result.isError=true`，而不是把 `isError` 塞进 `structuredContent`。
 - `tools/call`：
   - `search / extract / crawl / map` → HTTP full-pool 选 key，不做同请求自动重试。
   - `research` → 保留 usage-diff 计费，并把 usage delta 回填到 MCP `structuredContent.usage.credits`。
+- `/mcp` 的本地协议拦截要求：
+  - 非法 JSON → `-32700 Parse error`
+  - 空 batch `[]` → 单个 `-32600 Invalid Request`
+  - 单条 notification → `202` 空 body
+  - response-only batch → 本地 `400` 拒绝，不伪造成 JSON-RPC 结果数组
+  - initialize 之后缺失 `mcp-session-id` 的 follow-up 请求 → 本地 `400`
+  - 无效 / 已撤销 / 失效 session 的 follow-up 请求 → `404 Not Found`
 
 ### Rebalance HTTP headers
 
@@ -157,6 +165,22 @@
 - Given Rebalance 会话收到 `prompts/list`、`resources/list` 或 `resources/templates/list`
   When 客户端执行控制面探测
   Then gateway 必须本地返回 `200 success` 与空列表结果，且不命中 upstream `/mcp`。
+
+- Given Rebalance 工具调用命中上游 4xx/5xx 或本地 502 fallback
+  When gateway 组装 `CallToolResult`
+  Then 返回体必须包含顶层 `result.content`，并在工具执行失败时设置顶层 `result.isError=true`，而 `structuredContent` 仅保留结构化字段与状态信息。
+
+- Given `/mcp` 收到非法 JSON、空 batch `[]` 或 response-only batch
+  When gateway 在本地完成协议校验
+  Then 非法 JSON 返回 `-32700 Parse error`，空 batch / response-only batch 返回 `-32600 Invalid Request`，且这些请求都不得命中 upstream。
+
+- Given initialize 之后的 `/mcp` follow-up 请求缺少 `mcp-session-id`
+  When 请求进入 gateway
+  Then gateway 必须本地返回 `400`，提示 session header 必填，并且不命中 upstream。
+
+- Given 已存在的 proxy session 已失效、被撤销、或其上游 session 已不可用
+  When 客户端继续携带旧 `mcp-session-id` 发 follow-up
+  Then gateway 必须返回 `404 Not Found` 与 `session_unavailable` 语义化 body，不再返回 `409 Conflict`。
 
 - Given 管理员查看请求详情
   When 请求来自 control 或 rebalance 路径

--- a/src/server/proxy.rs
+++ b/src/server/proxy.rs
@@ -403,23 +403,141 @@ fn header_string(headers: &ReqHeaderMap, name: &'static str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn mcp_request_contains_method(body: &[u8], needle: &str) -> bool {
-    let Ok(value) = serde_json::from_slice::<Value>(body) else {
-        return false;
-    };
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpJsonRpcMessageKind {
+    Request,
+    Notification,
+    Response,
+    Invalid,
+}
 
-    let matches_method = |value: &Value| {
-        value
-            .get("method")
-            .and_then(|method| method.as_str())
-            .is_some_and(|method| method == needle)
-    };
+#[derive(Debug, Clone, Default)]
+struct McpJsonRpcBodySummary {
+    contains_initialize: bool,
+    request_count: usize,
+    notification_count: usize,
+    response_count: usize,
+    invalid_count: usize,
+    explicit_jsonrpc_follow_up_count: usize,
+    is_batch: bool,
+    is_empty_batch: bool,
+}
 
-    match value {
-        Value::Object(_) => matches_method(&value),
-        Value::Array(items) => items.iter().any(matches_method),
-        _ => false,
+impl McpJsonRpcBodySummary {
+    fn requires_session_header(&self) -> bool {
+        self.explicit_jsonrpc_follow_up_count > 0
     }
+
+    fn is_single_response(&self) -> bool {
+        !self.is_batch
+            && self.response_count == 1
+            && self.request_count == 0
+            && self.notification_count == 0
+            && self.invalid_count == 0
+    }
+
+    fn is_response_only_batch(&self) -> bool {
+        self.is_batch
+            && self.response_count > 0
+            && self.request_count == 0
+            && self.notification_count == 0
+            && self.invalid_count == 0
+    }
+}
+
+fn classify_mcp_jsonrpc_message(value: &Value) -> McpJsonRpcMessageKind {
+    let Some(map) = value.as_object() else {
+        return McpJsonRpcMessageKind::Invalid;
+    };
+
+    let explicit_jsonrpc = match map.get("jsonrpc") {
+        Some(Value::String(version)) if version == "2.0" => true,
+        Some(_) => return McpJsonRpcMessageKind::Invalid,
+        None => false,
+    };
+    let has_method = map
+        .get("method")
+        .and_then(Value::as_str)
+        .is_some_and(|method| !method.trim().is_empty());
+    let has_id = map.contains_key("id");
+    let id_is_non_null = map.get("id").is_some_and(|id| !id.is_null());
+    let has_result = map.contains_key("result");
+    let has_error = map.contains_key("error");
+
+    if has_method {
+        return if explicit_jsonrpc {
+            if has_id && id_is_non_null {
+                McpJsonRpcMessageKind::Request
+            } else if !has_id {
+                McpJsonRpcMessageKind::Notification
+            } else {
+                McpJsonRpcMessageKind::Invalid
+            }
+        } else {
+            McpJsonRpcMessageKind::Request
+        };
+    }
+
+    if has_id && (has_result || has_error) {
+        return McpJsonRpcMessageKind::Response;
+    }
+
+    McpJsonRpcMessageKind::Invalid
+}
+
+fn summarize_mcp_jsonrpc_body(body: &[u8]) -> Result<McpJsonRpcBodySummary, serde_json::Error> {
+    let parsed = serde_json::from_slice::<Value>(body)?;
+    let mut summary = McpJsonRpcBodySummary::default();
+
+    let mut record = |item: &Value| {
+        let explicit_jsonrpc = item
+            .get("jsonrpc")
+            .and_then(Value::as_str)
+            .is_some_and(|version| version == "2.0");
+        let method_name = item
+            .get("method")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|method| !method.is_empty());
+        let requires_session_header =
+            explicit_jsonrpc && method_name.is_some_and(|method| method != "initialize");
+        match classify_mcp_jsonrpc_message(item) {
+            McpJsonRpcMessageKind::Request => {
+                summary.request_count += 1;
+                summary.contains_initialize |= method_name.is_some_and(|method| method == "initialize");
+                if requires_session_header {
+                    summary.explicit_jsonrpc_follow_up_count += 1;
+                }
+            }
+            McpJsonRpcMessageKind::Notification => {
+                summary.notification_count += 1;
+                if requires_session_header {
+                    summary.explicit_jsonrpc_follow_up_count += 1;
+                }
+            }
+            McpJsonRpcMessageKind::Response => {
+                summary.response_count += 1;
+            }
+            McpJsonRpcMessageKind::Invalid => summary.invalid_count += 1,
+        }
+    };
+
+    match parsed {
+        Value::Object(_) => record(&parsed),
+        Value::Array(items) => {
+            summary.is_batch = true;
+            if items.is_empty() {
+                summary.is_empty_batch = true;
+            } else {
+                for item in &items {
+                    record(item);
+                }
+            }
+        }
+        _ => summary.invalid_count += 1,
+    }
+
+    Ok(summary)
 }
 
 fn is_mcp_session_delete_request(method: &Method, path: &str) -> bool {
@@ -526,8 +644,10 @@ fn build_rebalance_mcp_success_body(response_id: Option<&Value>, result: Value) 
         envelope.insert("id".to_string(), id.clone());
     }
     envelope.insert("result".to_string(), result);
-    serde_json::to_vec(&Value::Object(envelope))
-        .unwrap_or_else(|_| br#"{"jsonrpc":"2.0","result":{"isError":true,"status":500}}"#.to_vec())
+    serde_json::to_vec(&Value::Object(envelope)).unwrap_or_else(|_| {
+        br#"{"jsonrpc":"2.0","result":{"content":[],"isError":true,"structuredContent":{"status":500}}}"#
+            .to_vec()
+    })
 }
 
 fn build_rebalance_mcp_error_body(
@@ -553,6 +673,91 @@ fn build_rebalance_mcp_error_body(
         br#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal error"}}"#
             .to_vec()
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_and_log_local_mcp_protocol_response(
+    state: &Arc<AppState>,
+    token_id: Option<&str>,
+    method: &Method,
+    path: &str,
+    query: Option<&str>,
+    request_body: &[u8],
+    response_status: StatusCode,
+    response_body: &[u8],
+    failure_kind: Option<&str>,
+    gateway_mode: Option<&str>,
+    experiment_variant: Option<&str>,
+    proxy_session_id: Option<&str>,
+    routing_subject_hash: Option<&str>,
+    upstream_operation: Option<&str>,
+    fallback_reason: Option<&str>,
+) -> Result<Response<Body>, StatusCode> {
+    let analysis = analyze_mcp_attempt(response_status, response_body);
+    let request_kind = classify_token_request_kind(path, Some(request_body));
+    let empty_headers: [String; 0] = [];
+    let request_log_id = match state
+        .proxy
+        .record_local_request_log_without_key_with_diagnostics(
+            token_id,
+            method,
+            path,
+            query,
+            response_status,
+            analysis.tavily_status_code,
+            request_body,
+            response_body,
+            analysis.status,
+            failure_kind.or(analysis.failure_kind.as_deref()),
+            gateway_mode,
+            experiment_variant,
+            proxy_session_id,
+            routing_subject_hash,
+            upstream_operation,
+            fallback_reason,
+            &empty_headers,
+            &empty_headers,
+        )
+        .await
+    {
+        Ok(log_id) => Some(log_id),
+        Err(err) => {
+            eprintln!("local MCP protocol request_log failed for {path}: {err}");
+            None
+        }
+    };
+
+    if let Some(token_id) = token_id {
+        let _ = state
+            .proxy
+            .record_token_attempt_with_kind_request_log_metadata(
+                token_id,
+                method,
+                path,
+                query,
+                Some(response_status.as_u16() as i64),
+                analysis.tavily_status_code,
+                false,
+                analysis.status,
+                None,
+                &request_kind,
+                failure_kind.or(analysis.failure_kind.as_deref()),
+                Some("none"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                request_log_id,
+            )
+            .await;
+    }
+
+    Response::builder()
+        .status(response_status)
+        .header(CONTENT_TYPE, "application/json; charset=utf-8")
+        .body(Body::from(response_body.to_vec()))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
 
 fn build_rebalance_mcp_initialize_body(
@@ -760,7 +965,7 @@ async fn handle_rebalance_mcp_single_message(
         .filter(|value| !value.is_empty());
 
     let Some(method_name) = method_name else {
-        let body = build_rebalance_mcp_error_body(response_id, -32600, "Invalid JSON-RPC request");
+        let body = build_rebalance_mcp_error_body(response_id, -32600, "Invalid Request");
         let request_log_id = log_rebalance_local_control_plane_response(
             state,
             token_id,
@@ -1134,8 +1339,8 @@ async fn handle_rebalance_mcp_request_body(
     incoming_protocol_version: Option<&str>,
     routing_subject_hash: Option<&str>,
 ) -> Result<ProxyResponse, StatusCode> {
-    let parsed =
-        serde_json::from_slice::<Value>(body_bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let parsed = serde_json::from_slice::<Value>(body_bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let summary = summarize_mcp_jsonrpc_body(body_bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
 
     match parsed {
         Value::Object(_) => {
@@ -1154,6 +1359,28 @@ async fn handle_rebalance_mcp_request_body(
             .await
         }
         Value::Array(items) => {
+            if summary.is_empty_batch || summary.is_response_only_batch() {
+                let body = build_rebalance_mcp_error_body(None, -32600, "Invalid Request");
+                let request_log_id = log_rebalance_local_control_plane_response(
+                    state,
+                    token_id,
+                    method,
+                    path,
+                    body_bytes,
+                    StatusCode::BAD_REQUEST,
+                    &body,
+                    proxy_session_id,
+                    routing_subject_hash,
+                    Some("invalid_jsonrpc_request"),
+                )
+                .await;
+                return Ok(proxy_response_with_json_body(
+                    StatusCode::BAD_REQUEST,
+                    body,
+                    request_log_id,
+                ));
+            }
+
             let mut responses: Vec<Value> = Vec::new();
             let mut last_response: Option<ProxyResponse> = None;
 
@@ -1212,7 +1439,7 @@ async fn handle_rebalance_mcp_request_body(
             Ok(aggregated)
         }
         _ => {
-            let body = build_rebalance_mcp_error_body(None, -32600, "Invalid JSON-RPC request");
+            let body = build_rebalance_mcp_error_body(None, -32600, "Invalid Request");
             let request_log_id = log_rebalance_local_control_plane_response(
                 state,
                 token_id,
@@ -1352,6 +1579,7 @@ async fn proxy_handler(
         .await
         .map_err(|_| StatusCode::BAD_REQUEST)?;
     let is_mcp_request = path.starts_with("/mcp");
+    let is_mcp_delete_root_request = is_mcp_session_delete_request(&method, &path);
     if is_mcp_request && using_dev_open_admin_fallback {
         return mcp_session_response(
             StatusCode::UNAUTHORIZED,
@@ -1359,8 +1587,15 @@ async fn proxy_handler(
             "MCP requests must provide an explicit token when --dev-open-admin is enabled.",
         );
     }
-    let is_mcp_initialize =
-        is_mcp_request && mcp_request_contains_method(&body_bytes, "initialize");
+    let mcp_body_summary = if is_mcp_request && !is_mcp_delete_root_request {
+        Some(summarize_mcp_jsonrpc_body(&body_bytes))
+    } else {
+        None
+    };
+    let is_mcp_initialize = mcp_body_summary
+        .as_ref()
+        .and_then(|summary| summary.as_ref().ok())
+        .is_some_and(|summary| summary.contains_initialize);
     let incoming_proxy_session_id = if is_mcp_request {
         header_string(&headers, "mcp-session-id")
     } else {
@@ -1376,6 +1611,201 @@ async fn proxy_handler(
     } else {
         None
     };
+    if is_mcp_request && !is_mcp_delete_root_request {
+        match mcp_body_summary.as_ref().expect("mcp body summary must exist") {
+            Err(_) => {
+                let response_body =
+                    build_rebalance_mcp_error_body(None, -32700, "Parse error");
+                return build_and_log_local_mcp_protocol_response(
+                    &state,
+                    token_id.as_deref(),
+                    &method,
+                    &path,
+                    query.as_deref(),
+                    &body_bytes,
+                    StatusCode::BAD_REQUEST,
+                    &response_body,
+                    Some("invalid_jsonrpc_request"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("mcp"),
+                    Some("parse_error"),
+                )
+                .await;
+            }
+            Ok(summary) if summary.is_empty_batch => {
+                let response_body =
+                    build_rebalance_mcp_error_body(None, -32600, "Invalid Request");
+                return build_and_log_local_mcp_protocol_response(
+                    &state,
+                    token_id.as_deref(),
+                    &method,
+                    &path,
+                    query.as_deref(),
+                    &body_bytes,
+                    StatusCode::BAD_REQUEST,
+                    &response_body,
+                    Some("invalid_jsonrpc_request"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("mcp"),
+                    Some("empty_batch"),
+                )
+                .await;
+            }
+            Ok(summary)
+                if summary.is_response_only_batch()
+                    || (!summary.is_batch && summary.invalid_count > 0) =>
+            {
+                let response_body =
+                    build_rebalance_mcp_error_body(None, -32600, "Invalid Request");
+                return build_and_log_local_mcp_protocol_response(
+                    &state,
+                    token_id.as_deref(),
+                    &method,
+                    &path,
+                    query.as_deref(),
+                    &body_bytes,
+                    StatusCode::BAD_REQUEST,
+                    &response_body,
+                    Some("invalid_jsonrpc_request"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("mcp"),
+                    Some("invalid_request"),
+                )
+                .await;
+            }
+            Ok(summary)
+                if summary.is_single_response() && incoming_proxy_session_id.is_none() =>
+            {
+                let response_body = mcp_session_body(
+                    "session_required",
+                    "MCP requests after initialize must include mcp-session-id.",
+                );
+                return build_and_log_local_mcp_protocol_response(
+                    &state,
+                    token_id.as_deref(),
+                    &method,
+                    &path,
+                    query.as_deref(),
+                    &body_bytes,
+                    StatusCode::BAD_REQUEST,
+                    &response_body,
+                    Some("invalid_jsonrpc_request"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("mcp"),
+                    Some("missing_session_id"),
+                )
+                .await;
+            }
+            Ok(summary)
+                if summary.is_single_response() && incoming_proxy_session_id.is_some() =>
+            {
+                let proxy_session_id = incoming_proxy_session_id
+                    .as_deref()
+                    .expect("response-only branch requires session id");
+                if state
+                    .proxy
+                    .get_active_mcp_session(proxy_session_id)
+                    .await
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+                    .is_none()
+                {
+                    let response_body = mcp_session_body(
+                        "session_unavailable",
+                        "MCP session is unavailable, please reconnect to initialize a new session.",
+                    );
+                    return build_and_log_local_mcp_protocol_response(
+                        &state,
+                        token_id.as_deref(),
+                        &method,
+                        &path,
+                        query.as_deref(),
+                        &body_bytes,
+                        StatusCode::NOT_FOUND,
+                        &response_body,
+                        Some("session_unavailable"),
+                        None,
+                        None,
+                        Some(proxy_session_id),
+                        None,
+                        Some("mcp"),
+                        Some("response_session_unavailable"),
+                    )
+                    .await;
+                }
+                let response_body = Vec::new();
+                return build_and_log_local_mcp_protocol_response(
+                    &state,
+                    token_id.as_deref(),
+                    &method,
+                    &path,
+                    query.as_deref(),
+                    &body_bytes,
+                    StatusCode::ACCEPTED,
+                    &response_body,
+                    None,
+                    None,
+                    None,
+                    Some(proxy_session_id),
+                    None,
+                    Some("mcp"),
+                    Some("response_accepted"),
+                )
+                .await;
+            }
+            Ok(summary)
+                if !summary.contains_initialize
+                    && summary.requires_session_header()
+                    && incoming_proxy_session_id.is_none() =>
+            {
+                let requires_session = if let Some(token_id) = token_id.as_deref() {
+                    state
+                        .proxy
+                        .token_has_active_mcp_session(token_id)
+                        .await
+                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+                } else {
+                    false
+                };
+                if requires_session {
+                    let response_body = mcp_session_body(
+                        "session_required",
+                        "MCP requests after initialize must include mcp-session-id.",
+                    );
+                    return build_and_log_local_mcp_protocol_response(
+                        &state,
+                        token_id.as_deref(),
+                        &method,
+                        &path,
+                        query.as_deref(),
+                        &body_bytes,
+                        StatusCode::BAD_REQUEST,
+                        &response_body,
+                        Some("invalid_jsonrpc_request"),
+                        None,
+                        None,
+                        None,
+                        None,
+                        Some("mcp"),
+                        Some("missing_session_id"),
+                    )
+                    .await;
+                }
+            }
+            _ => {}
+        }
+    }
     let token_user_id = if is_mcp_request {
         if let Some(token_id) = token_id.as_deref() {
             state
@@ -1428,7 +1858,7 @@ async fn proxy_handler(
 
         let Some(session) = session else {
             return mcp_session_response(
-                StatusCode::CONFLICT,
+                StatusCode::NOT_FOUND,
                 "session_unavailable",
                 "MCP session is unavailable, please reconnect to initialize a new session.",
             );
@@ -1458,7 +1888,7 @@ async fn proxy_handler(
         if session.gateway_mode == tavily_hikari::MCP_GATEWAY_MODE_UPSTREAM {
             let Some(upstream_session_id) = session.upstream_session_id.as_deref() else {
                 return mcp_session_response(
-                    StatusCode::CONFLICT,
+                    StatusCode::NOT_FOUND,
                     "session_unavailable",
                     "MCP session is unavailable, please reconnect to initialize a new session.",
                 );
@@ -1470,7 +1900,7 @@ async fn proxy_handler(
             );
             let Some(upstream_key_id) = session.upstream_key_id.clone() else {
                 return mcp_session_response(
-                    StatusCode::CONFLICT,
+                    StatusCode::NOT_FOUND,
                     "session_unavailable",
                     "MCP session is unavailable, please reconnect to initialize a new session.",
                 );
@@ -1480,7 +1910,6 @@ async fn proxy_handler(
         active_mcp_session = Some(session);
     }
     let request_kind = classify_token_request_kind(&path, Some(body_bytes.as_ref()));
-    let is_mcp_delete_root_request = is_mcp_session_delete_request(&method, &path);
 
     // Billing plan (1:1 upstream credits):
     // - Non-business whitelist methods are ignored by business quota.
@@ -2048,8 +2477,7 @@ async fn proxy_handler(
         {
             Ok(response) => Ok(response),
             Err(status) => {
-                let payload =
-                    build_rebalance_mcp_error_body(None, -32600, "Invalid JSON-RPC request");
+                let payload = build_rebalance_mcp_error_body(None, -32700, "Parse error");
                 let response = Response::builder()
                     .status(status)
                     .header(CONTENT_TYPE, "application/json; charset=utf-8")
@@ -2074,8 +2502,7 @@ async fn proxy_handler(
         {
             Ok(response) => Ok(response),
             Err(status) => {
-                let payload =
-                    build_rebalance_mcp_error_body(None, -32600, "Invalid JSON-RPC request");
+                let payload = build_rebalance_mcp_error_body(None, -32700, "Parse error");
                 let response = Response::builder()
                     .status(status)
                     .header(CONTENT_TYPE, "application/json; charset=utf-8")
@@ -2144,7 +2571,7 @@ async fn proxy_handler(
                             .proxy
                             .revoke_mcp_session(proxy_session_id, "upstream_session_invalid")
                             .await;
-                        resp.status = StatusCode::CONFLICT;
+                        resp.status = StatusCode::NOT_FOUND;
                         resp.headers = ReqHeaderMap::new();
                         resp.headers.insert(
                             CONTENT_TYPE,
@@ -2569,7 +2996,7 @@ async fn proxy_handler(
                     .revoke_mcp_session(proxy_session_id, "pinned_key_unavailable")
                     .await;
                 return mcp_session_response(
-                    StatusCode::CONFLICT,
+                    StatusCode::NOT_FOUND,
                     "session_unavailable",
                     "The pinned MCP session key is unavailable. Please reconnect.",
                 );

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2954,6 +2954,50 @@ mod tests {
         addr
     }
 
+    async fn spawn_rebalance_gateway_http_error_mock(
+        expected_api_key: String,
+        seen: RecordedRebalanceGatewayCalls,
+        status: StatusCode,
+        body: Value,
+    ) -> SocketAddr {
+        let seen_for_search = seen.clone();
+        let app = Router::new().route(
+            "/search",
+            post({
+                move |headers: HeaderMap, Json(request_body): Json<Value>| {
+                    let expected_api_key = expected_api_key.clone();
+                    let seen = seen_for_search.clone();
+                    let response_body = body.clone();
+                    async move {
+                        assert_upstream_json_auth(
+                            &headers,
+                            &request_body,
+                            &expected_api_key,
+                            "/search",
+                        );
+                        seen.lock()
+                            .expect("rebalance gateway error calls lock")
+                            .push(RecordedRebalanceGatewayCall {
+                                path: "/search".to_string(),
+                                headers: headers.clone(),
+                                body: request_body.clone(),
+                            });
+                        (status, Json(response_body))
+                    }
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+        addr
+    }
+
     async fn spawn_http_search_mock_with_usage(
         expected_api_key: String,
     ) -> (SocketAddr, Arc<AtomicUsize>) {
@@ -20165,7 +20209,15 @@ colo=LAX
         );
         let resp = client
             .post(url)
-            .body("{}")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "query-token-init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
             .send()
             .await
             .expect("request to proxy succeeds");
@@ -23974,7 +24026,7 @@ colo=LAX
             .await
             .expect("follow-up request");
 
-        assert_eq!(follow_up.status(), reqwest::StatusCode::CONFLICT);
+        assert_eq!(follow_up.status(), reqwest::StatusCode::NOT_FOUND);
         let body: Value = follow_up.json().await.expect("parse reconnect body");
         assert_eq!(
             body.get("error").and_then(|value| value.as_str()),
@@ -24244,7 +24296,7 @@ colo=LAX
             .await
             .expect("stale follow-up");
 
-        assert_eq!(stale_follow_up.status(), reqwest::StatusCode::CONFLICT);
+        assert_eq!(stale_follow_up.status(), reqwest::StatusCode::NOT_FOUND);
         let stale_body: Value = stale_follow_up.json().await.expect("parse stale body");
         assert_eq!(
             stale_body.get("error").and_then(|value| value.as_str()),
@@ -24445,7 +24497,7 @@ colo=LAX
             .send()
             .await
             .expect("stale follow-up");
-        assert_eq!(stale_follow_up.status(), reqwest::StatusCode::CONFLICT);
+        assert_eq!(stale_follow_up.status(), reqwest::StatusCode::NOT_FOUND);
 
         let healthy_follow_up = client
             .post(&second_url)
@@ -25856,6 +25908,561 @@ colo=LAX
                 .try_get::<String, _>("upstream_operation")
                 .unwrap(),
             "http_search"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_rebalance_tool_errors_use_top_level_is_error_and_content_array() {
+        let db_path = temp_db_path("mcp-rebalance-search-http-error");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-rebalance-search-http-error";
+        let seen: RecordedRebalanceGatewayCalls = Arc::new(Mutex::new(Vec::new()));
+        let upstream_addr = spawn_rebalance_gateway_http_error_mock(
+            expected_api_key.to_string(),
+            seen,
+            StatusCode::BAD_REQUEST,
+            json!({
+                "status": 400,
+                "detail": "bad query"
+            }),
+        )
+        .await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        proxy
+            .set_system_settings(&tavily_hikari::SystemSettings {
+                mcp_session_affinity_key_count: 5,
+                rebalance_mcp_enabled: true,
+                rebalance_mcp_session_percent: 100,
+            })
+            .await
+            .expect("enable rebalance mcp");
+        let access_token = proxy
+            .create_access_token(Some("mcp-rebalance-search-http-error"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+        let client = Client::new();
+
+        let initialize = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "rebalance-error-init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("initialize request");
+        assert_eq!(initialize.status(), StatusCode::OK);
+        let proxy_session_id = initialize
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|value| value.to_str().ok())
+            .expect("initialize response should expose mcp-session-id")
+            .to_string();
+
+        let search = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .header("mcp-session-id", proxy_session_id.as_str())
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "rebalance-search-error",
+                "method": "tools/call",
+                "params": {
+                    "name": "tavily_search",
+                    "arguments": {
+                        "query": "bad input"
+                    }
+                }
+            }))
+            .send()
+            .await
+            .expect("rebalance search request");
+        assert_eq!(search.status(), StatusCode::OK);
+        let body: Value = search
+            .json()
+            .await
+            .expect("decode rebalance error response");
+        assert_eq!(body["result"]["isError"].as_bool(), Some(true));
+        assert!(
+            body["result"]["content"].is_array(),
+            "rebalance error responses must keep a top-level content array"
+        );
+        assert_eq!(
+            body["result"]["structuredContent"]["isError"].as_bool(),
+            None,
+            "isError must not be nested inside structuredContent"
+        );
+        assert_eq!(
+            body["result"]["structuredContent"]["status"].as_i64(),
+            Some(400)
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_rebalance_parse_error_returns_jsonrpc_parse_error() {
+        let db_path = temp_db_path("mcp-rebalance-parse-error");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-rebalance-parse-error";
+        let seen: RecordedRebalanceGatewayCalls = Arc::new(Mutex::new(Vec::new()));
+        let upstream_addr =
+            spawn_rebalance_gateway_mock(expected_api_key.to_string(), seen.clone()).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        proxy
+            .set_system_settings(&tavily_hikari::SystemSettings {
+                mcp_session_affinity_key_count: 5,
+                rebalance_mcp_enabled: true,
+                rebalance_mcp_session_percent: 100,
+            })
+            .await
+            .expect("enable rebalance mcp");
+        let access_token = proxy
+            .create_access_token(Some("mcp-rebalance-parse-error"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+        let client = Client::new();
+
+        let response = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body("{")
+            .send()
+            .await
+            .expect("parse-error request");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: Value = response.json().await.expect("decode parse-error body");
+        assert_eq!(body["error"]["code"].as_i64(), Some(-32700));
+        assert_eq!(body["error"]["message"].as_str(), Some("Parse error"));
+
+        let recorded = seen
+            .lock()
+            .expect("rebalance gateway calls lock poisoned")
+            .clone();
+        assert!(
+            recorded.is_empty(),
+            "parse errors must be rejected locally before any upstream hit"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_rebalance_empty_batch_returns_invalid_request() {
+        let db_path = temp_db_path("mcp-rebalance-empty-batch");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-rebalance-empty-batch";
+        let seen: RecordedRebalanceGatewayCalls = Arc::new(Mutex::new(Vec::new()));
+        let upstream_addr =
+            spawn_rebalance_gateway_mock(expected_api_key.to_string(), seen.clone()).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        proxy
+            .set_system_settings(&tavily_hikari::SystemSettings {
+                mcp_session_affinity_key_count: 5,
+                rebalance_mcp_enabled: true,
+                rebalance_mcp_session_percent: 100,
+            })
+            .await
+            .expect("enable rebalance mcp");
+        let access_token = proxy
+            .create_access_token(Some("mcp-rebalance-empty-batch"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+        let client = Client::new();
+
+        let response = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .json(&json!([]))
+            .send()
+            .await
+            .expect("empty-batch request");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: Value = response.json().await.expect("decode empty-batch body");
+        assert_eq!(body["error"]["code"].as_i64(), Some(-32600));
+        assert_eq!(body["error"]["message"].as_str(), Some("Invalid Request"));
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_rebalance_response_only_batch_is_rejected_locally() {
+        let db_path = temp_db_path("mcp-rebalance-response-only-batch");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-rebalance-response-only-batch";
+        let seen: RecordedRebalanceGatewayCalls = Arc::new(Mutex::new(Vec::new()));
+        let upstream_addr =
+            spawn_rebalance_gateway_mock(expected_api_key.to_string(), seen.clone()).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        proxy
+            .set_system_settings(&tavily_hikari::SystemSettings {
+                mcp_session_affinity_key_count: 5,
+                rebalance_mcp_enabled: true,
+                rebalance_mcp_session_percent: 100,
+            })
+            .await
+            .expect("enable rebalance mcp");
+        let access_token = proxy
+            .create_access_token(Some("mcp-rebalance-response-only-batch"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+        let client = Client::new();
+
+        let initialize = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "rebalance-response-only-init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("initialize request");
+        assert_eq!(initialize.status(), StatusCode::OK);
+        let proxy_session_id = initialize
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|value| value.to_str().ok())
+            .expect("initialize response should expose mcp-session-id")
+            .to_string();
+
+        let response = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .header("mcp-session-id", proxy_session_id.as_str())
+            .json(&json!([
+                {
+                    "jsonrpc": "2.0",
+                    "id": "server-request-1",
+                    "result": { "ok": true }
+                }
+            ]))
+            .send()
+            .await
+            .expect("response-only batch request");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: Value = response
+            .json()
+            .await
+            .expect("decode response-only batch body");
+        assert_eq!(body["error"]["code"].as_i64(), Some(-32600));
+
+        let recorded = seen
+            .lock()
+            .expect("rebalance gateway calls lock poisoned")
+            .clone();
+        assert!(
+            recorded.is_empty(),
+            "response-only batches must be rejected locally"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_call_follow_up_without_session_header_is_rejected_locally() {
+        let db_path = temp_db_path("mcp-tools-call-follow-up-missing-session-id");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-mcp-tools-call-follow-up-missing-session-id";
+        let (upstream_addr, calls) =
+            spawn_mock_mcp_upstream_for_session_headers(vec![expected_api_key.to_string()]).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        let access_token = proxy
+            .create_access_token(Some("mcp-tools-call-follow-up-missing-session-id"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let client = Client::new();
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+
+        let initialize = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "init-tools-call-missing-session-id",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("initialize request");
+        assert_eq!(initialize.status(), StatusCode::OK);
+
+        let rejected = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "tools-call-missing-session-id",
+                "method": "tools/call",
+                "params": {
+                    "name": "tavily-search",
+                    "arguments": {
+                        "query": "missing session id follow-up",
+                        "search_depth": "basic"
+                    }
+                }
+            }))
+            .send()
+            .await
+            .expect("tools/call follow-up without session id");
+        assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+        let body: Value = rejected
+            .json()
+            .await
+            .expect("parse missing-session-id tools/call body");
+        assert_eq!(
+            body.get("error").and_then(|value| value.as_str()),
+            Some("session_required")
+        );
+
+        let recorded = calls
+            .lock()
+            .expect("session header calls lock poisoned")
+            .clone();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "missing-session-id tools/call follow-up should be rejected locally"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_response_only_follow_up_with_revoked_session_returns_not_found() {
+        let db_path = temp_db_path("mcp-response-only-revoked-session");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-mcp-response-only-revoked-session";
+        let upstream_addr = spawn_mock_upstream(expected_api_key.to_string()).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy = TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+            .await
+            .expect("proxy created");
+        let mut settings = proxy
+            .get_system_settings()
+            .await
+            .expect("load system settings");
+        settings.rebalance_mcp_enabled = true;
+        settings.rebalance_mcp_session_percent = 100;
+        proxy
+            .set_system_settings(&settings)
+            .await
+            .expect("enable rebalance session routing");
+        let access_token = proxy
+            .create_access_token(Some("mcp-response-only-revoked-session"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let client = Client::new();
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+
+        let initialize = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "init-revoked-response-only",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("initialize request");
+        assert_eq!(initialize.status(), StatusCode::OK);
+        let proxy_session_id = initialize
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+            .expect("initialize should return mcp-session-id");
+
+        proxy
+            .revoke_mcp_session(&proxy_session_id, "test_revoked")
+            .await
+            .expect("revoke session");
+
+        let response_only = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .header("mcp-session-id", proxy_session_id.as_str())
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "server-request-1",
+                "result": { "ok": true }
+            }))
+            .send()
+            .await
+            .expect("response-only request");
+        assert_eq!(response_only.status(), StatusCode::NOT_FOUND);
+        let body: Value = response_only
+            .json()
+            .await
+            .expect("parse response-only revoked-session body");
+        assert_eq!(
+            body.get("error").and_then(|value| value.as_str()),
+            Some("session_unavailable")
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_follow_up_without_session_header_is_rejected_locally() {
+        let db_path = temp_db_path("mcp-follow-up-missing-session-id");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-mcp-follow-up-missing-session-id";
+        let (upstream_addr, calls) =
+            spawn_mock_mcp_upstream_for_session_headers(vec![expected_api_key.to_string()]).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        let access_token = proxy
+            .create_access_token(Some("mcp-follow-up-missing-session-id"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let client = Client::new();
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+
+        let initialize = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "init-missing-session-id",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("initialize request");
+        assert_eq!(initialize.status(), StatusCode::OK);
+
+        let rejected = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "tools-missing-session-id",
+                "method": "tools/list"
+            }))
+            .send()
+            .await
+            .expect("follow-up request without session id");
+        assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+        let body: Value = rejected.json().await.expect("parse missing-session-id body");
+        assert_eq!(
+            body.get("error").and_then(|value| value.as_str()),
+            Some("session_required")
+        );
+
+        let recorded = calls
+            .lock()
+            .expect("session header calls lock poisoned")
+            .clone();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "missing-session-id follow-up should be rejected locally"
         );
 
         let _ = std::fs::remove_file(db_path);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -9289,6 +9289,28 @@ impl KeyStore {
             .await
     }
 
+    pub(crate) async fn has_active_mcp_sessions_for_token(
+        &self,
+        token_id: &str,
+        now: i64,
+    ) -> Result<bool, ProxyError> {
+        let exists = sqlx::query_scalar::<_, i64>(
+            r#"SELECT EXISTS(
+                   SELECT 1
+                     FROM mcp_sessions
+                    WHERE auth_token_id = ?
+                      AND revoked_at IS NULL
+                      AND expires_at > ?
+                    LIMIT 1
+               )"#,
+        )
+        .bind(token_id)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists != 0)
+    }
+
     pub(crate) async fn list_active_api_key_transient_backoffs(
         &self,
         key_ids: &[String],

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -5089,13 +5089,12 @@ impl TavilyProxy {
             }),
         };
 
+        let mut is_error = !upstream_status.is_success();
         if let Value::Object(ref mut map) = structured_content {
             map.entry("status".to_string())
                 .or_insert(Value::from(i64::from(upstream_status.as_u16())));
-            if !upstream_status.is_success() {
-                map.entry("isError".to_string())
-                    .or_insert(Value::Bool(true));
-            }
+            is_error |= map.get("isError").and_then(Value::as_bool).unwrap_or(false);
+            map.remove("isError");
             if let Some(usage_credits) = usage_credits_override {
                 map.insert(
                     "usage".to_string(),
@@ -5105,12 +5104,16 @@ impl TavilyProxy {
         }
 
         let mut result = serde_json::Map::new();
+        result.insert("content".to_string(), Value::Array(Vec::new()));
         result.insert("structuredContent".to_string(), structured_content);
         if !raw_text.trim().is_empty() {
             result.insert(
                 "content".to_string(),
                 serde_json::json!([{ "type": "text", "text": raw_text }]),
             );
+        }
+        if is_error {
+            result.insert("isError".to_string(), Value::Bool(true));
         }
 
         let mut envelope = serde_json::Map::new();
@@ -5121,7 +5124,7 @@ impl TavilyProxy {
         envelope.insert("result".to_string(), Value::Object(result));
 
         serde_json::to_vec(&Value::Object(envelope)).unwrap_or_else(|_| {
-            br#"{"jsonrpc":"2.0","result":{"structuredContent":{"status":500,"isError":true}}}"#
+            br#"{"jsonrpc":"2.0","result":{"content":[],"isError":true,"structuredContent":{"status":500}}}"#
                 .to_vec()
         })
     }
@@ -5287,8 +5290,13 @@ impl TavilyProxy {
             }
             Err(err) => {
                 log_proxy_error(&lease.secret, method, display_path, None, &err);
-                let response_body = br#"{"jsonrpc":"2.0","result":{"structuredContent":{"status":502,"isError":true}}}"#
-                    .to_vec();
+                let response_body = Self::build_rebalance_mcp_tool_result_body(
+                    response_id,
+                    StatusCode::BAD_GATEWAY,
+                    err.to_string().as_bytes(),
+                    None,
+                );
+                let mcp_analysis = analyze_mcp_attempt(StatusCode::OK, &response_body);
                 let request_log_id = self
                     .key_store
                     .log_attempt(AttemptLog {
@@ -5297,13 +5305,13 @@ impl TavilyProxy {
                         method,
                         path: display_path,
                         query: None,
-                        status: Some(StatusCode::BAD_GATEWAY),
-                        tavily_status_code: Some(StatusCode::BAD_GATEWAY.as_u16() as i64),
+                        status: Some(StatusCode::OK),
+                        tavily_status_code: mcp_analysis.tavily_status_code,
                         error: Some(&err.to_string()),
                         request_body: original_request_body,
                         response_body: &response_body,
-                        outcome: OUTCOME_ERROR,
-                        failure_kind: None,
+                        outcome: mcp_analysis.status,
+                        failure_kind: mcp_analysis.failure_kind.as_deref(),
                         key_effect_code: KEY_EFFECT_NONE,
                         key_effect_summary: None,
                         binding_effect_code: KEY_EFFECT_NONE,
@@ -5326,7 +5334,7 @@ impl TavilyProxy {
                     HeaderValue::from_static("application/json; charset=utf-8"),
                 );
                 Ok(ProxyResponse {
-                    status: StatusCode::BAD_GATEWAY,
+                    status: StatusCode::OK,
                     headers,
                     body: Bytes::from(response_body),
                     api_key_id: Some(lease.id),
@@ -5551,8 +5559,13 @@ impl TavilyProxy {
             }
             Err(err) => {
                 log_proxy_error(&lease.secret, method, display_path, None, &err);
-                let response_body = br#"{"jsonrpc":"2.0","result":{"structuredContent":{"status":502,"isError":true}}}"#
-                    .to_vec();
+                let response_body = Self::build_rebalance_mcp_tool_result_body(
+                    response_id,
+                    StatusCode::BAD_GATEWAY,
+                    err.to_string().as_bytes(),
+                    None,
+                );
+                let mcp_analysis = analyze_mcp_attempt(StatusCode::OK, &response_body);
                 let request_log_id = self
                     .key_store
                     .log_attempt(AttemptLog {
@@ -5561,13 +5574,13 @@ impl TavilyProxy {
                         method,
                         path: display_path,
                         query: None,
-                        status: Some(StatusCode::BAD_GATEWAY),
-                        tavily_status_code: Some(StatusCode::BAD_GATEWAY.as_u16() as i64),
+                        status: Some(StatusCode::OK),
+                        tavily_status_code: mcp_analysis.tavily_status_code,
                         error: Some(&err.to_string()),
                         request_body: original_request_body,
                         response_body: &response_body,
-                        outcome: OUTCOME_ERROR,
-                        failure_kind: None,
+                        outcome: mcp_analysis.status,
+                        failure_kind: mcp_analysis.failure_kind.as_deref(),
                         key_effect_code: KEY_EFFECT_NONE,
                         key_effect_summary: None,
                         binding_effect_code: KEY_EFFECT_NONE,
@@ -5590,7 +5603,7 @@ impl TavilyProxy {
                     HeaderValue::from_static("application/json; charset=utf-8"),
                 );
                 Ok(ProxyResponse {
-                    status: StatusCode::BAD_GATEWAY,
+                    status: StatusCode::OK,
                     headers,
                     body: Bytes::from(response_body),
                     api_key_id: Some(lease.id),
@@ -8988,6 +9001,12 @@ impl TavilyProxy {
     ) -> Result<Option<McpSessionBinding>, ProxyError> {
         self.key_store
             .get_active_mcp_session(proxy_session_id, Utc::now().timestamp())
+            .await
+    }
+
+    pub async fn token_has_active_mcp_session(&self, token_id: &str) -> Result<bool, ProxyError> {
+        self.key_store
+            .has_active_mcp_sessions_for_token(token_id, Utc::now().timestamp())
             .await
     }
 

--- a/tests/server_http_contract.rs
+++ b/tests/server_http_contract.rs
@@ -120,6 +120,35 @@ async fn wait_for_health_ready(port: u16) -> bool {
     false
 }
 
+async fn initialize_mcp_session(client: &Client, mcp_url: &str, token: &str) -> String {
+    let initialize = client
+        .post(mcp_url)
+        .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            axum::http::header::ACCEPT,
+            "application/json, text/event-stream",
+        )
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "contract-initialize",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {}
+            }
+        }))
+        .send()
+        .await
+        .expect("mcp initialize request");
+    assert_eq!(initialize.status(), reqwest::StatusCode::OK);
+    initialize
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+        .expect("initialize should return mcp-session-id")
+}
+
 fn spawn_backend_process_with_urls(
     port: u16,
     upstream: &str,
@@ -354,6 +383,22 @@ async fn spawn_mock_mcp_probe_upstream_at_route(
                     calls.lock().expect("mcp probe calls lock poisoned").push(method.clone());
 
                     match method.as_str() {
+                        "initialize" => (
+                            StatusCode::OK,
+                            [
+                                ("mcp-session-id", "upstream-probe-session"),
+                                ("mcp-protocol-version", "2025-03-26"),
+                            ],
+                            axum::Json(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": body.get("id").cloned().unwrap_or_else(|| serde_json::json!("probe-initialize")),
+                                "result": {
+                                    "protocolVersion": "2025-03-26",
+                                    "capabilities": {}
+                                }
+                            })),
+                        )
+                            .into_response(),
                         "ping" => (
                             StatusCode::OK,
                             axum::Json(serde_json::json!({
@@ -431,6 +476,22 @@ async fn spawn_mock_mcp_tools_contract_upstream(
                     calls.lock().expect("mcp tools contract calls lock poisoned").push(method.clone());
 
                     match method.as_str() {
+                        "initialize" => (
+                            StatusCode::OK,
+                            [
+                                ("mcp-session-id", "upstream-tools-session"),
+                                ("mcp-protocol-version", "2025-03-26"),
+                            ],
+                            axum::Json(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": body.get("id").cloned().unwrap_or_else(|| serde_json::json!("probe-initialize")),
+                                "result": {
+                                    "protocolVersion": "2025-03-26",
+                                    "capabilities": {}
+                                }
+                            })),
+                        )
+                            .into_response(),
                         "tools/list" => (
                             StatusCode::OK,
                             axum::Json(serde_json::json!({
@@ -883,6 +944,7 @@ async fn mcp_probe_requests_with_authorization_header_reach_upstream() {
     let client = Client::new();
     let token = "th-zjvc-abcdefghijkl";
     let mcp_url = format!("http://127.0.0.1:{port}/mcp");
+    let session_id = initialize_mcp_session(&client, &mcp_url, token).await;
 
     let ping = client
         .post(&mcp_url)
@@ -891,6 +953,7 @@ async fn mcp_probe_requests_with_authorization_header_reach_upstream() {
             axum::http::header::ACCEPT,
             "application/json, text/event-stream",
         )
+        .header("mcp-session-id", session_id.as_str())
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": "probe-ping",
@@ -909,6 +972,7 @@ async fn mcp_probe_requests_with_authorization_header_reach_upstream() {
             axum::http::header::ACCEPT,
             "application/json, text/event-stream",
         )
+        .header("mcp-session-id", session_id.as_str())
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": "probe-tools-list",
@@ -935,7 +999,11 @@ async fn mcp_probe_requests_with_authorization_header_reach_upstream() {
     let upstream_calls = calls.lock().expect("mcp probe calls lock poisoned").clone();
     assert_eq!(
         upstream_calls,
-        vec!["ping".to_string(), "tools/list".to_string()]
+        vec![
+            "initialize".to_string(),
+            "ping".to_string(),
+            "tools/list".to_string(),
+        ]
     );
 }
 
@@ -955,6 +1023,7 @@ async fn mcp_probe_requests_preserve_prefixed_upstream_path() {
     let client = Client::new();
     let token = "th-zjvc-abcdefghijkl";
     let mcp_url = format!("http://127.0.0.1:{port}/mcp");
+    let session_id = initialize_mcp_session(&client, &mcp_url, token).await;
 
     let ping = client
         .post(&mcp_url)
@@ -963,6 +1032,7 @@ async fn mcp_probe_requests_preserve_prefixed_upstream_path() {
             axum::http::header::ACCEPT,
             "application/json, text/event-stream",
         )
+        .header("mcp-session-id", session_id.as_str())
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": "probe-ping",
@@ -978,7 +1048,10 @@ async fn mcp_probe_requests_preserve_prefixed_upstream_path() {
         .lock()
         .expect("mcp prefixed calls lock poisoned")
         .clone();
-    assert_eq!(upstream_calls, vec!["ping".to_string()]);
+    assert_eq!(
+        upstream_calls,
+        vec!["initialize".to_string(), "ping".to_string()]
+    );
 }
 
 #[tokio::test]
@@ -1003,10 +1076,12 @@ async fn mcp_tools_list_advertised_tools_can_all_be_called_via_authorization_hea
     let client = Client::new();
     let token = "th-zjvc-abcdefghijkl";
     let mcp_url = format!("http://127.0.0.1:{port}/mcp");
+    let session_id = initialize_mcp_session(&client, &mcp_url, token).await;
 
     let tools_list = client
         .post(&mcp_url)
         .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("mcp-session-id", session_id.as_str())
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": "probe-tools-list",
@@ -1058,6 +1133,7 @@ async fn mcp_tools_list_advertised_tools_can_all_be_called_via_authorization_hea
         let response = client
             .post(&mcp_url)
             .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("mcp-session-id", session_id.as_str())
             .json(&serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": format!("call-{tool_name}"),
@@ -1116,10 +1192,12 @@ async fn mcp_tools_list_legacy_underscore_tools_still_apply_supported_tavily_met
     let client = Client::new();
     let token = "th-zjvc-abcdefghijkl";
     let mcp_url = format!("http://127.0.0.1:{port}/mcp");
+    let session_id = initialize_mcp_session(&client, &mcp_url, token).await;
 
     let tools_list = client
         .post(&mcp_url)
         .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("mcp-session-id", session_id.as_str())
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": "probe-tools-list",
@@ -1171,6 +1249,7 @@ async fn mcp_tools_list_legacy_underscore_tools_still_apply_supported_tavily_met
         let response = client
             .post(&mcp_url)
             .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("mcp-session-id", session_id.as_str())
             .json(&serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": format!("call-{tool_name}"),


### PR DESCRIPTION
## Summary
- align rebalance MCP request/response handling with MCP 2025-03-26 + JSON-RPC 2.0 expectations
- fix tools/call error envelopes, parse vs invalid request mapping, session lifecycle status codes, and notification/batch semantics
- update protocol specs and regression coverage, including follow-up session enforcement and response-only session validation

## Behavior changes
- return `result.isError` + always-present `result.content` for rebalance tool failures
- distinguish `-32700 Parse error` from `-32600 Invalid Request`
- reject empty batches and response-only batches locally; keep notifications response-free
- return `404 session_unavailable` for stale/revoked MCP sessions instead of `409`
- require `mcp-session-id` for post-initialize JSON-RPC follow-ups, including `tools/call`, while preserving stateless legacy MCP request shapes

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`
- targeted regressions for rebalance error envelopes, parse/batch handling, missing-session follow-ups, revoked response-only follow-ups, and server HTTP MCP contracts