### PR TITLE
fix(proxy): restore xray readiness after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If `--keys`/`TAVILY_API_KEYS` is supplied, the database sync logic adds or reviv
 
 | Method   | Path                   | Description                                                       | Auth         |
 | -------- | ---------------------- | ----------------------------------------------------------------- | ------------ |
-| `GET`    | `/health`              | Liveness probe.                                                   | none         |
+| `GET`    | `/health`              | Liveness plus xray readiness after startup grace.                 | none         |
 | `GET`    | `/api/summary`         | High-level success/failure stats and last activity.               | none         |
 | `GET`    | `/api/keys`            | Lists short IDs, status, and counters.                            | Admin        |
 | `GET`    | `/api/logs?page=1`     | Recent proxy logs (paginated, default 20 per page).               | Admin        |

--- a/docs/specs/4ua2f-forward-proxy-shared-xray-hot-reload/SPEC.md
+++ b/docs/specs/4ua2f-forward-proxy-shared-xray-hot-reload/SPEC.md
@@ -6,6 +6,8 @@
 - 非 Direct 节点继续按节点维度选路，但节点的 `endpointUrl` 改为指向 shared xray 内部某个独立 relay handle 的 loopback socks 入口。
 - settings save、subscription refresh、revalidate、validate、probe、trace 与真实 Tavily 请求统一复用 shared xray；配置变化通过同 PID 内增量 apply 生效。
 - 被删除或变更的 relay handle 必须立刻停止新分配，但已有请求继续排空；只有 lease 归零后才允许删除 handle、端口和 runtime 文件。
+- 进程启动时如果订阅刷新全失败，必须从本地 `forward_proxy_runtime` 恢复上一轮可解析的 subscription 节点，并立即同步 shared xray relay，避免重启后退化为只剩 direct/manual。
+- `/health` 在启动宽限期内保持 `200 ok`；宽限期后，如果当前 forward proxy 节点需要 local relay 但 shared xray 未就绪，返回 `503 xray not ready`，响应不得包含订阅 URL、节点 URL 或 key。
 - `/api/settings`、`/api/settings/forward-proxy`、`/api/stats/forward-proxy`、`/api/stats/forward-proxy/summary` 的 JSON contract 与现有 admin UI 字段保持不变。
 
 ## Functional/Behavior Spec
@@ -36,6 +38,14 @@
 - `ForwardProxyClientPool` 继续按 `endpointUrl` 缓存 client；当节点 generation 切换导致 `endpointUrl` 变化时，新请求自动命中新 client，旧 client 仅服务仍持有 lease 的在途请求。
 - Direct 节点仍走 native reqwest 直连，不纳入 shared xray 单实例约束。
 
+### Startup recovery and health readiness
+
+- 启动订阅刷新失败不得清空上一轮已持久化的 subscription 节点。恢复来源仅限本地 SQLite `forward_proxy_runtime` 中 `source=subscription` 且 `proxy_key` 仍可解析的非 direct 节点。
+- 恢复后的节点必须进入正常 endpoint merge、runtime weight 与 shared xray sync 流程；不得复用上一进程留下的 loopback socks `endpointUrl`。
+- 启动阶段完成 manager 初始化后必须主动执行 shared xray sync。xray 创建失败只反映到 readiness/runtime 状态，不应阻断进程启动。
+- `/health` 的 xray readiness 只在存在 local relay 依赖时生效；没有 local relay 依赖时，宽限期后仍返回 `200 ok`。
+- 启动宽限期默认 90 秒；测试可用短宽限期覆盖宽限后语义。
+
 ## Acceptance
 
 - 在订阅展开为多 share-link 节点时，进程视角只能看到 `tavily-hikari` + **1 个 shared xray child**；不得再出现按节点常驻的 `xray run` 进程。
@@ -43,11 +53,15 @@
 - unchanged 节点复用原 loopback endpoint；changed 节点切换到新 endpoint；removed 节点立即从 active stats/settings 中消失。
 - 当旧 handle 仍有 lease 时，runtime 必须保留 retiring handle；lease 归零后 retiring handle 会被清掉，不遗留孤儿 handle、孤儿端口或 runtime 文件。
 - validate-only 临时 handle 在结束后不会留下 shared child、临时 config 文件或永久滞留的 retiring entry。
