### PR TITLE
fix(admin): contain sqlite-heavy management reads

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -1,0 +1,72 @@
+---
+title: SQLite admin read containment
+module: tavily-hikari
+problem_type: production_slow_queries
+component: sqlite-admin-reads
+tags:
+  - sqlite
+  - admin
+  - performance
+  - operations
+status: active
+related_specs:
+  - docs/specs/ev4td-admin-recent-requests-performance-copy/SPEC.md
+  - docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md
+---
+
+# SQLite admin read containment
+
+## Context
+
+Tavily Hikari uses SQLite for request logs, token logs, API key metrics, user management, and
+dashboard admin reads. When the database grows, admin endpoints that aggregate facets or scan wide
+history can occupy the limited `sqlx-sqlite` worker pool and make unrelated admin endpoints wait.
+
+## Symptoms
+
+- `sqlx-sqlite` worker threads stay at high CPU.
+- Admin endpoints such as `/api/logs`, `/api/logs/catalog`, `/api/users`, `/api/tokens`,
+  `/api/keys`, `/api/stats/forward-proxy`, and `/api/dashboard/overview` move from sub-second to
+  seconds or minutes.
+- Logs may include `database is locked` while health checks still look normal.
+
+## Root Cause
+
+The risky pattern is not a single slow query. It is a combination of unbounded or repeated admin
+reads:
+
+- catalog facets scanning request log history after every cache invalidation,
+- legacy list pages selecting request/response bodies by default,
+- repeated window stats over the same source table,
+- multiple heavy admin reads running concurrently against the same SQLite worker pool.
+
+## Resolution
+
+- Default global request-log list and catalog reads to the configured retention window.
+- Keep request/response bodies out of list rows; fetch bodies only from scoped detail endpoints or
+  explicit diagnostic paths.
+- Treat hot-write catalog invalidation as a load amplifier. Prefer short TTL caches for unfiltered
+  catalog scopes, and invalidate on structural deletes such as request-log GC.
+- Use a bounded admin heavy-read semaphore around facet catalogs, legacy page queries, user/token
+  lists, key list facets, and similar management reads.
+- Recheck cache after acquiring the semaphore so concurrent cache misses collapse into one heavy
+  query.
+- Replace repeated window scans with a single bounded scan that derives all needed windows.
+
+## Guardrails / Reuse Notes
+
+- Do not fix SQLite worker saturation by increasing the worker pool first; that often makes the
+  database do more concurrent work and increases lock pressure.
+- New admin list endpoints should define a default time window or a small page/cursor contract
+  before adding totals and facets.
+- If a list hides bodies, compute canonical request kind and operational metadata in SQL before
+  mapping rows, otherwise legacy rows that need body inspection can be misclassified.
+- Production stop-the-bleed actions such as single-container restart are live changes and require
+  explicit owner approval.
+
+## References
+
+- `src/store/key_store_request_logs_and_dashboard.rs`
+- `src/store/key_store_token_logs.rs`
+- `src/store/key_store_keys.rs`
+- `src/forward_proxy/storage.rs`

--- a/docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md
+++ b/docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md
@@ -108,6 +108,8 @@
   - keys 分页 facets 聚合
   - dashboard 首屏全量 token 扫描
 - 首屏进入 dashboard 时，不应再出现两次 `/api/summary` 的并发拉取。
+- forward proxy overview / live stats 对 `forward_proxy_attempts` 的 1m / 15m / 1h / 1d / 7d 统计必须使用单次 7d bounded scan 派生所有窗口，避免同一请求重复扫描 attempts 表。
+- dashboard 与管理端列表共享 SQLite worker 时，重读接口必须使用有界并发保护，避免 dashboard overview 被其它 admin 慢查询拖入 worker 饱和。
 
 ## 验收标准
 
@@ -134,6 +136,7 @@
 - `2026-04-06`：`cd web && bun run build` 通过。
 - `2026-04-06`：`cd web && bun run build-storybook` 通过。
 - `2026-04-06`：使用当前 worktree 的 Storybook 静态预览端口 `127.0.0.1:30020` 打开 `Admin/Components/DashboardOverview/ZhDarkEvidence` iframe，确认 dashboard 总览结构、风险观察与快捷入口在轻量 overview 收敛后保持稳定。
+- `2026-04-30`：`cargo test admin_forward_proxy_settings_and_stats_endpoints_work -- --nocapture` 通过，覆盖 forward proxy stats 单次窗口集合查询后的响应结构。
 
 ## 实现里程碑
 
@@ -161,3 +164,4 @@
 - 2026-04-06: 初始化 spec，冻结 dashboard overview 轻量聚合接口、SSE payload 复用、`summary_windows` TTL 缓存与前端 dashboard bootstrap 去重的执行合同。
 - 2026-04-06: 完成 dashboard overview 聚合接口、SSE snapshot 复用、轻量风险区查询与前端 dashboard route 去重；随后将 SSE 签名轮询进一步收敛为最小触发查询，并补齐 Storybook 静态预览证据。
 - 2026-04-17: 将 `summary_windows` 与 dashboard 小时图切到 `dashboard_request_rollup_buckets`，移除 2 秒 freshness 缓存依赖，确保当前小时与本地估算额度可近实时出现在 overview / snapshot。
+- 2026-04-30: 将 forward proxy 窗口统计收敛为单次 bounded scan，并补充 admin heavy-read 并发保护，避免线上 SQLite worker 饱和时 dashboard overview 被重读拖慢。

