### PR TITLE
fix(admin): stabilize alerts center refresh loading

### DIFF
--- a/web/src/admin/AlertsCenter.render.test.tsx
+++ b/web/src/admin/AlertsCenter.render.test.tsx
@@ -1,0 +1,218 @@
+import '../../test/happydom'
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { act, type ComponentProps } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import type { AlertCatalog, AlertEvent, AlertsPage } from '../api'
+import AlertsCenter from './AlertsCenter'
+import { alertsPath } from './routes'
+
+const storyCatalog: AlertCatalog = {
+  retentionDays: 30,
+  types: [
+    { value: 'user_quota_exhausted', count: 2 },
+    { value: 'upstream_rate_limited_429', count: 1 },
+  ],
+  requestKindOptions: [
+    { key: 'tavily_search', label: 'Tavily Search', protocol_group: 'api', billing_group: 'billable', count: 2 },
+    { key: 'mcp_search', label: 'MCP Search', protocol_group: 'mcp', billing_group: 'billable', count: 1 },
+  ],
+  users: [{ value: 'usr_alice', label: 'Alice Wang', count: 2 }],
+  tokens: [{ value: 'tok_ops_01', label: 'tok_ops_01', count: 2 }],
+  keys: [{ value: 'key_001', label: 'key_001', count: 1 }],
+}
+
+const storyEvents: AlertsPage<AlertEvent> = {
+  page: 1,
+  perPage: 20,
+  total: 1,
+  items: [
+    {
+      id: 'alert_evt_001',
+      type: 'user_quota_exhausted',
+      title: '用户额度耗尽',
+      summary: 'Alice Wang 的 Tavily Search 请求触发本地额度上限。',
+      occurredAt: 1_776_220_680,
+      subjectKind: 'user',
+      subjectId: 'usr_alice',
+      subjectLabel: 'Alice Wang',
+      user: { userId: 'usr_alice', displayName: 'Alice Wang', username: 'alice' },
+      token: { id: 'tok_ops_01', label: 'tok_ops_01' },
+      key: null,
+      request: { id: 501, method: 'POST', path: '/api/tavily/search', query: null },
+      requestKind: { key: 'tavily_search', label: 'Tavily Search', detail: 'POST /api/tavily/search' },
+      failureKind: null,
+      resultStatus: 'quota_exhausted',
+      errorMessage: 'quota exhausted',
+      reasonCode: null,
+      reasonSummary: null,
+      reasonDetail: null,
+      source: { kind: 'auth_token_log', id: 'log_501' },
+    },
+  ],
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+interface MountedAlertsCenter {
+  container: HTMLDivElement
+  root: Root
+  rerender: (patch?: Partial<AlertsCenterProps>) => Promise<void>
+}
+
+type AlertsCenterProps = ComponentProps<typeof AlertsCenter>
+
+async function mountAlertsCenter(partialProps: Partial<AlertsCenterProps> = {}): Promise<MountedAlertsCenter> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  let props: AlertsCenterProps = {
+    language: 'zh',
+    search: alertsPath({ view: 'events', requestKinds: ['tavily_search'] }).replace('/admin/alerts', ''),
+    refreshToken: 0,
+    onNavigate: () => {},
+    onOpenUser: () => {},
+    onOpenToken: () => {},
+    onOpenKey: () => {},
+    formatTime: () => '04/19 09:00',
+    formatTimeDetail: () => '04/19 09:00',
+    catalogLoader: async () => storyCatalog,
+    eventsLoader: async () => storyEvents,
+    groupsLoader: async () => ({ page: 1, perPage: 20, total: 0, items: [] }),
+    requestLoader: async () => ({ request_body: null, response_body: null }),
+    ...partialProps,
+  }
+
+  await act(async () => {
+    root.render(<AlertsCenter {...props} />)
+  })
+  await flushEffects()
+
+  return {
+    container,
+    root,
+    rerender: async (patch = {}) => {
+      props = { ...props, ...patch }
+      await act(async () => {
+        root.render(<AlertsCenter {...props} />)
+      })
+      await flushEffects()
+    },
+  }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('AlertsCenter loading behavior', () => {
+  it('does not keep refetching when the search string is stable', async () => {
+    let catalogCalls = 0
+    let eventsCalls = 0
+    const { root, rerender } = await mountAlertsCenter({
+      catalogLoader: async () => {
+        catalogCalls += 1
+        return storyCatalog
+      },
+      eventsLoader: async () => {
+        eventsCalls += 1
+        return storyEvents
+      },
+    })
+
+    await flushEffects()
+    expect(catalogCalls).toBe(1)
+    expect(eventsCalls).toBe(1)
+
+    await rerender()
+    expect(catalogCalls).toBe(1)
+    expect(eventsCalls).toBe(1)
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
+  it('keeps current rows visible during a same-query background refresh', async () => {
+    let eventsCalls = 0
+    const secondResponse = deferred<AlertsPage<AlertEvent>>()
+    const { container, root, rerender } = await mountAlertsCenter({
+      initialCatalog: storyCatalog,
+      initialEventsPage: storyEvents,
+      eventsLoader: async () => {
+        eventsCalls += 1
+        if (eventsCalls === 1) {
+          return storyEvents
+        }
+        return secondResponse.promise
+      },
+    })
+
+    expect(eventsCalls).toBe(1)
+
+    await rerender({ refreshToken: 1 })
+    expect(eventsCalls).toBe(2)
+    expect(container.textContent).toContain('用户额度耗尽')
+    expect(container.querySelector('.alerts-center-table-shell .admin-loading-region-placeholder')).toBeNull()
+
+    await flushEffects()
+    expect(eventsCalls).toBe(2)
+
+    secondResponse.resolve(storyEvents)
+    await flushEffects()
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
+  it('uses a blocking load exactly once when the alert query changes', async () => {
+    let eventsCalls = 0
+    const switchedResponse = deferred<AlertsPage<AlertEvent>>()
+    const { container, root, rerender } = await mountAlertsCenter({
+      initialCatalog: storyCatalog,
+      initialEventsPage: storyEvents,
+      eventsLoader: async () => {
+        eventsCalls += 1
+        if (eventsCalls === 1) {
+          return storyEvents
+        }
+        return switchedResponse.promise
+      },
+    })
+
+    expect(eventsCalls).toBe(1)
+
+    await rerender({
+      search: alertsPath({ view: 'events', requestKinds: ['mcp_search'] }).replace('/admin/alerts', ''),
+    })
+    expect(eventsCalls).toBe(2)
+    expect(container.querySelector('.alerts-center-table-shell .admin-loading-region-placeholder')).not.toBeNull()
+
+    await flushEffects()
+    expect(eventsCalls).toBe(2)
+
+    switchedResponse.resolve(storyEvents)
+    await flushEffects()
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+})

--- a/web/src/admin/AlertsCenter.stories.test.tsx
+++ b/web/src/admin/AlertsCenter.stories.test.tsx
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'bun:test'
 import { renderToString } from 'react-dom/server'
 
-import { AlertsCenterStoryShell, EventsDefault, GroupsView } from './AlertsCenter.stories'
+import {
+  AlertsCenterRefreshingStoryShell,
+  AlertsCenterStoryShell,
+  BackgroundRefreshKeepsRows,
+  EventsDefault,
+  GroupsView,
+} from './AlertsCenter.stories'
 
 describe('AlertsCenter Storybook proofs', () => {
   it('keeps event and grouped alert stories available', () => {
     expect(EventsDefault.args?.initialSearch).toContain('view=events')
     expect(GroupsView.args?.initialSearch).toContain('view=groups')
+    expect(BackgroundRefreshKeepsRows.args?.initialSearch).toContain('requestKinds=tavily_search')
   })
 
   it('renders the grouped story with alert center chrome and shared filters', () => {
@@ -15,5 +22,13 @@ describe('AlertsCenter Storybook proofs', () => {
     expect(markup).toContain('聚合告警')
     expect(markup).toContain('上游 Key 封禁')
     expect(markup).toContain('请求类型')
+  })
+
+  it('renders the background-refresh story with loaded rows as the initial canvas state', () => {
+    const markup = renderToString(<AlertsCenterRefreshingStoryShell {...(BackgroundRefreshKeepsRows.args ?? {})} />)
+
+    expect(markup).toContain('告警中心')
+    expect(markup).toContain('用户额度耗尽')
+    expect(markup).not.toContain('admin-loading-region-placeholder')
   })
 })

--- a/web/src/admin/AlertsCenter.stories.tsx
+++ b/web/src/admin/AlertsCenter.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
@@ -173,16 +173,72 @@ export function AlertsCenterStoryShell({ initialSearch = alertsPath() }: { initi
         onNavigate={setSearch}
         onOpenUser={() => {}}
         onOpenToken={() => {}}
-      onOpenKey={() => {}}
-      formatTime={formatTs}
-      formatTimeDetail={formatTs}
-      initialCatalog={catalog}
-      initialEventsPage={{ page: 1, perPage: 20, total: baseEvents.length, items: baseEvents }}
-      initialGroupsPage={groupsPage}
-      disableAutoLoad
-      catalogLoader={async () => catalog}
-      eventsLoader={async () => ({ page: 1, perPage: 20, total: baseEvents.length, items: baseEvents })}
-      groupsLoader={async () => groupsPage}
+        onOpenKey={() => {}}
+        formatTime={formatTs}
+        formatTimeDetail={formatTs}
+        initialCatalog={catalog}
+        initialEventsPage={{ page: 1, perPage: 20, total: baseEvents.length, items: baseEvents }}
+        initialGroupsPage={groupsPage}
+        disableAutoLoad
+        catalogLoader={async () => catalog}
+        eventsLoader={async () => ({ page: 1, perPage: 20, total: baseEvents.length, items: baseEvents })}
+        groupsLoader={async () => groupsPage}
+        requestLoader={async (requestId) => requestBodies[requestId] ?? { request_body: null, response_body: null }}
+      />
+    </div>
+  )
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms))
+}
+
+export function AlertsCenterRefreshingStoryShell({
+  initialSearch = alertsPath({ view: 'events', requestKinds: ['tavily_search'] }),
+}: { initialSearch?: string }): JSX.Element {
+  const [search, setSearch] = useState(initialSearch.replace('/admin/alerts', ''))
+  const [refreshToken, setRefreshToken] = useState(0)
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setRefreshToken(1)
+    }, 220)
+    return () => window.clearTimeout(id)
+  }, [])
+
+  const delayedCatalogLoader = useMemo(() => async () => {
+    await wait(420)
+    return catalog
+  }, [])
+
+  const delayedEventsLoader = useMemo(() => async () => {
+    await wait(420)
+    return { page: 1, perPage: 20, total: baseEvents.length, items: baseEvents }
+  }, [])
+
+  const delayedGroupsLoader = useMemo(() => async () => {
+    await wait(420)
+    return groupsPage
+  }, [])
+
+  return (
+    <div style={{ padding: 24, background: 'hsl(var(--background))' }}>
+      <AlertsCenter
+        language="zh"
+        search={search}
+        refreshToken={refreshToken}
+        onNavigate={setSearch}
+        onOpenUser={() => {}}
+        onOpenToken={() => {}}
+        onOpenKey={() => {}}
+        formatTime={formatTs}
+        formatTimeDetail={formatTs}
+        initialCatalog={catalog}
+        initialEventsPage={{ page: 1, perPage: 20, total: baseEvents.length, items: baseEvents }}
+        initialGroupsPage={groupsPage}
+        catalogLoader={delayedCatalogLoader}
+        eventsLoader={delayedEventsLoader}
+        groupsLoader={delayedGroupsLoader}
         requestLoader={async (requestId) => requestBodies[requestId] ?? { request_body: null, response_body: null }}
       />
     </div>
@@ -216,5 +272,23 @@ export const EventsDefault: Story = {
 export const GroupsView: Story = {
   args: {
     initialSearch: alertsPath({ view: 'groups', type: 'upstream_key_blocked', requestKinds: ['mcp_search'] }),
+  },
+}
+
+export const BackgroundRefreshKeepsRows: Story = {
+  render: (args) => <AlertsCenterRefreshingStoryShell {...args} />,
+  args: {
+    initialSearch: alertsPath({ view: 'events', requestKinds: ['tavily_search'] }),
+  },
+  play: async ({ canvasElement }) => {
+    await wait(260)
+    const placeholder = canvasElement.querySelector('.alerts-center-table-shell .admin-loading-region-placeholder')
+    if (placeholder) {
+      throw new Error('Expected background refresh to keep the current rows visible instead of switching to a blocking skeleton.')
+    }
+    const text = canvasElement.textContent ?? ''
+    if (!text.includes('用户额度耗尽')) {
+      throw new Error('Expected background refresh story to keep the loaded event row visible during refresh.')
+    }
   },
 }

--- a/web/src/admin/AlertsCenter.tsx
+++ b/web/src/admin/AlertsCenter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
   AlertCatalog,
@@ -11,7 +11,7 @@ import type {
 } from '../api'
 import { fetchAlertCatalog, fetchAlertEvents, fetchAlertGroups, fetchRequestLogDetails } from '../api'
 import type { Language } from '../i18n'
-import type { QueryLoadState } from './queryLoadState'
+import { getBlockingLoadState, getRefreshingLoadState, type QueryLoadState } from './queryLoadState'
 import {
   alertsPath,
   getAlertKeyIdFromSearch,
@@ -256,6 +256,33 @@ function paginationSummary(copy: ReturnType<typeof defaultCopy>, total: number, 
   return `${total} · ${page}/${totalPageCount}`
 }
 
+interface AlertsSearchState {
+  view: AlertsCenterView
+  type: AlertType | null
+  since: string | null
+  until: string | null
+  userId: string | null
+  tokenId: string | null
+  keyId: string | null
+  requestKinds: string[]
+  page: number
+}
+
+function listQueryKey(view: AlertsCenterView, query: AlertsQuery): string {
+  return JSON.stringify({
+    view,
+    page: query.page ?? 1,
+    perPage: query.perPage ?? 20,
+    type: query.type ?? null,
+    since: query.since ?? null,
+    until: query.until ?? null,
+    userId: query.userId ?? null,
+    tokenId: query.tokenId ?? null,
+    keyId: query.keyId ?? null,
+    requestKinds: [...(query.requestKinds ?? [])],
+  })
+}
+
 interface AlertsCenterProps {
   language: Language
   search: string
@@ -296,15 +323,21 @@ export default function AlertsCenter({
   disableAutoLoad = false,
 }: AlertsCenterProps): JSX.Element {
   const copy = useMemo(() => defaultCopy(language), [language])
-  const view = getAlertsViewFromSearch(search)
-  const type = getAlertTypeFromSearch(search) as AlertType | null
-  const since = getAlertSinceFromSearch(search)
-  const until = getAlertUntilFromSearch(search)
-  const userId = getAlertUserIdFromSearch(search)
-  const tokenId = getAlertTokenIdFromSearch(search)
-  const keyId = getAlertKeyIdFromSearch(search)
-  const requestKinds = getAlertRequestKindsFromSearch(search)
-  const page = getAlertPageFromSearch(search)
+  const searchState = useMemo<AlertsSearchState>(
+    () => ({
+      view: getAlertsViewFromSearch(search),
+      type: getAlertTypeFromSearch(search) as AlertType | null,
+      since: getAlertSinceFromSearch(search),
+      until: getAlertUntilFromSearch(search),
+      userId: getAlertUserIdFromSearch(search),
+      tokenId: getAlertTokenIdFromSearch(search),
+      keyId: getAlertKeyIdFromSearch(search),
+      requestKinds: getAlertRequestKindsFromSearch(search),
+      page: getAlertPageFromSearch(search),
+    }),
+    [search],
+  )
+  const { view, type, since, until, userId, tokenId, keyId, requestKinds, page } = searchState
 
   const [draftSince, setDraftSince] = useState(() => isoToDateTimeLocal(since))
   const [draftUntil, setDraftUntil] = useState(() => isoToDateTimeLocal(until))
@@ -323,6 +356,28 @@ export default function AlertsCenter({
   const [requestBodies, setRequestBodies] = useState<RequestLogBodies | null>(null)
   const [requestLoadState, setRequestLoadState] = useState<QueryLoadState>('initial_loading')
   const [requestLoadError, setRequestLoadError] = useState<string | null>(null)
+  const hasLoadedCatalogRef = useRef(Boolean(initialCatalog))
+  const currentPerPage = view === 'events' ? eventsPage.perPage : groupsPage.perPage
+  const currentListQuery = useMemo<AlertsQuery>(
+    () => ({
+      page,
+      perPage: currentPerPage,
+      type,
+      since,
+      until,
+      userId,
+      tokenId,
+      keyId,
+      requestKinds,
+    }),
+    [currentPerPage, keyId, page, requestKinds, since, tokenId, type, until, userId],
+  )
+  const currentListQueryKey = useMemo(() => listQueryKey(view, currentListQuery), [currentListQuery, view])
+  const hasInitialListPage = Boolean(view === 'events' ? initialEventsPage : initialGroupsPage)
+  const hasLoadedListRef = useRef(hasInitialListPage)
+  const lastListQueryKeyRef = useRef<string | null>(
+    hasInitialListPage ? currentListQueryKey : null,
+  )
 
   useEffect(() => {
     setDraftSince(isoToDateTimeLocal(since))
@@ -352,17 +407,20 @@ export default function AlertsCenter({
   useEffect(() => {
     if (disableAutoLoad) return
     const controller = new AbortController()
-    setCatalogLoadState((current) => (current === 'ready' ? 'refreshing' : 'initial_loading'))
+    setCatalogLoadState(hasLoadedCatalogRef.current ? 'refreshing' : 'initial_loading')
     setCatalogError(null)
     catalogLoader(controller.signal)
       .then((value) => {
         if (controller.signal.aborted) return
+        hasLoadedCatalogRef.current = true
         setCatalog(value)
         setCatalogLoadState('ready')
       })
       .catch((error) => {
         if (controller.signal.aborted) return
-        setCatalog(null)
+        if (!hasLoadedCatalogRef.current) {
+          setCatalog(null)
+        }
         setCatalogError(error instanceof Error ? error.message : 'Failed to load alert catalog')
         setCatalogLoadState('error')
       })
@@ -372,25 +430,21 @@ export default function AlertsCenter({
   useEffect(() => {
     if (disableAutoLoad) return
     const controller = new AbortController()
-    setListLoadState((current) => (current === 'ready' ? 'refreshing' : 'initial_loading'))
+    const queryChanged = lastListQueryKeyRef.current !== currentListQueryKey
+    setListLoadState(
+      queryChanged
+        ? getBlockingLoadState(hasLoadedListRef.current)
+        : getRefreshingLoadState(hasLoadedListRef.current),
+    )
     setListError(null)
-    const query = {
-      page,
-      perPage: view === 'events' ? eventsPage.perPage : groupsPage.perPage,
-      type,
-      since,
-      until,
-      userId,
-      tokenId,
-      keyId,
-      requestKinds,
-    }
+    lastListQueryKeyRef.current = currentListQueryKey
     const loader = view === 'events'
-      ? eventsLoader(query, controller.signal)
-      : groupsLoader(query, controller.signal)
+      ? eventsLoader(currentListQuery, controller.signal)
+      : groupsLoader(currentListQuery, controller.signal)
     loader
       .then((value) => {
         if (controller.signal.aborted) return
+        hasLoadedListRef.current = true
         if (view === 'events') {
           setEventsPage(value as AlertsPage<AlertEvent>)
         } else {
@@ -401,29 +455,21 @@ export default function AlertsCenter({
       .catch((error) => {
         if (controller.signal.aborted) return
         if (view === 'events') {
-          setEventsPage({ ...EMPTY_ALERT_EVENTS_PAGE, page, perPage: query.perPage ?? 20 })
+          setEventsPage({ ...EMPTY_ALERT_EVENTS_PAGE, page, perPage: currentListQuery.perPage ?? 20 })
         } else {
-          setGroupsPage({ ...EMPTY_ALERT_GROUPS_PAGE, page, perPage: query.perPage ?? 20 })
+          setGroupsPage({ ...EMPTY_ALERT_GROUPS_PAGE, page, perPage: currentListQuery.perPage ?? 20 })
         }
         setListError(error instanceof Error ? error.message : 'Failed to load alerts')
         setListLoadState('error')
       })
     return () => controller.abort()
   }, [
+    currentListQuery,
+    currentListQueryKey,
     disableAutoLoad,
     eventsLoader,
-    eventsPage.perPage,
     groupsLoader,
-    groupsPage.perPage,
-    keyId,
-    page,
     refreshToken,
-    requestKinds,
-    since,
-    tokenId,
-    type,
-    until,
-    userId,
     view,
   ])
 


### PR DESCRIPTION
## Summary
- stabilize the alert-center query parsing so unchanged search params do not retrigger list requests
- distinguish blocking query switches from same-query background refreshes so loaded rows stay visible
- add regression coverage for stable rerenders and the background-refresh Storybook scenario

## Testing
- cd /Users/ivan/Projects/Ivan/tavily-hikari/web && bun test
- cd /Users/ivan/Projects/Ivan/tavily-hikari/web && bun run build
- cd /Users/ivan/Projects/Ivan/tavily-hikari/web && bun run build-storybook
- browser verification on /admin/alerts and the Storybook background-refresh story (no screenshot artifacts per request)