+- 重启且订阅源不可访问时，上一轮持久化的 subscription 节点仍出现在 forward proxy stats/settings，并触发 shared xray relay 同步。
+- 启动宽限期内 `/health` 返回 `200 ok`；宽限期后，如果存在 xray relay 依赖但 shared xray 未就绪，返回 `503 xray not ready`；shared xray 就绪后返回 `200 ok`。
 
 ## Verification
 
 - `cargo test -q xray_supervisor_ -- --nocapture`
 - `cargo test -q tavily_proxy_save_and_revalidate_keep_shared_xray_pid -- --nocapture`
+- `cargo test -q startup_restores_persisted_subscription_nodes_and_prewarms_xray_when_subscription_down -- --nocapture`
+- `cargo test -q health_keeps_startup_grace_then_fails_when_xray_relay_is_not_ready -- --nocapture`
 - `cargo test -q admin_forward_proxy_ -- --nocapture`
 - `cargo fmt --check`
 - `cargo clippy --all-targets -- -D warnings`

--- a/src/forward_proxy/manager.rs
+++ b/src/forward_proxy/manager.rs
@@ -46,6 +46,24 @@ impl ForwardProxyManager {
         self.last_subscription_refresh_at = Some(Utc::now().timestamp());
     }
 
+    pub fn restore_persisted_subscription_endpoints(&mut self) -> usize {
+        let proxy_urls = self
+            .runtime
+            .values()
+            .filter(|entry| entry.source == FORWARD_PROXY_SOURCE_SUBSCRIPTION)
+            .filter(|entry| entry.proxy_key != FORWARD_PROXY_DIRECT_KEY)
+            .filter(|entry| parse_forward_proxy_entry(&entry.proxy_key).is_some())
+            .map(|entry| entry.proxy_key.clone())
+            .collect::<Vec<_>>();
+        let subscription_endpoints =
+            normalize_subscription_endpoints_from_urls(&proxy_urls, FORWARD_PROXY_SOURCE_SUBSCRIPTION);
+        let restored = subscription_endpoints.len();
+        if restored > 0 {
+            self.rebuild_endpoints(subscription_endpoints);
+        }
+        restored
+    }
+
     pub fn rebuild_endpoints(&mut self, subscription_endpoints: Vec<ForwardProxyEndpoint>) {
         let manual = normalize_proxy_endpoints_from_urls(&self.settings.proxy_urls);
         let mut merged: Vec<ForwardProxyEndpoint> = Vec::new();

--- a/src/forward_proxy/relay_and_xray.rs
+++ b/src/forward_proxy/relay_and_xray.rs
@@ -443,6 +443,12 @@ pub struct XraySupervisorDebugSnapshot {
     pub runtime_files: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct XraySupervisorReadinessSnapshot {
+    pub shared_process_running: bool,
+    pub active_endpoint_handles: usize,
+}
+
 #[derive(Debug, Default)]
 pub struct XraySupervisor {
     pub binary: String,
@@ -578,6 +584,14 @@ impl XraySupervisor {
         self.retiring_handles.clear();
         self.handle_by_url.clear();
         self.shutdown_shared_process().await;
+    }
+
+    pub fn readiness_snapshot(&mut self) -> XraySupervisorReadinessSnapshot {
+        self.reset_if_shared_process_exited();
+        XraySupervisorReadinessSnapshot {
+            shared_process_running: self.shared.is_some(),
+            active_endpoint_handles: self.active_endpoint_handles.len(),
+        }
     }
 
     pub async fn resolve_validation_endpoint(
@@ -1121,4 +1135,3 @@ impl XraySupervisor {
         )
     }
 }
-

--- a/src/forward_proxy/settings_and_endpoints.rs
+++ b/src/forward_proxy/settings_and_endpoints.rs
@@ -364,6 +364,13 @@ impl ForwardProxyEndpoint {
         self.relay_handle.as_ref().and_then(Weak::upgrade)
     }
 
+    pub(crate) fn has_ready_local_relay(&self) -> bool {
+        self.endpoint_url.is_some()
+            && self
+                .relay_handle()
+                .is_some_and(|handle| !handle.is_invalidated())
+    }
+
     fn set_relay_handle(&mut self, relay_handle: Option<&Arc<SharedXrayRelayHandle>>) {
         self.relay_handle = relay_handle.map(Arc::downgrade);
     }

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -486,6 +486,27 @@ if __name__ == "__main__":
         )
     }
 