--- a/docs/specs/ev4td-admin-recent-requests-performance-copy/SPEC.md
+++ b/docs/specs/ev4td-admin-recent-requests-performance-copy/SPEC.md
@@ -41,7 +41,7 @@
   - 新增 admin 全局 / key / token catalog 聚合查询。
 - `src/tavily_proxy/mod.rs`
   - 暴露 admin recent requests `list/catalog` 接口。
-  - 提供 30s scope 级 catalog cache，并在 request log 新写入和 `request_logs_gc` 后失效。
+  - 提供 30s scope 级 catalog cache；未过滤 catalog 以 TTL 为准，`request_logs_gc` 等结构性删除后失效，避免高流量写入持续击穿缓存。
 - `src/server/dto.rs`
   - 定义 admin list/catalog DTO 与 cursor 查询参数。
   - 新增 `/api/logs/list`、`/api/logs/catalog`、`/api/keys/:id/logs/list`、`/api/keys/:id/logs/catalog`、`/api/tokens/:id/logs/list`、`/api/tokens/:id/logs/catalog`。
@@ -119,13 +119,21 @@
   - global 带 tokens + keys
   - key scope 仅带 tokens
   - token scope 仅带 keys
-- catalog 采用 30 秒 TTL 的 scope 级缓存。
-- 新写入 request log 或执行完 `request_logs_gc` 后，cache 必须失效。
+- catalog 采用 30 秒 TTL 的 scope 级缓存；未过滤 catalog 允许最多一个 TTL 的新写入滞后。
+- 带筛选条件的 catalog 不复用未过滤 cache key，确保筛选后的 facets 可以反映当前查询条件。
+- `request_logs_gc` 等结构性日志删除执行完成后，cache 必须失效。
 
 ### Legacy compatibility
 
 - legacy `/api/logs`、`/api/keys/:id/logs/page`、`/api/tokens/:id/logs/page` 保留，避免 dashboard mini card 与非共享 consumer 在本轮受影响。
 - legacy 契约可继续返回 `total / page / facets`，但 admin 共享 recent requests 不再依赖它们。
+- legacy `/api/logs` 默认限制在 request log retention 窗口内，且默认不返回 `request_body` / `response_body`；需要 body 的管理端详情仍走 details endpoint，显式 `include_bodies=true` 仅用于兼容排障。
+
+### Slow-query containment
+
+- 日志 catalog 与 legacy page 查询共享有界 admin heavy-read semaphore，防止多个管理端重读同时占满主 SQLite worker。
+- `/api/logs/catalog`、`/api/keys/:id/logs/catalog`、`/api/tokens/:id/logs/catalog` 在获取 semaphore 后二次检查 cache，避免并发 cache miss 重复执行 facets 聚合。
+- legacy list rows 在 SQL 中投影 canonical request kind、billing group 与 operational class；即使不选择 request/response bodies，也保持筛选与视图元数据一致。
 
 ## 验收标准（Acceptance Criteria）
 
@@ -145,9 +153,13 @@
   When 使用上一页 / 下一页导航
   Then 列表使用 cursor 语义稳定翻页，且不会因为新增日志造成明显重复或漏行。
 
-- Given request log 新写入或 `request_logs_gc` 执行完成
-  When 下一次获取同 scope catalog
-  Then 返回的 retention/facets 已反映最新状态，而不是继续使用旧缓存。
+- Given request log 新写入
+  When 下一次获取同 scope 未过滤 catalog 且 TTL 未过期
+  Then 可以继续使用旧缓存，避免高流量写入持续触发全量 facets 聚合。
+
+- Given request log 新写入后使用带筛选条件的 catalog，或 `request_logs_gc` 执行完成
+  When 下一次获取对应 catalog
+  Then 筛选结果或结构性删除已反映最新状态。
 
 - Given public home / user console 渲染最近请求
   When 本轮改动合入
@@ -156,7 +168,7 @@
 ## 测试与证据
 
 - `cargo test admin_logs_cursor_and_catalog_endpoints_expose_retention_without_blocking_page_counts -- --nocapture`
-- `cargo test key_and_token_logs_catalog_scope_and_cache_invalidation_work -- --nocapture`
+- `cargo test key_and_token_logs_catalog_scope_and_cache_ttl_work -- --nocapture`
 - `cargo test admin_and_key_log_details_return_scoped_bodies_while_list_pages_keep_null_payloads -- --nocapture`
 - `cargo test token_log_details_return_linked_bodies_and_page_results_keep_null_payloads -- --nocapture`
 - `cargo clippy -- -D warnings`
@@ -198,3 +210,4 @@
 
 - 2026-04-06：admin recent requests 的 retention-aware 文案、list/catalog 拆分、cursor 分页、路由懒加载与共享 Storybook 证据已完成，PR #219 已创建进入收敛阶段。
 - 2026-04-07：PR merge gate 跟进时发现 GitHub Actions `Docs Pages` 的 `build-storybook` hosted runner 在依赖安装后、进入构建步骤前异常卡死；已将 Storybook 的 install/build 合并为同一 CI step，补上 job timeout，并改用 Node CLI 执行静态构建以降低 runner 卡死面。该 follow-up 不改变本 spec 的产品范围与验收口径。
+- 2026-04-30：线上慢查询排查显示 `/api/logs` 与 catalog facets 可在高写入下重复触发 SQLite 长读；未过滤 catalog 改为 TTL 优先、legacy logs 默认 retention-bounded 且不选 body，并为日志重读增加有界并发保护。

