### PR TITLE
fix(mcp): align rebalance remote parity

### DIFF
--- a/docs/specs/xm3dh-rebalance-mcp-gateway/SPEC.md
+++ b/docs/specs/xm3dh-rebalance-mcp-gateway/SPEC.md
@@ -4,7 +4,7 @@
 
 - Status: 进行中（快车道）
 - Created: 2026-04-13
-- Last: 2026-04-15
+- Last: 2026-04-27
 
 ## 背景 / 问题陈述
 
@@ -33,7 +33,8 @@
 - 不改公开 `/mcp` URL、用户 token 格式或鉴权方式。
 - 不承诺完全消灭 429；目标是显著缓解单会话/单 key 热点。
 - 不把 Rebalance 选路重新绑定回 `X-Project-ID` 亲和；非 research 工具调用保持“每次调用重新全池选 key”。
-- 不做生产 Tavily 验证；所有测试限定本地 / mock upstream。
+- CI 与回归测试限定本地 / mock upstream；允许一次受批准的官方 Remote MCP 行为对比，用于更新 schema
+  snapshot 与协议证据，不把生产 Tavily endpoint 纳入自动化测试。
 
 ## 范围（Scope）
 
@@ -98,26 +99,34 @@
   - `tavily_crawl`
   - `tavily_map`
   - `tavily_research`
-- `tools/list` 广播的 5 个 Tavily 工具必须带显式 `inputSchema`，并至少覆盖当前 Tavily HTTP contract 的必填字段：
-  - `tavily_search` → `query: string`
-  - `tavily_extract` → `urls: string | string[]`
-  - `tavily_crawl` → `url: string`
-  - `tavily_map` → `url: string`
-  - `tavily_research` → `input: string`
+- `tools/list` 广播的 5 个 Tavily 工具必须带显式 `inputSchema`，字段集合锁定到一次受批准的
+  `tavily-mcp v3.2.4` 官方 Remote MCP 实测 snapshot：
+  - `tavily_search` required `query`; properties:
+    `country,end_date,exact_match,exclude_domains,include_domains,include_favicon,include_image_descriptions,include_images,include_raw_content,max_results,query,search_depth,start_date,time_range,topic`
+  - `tavily_extract` required `urls`; properties:
+    `extract_depth,format,include_favicon,include_images,query,urls`
+  - `tavily_crawl` required `url`; properties:
+    `allow_external,extract_depth,format,include_favicon,instructions,limit,max_breadth,max_depth,select_domains,select_paths,url`
+  - `tavily_map` required `url`; properties:
+    `allow_external,instructions,limit,max_breadth,max_depth,select_domains,select_paths,url`
+  - `tavily_research` required `input`; properties: `input,model`
 - Rebalance tool surface 必须由单一 canonical schema registry 驱动；`tools/list` 广播与 `tools/call` 参数校验不得维护两份互相漂移的真相源。
 - `tools/call` 同时接受 underscore 与 hyphen 工具名别名。
 - `initialize / ping / tools/list / prompts/list / resources/list / resources/templates/list / notifications/*` 本地处理。
-- Rebalance `tools/call` 返回的 MCP `CallToolResult` 必须始终携带顶层 `content` 数组；工具执行失败使用顶层 `result.isError=true`，而不是把 `isError` 塞进 `structuredContent`。
+- Rebalance `/mcp` 对外响应使用官方 Remote MCP 风格的 SSE transport：
+  `Content-Type: text/event-stream`，payload 包装为 `event: message` + `data: <JSON-RPC>`.
+- Rebalance `tools/call` 返回的 MCP `CallToolResult` 必须始终携带顶层 `content` 数组；工具执行失败使用 HTTP 200，并设置顶层 `result.isError=true`，而不是 JSON-RPC top-level `error` 或嵌套的 `structuredContent.isError`。
 - `tools/call`：
   - `search / extract / crawl / map` → HTTP full-pool 选 key，不做同请求自动重试。
   - `research` → 保留 usage-diff 计费，并把 usage delta 回填到 MCP `structuredContent.usage.credits`。
-  - 对 Tavily 工具的 `arguments` 必须先做本地最小合同校验：顶层必须是 object，且必填字段存在并满足基础类型；不满足时返回本地 JSON-RPC `-32602 Invalid params`，不得继续命中下游 Tavily HTTP，也不得被 reserved-credit / business quota 预检抢先改写成 `429`。
+  - 对 Tavily 工具的 `arguments` 必须先做本地最小合同校验：顶层必须是 object，且必填字段存在并满足基础类型；不满足时返回 HTTP 200 的 `CallToolResult`，其中 `result.isError=true` 且 `result.content[]` 带错误文本，不得继续命中下游 Tavily HTTP，也不得被 reserved-credit / business quota 预检抢先改写成 `429`。
 - `/mcp` 的本地协议拦截要求：
   - 非法 JSON → `-32700 Parse error`
   - 空 batch `[]` → 单个 `-32600 Invalid Request`
   - 单条 notification → `202` 空 body
   - response-only batch → 本地 `400` 拒绝，不伪造成 JSON-RPC 结果数组
-  - initialize 之后缺失 `mcp-session-id` 的 follow-up 请求 → 本地 `400`
+  - Rebalance follow-up 不强制要求 `mcp-session-id`；若客户端携带旧 session header，仍按兼容路径接受并 touch 对应 session。
+  - control/upstream MCP follow-up 缺失 `mcp-session-id` 且 token 已存在 active upstream session → 本地 `400`
   - 无效 / 已撤销 / 失效 session 的 follow-up 请求 → `404 Not Found`
 
 ### Rebalance HTTP headers
@@ -170,9 +179,14 @@
   When 请求成功
   Then MCP 返回体必须包含 `structuredContent.usage.credits`，其值来自 research `/usage` 差分。
 
+- Given Rebalance 会话收到 `initialize`、`tools/list`、`ping` 或 `tools/call`
+  When 客户端读取响应
+  Then 响应必须使用 `text/event-stream` 的 `event: message` SSE envelope。
+
 - Given Rebalance 会话收到 `tools/list`
   When 客户端读取 Tavily tool descriptors
-  Then 5 个工具都必须带显式 `inputSchema` 与 required 字段，且字段口径与当前 Tavily HTTP contract 一致。
+  Then 5 个工具都必须带显式 `inputSchema` 与 required 字段，且字段集合与当前官方
+  `tavily-mcp v3.2.4` snapshot 一致。
 
 - Given Rebalance 会话收到 `prompts/list`、`resources/list` 或 `resources/templates/list`
   When 客户端执行控制面探测
@@ -186,13 +200,14 @@
   When gateway 在本地完成协议校验
   Then 非法 JSON 返回 `-32700 Parse error`，空 batch / response-only batch 返回 `-32600 Invalid Request`，且这些请求都不得命中 upstream。
 
-- Given Rebalance Tavily 工具调用缺少 `arguments`、`arguments` 不是 object、或缺少当前工具的必填字段
+- Given Rebalance Tavily 工具调用缺少 `arguments`、`arguments` 不是 object、缺少当前工具的必填字段，或工具名未知
   When 请求进入 gateway
-  Then gateway 必须本地返回 JSON-RPC `-32602 Invalid params`，并且不命中下游 Tavily HTTP。
+  Then gateway 必须本地返回 HTTP 200 + `result.isError=true` + `result.content[]`，并且不命中下游 Tavily HTTP。
 
-- Given initialize 之后的 `/mcp` follow-up 请求缺少 `mcp-session-id`
+- Given Rebalance initialize 之后的 `/mcp` follow-up 请求缺少 `mcp-session-id`
   When 请求进入 gateway