+    async fn spawn_single_response_subscription_server(body: String) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind fake subscription server");
+        let addr = listener.local_addr().expect("subscription server addr");
+        let handle = tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buffer = [0_u8; 1024];
+            let _ = socket.read(&mut buffer).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+        (format!("http://{addr}/subscription.txt"), handle)
+    }
+
     fn subscription_vless_endpoint(key: &str, host: &str, label: &str) -> ForwardProxyEndpoint {
         ForwardProxyEndpoint::new_subscription(
             key.to_string(),
@@ -807,6 +828,7 @@ if __name__ == "__main__":
                 forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
                     .expect("valid trace url"),
                 low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(90),
             },
         )
         .await
@@ -940,6 +962,7 @@ if __name__ == "__main__":
                 forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
                     .expect("valid trace url"),
                 low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(90),
             },
         )
         .await
@@ -985,6 +1008,7 @@ if __name__ == "__main__":
                 forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
                     .expect("valid trace url"),
                 low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(90),
             },
         )
         .await
@@ -1074,6 +1098,7 @@ if __name__ == "__main__":
                 forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
                     .expect("valid trace url"),
                 low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(90),
             },
         )
         .await
@@ -1132,6 +1157,107 @@ if __name__ == "__main__":
         );
 
         proxy.xray_supervisor.lock().await.shutdown_all().await;
+    }
+
+    #[tokio::test]
+    async fn startup_restores_persisted_subscription_nodes_and_prewarms_xray_when_subscription_down()
+    {
+        let root_dir = temp_runtime_dir("proxy-startup-restore-xray");
+        let db_path = root_dir.join("proxy.db");
+        let share_link = sample_vless_share_link("restore-sub.example.com", "Restore Sub");
+        let (subscription_url, subscription_handle) =
+            spawn_single_response_subscription_server(share_link.clone()).await;
+
+        let first_proxy = TavilyProxy::with_options(
+            Vec::<String>::new(),
+            "http://127.0.0.1:9/mcp",
+            db_path
+                .to_str()
+                .expect("database path should be valid utf-8"),
+            TavilyProxyOptions {
+                xray_binary: write_fake_xray_binary("proxy-startup-restore-xray-first"),
+                xray_runtime_dir: root_dir.join("xray-runtime-first"),
+                forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
+                    .expect("valid trace url"),
+                low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(0),
+            },
+        )
+        .await
+        .expect("create initial proxy with fake xray");
+
+        first_proxy
+            .update_forward_proxy_settings(
+                ForwardProxySettings {
+                    proxy_urls: Vec::new(),
+                    subscription_urls: vec![subscription_url],
+                    subscription_update_interval_secs: 3600,
+                    insert_direct: false,
+                    egress_socks5_enabled: false,
+                    egress_socks5_url: String::new(),
+                },
+                true,
+            )
+            .await
+            .expect("save subscription settings");
+        subscription_handle
+            .await
+            .expect("fake subscription server should exit after one response");
+        first_proxy
+            .xray_supervisor
+            .lock()
+            .await
+            .shutdown_all()
+            .await;
+        drop(first_proxy);
+
+        let restarted_proxy = TavilyProxy::with_options(
+            Vec::<String>::new(),
+            "http://127.0.0.1:9/mcp",
+            db_path
+                .to_str()
+                .expect("database path should be valid utf-8"),
+            TavilyProxyOptions {
+                xray_binary: write_fake_xray_binary("proxy-startup-restore-xray-restarted"),
+                xray_runtime_dir: root_dir.join("xray-runtime-restarted"),
+                forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
+                    .expect("valid trace url"),
+                low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(0),
+            },
+        )
+        .await
+        .expect("restart proxy while subscription server is down");
+
+        let settings = restarted_proxy
+            .get_forward_proxy_settings()
+            .await
+            .expect("load forward proxy settings");
+        let restored = settings
+            .nodes
+            .iter()
+            .find(|node| node.source == FORWARD_PROXY_SOURCE_SUBSCRIPTION)
+            .expect("persisted subscription node should be restored");
+        assert_eq!(restored.key, share_link);
+        assert!(
+            restarted_proxy.is_forward_proxy_xray_ready().await,
+            "restored subscription node should be prewarmed into shared xray"
+        );
+        let snapshot = restarted_proxy
+            .xray_supervisor
+            .lock()
+            .await
+            .debug_snapshot()
+            .await;
+        assert!(snapshot.shared_pid.is_some());
+        assert_eq!(snapshot.active_endpoint_handles, 1);
+
+        restarted_proxy
+            .xray_supervisor
+            .lock()
+            .await
+            .shutdown_all()
+            .await;
     }
 
     #[tokio::test]