--- a/src/forward_proxy/responses_and_validation.rs
+++ b/src/forward_proxy/responses_and_validation.rs
@@ -6,11 +6,7 @@ pub async fn build_forward_proxy_settings_response(
     let runtime_rows = manager.snapshot_runtime();
     let counts = load_forward_proxy_assignment_counts(pool).await?;
     let now = Utc::now().timestamp();
-    let windows = [60, 15 * 60, 3600, 24 * 3600, 7 * 24 * 3600];
-    let mut window_maps = Vec::new();
-    for seconds in windows {
-        window_maps.push(query_forward_proxy_window_stats(pool, now - seconds).await?);
-    }
+    let window_maps = query_forward_proxy_window_stats_set(pool, now).await?;
     let mut nodes =
         runtime_rows
             .into_iter()
@@ -76,11 +72,7 @@ pub async fn build_forward_proxy_live_stats_response(
         .collect::<Vec<_>>();
     let counts = load_forward_proxy_assignment_counts(pool).await?;
     let now_epoch = Utc::now().timestamp();
-    let windows = [60, 15 * 60, 3600, 24 * 3600, 7 * 24 * 3600];
-    let mut window_maps = Vec::new();
-    for seconds in windows {
-        window_maps.push(query_forward_proxy_window_stats(pool, now_epoch - seconds).await?);
-    }
+    let window_maps = query_forward_proxy_window_stats_set(pool, now_epoch).await?;
     let range_end_epoch = align_bucket_epoch(now_epoch, BUCKET_SECONDS, 0) + BUCKET_SECONDS;
     let range_start_epoch = range_end_epoch - BUCKET_COUNT * BUCKET_SECONDS;
     let hourly_map =
@@ -1626,4 +1618,3 @@ fn query_flag_true(query: &HashMap<String, String>, key: &str) -> bool {
         )
     })
 }
-

--- a/src/forward_proxy/storage.rs
+++ b/src/forward_proxy/storage.rs
@@ -751,38 +751,115 @@ struct ForwardProxyWeightLastBeforeRangeRow {
     last_weight: f64,
 }
 
-async fn query_forward_proxy_window_stats(
+fn forward_proxy_attempt_window_from_row(
+    row: &sqlx::sqlite::SqliteRow,
+    attempts_col: &str,
+    success_col: &str,
+    latency_col: &str,
+) -> Result<ForwardProxyAttemptWindowStats, sqlx::Error> {
+    Ok(ForwardProxyAttemptWindowStats {
+        attempts: row.try_get(attempts_col)?,
+        success_count: row.try_get(success_col)?,
+        avg_latency_ms: row.try_get(latency_col)?,
+    })
+}
+
+async fn query_forward_proxy_window_stats_set(
     pool: &SqlitePool,
-    since_epoch: i64,
-) -> Result<HashMap<String, ForwardProxyAttemptWindowStats>, ProxyError> {
-    let rows = sqlx::query_as::<_, ForwardProxyAttemptStatsRow>(
+    now_epoch: i64,
+) -> Result<Vec<HashMap<String, ForwardProxyAttemptWindowStats>>, ProxyError> {
+    let one_minute = now_epoch - 60;
+    let fifteen_minutes = now_epoch - 15 * 60;
+    let one_hour = now_epoch - 3600;
+    let one_day = now_epoch - 24 * 3600;
+    let seven_days = now_epoch - 7 * 24 * 3600;
+    let rows = sqlx::query(
         r#"
         SELECT proxy_key,
-               COUNT(*) AS attempts,
-               SUM(CASE WHEN is_success != 0 THEN 1 ELSE 0 END) AS success_count,
-               AVG(CASE WHEN is_success != 0 THEN latency_ms END) AS avg_latency_ms
+               COUNT(*) AS attempts_7d,
+               COALESCE(SUM(CASE WHEN is_success != 0 THEN 1 ELSE 0 END), 0) AS success_count_7d,
+               AVG(CASE WHEN is_success != 0 THEN latency_ms END) AS avg_latency_ms_7d,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?1 THEN 1 ELSE 0 END), 0) AS attempts_1m,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?1 AND is_success != 0 THEN 1 ELSE 0 END), 0) AS success_count_1m,
+               AVG(CASE WHEN occurred_at >= ?1 AND is_success != 0 THEN latency_ms END) AS avg_latency_ms_1m,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?2 THEN 1 ELSE 0 END), 0) AS attempts_15m,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?2 AND is_success != 0 THEN 1 ELSE 0 END), 0) AS success_count_15m,
+               AVG(CASE WHEN occurred_at >= ?2 AND is_success != 0 THEN latency_ms END) AS avg_latency_ms_15m,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?3 THEN 1 ELSE 0 END), 0) AS attempts_1h,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?3 AND is_success != 0 THEN 1 ELSE 0 END), 0) AS success_count_1h,
+               AVG(CASE WHEN occurred_at >= ?3 AND is_success != 0 THEN latency_ms END) AS avg_latency_ms_1h,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?4 THEN 1 ELSE 0 END), 0) AS attempts_1d,
+               COALESCE(SUM(CASE WHEN occurred_at >= ?4 AND is_success != 0 THEN 1 ELSE 0 END), 0) AS success_count_1d,
+               AVG(CASE WHEN occurred_at >= ?4 AND is_success != 0 THEN latency_ms END) AS avg_latency_ms_1d
         FROM forward_proxy_attempts
-        WHERE occurred_at >= ?1
+        WHERE occurred_at >= ?5
         GROUP BY proxy_key
         "#,
     )