-  Then gateway 必须本地返回 `400`，提示 session header 必填，并且不命中 upstream。
+  Then gateway 必须接受请求并继续走本地 Rebalance façade；`tools/list`、`ping` 与合法
+  `tools/call` 不得因为缺少 session header 失败。
 
 - Given 已存在的 proxy session 已失效、被撤销、或其上游 session 已不可用
   When 客户端继续携带旧 `mcp-session-id` 发 follow-up
@@ -254,6 +269,9 @@
 ## Change log
 
 - 2026-04-15：补平 Rebalance MCP 的 `prompts/list`、`resources/list`、`resources/templates/list` 本地空结果协议兼容，并让 control MCP 请求日志稳定落盘 `gateway_mode` / `experiment_variant` / `proxy_session_id` / `upstream_operation`。
+- 2026-04-27：按官方 Remote MCP 强一致目标更新 Rebalance transport/session/error/schema 合同；官方对比证据为
+  `https://mcp.tavily.com/mcp/` 返回 SSE `event: message`、`serverInfo.name=tavily-mcp`、
+  `serverInfo.version=3.2.4`、无 session header 的 `tools/list` 成功、5 个 Tavily 工具字段集合如上，缺参与未知工具均为 HTTP 200 `result.isError=true`。
 
 ## 实现里程碑（Milestones / Delivery checklist）
 
@@ -263,7 +281,7 @@
 - [x] M4: Admin settings / logs UI 与 Storybook 完成
 - [x] M5: 后端/前端测试与 clippy 通过
 - [x] M6: 视觉证据回传给主人
-- [ ] M7: fast-track PR 合并并 cleanup
+- [ ] M7: fast-track PR 收敛到 merge-ready（不自动 merge/cleanup）
 
 ## 风险 / 开放问题 / 假设（Risks, Open Questions, Assumptions）
 

--- a/src/server/proxy/mcp_helpers.rs
+++ b/src/server/proxy/mcp_helpers.rs
@@ -602,7 +602,8 @@ fn mcp_response_requires_reconnect(status: StatusCode, body: &[u8]) -> bool {
 }
 
 const REBALANCE_MCP_PROTOCOL_VERSION_DEFAULT: &str = "2025-03-26";
-const REBALANCE_MCP_SERVER_NAME: &str = "tavily-hikari-rebalance-mcp";
+const REBALANCE_MCP_SERVER_NAME: &str = "tavily-mcp";
+const REBALANCE_MCP_SERVER_VERSION: &str = "3.2.4";
 
 #[derive(Clone, Copy)]
 enum RebalanceMcpRequiredFieldType {
@@ -670,6 +671,18 @@ fn rebalance_mcp_tool_definition_by_name(tool: &str) -> Option<&'static Rebalanc
         .find(|definition| definition.hyphen_name == normalized)
 }
 
+fn schema_string(description: &str) -> Value {
+    json!({ "type": "string", "description": description })
+}
+
+fn schema_integer(description: &str, default: i64) -> Value {
+    json!({ "type": "integer", "description": description, "default": default })
+}
+
+fn schema_boolean(description: &str, default: bool) -> Value {
+    json!({ "type": "boolean", "description": description, "default": default })
+}
+
 fn rebalance_mcp_required_field_schema(kind: RebalanceMcpRequiredFieldType) -> Value {
     match kind {
         RebalanceMcpRequiredFieldType::String => json!({ "type": "string" }),
@@ -686,20 +699,124 @@ fn rebalance_mcp_required_field_schema(kind: RebalanceMcpRequiredFieldType) -> V
 }
 
 fn rebalance_mcp_tool_input_schema(tool: &RebalanceMcpToolDefinition) -> Value {
-    let mut properties = serde_json::Map::new();
-    properties.insert(
-        tool.required_field.to_string(),
-        rebalance_mcp_required_field_schema(tool.required_field_type),
-    );
-    Value::Object(serde_json::Map::from_iter([
-        ("type".to_string(), Value::String("object".to_string())),
-        ("properties".to_string(), Value::Object(properties)),
-        (
-            "required".to_string(),
-            Value::Array(vec![Value::String(tool.required_field.to_string())]),
-        ),
-        ("additionalProperties".to_string(), Value::Bool(true)),
-    ]))
+    let properties = match tool.upstream_tool {
+        "search" => json!({
+            "query": schema_string("Search query"),
+            "max_results": schema_integer("The maximum number of search results to return", 5),
+            "search_depth": {
+                "type": "string",
+                "description": "The depth of the search. 'basic' for generic results, 'advanced' for more thorough search, 'fast' for optimized low latency with high relevance, 'ultra-fast' for prioritizing latency above all else",
+                "enum": ["basic", "advanced", "fast", "ultra-fast"],
+                "default": "basic"
+            },
+            "topic": {
+                "type": "string",
+                "description": "The category of the search.",
+                "const": "general",
+                "default": "general"
+            },
+            "include_domains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "A list of domains to specifically include in the search results"
+            },
+            "exclude_domains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "A list of domains to specifically exclude from the search results"
+            },
+            "time_range": schema_string("Time range filter for search results"),
+            "start_date": schema_string("Start date for filtering search results"),
+            "end_date": schema_string("End date for filtering search results"),
+            "country": schema_string("Country filter for search results"),
+            "include_images": schema_boolean("Include a list of query-related images in the response", false),
+            "include_image_descriptions": schema_boolean("Include descriptions for returned images", false),
+            "include_raw_content": schema_boolean("Include cleaned and parsed HTML content for each search result", false),
+            "include_favicon": schema_boolean("Include favicon URLs for each result", true),
+            "exact_match": schema_boolean("Only return results that exactly match the query", false)
+        }),
+        "extract" => json!({
+            "urls": rebalance_mcp_required_field_schema(tool.required_field_type),
+            "extract_depth": {
+                "type": "string",
+                "description": "The depth of the extraction process",
+                "enum": ["basic", "advanced"],
+                "default": "basic"
+            },
+            "format": {
+                "type": "string",
+                "description": "The format of the extracted content",
+                "enum": ["markdown", "text"],
+                "default": "markdown"
+            },
+            "query": schema_string("Optional query to guide extraction"),
+            "include_images": schema_boolean("Include images extracted from the page", false),
+            "include_favicon": schema_boolean("Include favicon URLs in the response", true)
+        }),
+        "crawl" => json!({
+            "url": schema_string("The root URL to crawl"),
+            "max_depth": schema_integer("Maximum crawl depth", 1),
+            "max_breadth": schema_integer("Maximum number of links to follow per level", 20),
+            "limit": schema_integer("Maximum number of pages to crawl", 50),
+            "instructions": schema_string("Instructions to guide the crawl"),
+            "select_paths": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "URL path patterns to include"
+            },
+            "select_domains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Domains to include"
+            },
+            "allow_external": schema_boolean("Allow crawling external domains", false),
+            "extract_depth": {
+                "type": "string",
+                "description": "The depth of the extraction process",
+                "enum": ["basic", "advanced"],
+                "default": "basic"
+            },
+            "format": {
+                "type": "string",
+                "description": "The format of the extracted content",
+                "enum": ["markdown", "text"],
+                "default": "markdown"
+            },
+            "include_favicon": schema_boolean("Include favicon URLs in the response", true)
+        }),
+        "map" => json!({
+            "url": schema_string("The root URL to map"),
+            "max_depth": schema_integer("Maximum crawl depth", 1),
+            "max_breadth": schema_integer("Maximum number of links to follow per level", 20),
+            "limit": schema_integer("Maximum number of URLs to return", 50),
+            "instructions": schema_string("Instructions to guide site mapping"),
+            "select_paths": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "URL path patterns to include"
+            },
+            "select_domains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Domains to include"
+            },
+            "allow_external": schema_boolean("Allow mapping external domains", false)
+        }),
+        "research" => json!({
+            "input": schema_string("Research task or question"),
+            "model": schema_string("Research model to use")
+        }),
+        _ => json!({
+            tool.required_field: rebalance_mcp_required_field_schema(tool.required_field_type)
+        }),
+    };
+
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": [tool.required_field],
+        "additionalProperties": false,
+    })
 }
 
 fn rebalance_mcp_argument_matches_type(value: &Value, kind: RebalanceMcpRequiredFieldType) -> bool {
@@ -809,6 +926,40 @@ fn build_rebalance_mcp_error_body(
     })
 }
 