@@ -1262,6 +1388,7 @@ if __name__ == "__main__":
                 forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
                     .expect("valid trace url"),
                 low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(90),
             },
         )
         .await
@@ -1342,6 +1469,7 @@ if __name__ == "__main__":
                     forward_proxy_trace_url: Url::parse("http://127.0.0.1/cdn-cgi/trace")
                         .expect("valid trace url"),
                     low_quota_depletion_threshold: LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT,
+                health_readiness_grace_period: Duration::from_secs(90),
                 },
             )
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(&cli.low_quota_depletion_threshold),
             "LOW_QUOTA_DEPLETION_THRESHOLD",
         ),
+        health_readiness_grace_period: std::time::Duration::from_secs(90),
     };
     let proxy =
         TavilyProxy::with_options(cli.keys, &cli.upstream, &cli.db_path, proxy_options).await?;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -594,6 +594,10 @@ async fn debug_is_admin(
     }))
 }
 
-async fn health_check() -> &'static str {
-    "ok"
+async fn health_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    if state.proxy.is_forward_proxy_xray_ready().await {
+        (StatusCode::OK, "ok")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "xray not ready")
+    }
 }

--- a/src/server/tests/chunk_02.rs
+++ b/src/server/tests/chunk_02.rs
@@ -1441,6 +1441,7 @@ async fn spawn_proxy_server_with_dev(
     });
 
     let app = Router::new()
+        .route("/health", get(health_check))
         .route("/mcp", any(proxy_handler))
         .route("/mcp/*path", any(mcp_subpath_reject_handler))
         .route("/api/tavily/search", post(tavily_http_search))

--- a/src/server/tests/chunk_12.rs
+++ b/src/server/tests/chunk_12.rs
@@ -32,6 +32,98 @@
     }
 
     #[tokio::test]
