### PR TITLE
fix: move request user id backfill off startup

### DIFF
--- a/docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md
@@ -3,3 +3,7 @@
 - 2026-05-08: Added spec for trusted client IP parsing, 7-day distinct IP usage, and admin confirmation UI.
 - 2026-05-08: Kept default trusted proxy CIDRs loopback-only so private-network direct clients cannot spoof client IP headers unless an admin explicitly trusts those proxy ranges.
 - 2026-05-08: Denied sensitive header names in trusted client IP header settings so diagnostic snapshots cannot persist request secrets through operator typo.
+- 2026-05-10: Moved historical `request_user_id` backfill out of startup after
+  the `v0.47.0` production rollout exceeded Dockrev's healthcheck window on a
+  million-row `request_logs` database; repair now runs through a resumable batch
+  CLI.

--- a/docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md
@@ -3,10 +3,14 @@
 - Backend: request log schema, IP resolution, observed header values, recent IP count query.
 - API: system settings payload/response extension and admin-only observed header endpoint.
 - UI: system settings dialog, user IP count badges, recent request diagnostics.
+- Operations: historical `request_user_id` repair is an explicit resumable
+  `request_user_id_backfill` CLI batch job, not part of service startup.
 
 ## Status
 
 - Implemented on current fast-track branch.
+- Startup only applies schema-compatible changes; large historical request log
+  backfills must run outside the healthcheck path.
 
 ## Validation
 