+fn build_rebalance_mcp_tool_error_result_body(
+    response_id: Option<&Value>,
+    message: &str,
+) -> Vec<u8> {
+    build_rebalance_mcp_success_body(
+        response_id,
+        json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": message
+                }
+            ],
+            "isError": true
+        }),
+    )
+}
+
+fn wrap_mcp_sse_message_body(body: &[u8]) -> Vec<u8> {
+    if body.is_empty() {
+        return Vec::new();
+    }
+    let payload = String::from_utf8_lossy(body);
+    format!("event: message\ndata: {payload}\n\n").into_bytes()
+}
+
+fn parse_mcp_sse_message_body(body: &[u8]) -> Option<Value> {
+    let text = std::str::from_utf8(body).ok()?;
+    let data = text
+        .lines()
+        .find_map(|line| line.strip_prefix("data:").map(str::trim))?;
+    serde_json::from_str(data).ok()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn build_and_log_local_mcp_protocol_response(
     state: &Arc<AppState>,
@@ -913,7 +1064,7 @@ fn build_rebalance_mcp_initialize_body(
             },
             "serverInfo": {
                 "name": REBALANCE_MCP_SERVER_NAME,
-                "version": env!("CARGO_PKG_VERSION")
+                "version": REBALANCE_MCP_SERVER_VERSION
             }
         }),
     )
@@ -1012,6 +1163,22 @@ fn proxy_response_with_json_body(
         selection_effect_code: "none".to_string(),
         selection_effect_summary: None,
     }
+}
+
+fn proxy_response_with_mcp_body(
+    status: StatusCode,
+    body: Vec<u8>,
+    request_log_id: Option<i64>,
+) -> ProxyResponse {
+    let sse_body = wrap_mcp_sse_message_body(&body);
+    let mut response = proxy_response_with_json_body(status, sse_body, request_log_id);
+    if !response.body.is_empty() {
+        response.headers.insert(
+            CONTENT_TYPE,
+            ReqHeaderValue::from_static("text/event-stream"),
+        );
+    }
+    response
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/server/proxy/mcp_helpers.rs
+++ b/src/server/proxy/mcp_helpers.rs
@@ -977,6 +977,7 @@ async fn build_and_log_local_mcp_protocol_response(
     routing_subject_hash: Option<&str>,
     upstream_operation: Option<&str>,
     fallback_reason: Option<&str>,
+    sse_transport: bool,
 ) -> Result<Response<Body>, StatusCode> {
     let analysis = analyze_mcp_attempt(response_status, response_body);
     let request_kind = classify_token_request_kind(path, Some(request_body));
@@ -1038,10 +1039,22 @@ async fn build_and_log_local_mcp_protocol_response(
             .await;
     }
 
+    let (content_type, body) = if sse_transport && !response_body.is_empty() {
+        (
+            "text/event-stream",
+            wrap_mcp_sse_message_body(response_body),
+        )
+    } else {
+        (
+            "application/json; charset=utf-8",
+            response_body.to_vec(),
+        )
+    };
+
     Response::builder()
         .status(response_status)
-        .header(CONTENT_TYPE, "application/json; charset=utf-8")
-        .body(Body::from(response_body.to_vec()))
+        .header(CONTENT_TYPE, content_type)
+        .body(Body::from(body))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
 

--- a/src/server/proxy/proxy_handlers_and_views.rs
+++ b/src/server/proxy/proxy_handlers_and_views.rs
@@ -62,11 +62,41 @@ async fn proxy_handler(
     } else {
         None
     };
+    let early_mcp_rebalance_transport = if is_mcp_request && !is_mcp_delete_root_request {
+        if let Some(proxy_session_id) = incoming_proxy_session_id.as_deref()
+            && let Some(session) = state
+                .proxy
+                .get_active_mcp_session(proxy_session_id)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        {
+            session.gateway_mode == tavily_hikari::MCP_GATEWAY_MODE_REBALANCE
+        } else {
+            let has_active_control_session = if let Some(token_id) = token_id.as_deref() {
+                state
+                    .proxy
+                    .token_has_active_non_rebalance_mcp_session(token_id)
+                    .await
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            } else {
+                false
+            };
+            let settings = state
+                .proxy
+                .get_system_settings()
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            !has_active_control_session
+                && settings.rebalance_mcp_enabled
+                && settings.rebalance_mcp_session_percent > 0
+        }
+    } else {
+        false
+    };
     if is_mcp_request && !is_mcp_delete_root_request {
         match mcp_body_summary.as_ref().expect("mcp body summary must exist") {
             Err(_) => {
-                let response_body =
-                    build_rebalance_mcp_error_body(None, -32700, "Parse error");
+                let response_body = build_rebalance_mcp_error_body(None, -32700, "Parse error");
                 return build_and_log_local_mcp_protocol_response(
                     &state,
                     token_id.as_deref(),
@@ -83,6 +113,7 @@ async fn proxy_handler(
                     None,
                     Some("mcp"),
                     Some("parse_error"),
+                    early_mcp_rebalance_transport,
                 )
                 .await;
             }
@@ -105,6 +136,7 @@ async fn proxy_handler(
                     None,
                     Some("mcp"),
                     Some("empty_batch"),
+                    early_mcp_rebalance_transport,
                 )
                 .await;
             }
@@ -130,6 +162,7 @@ async fn proxy_handler(
                     None,
                     Some("mcp"),
                     Some("invalid_request"),
+                    early_mcp_rebalance_transport,
                 )
                 .await;
             }
@@ -156,6 +189,7 @@ async fn proxy_handler(
                     None,
                     Some("mcp"),
                     Some("missing_session_id"),
+                    false,
                 )
                 .await;
             }
@@ -192,6 +226,7 @@ async fn proxy_handler(
                         None,
                         Some("mcp"),
                         Some("response_session_unavailable"),
+                        false,
                     )
                     .await;
                 }
@@ -212,6 +247,7 @@ async fn proxy_handler(
                     None,
                     Some("mcp"),
                     Some("response_accepted"),
+                    false,
                 )
                 .await;
             }
@@ -250,6 +286,7 @@ async fn proxy_handler(
                         None,
                         Some("mcp"),
                         Some("missing_session_id"),
+                        false,
                     )
                     .await;
                 }
@@ -1003,8 +1040,8 @@ async fn proxy_handler(
                 let payload = build_rebalance_mcp_error_body(None, -32700, "Parse error");
                 let response = Response::builder()
                     .status(status)
-                    .header(CONTENT_TYPE, "application/json; charset=utf-8")
-                    .body(Body::from(payload))
+                    .header(CONTENT_TYPE, "text/event-stream")
+                    .body(Body::from(wrap_mcp_sse_message_body(&payload)))
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
                 return Ok(response);
             }
@@ -1030,8 +1067,8 @@ async fn proxy_handler(
                 let payload = build_rebalance_mcp_error_body(None, -32700, "Parse error");
                 let response = Response::builder()
                     .status(status)
-                    .header(CONTENT_TYPE, "application/json; charset=utf-8")
-                    .body(Body::from(payload))
+                    .header(CONTENT_TYPE, "text/event-stream")
+                    .body(Body::from(wrap_mcp_sse_message_body(&payload)))
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
                 return Ok(response);
             }