+    async fn health_keeps_startup_grace_then_fails_when_xray_relay_is_not_ready() {
+        let share_link =
+            "vless://0688fa59-e971-4278-8c03-4b35821a71dc@health-xray.example.com:443?encryption=none#Health";
+
+        let grace_db_path = temp_db_path("health-xray-grace");
+        let grace_db_str = grace_db_path.to_string_lossy().to_string();
+        let upstream_addr = spawn_forward_proxy_probe_upstream().await;
+        let upstream = format!("http://{}/mcp", upstream_addr);
+        let mut grace_options = tavily_hikari::TavilyProxyOptions::from_database_path(&grace_db_str);
+        grace_options.xray_binary = "/tmp/tavily-hikari-missing-xray".to_string();
+        grace_options.health_readiness_grace_period = Duration::from_secs(90);
+        let grace_proxy =
+            TavilyProxy::with_options::<Vec<String>, String>(
+                Vec::new(),
+                &upstream,
+                &grace_db_str,
+                grace_options,
+            )
+            .await
+            .expect("create grace proxy");
+        grace_proxy
+            .update_forward_proxy_settings(
+                ForwardProxySettings {
+                    proxy_urls: vec![share_link.to_string()],
+                    subscription_urls: Vec::new(),
+                    subscription_update_interval_secs: 3600,
+                    insert_direct: false,
+                    egress_socks5_enabled: false,
+                    egress_socks5_url: String::new(),
+                },
+                true,
+            )
+            .await
+            .expect("save xray relay settings");
+        let grace_addr =
+            spawn_proxy_server(grace_proxy, format!("http://{}", upstream_addr)).await;
+        let client = Client::new();
+        let grace_response = client
+            .get(format!("http://{grace_addr}/health"))
+            .send()
+            .await
+            .expect("call grace health");
+        assert_eq!(grace_response.status(), StatusCode::OK);
+        assert_eq!(grace_response.text().await.expect("grace body"), "ok");
+
+        let expired_db_path = temp_db_path("health-xray-expired");
+        let expired_db_str = expired_db_path.to_string_lossy().to_string();
+        let mut expired_options =
+            tavily_hikari::TavilyProxyOptions::from_database_path(&expired_db_str);
+        expired_options.xray_binary = "/tmp/tavily-hikari-missing-xray".to_string();
+        expired_options.health_readiness_grace_period = Duration::from_secs(0);
+        let expired_proxy =
+            TavilyProxy::with_options::<Vec<String>, String>(
+                Vec::new(),
+                &upstream,
+                &expired_db_str,
+                expired_options,
+            )
+            .await
+            .expect("create expired proxy");
+        expired_proxy
+            .update_forward_proxy_settings(
+                ForwardProxySettings {
+                    proxy_urls: vec![share_link.to_string()],
+                    subscription_urls: Vec::new(),
+                    subscription_update_interval_secs: 3600,
+                    insert_direct: false,
+                    egress_socks5_enabled: false,
+                    egress_socks5_url: String::new(),
+                },
+                true,
+            )
+            .await
+            .expect("save expired xray relay settings");
+        let expired_addr =
+            spawn_proxy_server(expired_proxy, format!("http://{}", upstream_addr)).await;
+        let expired_response = client
+            .get(format!("http://{expired_addr}/health"))
+            .send()
+            .await
+            .expect("call expired health");
+        assert_eq!(expired_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let expired_body = expired_response.text().await.expect("expired body");
+        assert_eq!(expired_body, "xray not ready");
+        assert!(!expired_body.contains("vless://"));
+        assert!(!expired_body.contains("health-xray.example.com"));
+
+        let _ = std::fs::remove_file(grace_db_path);
+        let _ = std::fs::remove_file(expired_db_path);
+    }
+
+    #[tokio::test]
     async fn admin_system_settings_reject_invalid_rebalance_percent() {
         let db_path = temp_db_path("admin-system-settings-invalid-rebalance-percent");
         let db_str = db_path.to_string_lossy().to_string();

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -215,6 +215,7 @@ pub struct TavilyProxy {
     pub(crate) mcp_session_init_locks: Arc<Mutex<HashMap<String, Weak<Mutex<()>>>>>,
     pub(crate) mcp_session_request_locks: Arc<Mutex<HashMap<String, Weak<Mutex<()>>>>>,
     pub(crate) low_quota_depletion_threshold: i64,
+    health_readiness_grace_until: Instant,
 }
 
 #[derive(Clone, Debug)]
@@ -223,6 +224,7 @@ pub struct TavilyProxyOptions {
     pub xray_runtime_dir: std::path::PathBuf,
     pub forward_proxy_trace_url: Url,
     pub low_quota_depletion_threshold: i64,
+    pub health_readiness_grace_period: Duration,
 }
 
 impl TavilyProxyOptions {
@@ -232,6 +234,7 @@ impl TavilyProxyOptions {
             xray_runtime_dir: forward_proxy::default_xray_runtime_dir(database_path),
             forward_proxy_trace_url: default_forward_proxy_trace_url(),
             low_quota_depletion_threshold: low_quota_depletion_threshold_from_env(),
+            health_readiness_grace_period: Duration::from_secs(90),
         }
     }
 }

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -460,6 +460,7 @@ impl TavilyProxy {
             mcp_session_init_locks: Arc::new(Mutex::new(HashMap::new())),
             mcp_session_request_locks: Arc::new(Mutex::new(HashMap::new())),
             low_quota_depletion_threshold: options.low_quota_depletion_threshold,
+            health_readiness_grace_until: Instant::now() + options.health_readiness_grace_period,
         };
         proxy.initialize_forward_proxy_runtime().await?;
         Ok(proxy)
@@ -467,10 +468,62 @@ impl TavilyProxy {
 
     pub(crate) async fn initialize_forward_proxy_runtime(&mut self) -> Result<(), ProxyError> {
         if let Err(err) = self.refresh_forward_proxy_subscriptions().await {
-            eprintln!("forward-proxy startup subscription refresh error: {err}");
+            eprintln!("forward-proxy startup subscription refresh failed: {err}");
+            let restored = {
+                let mut manager = self.forward_proxy.lock().await;
+                manager.restore_persisted_subscription_endpoints()
+            };
+            if restored > 0 {
+                eprintln!(
+                    "forward-proxy restored {restored} persisted subscription nodes after startup refresh failure"
+                );
+            }
+        }
+        {
+            let mut manager = self.forward_proxy.lock().await;
+            let egress_socks5_url = manager.settings.effective_egress_socks5_url();
+            {
+                let mut xray = self.xray_supervisor.lock().await;
+                if let Err(_err) = xray
+                    .sync_endpoints(&mut manager.endpoints, egress_socks5_url.as_ref())
+                    .await
+                {
+                    eprintln!("forward-proxy startup xray prewarm failed");
+                }
+            }
+            self.sync_forward_proxy_runtime_state(&mut manager).await?;
         }
         let manager = self.forward_proxy.lock().await;
         forward_proxy::sync_manager_runtime_to_store(&self.key_store, &manager).await
+    }
+
+    pub async fn is_forward_proxy_xray_ready(&self) -> bool {
+        if Instant::now() < self.health_readiness_grace_until {
+            return true;
+        }
+        let (requires_xray, endpoints_ready) = {
+            let manager = self.forward_proxy.lock().await;
+            let egress_socks5_url = manager.settings.effective_egress_socks5_url();
+            let mut requires_xray = false;
+            let mut endpoints_ready = true;
+            for endpoint in &manager.endpoints {
+                if !endpoint.needs_local_relay(egress_socks5_url.as_ref()) {
+                    continue;
+                }
+                requires_xray = true;
+                endpoints_ready &= endpoint.uses_local_relay && endpoint.has_ready_local_relay();
+            }
+            (requires_xray, endpoints_ready)
+        };
+        if !requires_xray {
+            return true;
+        }
+        if !endpoints_ready {
+            return false;
+        }
+        let mut xray = self.xray_supervisor.lock().await;
+        let snapshot = xray.readiness_snapshot();
+        snapshot.shared_process_running && snapshot.active_endpoint_handles > 0
     }
 
     pub async fn get_forward_proxy_settings(

--- a/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
+++ b/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
@@ -86,10 +86,8 @@ impl TavilyProxy {
                     fetched_any_subscription = true;
                     fetched.insert(subscription_url.clone(), urls);
                 }
-                Err(err) => {
-                    eprintln!(
-                        "failed to refresh forward proxy subscription {subscription_url}: {err}"
-                    );
+                Err(_err) => {
+                    eprintln!("failed to refresh forward proxy subscription");
                 }
             }
         }


### PR DESCRIPTION
## Summary\n- Restore persisted subscription nodes from forward_proxy_runtime when startup subscription refresh fails.\n- Prewarm shared xray during startup and expose xray readiness through /health after a startup grace period.\n- Add regression coverage for restart recovery, xray prewarm, and grace-period health semantics.\n\n## Validation\n- cargo fmt --check\n- cargo clippy --all-targets -- -D warnings\n- cargo test\n\n## References\n- Specs: docs/specs/4ua2f-forward-proxy-shared-xray-hot-reload/SPEC.md\n- Solutions: -\n- Project Docs: README.md