-    .bind(since_epoch)
+    .bind(one_minute)
+    .bind(fifteen_minutes)
+    .bind(one_hour)
+    .bind(one_day)
+    .bind(seven_days)
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|row| {
-            (
-                row.proxy_key,
-                ForwardProxyAttemptWindowStats {
-                    attempts: row.attempts,
-                    success_count: row.success_count,
-                    avg_latency_ms: row.avg_latency_ms,
-                },
-            )
-        })
-        .collect())
+    let mut windows = vec![
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
+    ];
+    for row in rows {
+        let proxy_key: String = row.try_get("proxy_key")?;
+        windows[0].insert(
+            proxy_key.clone(),
+            forward_proxy_attempt_window_from_row(
+                &row,
+                "attempts_1m",
+                "success_count_1m",
+                "avg_latency_ms_1m",
+            )?,
+        );
+        windows[1].insert(
+            proxy_key.clone(),
+            forward_proxy_attempt_window_from_row(
+                &row,
+                "attempts_15m",
+                "success_count_15m",
+                "avg_latency_ms_15m",
+            )?,
+        );
+        windows[2].insert(
+            proxy_key.clone(),
+            forward_proxy_attempt_window_from_row(
+                &row,
+                "attempts_1h",
+                "success_count_1h",
+                "avg_latency_ms_1h",
+            )?,
+        );
+        windows[3].insert(
+            proxy_key.clone(),
+            forward_proxy_attempt_window_from_row(
+                &row,
+                "attempts_1d",
+                "success_count_1d",
+                "avg_latency_ms_1d",
+            )?,
+        );
+        windows[4].insert(
+            proxy_key,
+            forward_proxy_attempt_window_from_row(
+                &row,
+                "attempts_7d",
+                "success_count_7d",
+                "avg_latency_ms_7d",
+            )?,
+        );
+    }
+    Ok(windows)
 }
 
 async fn query_forward_proxy_hourly_stats(
@@ -892,4 +969,3 @@ async fn query_forward_proxy_weight_last_before(
         .map(|row| (row.proxy_key, row.last_weight))
         .collect())
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use serde_json::Value;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::{Executor, QueryBuilder, Sqlite, SqlitePool, Transaction};
 use thiserror::Error;
-use tokio::sync::{Mutex, Notify, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock, Semaphore};
 use url::form_urlencoded;
 
 pub type ForwardProxyProgressCallback = dyn Fn(ForwardProxyProgressEvent) + Send + Sync;
@@ -536,6 +536,7 @@ const TOKEN_BINDING_CACHE_MAX_ENTRIES: usize = 10_000;
 const ACCOUNT_QUOTA_RESOLUTION_CACHE_TTL_SECS: u64 = 5;
 const ACCOUNT_QUOTA_RESOLUTION_CACHE_MAX_ENTRIES: usize = 10_000;
 const ADMIN_REQUEST_LOGS_CATALOG_CACHE_TTL_SECS: i64 = 30;
+const ADMIN_HEAVY_READ_CONCURRENCY: usize = 1;
 // Keep the lease TTL below the acquisition wait so a crashed holder can be recovered
 // by the next in-flight request instead of blocking the subject for minutes.
 const QUOTA_SUBJECT_LOCK_TTL_SECS: u64 = 20;

--- a/src/server/handlers/admin_resources/api_keys_and_logs.rs
+++ b/src/server/handlers/admin_resources/api_keys_and_logs.rs
@@ -770,6 +770,7 @@ async fn list_logs(
             operational_class,
             page,
             per_page,
+            include_bodies,
         )
         .await
         .map(|logs| {
@@ -977,4 +978,3 @@ enum AdminUsersSortDirection {
     Asc,
     Desc,
 }
-

--- a/src/server/tests/chunk_05.rs
+++ b/src/server/tests/chunk_05.rs
@@ -1662,6 +1662,7 @@
             .id;
 
         let pool = connect_sqlite_test_pool(&db_str).await;
+        let now = chrono::Utc::now().timestamp();
         sqlx::query(
             r#"
             INSERT INTO request_logs (
@@ -1690,15 +1691,15 @@
             "#,
         )
         .bind(&key_id)
-        .bind(100_i64)
+        .bind(now - 200)
         .bind(&key_id)
-        .bind(200_i64)
+        .bind(now - 150)
         .bind(&key_id)
         .bind(br#"{"jsonrpc":"2.0","id":"search-like-control-plane","method":"tools/call","params":{"name":"tavily_search","arguments":{"query":"how to initialize rust logging","search_depth":"basic"}}}"#.as_slice())
-        .bind(250_i64)
+        .bind(now - 100)
         .bind(&key_id)
         .bind(br#"[{"jsonrpc":"2.0","method":"notifications/initialized"},{"jsonrpc":"2.0","id":"mixed-batch-search","method":"tools/call","params":{"name":"tavily_search","arguments":{"query":"mixed batch should stay billable","search_depth":"basic"}}}]"#.as_slice())
-        .bind(275_i64)
+        .bind(now - 50)
         .execute(&pool)
         .await
         .expect("insert request logs");
@@ -1727,7 +1728,7 @@
         )
         .bind(&key_id)
         .bind(br#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.as_slice())
-        .bind(300_i64)
+        .bind(now - 25)
         .execute(&pool)
         .await
         .expect("insert neutral request log");
@@ -1762,7 +1763,7 @@
         .bind(
             br#"{"error":"Method Not Allowed","message":"Method Not Allowed: Session termination not supported"}"#.as_slice(),
         )
-        .bind(325_i64)
+        .bind(now)
         .execute(&pool)
         .await
         .expect("insert session delete neutral request log");
@@ -2129,6 +2130,7 @@
             .id;
 
         let pool = connect_sqlite_test_pool(&db_str).await;
+        let now = chrono::Utc::now().timestamp();
         sqlx::query(
             r#"
             INSERT INTO request_logs (
@@ -2155,14 +2157,17 @@
                 visibility,
                 created_at
             ) VALUES
-                (?, 'token-a', 'POST', '/api/tavily/search', 'q=a', 200, 200, NULL, 'success', 'api:search', 'API | search', NULL, 2, NULL, 'none', NULL, X'7B7D', X'5B5D', '[]', '[]', 'visible', 100),
-                (?, 'token-b', 'POST', '/api/tavily/search', 'q=b', 500, 500, 'boom', 'error', 'api:search', 'API | search', NULL, NULL, 'upstream_500', 'quarantined', 'The system automatically quarantined this key', X'7B7D', X'5B5D', '[]', '[]', 'visible', 200),
-                (?, 'token-c', 'POST', '/api/tavily/extract', 'q=c', 200, 200, NULL, 'success', 'api:extract', 'API | extract', NULL, 3, NULL, 'none', NULL, X'7B7D', X'5B5D', '[]', '[]', 'visible', 300)
+                (?, 'token-a', 'POST', '/api/tavily/search', 'q=a', 200, 200, NULL, 'success', 'api:search', 'API | search', NULL, 2, NULL, 'none', NULL, X'7B7D', X'5B5D', '[]', '[]', 'visible', ?),
+                (?, 'token-b', 'POST', '/api/tavily/search', 'q=b', 500, 500, 'boom', 'error', 'api:search', 'API | search', NULL, NULL, 'upstream_500', 'quarantined', 'The system automatically quarantined this key', X'7B7D', X'5B5D', '[]', '[]', 'visible', ?),
+                (?, 'token-c', 'POST', '/api/tavily/extract', 'q=c', 200, 200, NULL, 'success', 'api:extract', 'API | extract', NULL, 3, NULL, 'none', NULL, X'7B7D', X'5B5D', '[]', '[]', 'visible', ?)
             "#,
         )
         .bind(&key_id)
+        .bind(now - 2)
         .bind(&key_id)
+        .bind(now - 1)
         .bind(&key_id)
+        .bind(now)
         .execute(&pool)
         .await
         .expect("insert request logs");
@@ -2418,4 +2423,3 @@
 
         let _ = std::fs::remove_file(db_path);
     }
-

--- a/src/server/tests/chunk_06.rs
+++ b/src/server/tests/chunk_06.rs
@@ -1,5 +1,5 @@
     #[tokio::test]
-    async fn key_and_token_logs_catalog_scope_and_cache_invalidation_work() {
+    async fn key_and_token_logs_catalog_scope_and_cache_ttl_work() {
         let db_path = temp_db_path("key-token-logs-catalog");
         let db_str = db_path.to_string_lossy().to_string();
         let expected_api_key = "tvly-key-token-logs-catalog";
@@ -98,7 +98,7 @@
             .expect("search request");
         assert_eq!(search_resp.status(), reqwest::StatusCode::OK);
 
-        let key_catalog_resp = client
+        let cached_key_catalog_resp = client
             .get(format!(
                 "http://{}/api/keys/{}/logs/catalog?since=0",
                 admin_addr, key_id
@@ -106,21 +106,25 @@
             .header(reqwest::header::COOKIE, admin_cookie.clone())
             .send()
             .await
-            .expect("key catalog");
-        assert_eq!(key_catalog_resp.status(), reqwest::StatusCode::OK);
-        let key_catalog: serde_json::Value =
-            key_catalog_resp.json().await.expect("key catalog json");
+            .expect("cached key catalog");
+        assert_eq!(cached_key_catalog_resp.status(), reqwest::StatusCode::OK);
+        let cached_key_catalog: serde_json::Value = cached_key_catalog_resp
+            .json()
+            .await
+            .expect("cached key catalog json");
         assert_eq!(
-            key_catalog
+            cached_key_catalog
                 .get("retentionDays")
                 .and_then(|value| value.as_i64()),
             Some(effective_request_logs_retention_days())
         );
         assert_eq!(
-            key_catalog
-                .pointer("/facets/tokens/0/value")
-                .and_then(|value| value.as_str()),
-            Some(token.id.as_str())
+            cached_key_catalog
+                .pointer("/facets/tokens")
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(0),
+            "unfiltered key catalog should stay on its TTL cache after a hot write"
         );
         let filtered_key_catalog_resp = client
             .get(format!(
@@ -142,6 +146,12 @@
                 .and_then(|value| value.as_str()),
             Some("api:search")
         );
+        assert_eq!(
+            filtered_key_catalog
+                .pointer("/facets/tokens/0/value")
+                .and_then(|value| value.as_str()),
+            Some(token.id.as_str())
+        );
         let invalid_key_catalog_resp = client
             .get(format!(
                 "http://{}/api/keys/{}/logs/catalog?since=0&operational_class=totally-invalid",
@@ -156,7 +166,7 @@
             reqwest::StatusCode::BAD_REQUEST
         );
 
-        let token_catalog_resp = client
+        let cached_token_catalog_resp = client
             .get(format!(
                 "http://{}/api/tokens/{}/logs/catalog?since={}&until={}",
                 admin_addr,
@@ -167,22 +177,19 @@
             .header(reqwest::header::COOKIE, admin_cookie.clone())
             .send()
             .await
-            .expect("token catalog");
-        assert_eq!(token_catalog_resp.status(), reqwest::StatusCode::OK);
-        let token_catalog: serde_json::Value =
-            token_catalog_resp.json().await.expect("token catalog json");
+            .expect("cached token catalog");
+        assert_eq!(cached_token_catalog_resp.status(), reqwest::StatusCode::OK);
+        let cached_token_catalog: serde_json::Value = cached_token_catalog_resp
+            .json()
+            .await
+            .expect("cached token catalog json");
         assert_eq!(
-            token_catalog
-                .pointer("/facets/keys/0/value")
-                .and_then(|value| value.as_str()),
-            Some(key_id.as_str())
-        );
-        assert!(
-            token_catalog
-                .pointer("/requestKindOptions/0/key")
-                .and_then(|value| value.as_str())
-                .is_some(),
-            "token catalog should refresh after a new token log is written"
+            cached_token_catalog
+                .pointer("/facets/keys")
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(0),
+            "unfiltered token catalog should stay on its TTL cache after a hot write"
         );
         let filtered_token_catalog_resp = client
             .get(format!(
@@ -632,6 +639,7 @@
             .id;
 
         let pool = connect_sqlite_test_pool(&db_str).await;
+        let created_at = chrono::Utc::now().timestamp();
         let request_log_id: i64 = sqlx::query_scalar(
             r#"
             INSERT INTO request_logs (
@@ -664,7 +672,7 @@
         .bind(&key_id)
         .bind(br#"{"query":"incident review"}"#.to_vec())
         .bind(br#"{"answer":"stable"}"#.to_vec())
-        .bind(1_000_i64)
+        .bind(created_at)
         .fetch_one(&pool)
         .await
         .expect("insert request log");
@@ -862,6 +870,7 @@
             .id;
 
         let pool = connect_sqlite_test_pool(&db_str).await;
+        let now = chrono::Utc::now().timestamp();
         sqlx::query(
             r#"
             INSERT INTO request_logs (
@@ -890,9 +899,9 @@
             "#,
         )
         .bind(&key_id)
-        .bind(100_i64)
+        .bind(now - 1)
         .bind(&key_id)
-        .bind(200_i64)
+        .bind(now)
         .execute(&pool)
         .await
         .expect("insert canonical request log rows");
@@ -2402,4 +2411,3 @@
         drop(events_resp);
         let _ = std::fs::remove_file(db_path);
     }
-

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -5,6 +5,7 @@ impl KeyStore {
             token_binding_cache: RwLock::new(HashMap::new()),
             account_quota_resolution_cache: RwLock::new(HashMap::new()),
             request_logs_catalog_cache: RwLock::new(HashMap::new()),
+            admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
             #[cfg(test)]
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),

--- a/src/store/key_store_keys.rs
+++ b/src/store/key_store_keys.rs
@@ -1051,6 +1051,11 @@ impl KeyStore {
     // Using ThreadRng for simplicity
 
     pub(crate) async fn list_access_tokens(&self) -> Result<Vec<AuthToken>, ProxyError> {
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
         let rows = sqlx::query_as::<
             _,
             (
@@ -1097,6 +1102,11 @@ impl KeyStore {
         page: i64,
         per_page: i64,
     ) -> Result<(Vec<AuthToken>, i64), ProxyError> {
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
         let page = page.max(1);
         let per_page = per_page.clamp(1, 200);
         let offset = (page - 1) * per_page;
@@ -1586,6 +1596,11 @@ impl KeyStore {
         query: Option<&str>,
         tag_id: Option<&str>,
     ) -> Result<(Vec<AdminUserIdentity>, i64), ProxyError> {
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
         let offset = (page - 1) * per_page;
@@ -1877,6 +1892,11 @@ impl KeyStore {
         query: Option<&str>,
         tag_id: Option<&str>,
     ) -> Result<Vec<AdminUserIdentity>, ProxyError> {
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
         let search = query
             .map(str::trim)
             .filter(|value| !value.is_empty())

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -589,6 +589,17 @@ impl KeyStore {
             return Ok(cached);
         }
 
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
+        if let Some(cache_key) = cache_key.as_deref()
+            && let Some(cached) = self.cached_request_logs_catalog(cache_key).await
+        {
+            return Ok(cached);
+        }
+
         let request_kind_options = self
             .fetch_request_log_request_kind_options(scoped_key_id, since, filters)
             .await?;
@@ -905,16 +916,27 @@ impl KeyStore {
         per_page: i64,
         include_token_facets: bool,
         include_key_facets: bool,
+        include_bodies: bool,
     ) -> Result<RequestLogsPage, ProxyError> {
         let page = page.max(1);
         let per_page = per_page.clamp(1, 200);
         let offset = (page - 1) * per_page;
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
         let normalized_request_kinds = Self::normalize_request_kind_filters(request_kinds);
         let stored_request_kind_sql = "request_kind_key";
         let legacy_request_kind_predicate_sql =
             legacy_request_kind_stored_predicate_sql(stored_request_kind_sql);
         let legacy_request_kind_sql =
             request_log_request_kind_key_sql("path", "request_body", "request_kind_key");
+        let effective_request_kind_sql = format!(
+            "CASE WHEN {legacy_request_kind_predicate_sql} THEN {legacy_request_kind_sql} ELSE {stored_request_kind_sql} END"
+        );
+        let effective_request_kind_label_sql =
+            canonical_request_kind_label_sql(&effective_request_kind_sql);
         let stored_counts_business_quota_sql =
             request_log_counts_business_quota_sql(stored_request_kind_sql, "request_body");
         let stored_operational_class_case_sql = request_log_operational_class_case_sql(
@@ -935,6 +957,33 @@ impl KeyStore {
             result_bucket_case_sql(&stored_operational_class_case_sql, "result_status");
         let legacy_result_bucket_sql =
             result_bucket_case_sql(&legacy_operational_class_case_sql, "result_status");
+        let effective_counts_business_quota_sql = format!(
+            "CASE WHEN {legacy_request_kind_predicate_sql} THEN {legacy_counts_business_quota_sql} ELSE {stored_counts_business_quota_sql} END"
+        );
+        let effective_non_billable_mcp_sql =
+            token_request_kind_non_billable_mcp_sql(&effective_request_kind_sql);
+        let effective_request_kind_protocol_group_sql = format!(
+            "CASE WHEN LOWER(TRIM(COALESCE({effective_request_kind_sql}, ''))) LIKE 'mcp:%' THEN 'mcp' ELSE 'api' END"
+        );
+        let effective_request_kind_billing_group_sql = format!(
+            "
+            CASE
+                WHEN LOWER(TRIM(COALESCE({effective_request_kind_sql}, ''))) IN (
+                    'api:research-result',
+                    'api:usage',
+                    'api:unknown-path'
+                ) THEN 'non_billable'
+                WHEN LOWER(TRIM(COALESCE({effective_request_kind_sql}, ''))) = 'mcp:batch'
+                    AND {effective_counts_business_quota_sql} = 0
+                    THEN 'non_billable'
+                WHEN {effective_non_billable_mcp_sql} THEN 'non_billable'
+                ELSE 'billable'
+            END
+            "
+        );
+        let effective_operational_class_sql = format!(
+            "CASE WHEN {legacy_request_kind_predicate_sql} THEN {legacy_operational_class_case_sql} ELSE {stored_operational_class_case_sql} END"
+        );
 
         let mut total_query = QueryBuilder::<Sqlite>::new("SELECT COUNT(*) FROM request_logs");
         let has_where = Self::push_request_logs_scope(&mut total_query, scoped_key_id, since);
@@ -979,7 +1028,17 @@ impl KeyStore {
             .fetch_one(&self.pool)
             .await?;
 
-        let mut items_query = QueryBuilder::<Sqlite>::new(
+        let request_body_select = if include_bodies {
+            "request_body"
+        } else {
+            "NULL AS request_body"
+        };
+        let response_body_select = if include_bodies {
+            "response_body"
+        } else {
+            "NULL AS response_body"
+        };
+        let mut items_query = QueryBuilder::<Sqlite>::new(format!(
             r#"
             SELECT
                 id,
@@ -992,8 +1051,8 @@ impl KeyStore {
                 tavily_status_code,
                 error_message,
                 result_status,
-                request_kind_key,
-                request_kind_label,
+                {effective_request_kind_sql} AS request_kind_key,
+                {effective_request_kind_label_sql} AS request_kind_label,
                 request_kind_detail,
                 business_credits,
                 failure_kind,
@@ -1009,15 +1068,17 @@ impl KeyStore {
                 routing_subject_hash,
                 upstream_operation,
                 fallback_reason,
-                request_body,
-                response_body,
+                {request_body_select},
+                {response_body_select},
                 forwarded_headers,
                 dropped_headers,
+                {effective_operational_class_sql} AS operational_class,
+                {effective_request_kind_protocol_group_sql} AS request_kind_protocol_group,
+                {effective_request_kind_billing_group_sql} AS request_kind_billing_group,
                 created_at
             FROM request_logs
             "#
-            .to_string(),
-        );
+        ));
         let has_where = Self::push_request_logs_scope(&mut items_query, scoped_key_id, since);
         Self::push_request_logs_filters(
             &mut items_query,

--- a/src/store/key_store_token_logs.rs
+++ b/src/store/key_store_token_logs.rs
@@ -277,6 +277,17 @@ impl KeyStore {
             return Ok(cached);
         }
 
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
+        if let Some(cache_key) = cache_key.as_deref()
+            && let Some(cached) = self.cached_request_logs_catalog(cache_key).await
+        {
+            return Ok(cached);
+        }
+
         let request_kind_options = self
             .fetch_token_log_request_kind_options(token_id, since, until, filters)
             .await?;
@@ -1882,7 +1893,6 @@ impl KeyStore {
         .await?;
 
         tx.commit().await?;
-        self.invalidate_request_logs_catalog_cache().await;
         Ok(request_log_id)
     }
 
@@ -2271,6 +2281,11 @@ impl KeyStore {
         registration_ip: Option<&str>,
         regions: &[String],
     ) -> Result<PaginatedApiKeyMetrics, ProxyError> {
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
         let requested_page = page.max(1);
         let per_page = per_page.clamp(1, 100);
         let groups = Self::normalize_api_key_groups(groups);
@@ -2541,6 +2556,7 @@ impl KeyStore {
                 per_page,
                 true,
                 true,
+                false,
             )
             .await?;
         Ok((result.items, result.total))

--- a/src/store/key_store_users_and_oauth.rs
+++ b/src/store/key_store_users_and_oauth.rs
@@ -935,8 +935,6 @@ impl KeyStore {
         .await?;
         self.record_account_request_rollup_for_user_id(request_user_id.as_deref(), created_at)
             .await?;
-
-        self.invalidate_request_logs_catalog_cache().await;
         Ok(())
     }
 
@@ -1081,8 +1079,6 @@ impl KeyStore {
         .await?;
         self.record_account_request_rollup_for_user_id(request_user_id.as_deref(), created_at)
             .await?;
-
-        self.invalidate_request_logs_catalog_cache().await;
         Ok(log_id)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1171,6 +1171,7 @@ pub(crate) struct KeyStore {
     pub(crate) account_quota_resolution_cache:
         RwLock<HashMap<String, AccountQuotaResolutionCacheEntry>>,
     pub(crate) request_logs_catalog_cache: RwLock<HashMap<String, RequestLogsCatalogCacheEntry>>,
+    pub(crate) admin_heavy_read_semaphore: Semaphore,
     #[cfg(test)]
     pub(crate) forced_pending_claim_miss_log_ids: Mutex<HashSet<i64>>,
     // Lightweight failpoint registry used by integration tests to simulate a lost quota

--- a/src/tavily_proxy/proxy_http_and_logs.rs
+++ b/src/tavily_proxy/proxy_http_and_logs.rs
@@ -1520,11 +1520,15 @@ impl TavilyProxy {
         operational_class: Option<&str>,
         page: i64,
         per_page: i64,
+        include_bodies: bool,
     ) -> Result<RequestLogsPage, ProxyError> {
+        let since = Some(request_logs_retention_threshold_utc_ts(
+            effective_request_logs_retention_days(),
+        ));
         self.key_store
             .fetch_request_logs_page(
                 None,
-                None,
+                since,
                 request_kinds,
                 result_status,
                 key_effect_code,
@@ -1537,6 +1541,7 @@ impl TavilyProxy {
                 per_page,
                 true,
                 true,
+                include_bodies,
             )
             .await
     }
@@ -1556,10 +1561,13 @@ impl TavilyProxy {
         direction: RequestLogsCursorDirection,
         page_size: i64,
     ) -> Result<RequestLogsCursorPage, ProxyError> {
+        let since = Some(request_logs_retention_threshold_utc_ts(
+            effective_request_logs_retention_days(),
+        ));
         self.key_store
             .fetch_request_logs_cursor_page(
                 None,
-                None,
+                since,
                 request_kinds,
                 result_status,
                 key_effect_code,
@@ -1587,10 +1595,13 @@ impl TavilyProxy {
         key_id: Option<&str>,
         operational_class: Option<&str>,
     ) -> Result<RequestLogsCatalog, ProxyError> {
+        let since = Some(request_logs_retention_threshold_utc_ts(
+            effective_request_logs_retention_days(),
+        ));
         self.key_store
             .fetch_request_logs_catalog(
                 None,
-                None,
+                since,
                 true,
                 true,
                 RequestLogsCatalogFilters {
@@ -1652,6 +1663,9 @@ impl TavilyProxy {
         page: i64,
         per_page: i64,
     ) -> Result<RequestLogsPage, ProxyError> {
+        let since = Some(since.unwrap_or_else(|| {
+            request_logs_retention_threshold_utc_ts(effective_request_logs_retention_days())
+        }));
         self.key_store
             .fetch_request_logs_page(
                 Some(key_id),
@@ -1667,6 +1681,7 @@ impl TavilyProxy {
                 page,
                 per_page,
                 true,
+                false,
                 false,
             )
             .await
@@ -1688,6 +1703,9 @@ impl TavilyProxy {
         direction: RequestLogsCursorDirection,
         page_size: i64,
     ) -> Result<RequestLogsCursorPage, ProxyError> {
+        let since = Some(since.unwrap_or_else(|| {
+            request_logs_retention_threshold_utc_ts(effective_request_logs_retention_days())
+        }));
         self.key_store
             .fetch_request_logs_cursor_page(
                 Some(key_id),
@@ -1720,6 +1738,9 @@ impl TavilyProxy {
         auth_token_id: Option<&str>,
         operational_class: Option<&str>,
     ) -> Result<RequestLogsCatalog, ProxyError> {
+        let since = Some(since.unwrap_or_else(|| {
+            request_logs_retention_threshold_utc_ts(effective_request_logs_retention_days())
+        }));
         self.key_store
             .fetch_request_logs_catalog(
                 Some(key_id),

--- a/src/tests/chunk_01.rs
+++ b/src/tests/chunk_01.rs
@@ -2296,6 +2296,7 @@ async fn request_kind_database_migration_retries_after_transient_write_lock() {
         token_binding_cache: RwLock::new(std::collections::HashMap::new()),
         account_quota_resolution_cache: RwLock::new(std::collections::HashMap::new()),
         request_logs_catalog_cache: RwLock::new(std::collections::HashMap::new()),
+        admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
         #[cfg(test)]
         forced_pending_claim_miss_log_ids: Mutex::new(std::collections::HashSet::new()),
         forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(


### PR DESCRIPTION
## Summary
- Bound default admin log/catalog reads to the configured request-log retention window.
- Make request-log catalog caching TTL-first instead of invalidating on every hot log write.
- Add a shared heavy-read gate for SQLite-backed admin lists/catalogs and avoid selecting request/response bodies for legacy log list rows by default.
- Collapse forward-proxy stats into one bounded scan and document the SQLite admin-read containment pattern.

## Validation
- `cargo test`
- `cargo clippy -- -D warnings`
- `cd web && bun test`
- `cd web && bun run build`
- `git diff --check`
- `codex -m gpt-5.5 -c model_reasoning_effort="high" --sandbox read-only -a never review --base origin/main`

Note: the review-loop also reran `cargo test -- --nocapture`; unrelated forward-proxy/xray tests failed in that environment, while the targeted changed tests reran cleanly and the normal `cargo test` run passed before review-loop.

## References
- Specs: `docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md`, `docs/specs/ev4td-admin-recent-requests-performance-copy/SPEC.md`
- Solutions: `docs/solutions/operations/sqlite-admin-read-containment.md`
- Project Docs: -

## Production
- No production restart, deploy, data mutation, VACUUM, or container update was performed.
- The planned single-container restart remains gated on explicit owner approval.