--- a/src/server/proxy/proxy_handlers_and_views.rs
+++ b/src/server/proxy/proxy_handlers_and_views.rs
@@ -223,7 +223,7 @@ async fn proxy_handler(
                 let requires_session = if let Some(token_id) = token_id.as_deref() {
                     state
                         .proxy
-                        .token_has_active_mcp_session(token_id)
+                        .token_has_active_non_rebalance_mcp_session(token_id)
                         .await
                         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
                 } else {
@@ -360,6 +360,24 @@ async fn proxy_handler(
         }
         active_mcp_session = Some(session);
     }
+    let mut stateless_rebalance_proxy_session_id: Option<String> = None;
+    if is_mcp_request
+        && incoming_proxy_session_id.is_none()
+        && !is_mcp_initialize
+        && let Some(token_id) = token_id.as_deref()
+        && let Some(session) = state
+            .proxy
+            .latest_active_mcp_session_for_token(token_id)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        && session.gateway_mode == tavily_hikari::MCP_GATEWAY_MODE_REBALANCE
+        && session.auth_token_id.as_deref() == Some(token_id)
+    {
+        stateless_rebalance_proxy_session_id = Some(session.proxy_session_id.clone());
+        active_mcp_gateway_mode = session.gateway_mode.clone();
+        active_mcp_experiment_variant = session.experiment_variant.clone();
+        active_mcp_session = Some(session);
+    }
     let mut planned_initialize_proxy_session_id: Option<String> = None;
     let mut planned_initialize_ab_bucket: Option<i64> = None;
     let mut planned_initialize_gateway_mode = active_mcp_gateway_mode.clone();
@@ -387,6 +405,19 @@ async fn proxy_handler(
         } else {
             tavily_hikari::MCP_EXPERIMENT_VARIANT_CONTROL.to_string()
         };
+    } else if is_mcp_request
+        && incoming_proxy_session_id.is_none()
+        && active_mcp_session.is_none()
+        && !is_mcp_delete_root_request
+    {
+        let settings = state
+            .proxy
+            .get_system_settings()
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        if settings.rebalance_mcp_enabled && settings.rebalance_mcp_session_percent > 0 {
+            active_mcp_gateway_mode = tavily_hikari::MCP_GATEWAY_MODE_REBALANCE.to_string();
+        }
     }
     let rebalance_mcp_facade_active = is_mcp_request
         && (active_mcp_gateway_mode == tavily_hikari::MCP_GATEWAY_MODE_REBALANCE
@@ -986,7 +1017,9 @@ async fn proxy_handler(
             &headers,
             &body_bytes,
             token_id.as_deref(),
-            incoming_proxy_session_id.as_deref(),
+            incoming_proxy_session_id
+                .as_deref()
+                .or(stateless_rebalance_proxy_session_id.as_deref()),
             incoming_protocol_version.as_deref(),
             rebalance_routing_subject_hash.as_deref(),
         )
@@ -1113,6 +1146,51 @@ async fn proxy_handler(
                                     HeaderName::from_static("mcp-session-id"),
                                     proxy_header,
                                 );
+                            }
+                        }
+                    }
+                } else if let Some(proxy_session_id) =
+                    stateless_rebalance_proxy_session_id.as_deref()
+                {
+                    if active_mcp_gateway_mode == tavily_hikari::MCP_GATEWAY_MODE_REBALANCE {
+                        let response_protocol_version = resp
+                            .headers
+                            .get("mcp-protocol-version")
+                            .and_then(|value| value.to_str().ok())
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_string);
+                        let _ = state
+                            .proxy
+                            .touch_mcp_session(
+                                proxy_session_id,
+                                response_protocol_version
+                                    .as_deref()
+                                    .or(incoming_protocol_version.as_deref()),
+                                incoming_last_event_id.as_deref(),
+                            )
+                            .await;
+                        if rebalance_routing_subject_hash.is_some() {
+                            let _ = state
+                                .proxy
+                                .update_mcp_session_rebalance_metadata(
+                                    proxy_session_id,
+                                    rebalance_routing_subject_hash.as_deref(),
+                                    None,
+                                )
+                                .await;
+                        }
+                        if !resp.headers.contains_key("mcp-protocol-version") {
+                            let protocol_version = response_protocol_version
+                                .as_deref()
+                                .or(incoming_protocol_version.as_deref())
+                                .or(active_mcp_session
+                                    .as_ref()
+                                    .and_then(|session| session.protocol_version.as_deref()))
+                                .unwrap_or(REBALANCE_MCP_PROTOCOL_VERSION_DEFAULT);
+                            if let Ok(value) = ReqHeaderValue::from_str(protocol_version) {
+                                resp.headers
+                                    .insert(HeaderName::from_static("mcp-protocol-version"), value);
                             }
                         }
                     }

--- a/src/server/proxy/rebalance_handlers.rs
+++ b/src/server/proxy/rebalance_handlers.rs
@@ -33,7 +33,7 @@ async fn handle_rebalance_mcp_single_message(
             Some("invalid_jsonrpc_request"),
         )
         .await;
