### PR TITLE
fix(admin): filter empty rebalance IP diagnostics

### DIFF
--- a/docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md
@@ -7,3 +7,6 @@
   the `v0.47.0` production rollout exceeded Dockrev's healthcheck window on a
   million-row `request_logs` database; repair now runs through a resumable batch
   CLI.
+- 2026-05-12: Filtered empty rebalance local MCP control-plane rows out of the
+  observed client IP diagnostic endpoint so downstream/API/tool samples remain
+  visible.

--- a/docs/specs/r7k2p-client-ip-trust-and-usage/SPEC.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/SPEC.md
@@ -9,6 +9,7 @@
 - 可信代理 CIDR 与有序 IP 头配置持久化。
 - 仅在可信代理命中时解析 `clientIp`，并记录 `remoteAddr`、`clientIpSource`、可信状态与 IP 头快照。
 - IP 头快照保存已配置头与安全预设头的并集，便于管理员在启用 Cloudflare、EdgeOne 等头名前回看近期样本。
+- 近期请求 IP 诊断只展示有下游/API/tool 调用诊断价值的记录；空 IP 的 rebalance 本地 MCP 控制面日志不得挤占样本列表。
 - 默认仅信任 loopback 代理地址；私网或容器网段必须由管理员确认后显式加入。
 - 客户端 IP 头配置拒绝 `authorization`、`cookie`、API key 等敏感头名，避免误配置后落库秘密值。
 - 用户维度最近 7 天 `COUNT(DISTINCT clientIp)`。
@@ -23,6 +24,7 @@
 
 - 后端可安全解析并落盘 IP 审计字段。
 - 管理端可编辑可信代理 CIDR 与头顺序，可通过每个头名独立按钮快速追加通用反代、Cloudflare、EdgeOne 等常用头名，并查看近期观测值。
+- 近期观测值列表不会被 rebalance 本地 `initialize`、`tools/list`、`ping` 等空 IP 控制面日志刷屏。
 - 用户列表/详情可展示最近 7 天去重 IP 数。
 - Recent Requests 可展示 IP 诊断信息与头值快照。
 

--- a/src/server/tests/chunk_11.rs
+++ b/src/server/tests/chunk_11.rs
@@ -1709,6 +1709,102 @@
     }
 
     #[tokio::test]
+    async fn observed_client_ip_requests_skip_empty_rebalance_control_plane_logs() {
+        let db_path = temp_db_path("observed-client-ip-skip-rebalance-control");
+        let db_str = db_path.to_string_lossy().to_string();
+        let proxy = TavilyProxy::with_endpoint(
+            vec!["tvly-observed-client-ip-filter".to_string()],
+            "http://127.0.0.1:1",
+            &db_str,
+        )
+        .await
+        .expect("proxy created");
+        let pool = connect_sqlite_test_pool(&db_str).await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO request_logs (
+                method,
+                path,
+                status_code,
+                tavily_status_code,
+                result_status,
+                request_kind_key,
+                gateway_mode,
+                upstream_operation,
+                remote_addr,
+                client_ip,
+                client_ip_source,
+                client_ip_trusted,
+                ip_headers,
+                created_at
+            ) VALUES
+                (
+                    'POST', '/mcp', 200, 200, 'success', 'mcp:tools/list',
+                    ?, 'mcp', NULL, NULL, NULL, 0, NULL, 30
+                ),
+                (
+                    'POST', '/api/tavily/search', 200, 200, 'success', 'api:search',
+                    NULL, NULL, NULL, NULL, NULL, 0, NULL, 25
+                ),
+                (
+                    'POST', '/api/tavily/search', 200, 200, 'success', 'api:search',
+                    NULL, NULL, '172.24.0.176:51000', '203.0.113.10',
+                    'eo-connecting-ip', 1,
+                    '[{"name":"eo-connecting-ip","value":"203.0.113.10"}]', 20
+                ),
+                (
+                    'POST', '/mcp', 200, 200, 'success', 'mcp:search',
+                    ?, 'http_search', '172.24.0.176:51001', '172.24.0.176',
+                    'remote_addr', 0, '[]', 10
+                )
+            "#,
+        )
+        .bind(tavily_hikari::MCP_GATEWAY_MODE_REBALANCE)
+        .bind(tavily_hikari::MCP_GATEWAY_MODE_REBALANCE)
+        .execute(&pool)
+        .await
+        .expect("insert request logs");
+
+        let control_log_id: i64 = sqlx::query_scalar(
+            "SELECT id FROM request_logs WHERE upstream_operation = 'mcp'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("fetch control log id");
+
+        let observed = proxy
+            .recent_client_ip_requests(50)
+            .await
+            .expect("fetch observed client ip requests");
+        let observed_ids: Vec<i64> = observed.iter().map(|item| item.id).collect();
+
+        assert_eq!(observed.len(), 3);
+        assert!(
+            !observed_ids.contains(&control_log_id),
+            "empty rebalance control-plane logs should not crowd out IP diagnostics"
+        );
+        assert!(
+            observed.iter().any(|item| item.client_ip.is_none()),
+            "legacy rows without gateway metadata should not be removed by the rebalance filter"
+        );
+        let edge_one = observed
+            .iter()
+            .find(|item| item.client_ip.as_deref() == Some("203.0.113.10"))
+            .expect("EdgeOne observed row should remain");
+        assert_eq!(edge_one.client_ip_source.as_deref(), Some("eo-connecting-ip"));
+        assert_eq!(edge_one.ip_headers.len(), 1);
+        assert!(
+            observed
+                .iter()
+                .any(|item| item.client_ip_source.as_deref() == Some("remote_addr")),
+            "MCP tool rows with remote_addr should remain"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn mcp_rebalance_tools_call_search_uses_http_upstream_and_strict_headers() {
         let db_path = temp_db_path("mcp-rebalance-search-http");
         let db_str = db_path.to_string_lossy().to_string();

--- a/src/store/key_store_token_logs.rs
+++ b/src/store/key_store_token_logs.rs
@@ -2615,11 +2615,26 @@ impl KeyStore {
             SELECT id, created_at, remote_addr, client_ip, client_ip_source, client_ip_trusted, ip_headers
             FROM request_logs
             WHERE visibility = ?
+              AND NOT (
+                gateway_mode IS NOT NULL
+                AND upstream_operation IS NOT NULL
+                AND gateway_mode = ?
+                AND upstream_operation = ?
+                AND remote_addr IS NULL
+                AND client_ip IS NULL
+                AND (
+                  ip_headers IS NULL
+                  OR TRIM(ip_headers) = ''
+                  OR TRIM(ip_headers) = '[]'
+                )
+              )
             ORDER BY created_at DESC, id DESC
             LIMIT ?
             "#,
         )
         .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
+        .bind(MCP_GATEWAY_MODE_REBALANCE)
+        .bind("mcp")
         .bind(row_limit)
         .fetch_all(&self.pool)
         .await?;


### PR DESCRIPTION
## Summary
- Filter empty rebalance local MCP control-plane rows out of the observed client IP diagnostics endpoint.
- Keep API response shape unchanged while preserving downstream/API/tool request samples.
- Sync the trusted client IP spec with the diagnostic filtering behavior.

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test observed_client_ip_requests_skip_empty_rebalance_control_plane_logs`
- `cargo test mcp_rebalance_control_plane_lists_stay_local_and_return_empty_results`
- `cargo test`

## References
- Specs: `docs/specs/r7k2p-client-ip-trust-and-usage/SPEC.md`
- Solutions: -
- Project Docs: -