--- a/src/bin/request_user_id_backfill.rs
+++ b/src/bin/request_user_id_backfill.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Write};
+
+use clap::Parser;
+use dotenvy::dotenv;
+use tavily_hikari::{REQUEST_USER_ID_BACKFILL_BATCH_SIZE, run_request_user_id_backfill};
+
+#[derive(Debug, Parser)]
+#[command(
+    author,
+    version,
+    about = "Backfill request_user_id in historical request logs"
+)]
+struct Cli {
+    #[arg(long, env = "PROXY_DB_PATH", default_value = "data/tavily_proxy.db")]
+    db_path: String,
+
+    #[arg(long, default_value_t = REQUEST_USER_ID_BACKFILL_BATCH_SIZE)]
+    batch_size: i64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv().ok();
+    let cli = Cli::parse();
+    let report = run_request_user_id_backfill(&cli.db_path, cli.batch_size).await?;
+    serde_json::to_writer_pretty(io::stdout(), &report)?;
+    io::stdout().write_all(b"\n")?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,16 @@ pub struct RequestKindCanonicalBackfillReport {
     pub auth_token_logs: RequestKindCanonicalBackfillTableReport,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestUserIdBackfillReport {
+    pub batch_size: i64,
+    pub cursor_before: i64,
+    pub cursor_after: i64,
+    pub upper_bound: i64,
+    pub rows_scanned: i64,
+    pub rows_updated: i64,
+}
+
 impl ForwardProxyProgressEvent {
     pub fn phase(operation: &'static str, phase_key: &'static str, label: &'static str) -> Self {
         Self::Phase {
@@ -336,6 +346,8 @@ const OUTCOME_UNKNOWN: &str = "unknown";
 pub const REQUEST_LOG_VISIBILITY_VISIBLE: &str = "visible";
 pub const REQUEST_LOG_VISIBILITY_SUPPRESSED_RETRY_SHADOW: &str = "suppressed_retry_shadow";
 pub const REQUEST_KIND_CANONICAL_BACKFILL_BATCH_SIZE: i64 = 500;
+pub const REQUEST_USER_ID_BACKFILL_BATCH_SIZE: i64 = 1000;
+const REQUEST_USER_ID_BACKFILL_STABILITY_GRACE_SECS: i64 = 60;
 const REQUEST_KIND_CANONICAL_MIGRATION_WAIT_POLL_MS: u64 = 200;
 const REQUEST_KIND_CANONICAL_MIGRATION_STALE_SECS: i64 = 300;
 const FAILURE_KIND_UPSTREAM_GATEWAY_5XX: &str = "upstream_gateway_5xx";
@@ -649,6 +661,7 @@ const META_KEY_REQUEST_KIND_CANONICAL_BACKFILL_REQUEST_LOGS_CURSOR_V1: &str =
     "request_kind_canonical_backfill_request_logs_v1";
 const META_KEY_REQUEST_KIND_CANONICAL_BACKFILL_AUTH_TOKEN_LOGS_CURSOR_V1: &str =
     "request_kind_canonical_backfill_auth_token_logs_v1";
+const META_KEY_REQUEST_USER_ID_BACKFILL_CURSOR_V1: &str = "request_user_id_backfill_cursor_v1";
 const META_KEY_API_KEY_CREATED_AT_BACKFILL_V1: &str = "api_key_created_at_backfill_v1";
 // Cutover marker for switching business quota counters from "requests" to "credits".
 // We cannot retroactively convert legacy request counts into credits, so we reset the
@@ -673,6 +686,14 @@ pub async fn run_request_kind_canonical_backfill(
     let pool = store::open_sqlite_pool(database_path, true, false).await?;
     store::run_request_kind_canonical_backfill_with_pool(&pool, batch_size, dry_run, None, None)
         .await
+}
+
+pub async fn run_request_user_id_backfill(
+    database_path: &str,
+    batch_size: i64,
+) -> Result<RequestUserIdBackfillReport, ProxyError> {
+    let pool = store::open_sqlite_pool(database_path, true, false).await?;
+    store::run_request_user_id_backfill_with_pool(&pool, batch_size).await
 }
 
 fn token_limit_from_env(var: &str, default: i64) -> i64 {

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -921,23 +921,6 @@ impl KeyStore {
             .await?;
         }
 
-        sqlx::query(
-            r#"
-            UPDATE request_logs
-            SET request_user_id = (
-                SELECT atl.request_user_id
-                FROM auth_token_logs atl
-                WHERE atl.request_log_id = request_logs.id
-                  AND atl.request_user_id IS NOT NULL
-                ORDER BY atl.id DESC
-                LIMIT 1
-            )
-            WHERE request_user_id IS NULL
-            "#,
-        )
-        .execute(&self.pool)
-        .await?;
-
         if self
             .auth_token_logs_have_legacy_request_kind_columns()
             .await?

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1208,6 +1208,175 @@ pub(crate) async fn run_request_kind_canonical_backfill_with_pool(
     })
 }
 
+pub(crate) async fn run_request_user_id_backfill_with_pool(
+    pool: &SqlitePool,
+    batch_size: i64,
+) -> Result<RequestUserIdBackfillReport, ProxyError> {
+    let batch_size = batch_size.max(1);
+    let cursor_before =
+        read_request_kind_backfill_meta_i64(pool, META_KEY_REQUEST_USER_ID_BACKFILL_CURSOR_V1)
+            .await?;
+    let upper_bound = sqlx::query_scalar::<_, i64>("SELECT COALESCE(MAX(id), 0) FROM request_logs")
+        .fetch_one(pool)
+        .await?;
+    let stable_before = Utc::now()
+        .timestamp()
+        .saturating_sub(REQUEST_USER_ID_BACKFILL_STABILITY_GRACE_SECS);
+
+    sqlx::query(
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_auth_token_logs_request_log_user_id
+        ON auth_token_logs(request_log_id, request_user_id, id)
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            request_logs.id AS id,
+            (
+                SELECT atl.request_user_id
+                FROM auth_token_logs atl
+                WHERE atl.request_log_id = request_logs.id
+                  AND atl.request_user_id IS NOT NULL
+                ORDER BY atl.id DESC
+                LIMIT 1
+            ) AS request_user_id
+        FROM request_logs
+        WHERE request_logs.id > ?
+          AND request_logs.id <= ?
+          AND request_logs.created_at <= ?
+          AND request_logs.request_user_id IS NULL
+        ORDER BY id ASC
+        LIMIT ?
+        "#,
+    )
+    .bind(cursor_before)
+    .bind(upper_bound)
+    .bind(stable_before)
+    .bind(batch_size)
+    .fetch_all(pool)
+    .await?;
+    if rows.is_empty() {
+        return Ok(RequestUserIdBackfillReport {
+            batch_size,
+            cursor_before,
+            cursor_after: cursor_before,
+            upper_bound,
+            rows_scanned: 0,
+            rows_updated: 0,
+        });
+    }
+
+    let updates = rows
+        .into_iter()
+        .map(|row| {
+            Ok((
+                row.try_get::<i64, _>("id")?,
+                row.try_get::<Option<String>, _>("request_user_id")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()?;
+    let batch_max_id = updates
+        .last()
+        .map(|(id, _)| *id)
+        .unwrap_or(cursor_before)
+        .max(cursor_before);
+    let rows_scanned = updates.len() as i64;
+    let rows_updated: i64;
+
+    loop {
+        let mut tx = match pool.begin().await {
+            Ok(tx) => tx,
+            Err(err) => {
+                let err = ProxyError::Database(err);
+                if is_transient_sqlite_write_error(&err) {
+                    tokio::time::sleep(Duration::from_millis(
+                        REQUEST_KIND_CANONICAL_MIGRATION_WAIT_POLL_MS,
+                    ))
+                    .await;
+                    continue;
+                }
+                return Err(err);
+            }
+        };
+
+        let batch_result: Result<u64, ProxyError> = async {
+            let mut updated = 0_u64;
+            for (id, request_user_id) in &updates {
+                let Some(request_user_id) = request_user_id else {
+                    continue;
+                };
+                let result = sqlx::query(
+                    r#"
+                    UPDATE request_logs
+                    SET request_user_id = ?
+                    WHERE id = ?
+                      AND request_user_id IS NULL
+                    "#,
+                )
+                .bind(request_user_id)
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+                updated += result.rows_affected();
+            }
+
+            write_request_kind_backfill_meta_i64(
+                &mut tx,
+                META_KEY_REQUEST_USER_ID_BACKFILL_CURSOR_V1,
+                batch_max_id,
+            )
+            .await?;
+            Ok(updated)
+        }
+        .await;
+
+        match batch_result {
+            Ok(updated) => match tx.commit().await {
+                Ok(()) => {
+                    rows_updated = updated as i64;
+                    break;
+                }
+                Err(err) => {
+                    let err = ProxyError::Database(err);
+                    if is_transient_sqlite_write_error(&err) {
+                        tokio::time::sleep(Duration::from_millis(
+                            REQUEST_KIND_CANONICAL_MIGRATION_WAIT_POLL_MS,
+                        ))
+                        .await;
+                        continue;
+                    }
+                    return Err(err);
+                }
+            },
+            Err(err) => {
+                let retry = is_transient_sqlite_write_error(&err);
+                let _ = tx.rollback().await;
+                if retry {
+                    tokio::time::sleep(Duration::from_millis(
+                        REQUEST_KIND_CANONICAL_MIGRATION_WAIT_POLL_MS,
+                    ))
+                    .await;
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(RequestUserIdBackfillReport {
+        batch_size,
+        cursor_before,
+        cursor_after: batch_max_id,
+        upper_bound,
+        rows_scanned,
+        rows_updated,
+    })
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RequestLogsCatalogCacheEntry {
     value: RequestLogsCatalog,

--- a/src/tests/chunk_04.rs
+++ b/src/tests/chunk_04.rs
@@ -304,8 +304,10 @@ async fn public_success_breakdown_month_falls_back_to_usage_buckets_for_partial_
         .await
         .expect("public success breakdown");
     let current_month_start = start_of_month(Utc::now()).timestamp();
-    let expected_public_monthly_success = if month_start >= current_month_start {
+    let expected_public_monthly_success = if first_full_bucket_start >= current_month_start {
         13
+    } else if partial_bucket_start >= current_month_start {
+        6
     } else {
         0
     };

--- a/src/tests/chunk_08.rs
+++ b/src/tests/chunk_08.rs
@@ -818,3 +818,212 @@ async fn monthly_blocked_key_count_excludes_quota_exhausted_and_counts_only_bloc
     assert_eq!(page.items[0].key_id, blocked_key_id);
     assert_eq!(page.items[0].reason_code.as_deref(), Some("account_deactivated"));
 }
+
+#[tokio::test]
+async fn startup_does_not_backfill_request_log_user_snapshots() {
+    let db_path = temp_db_path("startup-skips-request-user-id-backfill");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "startup-skips-request-user-backfill".to_string(),
+            username: Some("startup_skips_request_user_backfill".to_string()),
+            name: Some("Startup Skips Request User Backfill".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("startup-skips-request-user-backfill"))
+        .await
+        .expect("bind token");
+
+    let request_log_id = proxy
+        .record_local_request_log_without_key(
+            Some(&token.id),
+            &Method::GET,
+            "/search",
+            Some("q=startup-skips-request-user-backfill"),
+            StatusCode::OK,
+            Some(200),
+            b"{}",
+            b"{}",
+            OUTCOME_SUCCESS,
+            None,
+            &[],
+            &[],
+            None,
+        )
+        .await
+        .expect("record token attempt");
+    proxy
+        .record_token_attempt_request_log_metadata(
+            &token.id,
+            &Method::GET,
+            "/search",
+            Some("q=startup-skips-request-user-backfill"),
+            Some(StatusCode::OK.as_u16() as i64),
+            Some(200),
+            true,
+            OUTCOME_SUCCESS,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(request_log_id),
+        )
+        .await
+        .expect("record linked token attempt");
+    sqlx::query("UPDATE request_logs SET request_user_id = NULL WHERE id = ?")
+        .bind(request_log_id)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("clear request user id");
+    drop(proxy);
+
+    let reopened = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy reopened");
+    let request_user_id: Option<String> =
+        sqlx::query_scalar("SELECT request_user_id FROM request_logs WHERE id = ?")
+            .bind(request_log_id)
+            .fetch_one(&reopened.key_store.pool)
+            .await
+            .expect("reload request user id after startup");
+    assert_eq!(request_user_id, None);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn request_user_id_backfill_runs_in_resumable_batches() {
+    let db_path = temp_db_path("request-user-id-backfill-resumable");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "request-user-backfill-resumable".to_string(),
+            username: Some("request_user_backfill_resumable".to_string()),
+            name: Some("Request User Backfill Resumable".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("request-user-backfill-resumable"))
+        .await
+        .expect("bind token");
+
+    for index in 0..3 {
+        let request_log_id = proxy
+            .record_local_request_log_without_key(
+                Some(&token.id),
+                &Method::GET,
+                "/search",
+                Some(&format!("q=request-user-backfill-resumable-{index}")),
+                StatusCode::OK,
+                Some(200),
+                b"{}",
+                b"{}",
+                OUTCOME_SUCCESS,
+                None,
+                &[],
+                &[],
+                None,
+            )
+            .await
+            .expect("record token attempt");
+        proxy
+            .record_token_attempt_request_log_metadata(
+                &token.id,
+                &Method::GET,
+                "/search",
+                Some(&format!("q=request-user-backfill-resumable-{index}")),
+                Some(StatusCode::OK.as_u16() as i64),
+                Some(200),
+                true,
+                OUTCOME_SUCCESS,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(request_log_id),
+            )
+            .await
+            .expect("record linked token attempt");
+    }
+
+    sqlx::query("UPDATE request_logs SET created_at = ?")
+        .bind(Utc::now().timestamp() - 120)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("age request logs past backfill stability grace");
+    sqlx::query("UPDATE request_logs SET request_user_id = NULL")
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("clear request user snapshots");
+
+    let first = crate::store::run_request_user_id_backfill_with_pool(&proxy.key_store.pool, 2)
+        .await
+        .expect("run first request user id backfill batch");
+    assert_eq!(first.rows_scanned, 2);
+    assert_eq!(first.rows_updated, 2);
+    assert_eq!(first.cursor_after, 2);
+
+    let filled_after_first: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM request_logs
+        WHERE request_user_id = ?
+        "#,
+    )
+    .bind(&user.user_id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count filled request logs after first batch");
+    assert_eq!(filled_after_first, 2);
+
+    let second = crate::store::run_request_user_id_backfill_with_pool(&proxy.key_store.pool, 2)
+        .await
+        .expect("run second request user id backfill batch");
+    assert_eq!(second.cursor_before, 2);
+    assert_eq!(second.rows_scanned, 1);
+    assert_eq!(second.rows_updated, 1);
+
+    let filled_after_second: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM request_logs
+        WHERE request_user_id = ?
+        "#,
+    )
+    .bind(&user.user_id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count filled request logs after second batch");
+    assert_eq!(filled_after_second, 3);
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
## Summary
- remove historical request_user_id backfill from service startup
- add explicit resumable request_user_id_backfill CLI with stable-window cursor batches and CLI-path auth token lookup index
- cover startup no-backfill and resumable backfill behavior; stabilize date-bound public success breakdown expectation

## Validation
- cargo fmt --check
- cargo test request_user_id_backfill_runs_in_resumable_batches
- cargo test startup_does_not_backfill_request_log_user_snapshots
- cargo run --bin request_user_id_backfill -- --help
- cargo clippy -- -D warnings
- cargo test
- codex review --base origin/main (clear)

## References
- Specs: docs/specs/r7k2p-client-ip-trust-and-usage
- Solutions: -
- Project Docs: -