-        return Ok(proxy_response_with_json_body(
+        return Ok(proxy_response_with_mcp_body(
             StatusCode::BAD_REQUEST,
             body,
             request_log_id,
@@ -58,7 +58,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::OK,
                 body,
                 request_log_id,
@@ -79,7 +79,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::ACCEPTED,
                 body,
                 request_log_id,
@@ -100,7 +100,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::OK,
                 body,
                 request_log_id,
@@ -121,7 +121,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::OK,
                 body,
                 request_log_id,
@@ -142,7 +142,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::OK,
                 body,
                 request_log_id,
@@ -163,7 +163,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::OK,
                 body,
                 request_log_id,
@@ -184,7 +184,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::OK,
                 body,
                 request_log_id,
@@ -193,9 +193,8 @@ async fn handle_rebalance_mcp_single_message(
         "tools/call" => {
             let params = message.get("params").and_then(Value::as_object);
             let Some(params) = params else {
-                let body = build_rebalance_mcp_error_body(
+                let body = build_rebalance_mcp_tool_error_result_body(
                     response_id,
-                    -32602,
                     "Invalid tools/call params",
                 );
                 let request_log_id = log_rebalance_local_control_plane_response(
@@ -204,15 +203,15 @@ async fn handle_rebalance_mcp_single_message(
                     method,
                     path,
                     message_body,
-                    StatusCode::BAD_REQUEST,
+                    StatusCode::OK,
                     &body,
                     proxy_session_id,
                     routing_subject_hash,
                     Some("invalid_tool_params"),
                 )
                 .await;
-                return Ok(proxy_response_with_json_body(
-                    StatusCode::BAD_REQUEST,
+                return Ok(proxy_response_with_mcp_body(
+                    StatusCode::OK,
                     body,
                     request_log_id,
                 ));
@@ -222,22 +221,23 @@ async fn handle_rebalance_mcp_single_message(
                 .and_then(Value::as_str)
                 .unwrap_or_default();
             let Some(tool) = rebalance_mcp_tool_definition_by_name(tool_name) else {
-                let body = build_rebalance_mcp_error_body(response_id, -32601, "Unknown tool");
+                let message = format!("Not found: Unknown tool: '{tool_name}'");
+                let body = build_rebalance_mcp_tool_error_result_body(response_id, &message);
                 let request_log_id = log_rebalance_local_control_plane_response(
                     state,
                     token_id,
                     method,
                     path,
                     message_body,
-                    StatusCode::NOT_FOUND,
+                    StatusCode::OK,
                     &body,
                     proxy_session_id,
                     routing_subject_hash,
                     Some("unknown_tool"),
                 )
                 .await;
-                return Ok(proxy_response_with_json_body(
-                    StatusCode::NOT_FOUND,
+                return Ok(proxy_response_with_mcp_body(
+                    StatusCode::OK,
                     body,
                     request_log_id,
                 ));
@@ -245,22 +245,22 @@ async fn handle_rebalance_mcp_single_message(
             let options = match validate_rebalance_mcp_tool_arguments(tool, params.get("arguments")) {
                 Ok(arguments) => arguments,
                 Err(message) => {
-                    let body = build_rebalance_mcp_error_body(response_id, -32602, &message);
+                    let body = build_rebalance_mcp_tool_error_result_body(response_id, &message);
                     let request_log_id = log_rebalance_local_control_plane_response(
                         state,
                         token_id,
                         method,
                         path,
                         message_body,
-                        StatusCode::BAD_REQUEST,
+                        StatusCode::OK,
                         &body,
                         proxy_session_id,
                         routing_subject_hash,
                         Some("invalid_tool_arguments"),
                     )
                     .await;
-                    return Ok(proxy_response_with_json_body(
-                        StatusCode::BAD_REQUEST,
+                    return Ok(proxy_response_with_mcp_body(
+                        StatusCode::OK,
                         body,
                         request_log_id,
                     ));
@@ -374,7 +374,7 @@ async fn handle_rebalance_mcp_single_message(
                 None,
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::ACCEPTED,
                 body,
                 request_log_id,
@@ -395,7 +395,7 @@ async fn handle_rebalance_mcp_single_message(
                 Some("method_not_found"),
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::NOT_FOUND,
                 body,
                 request_log_id,
@@ -451,7 +451,7 @@ async fn handle_rebalance_mcp_request_body(
                     Some("invalid_jsonrpc_request"),
                 )
                 .await;
-                return Ok(proxy_response_with_json_body(
+                return Ok(proxy_response_with_mcp_body(
                     StatusCode::BAD_REQUEST,
                     body,
                     request_log_id,
@@ -478,7 +478,8 @@ async fn handle_rebalance_mcp_request_body(
                 .await?;
 
                 if !response.body.is_empty()
-                    && let Ok(value) = serde_json::from_slice::<Value>(&response.body)
+                    && let Some(value) = parse_mcp_sse_message_body(&response.body)
+                        .or_else(|| serde_json::from_slice::<Value>(&response.body).ok())
                 {
                     responses.push(value);
                 }
@@ -489,14 +490,14 @@ async fn handle_rebalance_mcp_request_body(
                 let request_log_id = last_response
                     .as_ref()
                     .and_then(|response| response.request_log_id);
-                return Ok(proxy_response_with_json_body(
+                return Ok(proxy_response_with_mcp_body(
                     StatusCode::ACCEPTED,
                     Vec::new(),
                     request_log_id,
                 ));
             }
 
-            let mut aggregated = proxy_response_with_json_body(
+            let mut aggregated = proxy_response_with_mcp_body(
                 StatusCode::OK,
                 serde_json::to_vec(&Value::Array(responses))
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
@@ -530,7 +531,7 @@ async fn handle_rebalance_mcp_request_body(
                 Some("invalid_jsonrpc_request"),
             )
             .await;
-            Ok(proxy_response_with_json_body(
+            Ok(proxy_response_with_mcp_body(
                 StatusCode::BAD_REQUEST,
                 body,
                 request_log_id,
@@ -623,4 +624,3 @@ async fn mcp_subpath_reject_handler(
         .body(Body::from(response_body.to_vec()))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
-

--- a/src/server/tests/chunk_11.rs
+++ b/src/server/tests/chunk_11.rs
@@ -1,3 +1,21 @@
+    fn decode_sse_json_text(text: &str) -> Value {
+        if let Ok(value) = serde_json::from_str::<Value>(text) {
+            return value;
+        }
+        let data = text
+            .lines()
+            .find_map(|line| line.strip_prefix("data:").map(str::trim))
+            .unwrap_or_else(|| panic!("SSE response should include a data line, got: {text}"));
+        serde_json::from_str(data).unwrap_or_else(|err| {
+            panic!("SSE data line should decode as JSON: {err}; data: {data}")
+        })
+    }
+
+    async fn decode_sse_json_response(response: reqwest::Response) -> Value {
+        let text = response.text().await.expect("read SSE response body");
+        decode_sse_json_text(&text)
+    }
+
     #[tokio::test]
     async fn mcp_primary_rebind_only_revokes_sessions_on_the_old_key() {
         let db_path = temp_db_path("mcp-session-rebind-scoped");
@@ -1187,10 +1205,24 @@
             .and_then(|value| value.to_str().ok())
             .expect("initialize response should expose mcp-session-id")
             .to_string();
-        let initialize_body: Value = initialize
-            .json()
-            .await
-            .expect("decode rebalance initialize response");
+        assert_eq!(
+            initialize
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("text/event-stream")),
+            Some(true),
+            "rebalance initialize should use official-style SSE transport"
+        );
+        let initialize_body = decode_sse_json_response(initialize).await;
+        assert_eq!(
+            initialize_body["result"]["serverInfo"],
+            json!({
+                "name": "tavily-mcp",
+                "version": "3.2.4"
+            }),
+            "rebalance initialize should match the official Remote MCP serverInfo snapshot"
+        );
         assert_eq!(
             initialize_body["result"]["capabilities"]["prompts"]["listChanged"].as_bool(),
             Some(false),
@@ -1208,7 +1240,6 @@
             .header("accept", "application/json, text/event-stream")
             .header("content-type", "application/json")
             .header("mcp-protocol-version", "2025-03-26")
-            .header("mcp-session-id", proxy_session_id.as_str())
             .json(&json!({
                 "jsonrpc": "2.0",
                 "id": "rebalance-tools-list",
@@ -1218,7 +1249,16 @@
             .await
             .expect("tools/list request");
         assert_eq!(tools_list.status(), StatusCode::OK);
-        let body: Value = tools_list.json().await.expect("decode tools/list response");
+        assert_eq!(
+            tools_list
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("text/event-stream")),
+            Some(true),
+            "rebalance tools/list should use official-style SSE transport"
+        );
+        let body = decode_sse_json_response(tools_list).await;
         assert_eq!(
             body["result"]["tools"].as_array().map(Vec::len),
             Some(5),
@@ -1234,84 +1274,119 @@
                 Some((name, tool))
             })
             .collect::<std::collections::HashMap<_, _>>();
+        let prop_keys = |name: &str| {
+            let mut keys = tool_by_name[name]["inputSchema"]["properties"]
+                .as_object()
+                .expect("schema properties object")
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>();
+            keys.sort();
+            keys
+        };
         assert_eq!(
-            tool_by_name
-                .get("tavily_search")
-                .and_then(|tool| tool.get("inputSchema")),
-            Some(&json!({
-                "type": "object",
-                "properties": {
-                    "query": { "type": "string" }
-                },
-                "required": ["query"],
-                "additionalProperties": true
-            })),
-            "rebalance search schema should advertise required query"
+            prop_keys("tavily_search"),
+            vec![
+                "country",
+                "end_date",
+                "exact_match",
+                "exclude_domains",
+                "include_domains",
+                "include_favicon",
+                "include_image_descriptions",
+                "include_images",
+                "include_raw_content",
+                "max_results",
+                "query",
+                "search_depth",
+                "start_date",
+                "time_range",
+                "topic",
+            ],
+            "rebalance search schema should match the official field set"
         );
         assert_eq!(
-            tool_by_name
-                .get("tavily_extract")
-                .and_then(|tool| tool.get("inputSchema")),
-            Some(&json!({
-                "type": "object",
-                "properties": {
-                    "urls": {
-                        "oneOf": [
-                            { "type": "string" },
-                            {
-                                "type": "array",
-                                "items": { "type": "string" }
-                            }
-                        ]
-                    }
-                },
-                "required": ["urls"],
-                "additionalProperties": true
-            })),
-            "rebalance extract schema should advertise required urls"
+            prop_keys("tavily_extract"),
+            vec![
+                "extract_depth",
+                "format",
+                "include_favicon",
+                "include_images",
+                "query",
+                "urls",
+            ],
+            "rebalance extract schema should match the official field set"
         );
         assert_eq!(
-            tool_by_name
-                .get("tavily_crawl")
-                .and_then(|tool| tool.get("inputSchema")),
-            Some(&json!({
-                "type": "object",
-                "properties": {
-                    "url": { "type": "string" }
-                },
-                "required": ["url"],
-                "additionalProperties": true
-            })),
-            "rebalance crawl schema should advertise required url"
+            prop_keys("tavily_crawl"),
+            vec![
+                "allow_external",
+                "extract_depth",
+                "format",
+                "include_favicon",
+                "instructions",
+                "limit",
+                "max_breadth",
+                "max_depth",
+                "select_domains",
+                "select_paths",
+                "url",
+            ],
+            "rebalance crawl schema should match the official field set"
         );
         assert_eq!(
-            tool_by_name
-                .get("tavily_map")
-                .and_then(|tool| tool.get("inputSchema")),
-            Some(&json!({
-                "type": "object",
-                "properties": {
-                    "url": { "type": "string" }
-                },
-                "required": ["url"],
-                "additionalProperties": true
-            })),
-            "rebalance map schema should advertise required url"
+            prop_keys("tavily_map"),
+            vec![
+                "allow_external",
+                "instructions",
+                "limit",
+                "max_breadth",
+                "max_depth",
+                "select_domains",
+                "select_paths",
+                "url",
+            ],
+            "rebalance map schema should match the official field set"
         );
         assert_eq!(
-            tool_by_name
-                .get("tavily_research")
-                .and_then(|tool| tool.get("inputSchema")),
-            Some(&json!({
-                "type": "object",
-                "properties": {
-                    "input": { "type": "string" }
-                },
-                "required": ["input"],
-                "additionalProperties": true
-            })),
-            "rebalance research schema should advertise required input"
+            prop_keys("tavily_research"),
+            vec!["input", "model"],
+            "rebalance research schema should match the official field set"
         );
+        for (name, required) in [
+            ("tavily_search", "query"),
+            ("tavily_extract", "urls"),
+            ("tavily_crawl", "url"),
+            ("tavily_map", "url"),
+            ("tavily_research", "input"),
+        ] {
+            assert_eq!(
+                tool_by_name[name]["inputSchema"]["required"],
+                json!([required]),
+                "{name} should keep the official required field"
+            );
+        }
+
+        let ping = client
+            .post(&url)
+            .header("accept", "application/json, text/event-stream")
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "rebalance-ping-no-session",
+                "method": "ping"
+            }))
+            .send()
+            .await
+            .expect("ping request");
+        assert_eq!(
+            ping.status(),
+            StatusCode::OK,
+            "rebalance ping follow-up should not require mcp-session-id"
+        );
+        let ping_body = decode_sse_json_response(ping).await;
+        assert_eq!(ping_body["result"], json!({}));
 
         let recorded = seen
             .lock()
@@ -1351,6 +1426,134 @@
         assert_eq!(
             row.try_get::<Option<String>, _>("upstream_key_id").unwrap(),
             None
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn mcp_rebalance_no_session_follow_up_does_not_bypass_active_control_session() {
+        let db_path = temp_db_path("mcp-rebalance-no-session-mixed-control");
+        let db_str = db_path.to_string_lossy().to_string();
+        let expected_api_key = "tvly-rebalance-no-session-mixed-control";
+        let (upstream_addr, calls) =
+            spawn_mock_mcp_upstream_for_session_headers(vec![expected_api_key.to_string()]).await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        proxy
+            .set_system_settings(&tavily_hikari::SystemSettings {
+                request_rate_limit: request_rate_limit(),
+                mcp_session_affinity_key_count: 5,
+                rebalance_mcp_enabled: false,
+                rebalance_mcp_session_percent: 0,
+                user_blocked_key_base_limit: 7,
+            })
+            .await
+            .expect("disable rebalance mcp");
+        let access_token = proxy
+            .create_access_token(Some("mcp-rebalance-no-session-mixed-control"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+        let client = Client::new();
+
+        let control_initialize = client
+            .post(&url)
+            .header("accept", "application/json, text/event-stream")
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "control-init",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("control initialize request");
+        assert_eq!(control_initialize.status(), StatusCode::OK);
+        assert!(
+            control_initialize.headers().get("mcp-session-id").is_some(),
+            "control initialize should create an upstream-backed proxy session"
+        );
+
+        proxy
+            .set_system_settings(&tavily_hikari::SystemSettings {
+                request_rate_limit: request_rate_limit(),
+                mcp_session_affinity_key_count: 5,
+                rebalance_mcp_enabled: true,
+                rebalance_mcp_session_percent: 100,
+                user_blocked_key_base_limit: 7,
+            })
+            .await
+            .expect("enable rebalance mcp");
+        let rebalance_initialize = client
+            .post(&url)
+            .header("accept", "application/json, text/event-stream")
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "rebalance-init-after-control",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {}
+                }
+            }))
+            .send()
+            .await
+            .expect("rebalance initialize request");
+        assert_eq!(rebalance_initialize.status(), StatusCode::OK);
+        assert!(
+            rebalance_initialize.headers().get("mcp-session-id").is_some(),
+            "rebalance initialize should create a local proxy session"
+        );
+
+        let missing_session = client
+            .post(&url)
+            .header("accept", "application/json, text/event-stream")
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-03-26")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "ambiguous-tools-list",
+                "method": "tools/list"
+            }))
+            .send()
+            .await
+            .expect("headerless tools/list request");
+        assert_eq!(
+            missing_session.status(),
+            StatusCode::BAD_REQUEST,
+            "headerless follow-up should not bypass an active control session on the same token"
+        );
+        let body = decode_sse_json_response(missing_session).await;
+        assert_eq!(
+            body.get("error").and_then(Value::as_str),
+            Some("session_required")
+        );
+
+        let recorded = calls
+            .lock()
+            .expect("session header calls lock poisoned")
+            .clone();
+        assert_eq!(
+            recorded.iter().filter(|call| call.method == "initialize").count(),
+            1,
+            "only the control initialize should hit upstream /mcp"
         );
 
         let _ = std::fs::remove_file(db_path);
@@ -1446,10 +1649,7 @@
                 StatusCode::OK,
                 "{method_name} should succeed under rebalance parity"
             );
-            let body: Value = response
-                .json()
-                .await
-                .unwrap_or_else(|err| panic!("decode {method_name} response: {err}"));
+            let body = decode_sse_json_response(response).await;
             assert_eq!(
                 body["result"][expected_field].as_array().map(Vec::len),
                 Some(0),
@@ -1465,6 +1665,29 @@
             recorded.is_empty(),
             "initialize + prompts/resources parity methods should stay local under rebalance mode"
         );
+
+        let pool = connect_sqlite_test_pool(&db_str).await;
+        let rows = sqlx::query(
+            r#"
+            SELECT proxy_session_id
+            FROM request_logs
+            WHERE path = '/mcp'
+            ORDER BY id ASC
+            "#,
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("fetch rebalance control-plane request logs");
+        assert_eq!(rows.len(), 4, "initialize plus three list calls should be logged");
+        for row in rows {
+            assert_eq!(
+                row.try_get::<Option<String>, _>("proxy_session_id")
+                    .unwrap()
+                    .as_deref(),
+                Some(proxy_session_id.as_str()),
+                "stateful rebalance requests must preserve proxy session attribution"
+            );
+        }
 
         let _ = std::fs::remove_file(db_path);
     }
@@ -1535,7 +1758,6 @@
             .header("accept", "application/json, text/event-stream")
             .header("content-type", "application/json")
             .header("mcp-protocol-version", "2025-03-26")
-            .header("mcp-session-id", proxy_session_id.as_str())
             .header("x-forwarded-for", "198.51.100.1")
             .header("cookie", "session=should-not-leak")
             .header("sec-fetch-mode", "cors")
@@ -1555,7 +1777,16 @@
             .await
             .expect("rebalance search request");
         assert_eq!(search.status(), StatusCode::OK);
-        let body: Value = search.json().await.expect("decode rebalance search body");
+        assert_eq!(
+            search
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("text/event-stream")),
+            Some(true),
+            "rebalance tools/call should use official-style SSE transport"
+        );
+        let body = decode_sse_json_response(search).await;
         assert_eq!(
             body["result"]["structuredContent"]["usage"]["credits"].as_i64(),
             Some(1)
@@ -1774,10 +2005,7 @@
             .await
             .expect("rebalance search request");
         assert_eq!(search.status(), StatusCode::OK);
-        let body: Value = search
-            .json()
-            .await
-            .expect("decode rebalance error response");
+        let body = decode_sse_json_response(search).await;
         assert_eq!(body["result"]["isError"].as_bool(), Some(true));
         assert!(
             body["result"]["content"].is_array(),
@@ -1840,7 +2068,7 @@
             .await
             .expect("parse-error request");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body: Value = response.json().await.expect("decode parse-error body");
+        let body = decode_sse_json_response(response).await;
         assert_eq!(body["error"]["code"].as_i64(), Some(-32700));
         assert_eq!(body["error"]["message"].as_str(), Some("Parse error"));
 
@@ -1900,7 +2128,7 @@
             .await
             .expect("empty-batch request");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body: Value = response.json().await.expect("decode empty-batch body");
+        let body = decode_sse_json_response(response).await;
         assert_eq!(body["error"]["code"].as_i64(), Some(-32600));
         assert_eq!(body["error"]["message"].as_str(), Some("Invalid Request"));
 
@@ -1983,10 +2211,7 @@
             .await
             .expect("response-only batch request");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body: Value = response
-            .json()
-            .await
-            .expect("decode response-only batch body");
+        let body = decode_sse_json_response(response).await;
         assert_eq!(body["error"]["code"].as_i64(), Some(-32600));
 
         let recorded = seen

--- a/src/server/tests/chunk_11.rs
+++ b/src/server/tests/chunk_11.rs
@@ -2068,6 +2068,15 @@
             .await
             .expect("parse-error request");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("text/event-stream")),
+            Some(true),
+            "rebalance parse errors should use official-style SSE transport"
+        );
         let body = decode_sse_json_response(response).await;
         assert_eq!(body["error"]["code"].as_i64(), Some(-32700));
         assert_eq!(body["error"]["message"].as_str(), Some("Parse error"));
@@ -2128,6 +2137,15 @@
             .await
             .expect("empty-batch request");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("text/event-stream")),
+            Some(true),
+            "rebalance empty batch errors should use official-style SSE transport"
+        );
         let body = decode_sse_json_response(response).await;
         assert_eq!(body["error"]["code"].as_i64(), Some(-32600));
         assert_eq!(body["error"]["message"].as_str(), Some("Invalid Request"));
@@ -2211,6 +2229,15 @@
             .await
             .expect("response-only batch request");
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.starts_with("text/event-stream")),
+            Some(true),
+            "rebalance invalid JSON-RPC shape errors should use official-style SSE transport"
+        );
         let body = decode_sse_json_response(response).await;
         assert_eq!(body["error"]["code"].as_i64(), Some(-32600));
 

--- a/src/server/tests/chunk_12.rs
+++ b/src/server/tests/chunk_12.rs
@@ -1558,19 +1558,20 @@
                 .unwrap_or_else(|err| panic!("{case_id} request should complete: {err}"));
             assert_eq!(
                 response.status(),
-                StatusCode::BAD_REQUEST,
-                "{case_id} should be rejected locally"
+                StatusCode::OK,
+                "{case_id} should return an official-style tool error envelope"
             );
-            let body: Value = response
-                .json()
-                .await
-                .unwrap_or_else(|err| panic!("{case_id} response should decode: {err}"));
+            let body = decode_sse_json_response(response).await;
             assert_eq!(
-                body["error"]["code"].as_i64(),
-                Some(-32602),
-                "{case_id} should return invalid params"
+                body["result"]["isError"].as_bool(),
+                Some(true),
+                "{case_id} should return result.isError=true"
             );
-            let message = body["error"]["message"]
+            assert!(
+                body["result"]["content"].as_array().is_some(),
+                "{case_id} should return a content array"
+            );
+            let message = body["result"]["content"][0]["text"]
                 .as_str()
                 .unwrap_or_else(|| panic!("{case_id} should include error message"));
             assert!(
@@ -1608,8 +1609,8 @@
         for row in rows.iter().skip(1) {
             assert_eq!(
                 row.try_get::<Option<i64>, _>("status_code").unwrap(),
-                Some(400),
-                "invalid tool arguments should log bad request status"
+                Some(200),
+                "invalid tool arguments should log official-style HTTP 200 status"
             );
             assert_eq!(
                 row.try_get::<Option<String>, _>("failure_kind")
@@ -1718,10 +1719,13 @@
             .send()
             .await
             .expect("unknown tool request");
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        let body: Value = response.json().await.expect("decode unknown tool response");
-        assert_eq!(body["error"]["code"].as_i64(), Some(-32601));
-        assert_eq!(body["error"]["message"].as_str(), Some("Unknown tool"));
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = decode_sse_json_response(response).await;
+        assert_eq!(body["result"]["isError"].as_bool(), Some(true));
+        assert_eq!(
+            body["result"]["content"][0]["text"].as_str(),
+            Some("Not found: Unknown tool: 'totally_not_real'")
+        );
 
         let recorded = seen
             .lock()
@@ -1747,8 +1751,8 @@
         .expect("fetch unknown tool request log");
         assert_eq!(
             row.try_get::<Option<i64>, _>("status_code").unwrap(),
-            Some(404),
-            "unknown tool should log not found status"
+            Some(200),
+            "unknown tool should log official-style HTTP 200 status"
         );
         assert_eq!(
             row.try_get::<Option<String>, _>("failure_kind")
@@ -1840,18 +1844,15 @@
             response.headers().get("mcp-session-id").is_some(),
             "initialize batch should still mint a proxy mcp-session-id"
         );
-        let body: Value = response
-            .json()
-            .await
-            .expect("decode initialize batch response");
+        let body = decode_sse_json_response(response).await;
         let items = body
             .as_array()
             .expect("initialize batch should return a JSON-RPC array");
         assert_eq!(items.len(), 2, "initialize batch should return two responses");
         assert_eq!(
-            items[1]["error"]["code"].as_i64(),
-            Some(-32602),
-            "invalid rebalance tool args should be rejected by the local facade even in an initialize batch"
+            items[1]["result"]["isError"].as_bool(),
+            Some(true),
+            "invalid rebalance tool args should return an official-style tool error even in an initialize batch"
         );
 
         let recorded = seen

--- a/src/store/key_store_keys.rs
+++ b/src/store/key_store_keys.rs
@@ -2247,6 +2247,96 @@ impl KeyStore {
         }))
     }
 
+    pub(crate) async fn get_latest_active_mcp_session_for_token(
+        &self,
+        token_id: &str,
+        now: i64,
+    ) -> Result<Option<McpSessionBinding>, ProxyError> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                proxy_session_id,
+                upstream_session_id,
+                upstream_key_id,
+                auth_token_id,
+                user_id,
+                protocol_version,
+                last_event_id,
+                gateway_mode,
+                experiment_variant,
+                ab_bucket,
+                routing_subject_hash,
+                fallback_reason,
+                rate_limited_until,
+                last_rate_limited_at,
+                last_rate_limit_reason,
+                created_at,
+                updated_at,
+                expires_at,
+                revoked_at,
+                revoke_reason
+            FROM mcp_sessions
+            WHERE auth_token_id = ?
+              AND revoked_at IS NULL
+              AND expires_at > ?
+            ORDER BY updated_at DESC, expires_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(token_id)
+        .bind(now)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|row| McpSessionBinding {
+            proxy_session_id: row.get("proxy_session_id"),
+            upstream_session_id: row.get("upstream_session_id"),
+            upstream_key_id: row.get("upstream_key_id"),
+            auth_token_id: row.get("auth_token_id"),
+            user_id: row.get("user_id"),
+            protocol_version: row.get("protocol_version"),
+            last_event_id: row.get("last_event_id"),
+            gateway_mode: row.get("gateway_mode"),
+            experiment_variant: row.get("experiment_variant"),
+            ab_bucket: row.get("ab_bucket"),
+            routing_subject_hash: row.get("routing_subject_hash"),
+            fallback_reason: row.get("fallback_reason"),
+            rate_limited_until: row.get("rate_limited_until"),
+            last_rate_limited_at: row.get("last_rate_limited_at"),
+            last_rate_limit_reason: row.get("last_rate_limit_reason"),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+            expires_at: row.get("expires_at"),
+            revoked_at: row.get("revoked_at"),
+            revoke_reason: row.get("revoke_reason"),
+        }))
+    }
+
+    pub(crate) async fn has_active_non_rebalance_mcp_session_for_token(
+        &self,
+        token_id: &str,
+        now: i64,
+    ) -> Result<bool, ProxyError> {
+        let exists: i64 = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM mcp_sessions
+                WHERE auth_token_id = ?
+                  AND gateway_mode <> ?
+                  AND revoked_at IS NULL
+                  AND expires_at > ?
+            )
+            "#,
+        )
+        .bind(token_id)
+        .bind(MCP_GATEWAY_MODE_REBALANCE)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists != 0)
+    }
+
     pub(crate) async fn touch_mcp_session(
         &self,
         proxy_session_id: &str,

--- a/src/tavily_proxy/proxy_http_and_logs.rs
+++ b/src/tavily_proxy/proxy_http_and_logs.rs
@@ -514,6 +514,14 @@ impl TavilyProxy {
         })
     }
 
+    fn wrap_rebalance_mcp_sse_message_body(body: &[u8]) -> Bytes {
+        if body.is_empty() {
+            return Bytes::new();
+        }
+        let payload = String::from_utf8_lossy(body);
+        Bytes::from(format!("event: message\ndata: {payload}\n\n"))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn proxy_rebalance_mcp_http_json_endpoint(
         &self,
@@ -656,13 +664,14 @@ impl TavilyProxy {
                 let mut headers = HeaderMap::new();
                 headers.insert(
                     reqwest::header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/json; charset=utf-8"),
+                    HeaderValue::from_static("text/event-stream"),
                 );
+                let response_body = Self::wrap_rebalance_mcp_sse_message_body(&response_body);
 
                 Ok(ProxyResponse {
                     status: StatusCode::OK,
                     headers,
-                    body: Bytes::from(response_body),
+                    body: response_body,
                     api_key_id: Some(lease.id),
                     request_log_id: Some(request_log_id),
                     key_effect_code: key_effect.code,
@@ -716,12 +725,13 @@ impl TavilyProxy {
                 let mut headers = HeaderMap::new();
                 headers.insert(
                     reqwest::header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/json; charset=utf-8"),
+                    HeaderValue::from_static("text/event-stream"),
                 );
+                let response_body = Self::wrap_rebalance_mcp_sse_message_body(&response_body);
                 Ok(ProxyResponse {
                     status: StatusCode::OK,
                     headers,
-                    body: Bytes::from(response_body),
+                    body: response_body,
                     api_key_id: Some(lease.id),
                     request_log_id: Some(request_log_id),
                     key_effect_code: KEY_EFFECT_NONE.to_string(),
@@ -925,13 +935,14 @@ impl TavilyProxy {
                 let mut headers = HeaderMap::new();
                 headers.insert(
                     reqwest::header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/json; charset=utf-8"),
+                    HeaderValue::from_static("text/event-stream"),
                 );
+                let response_body = Self::wrap_rebalance_mcp_sse_message_body(&response_body);
 
                 Ok(ProxyResponse {
                     status: StatusCode::OK,
                     headers,
-                    body: Bytes::from(response_body),
+                    body: response_body,
                     api_key_id: Some(lease.id),
                     request_log_id: Some(request_log_id),
                     key_effect_code: key_effect.code,
@@ -985,12 +996,13 @@ impl TavilyProxy {
                 let mut headers = HeaderMap::new();
                 headers.insert(
                     reqwest::header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/json; charset=utf-8"),
+                    HeaderValue::from_static("text/event-stream"),
                 );
+                let response_body = Self::wrap_rebalance_mcp_sse_message_body(&response_body);
                 Ok(ProxyResponse {
                     status: StatusCode::OK,
                     headers,
-                    body: Bytes::from(response_body),
+                    body: response_body,
                     api_key_id: Some(lease.id),
                     request_log_id: Some(request_log_id),
                     key_effect_code: KEY_EFFECT_NONE.to_string(),

--- a/src/tavily_proxy/proxy_request_limits.rs
+++ b/src/tavily_proxy/proxy_request_limits.rs
@@ -617,6 +617,24 @@ impl TavilyProxy {
             .await
     }
 
+    pub async fn token_has_active_non_rebalance_mcp_session(
+        &self,
+        token_id: &str,
+    ) -> Result<bool, ProxyError> {
+        self.key_store
+            .has_active_non_rebalance_mcp_session_for_token(token_id, Utc::now().timestamp())
+            .await
+    }
+
+    pub async fn latest_active_mcp_session_for_token(
+        &self,
+        token_id: &str,
+    ) -> Result<Option<McpSessionBinding>, ProxyError> {
+        self.key_store
+            .get_latest_active_mcp_session_for_token(token_id, Utc::now().timestamp())
+            .await
+    }
+
     pub async fn create_mcp_session(
         &self,
         upstream_session_id: &str,


### PR DESCRIPTION
## Summary
- Align Rebalance MCP local facade responses with official Remote MCP SSE transport and `tavily-mcp` initialize metadata.
- Allow Rebalance follow-up requests without `mcp-session-id` while preserving upstream/control-session rejection semantics.
- Lock Tavily tool schema field sets to the approved official `tavily-mcp v3.2.4` snapshot and return tool failures as HTTP 200 `result.isError=true` envelopes.
- Preserve Hikari HTTP key-pool selection, request diagnostics, and forbidden-header stripping for Tavily tool calls.

## Validation
- `cargo test mcp_rebalance_ -- --nocapture`
- `cargo test -- --test-threads=1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `codex -m gpt-5.5 -c model_reasoning_effort="low" -s read-only -a never review --base origin/main` (no findings)
- Approved official comparison against `https://mcp.tavily.com/mcp/` using a redacted Tavily key; evidence recorded in the spec only as behavior, not secrets.

Note: default parallel `cargo test` hit a transient existing `forward_proxy::tests::retired_handle_cleanup_does_not_restart_shared_process_after_crash` race; the same test passed standalone and the full suite passed with `--test-threads=1`.

## References
- Specs: `docs/specs/xm3dh-rebalance-mcp-gateway/SPEC.md`
- Solutions: -
- Project Docs: none

## Rollout
- No automatic production rollout. Existing operator-controlled Rebalance MCP settings remain the switch.