### PR TITLE
fix(system-settings): autosave controls immediately

### DIFF
--- a/docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md
@@ -13,3 +13,6 @@
 - 2026-05-12: Filtered empty rebalance local MCP control-plane rows out of the
   observed client IP diagnostic endpoint so downstream/API/tool samples remain
   visible.
+- 2026-05-13: Changed the trusted client IP settings dialog to use explicit
+  Apply/Cancel closure only, with the default close affordance hidden to keep
+  the draft state isolated until confirmation.

--- a/docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 - Backend: request log schema, IP resolution, observed header values, recent 24h/7d IP count query, capped per-user IP address lists, and capped 7-day IP timeline query.
 - API: system settings payload/response extension and admin-only observed header endpoint.
-- UI: system settings dialog, global IP limit input, user IP count badges, user detail IP chart/list, recent request diagnostics.
+- UI: system settings dialog, global IP limit input, trusted client IP Apply/Cancel-confirmed draft editor, user IP count badges, user detail IP chart/list, recent request diagnostics.
 - Operations: historical `request_user_id` repair is an explicit resumable
   `request_user_id_backfill` CLI batch job, not part of service startup.
 

--- a/docs/specs/r7k2p-client-ip-trust-and-usage/SPEC.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/SPEC.md
@@ -15,6 +15,7 @@
 - 用户维度最近 24 小时与 7 天 `COUNT(DISTINCT clientIp)`。
 - 系统设置增加全局 IP 数提示阈值，默认 `5`；超过阈值只在管理端标红，不影响鉴权、转发、封禁或限流。
 - 系统设置对话框、近期请求 IP 诊断、用户列表/详情 IP 数展示。
+- 系统设置对话框中的可信客户端 IP 编辑区只能通过“应用/取消”关闭，不能通过遮罩、Escape 或默认关闭按钮绕过确认。
 - 用户详情共享额度趋势 tab 在 `月` 后新增 `IP`，展示最近 7 天 IP 使用情况图，纵轴为 IP 地址，横轴为时间。
 - 用户详情展示最近 24 小时与 7 天的唯一 IP 地址列表和数量。
 
@@ -50,6 +51,7 @@
 
 - 后端可安全解析并落盘 IP 审计字段。
 - 管理端可编辑可信代理 CIDR 与头顺序，可通过每个头名独立按钮快速追加通用反代、Cloudflare、EdgeOne 等常用头名，并查看近期观测值。
+- 管理端编辑可信代理 CIDR 与头顺序时，必须通过“应用/取消”关闭弹窗；取消会丢弃草稿，应用会保存并关闭。
 - 近期观测值列表不会被 rebalance 本地 `initialize`、`tools/list`、`ping` 等空 IP 控制面日志刷屏。
 - 用户列表/详情可展示最近 24 小时与 7 天去重 IP 数；24 小时数超过全局阈值时仅界面标红。
 - 用户详情可查看最近 7 天按 IP 分行的时间线，以及最近 24 小时/7 天唯一 IP 列表。
@@ -60,7 +62,7 @@
 - source_type: storybook_canvas
   story_id_or_title: Admin/SystemSettingsModule/ClientIpDialogWithObservedValues
   scenario: trusted client IP settings dialog with observed header values
-  evidence_note: verifies the dialog exposes trusted proxy CIDRs, ordered client IP headers, and recent observed header values.
+  evidence_note: verifies the dialog exposes trusted proxy CIDRs, ordered client IP headers, recent observed header values, and only closes via Apply/Cancel.
   image:
   ![Trusted client IP settings dialog](./assets/client-ip-settings-dialog.png)
 

--- a/docs/specs/tjhrr-system-request-rate-limit-setting/SPEC.md
+++ b/docs/specs/tjhrr-system-request-rate-limit-setting/SPEC.md
@@ -35,6 +35,7 @@
 - `GET /api/settings` 与 `PUT /api/settings/system` 读写新字段，并兼容旧 payload 缺省该字段。
 - 内存 request-rate limiter 支持运行时热更新阈值，且不清空当前窗口计数。
 - Admin `System Settings` 表单、文案、Storybook、render/browser 回归、spec 视觉证据。
+- 系统设置页采用控件级直接生效：开关立即保存，数字输入在失焦或按 Enter 且合法时保存，不再依赖页面底部统一“应用设置”按钮。
 
 ### Out of scope
 
@@ -48,6 +49,7 @@
 
 - `requestRateLimit` 必须是正整数；前端限定为 JS safe integer，后端限定 `>= 1`。
 - 旧客户端 `PUT /api/settings/system` 未携带 `requestRateLimit` 时，服务端必须保留现值。
+- 系统设置页普通字段不得再依赖页面底部统一“应用设置”作为必经路径；开关立即保存，数字输入仅在失焦或 Enter 时提交合法值。
 - request-rate 429 payload、默认视图、snapshot fallback 必须反映当前生效阈值，而不是硬编码 `100` 之外的旧默认值。
 - 保存设置后不得清空现有内存窗口计数；仅切换阈值。
 

--- a/web/src/admin/SystemSettingsModule.interaction.test.tsx
+++ b/web/src/admin/SystemSettingsModule.interaction.test.tsx
@@ -1,8 +1,8 @@
 import '../../test/happydom'
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import { act, useState } from 'react'
-import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
 
 import type { SystemSettings } from '../api'
 import { translations } from '../i18n'
@@ -23,91 +23,12 @@ const initialSettings: SystemSettings = {
   trustedClientIpHeaders: ['cf-connecting-ip', 'x-forwarded-for'],
 }
 
-function setNativeValue<T extends HTMLInputElement | HTMLTextAreaElement>(element: T, value: string): void {
-  const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value')
-  descriptor?.set?.call(element, value)
-  element.dispatchEvent(new Event('input', { bubbles: true }))
-}
-
 async function flushEffects(): Promise<void> {
   await act(async () => {
     await Promise.resolve()
     await Promise.resolve()
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
   })
-}
-
-function installObservedHeadersFetchMock(): () => void {
-  const originalFetch = window.fetch.bind(window)
-
-  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const request =
-      input instanceof Request
-        ? input
-        : new Request(typeof input === 'string' && input.startsWith('/') ? `http://localhost${input}` : input, init)
-    const url = new URL(request.url, 'http://localhost')
-
-    if (url.pathname === '/api/settings/client-ip/observed-headers') {
-      return new Response(
-        JSON.stringify({
-          items: [
-            {
-              id: 1042,
-              createdAt: 1_774_693_640,
-              remoteAddr: '10.0.0.4',
-              clientIp: '203.0.113.7',
-              clientIpSource: 'cf-connecting-ip',
-              clientIpTrusted: true,
-              ipHeaders: [
-                { name: 'cf-connecting-ip', value: '203.0.113.7' },
-                { name: 'x-forwarded-for', value: '198.51.100.10, 10.0.0.4' },
-              ],
-            },
-          ],
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      )
-    }
-
-    return originalFetch(request, init)
-  }
-
-  return () => {
-    window.fetch = originalFetch
-  }
-}
-
-async function mountSystemSettingsModule(): Promise<{
-  root: Root
-  applied: SystemSettings[]
-}> {
-  const applied: SystemSettings[] = []
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  const root = createRoot(container)
-
-  function Harness(): JSX.Element {
-    const [settings, setSettings] = useState<SystemSettings>(initialSettings)
-    return (
-      <SystemSettingsModule
-        strings={strings}
-        settings={settings}
-        loadState="ready"
-        error={null}
-        saving={false}
-        onApply={(nextSettings) => {
-          applied.push(nextSettings)
-          setSettings(nextSettings)
-        }}
-      />
-    )
-  }
-
-  await act(async () => {
-    root.render(<Harness />)
-  })
-  await flushEffects()
-
-  return { root, applied }
 }
 
 afterEach(() => {
@@ -154,83 +75,5 @@ describe('SystemSettingsModule interactions', () => {
     expect(switchButton!.getAttribute('aria-checked')).toBe('false')
 
     await act(async () => root.unmount())
-  })
-
-  it('keeps trusted client IP changes inside the dialog until apply or cancel', async () => {
-    const restoreFetch = installObservedHeadersFetchMock()
-    const { root, applied } = await mountSystemSettingsModule()
-
-    await act(async () => {
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent?.includes('配置可信 IP'))
-        ?.click()
-    })
-    await flushEffects()
-
-    expect(document.body.textContent).toContain('可信客户端 IP')
-    expect(document.body.textContent).toContain('取消')
-    expect(document.body.textContent).toContain('应用')
-    expect(document.body.textContent).not.toContain('Close')
-
-    await act(async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }))
-    })
-    await flushEffects()
-    expect(document.body.textContent).toContain('可信客户端 IP')
-
-    await act(async () => {
-      document.querySelector<HTMLElement>('.layer-modal-overlay')?.dispatchEvent(
-        new PointerEvent('pointerdown', { bubbles: true }),
-      )
-    })
-    await flushEffects()
-    expect(document.body.textContent).toContain('可信客户端 IP')
-
-    const textareas = Array.from(document.querySelectorAll<HTMLTextAreaElement>('textarea'))
-    expect(textareas.length).toBeGreaterThanOrEqual(2)
-
-    await act(async () => {
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent?.trim() === 'x-real-ip')
-        ?.click()
-    })
-    await flushEffects()
-    expect(applied.length).toBe(0)
-
-    await act(async () => {
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent?.includes('取消'))
-        ?.click()
-    })
-    await flushEffects()
-    expect(document.body.textContent).not.toContain('最近请求中的字段值')
-    expect(applied.length).toBe(0)
-
-    await act(async () => {
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent?.includes('配置可信 IP'))
-        ?.click()
-    })
-    await flushEffects()
-
-    const reopenedTextareas = Array.from(document.querySelectorAll<HTMLTextAreaElement>('textarea'))
-    expect(reopenedTextareas.length).toBeGreaterThanOrEqual(2)
-    await act(async () => {
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent?.trim() === 'x-real-ip')
-        ?.click()
-    })
-    await act(async () => {
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent?.includes('应用'))
-        ?.click()
-    })
-    await flushEffects()
-
-    expect(applied.at(-1)?.trustedClientIpHeaders).toEqual(['cf-connecting-ip', 'x-forwarded-for', 'x-real-ip'])
-    expect(document.body.textContent).not.toContain('最近请求中的字段值')
-
-    await act(async () => root.unmount())
-    restoreFetch()
   })
 })

--- a/web/src/admin/SystemSettingsModule.interaction.test.tsx
+++ b/web/src/admin/SystemSettingsModule.interaction.test.tsx
@@ -1,0 +1,236 @@
+import '../../test/happydom'
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import type { SystemSettings } from '../api'
+import { translations } from '../i18n'
+import SystemSettingsModule from './SystemSettingsModule'
+
+const strings = translations.zh.admin.systemSettings
+
+const initialSettings: SystemSettings = {
+  requestRateLimit: 100,
+  mcpSessionAffinityKeyCount: 5,
+  rebalanceMcpEnabled: false,
+  rebalanceMcpSessionPercent: 100,
+  apiRebalanceEnabled: false,
+  apiRebalancePercent: 0,
+  userBlockedKeyBaseLimit: 5,
+  globalIpLimit: 5,
+  trustedProxyCidrs: ['127.0.0.0/8', '::1/128'],
+  trustedClientIpHeaders: ['cf-connecting-ip', 'x-forwarded-for'],
+}
+
+function setNativeValue<T extends HTMLInputElement | HTMLTextAreaElement>(element: T, value: string): void {
+  const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value')
+  descriptor?.set?.call(element, value)
+  element.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function installObservedHeadersFetchMock(): () => void {
+  const originalFetch = window.fetch.bind(window)
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request =
+      input instanceof Request
+        ? input
+        : new Request(typeof input === 'string' && input.startsWith('/') ? `http://localhost${input}` : input, init)
+    const url = new URL(request.url, 'http://localhost')
+
+    if (url.pathname === '/api/settings/client-ip/observed-headers') {
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: 1042,
+              createdAt: 1_774_693_640,
+              remoteAddr: '10.0.0.4',
+              clientIp: '203.0.113.7',
+              clientIpSource: 'cf-connecting-ip',
+              clientIpTrusted: true,
+              ipHeaders: [
+                { name: 'cf-connecting-ip', value: '203.0.113.7' },
+                { name: 'x-forwarded-for', value: '198.51.100.10, 10.0.0.4' },
+              ],
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    return originalFetch(request, init)
+  }
+
+  return () => {
+    window.fetch = originalFetch
+  }
+}
+
+async function mountSystemSettingsModule(): Promise<{
+  root: Root
+  applied: SystemSettings[]
+}> {
+  const applied: SystemSettings[] = []
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  function Harness(): JSX.Element {
+    const [settings, setSettings] = useState<SystemSettings>(initialSettings)
+    return (
+      <SystemSettingsModule
+        strings={strings}
+        settings={settings}
+        loadState="ready"
+        error={null}
+        saving={false}
+        onApply={(nextSettings) => {
+          applied.push(nextSettings)
+          setSettings(nextSettings)
+        }}
+      />
+    )
+  }
+
+  await act(async () => {
+    root.render(<Harness />)
+  })
+  await flushEffects()
+
+  return { root, applied }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('SystemSettingsModule interactions', () => {
+  it('saves switches immediately and keeps the previous value when save fails', async () => {
+    const applied: SystemSettings[] = []
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    function Harness(): JSX.Element {
+      return (
+        <SystemSettingsModule
+          strings={strings}
+          settings={initialSettings}
+          loadState="ready"
+          error="保存系统设置失败。"
+          saving={false}
+          onApply={(nextSettings) => {
+            applied.push(nextSettings)
+            throw new Error('save failed')
+          }}
+        />
+      )
+    }
+
+    await act(async () => {
+      root.render(<Harness />)
+    })
+    await flushEffects()
+
+    const switchButton = document.querySelector<HTMLButtonElement>('#system-settings-rebalance-switch')
+    expect(switchButton).not.toBeNull()
+
+    await act(async () => {
+      switchButton!.click()
+    })
+    await flushEffects()
+
+    expect(applied.at(-1)?.rebalanceMcpEnabled).toBe(true)
+    expect(switchButton!.getAttribute('aria-checked')).toBe('false')
+
+    await act(async () => root.unmount())
+  })
+
+  it('keeps trusted client IP changes inside the dialog until apply or cancel', async () => {
+    const restoreFetch = installObservedHeadersFetchMock()
+    const { root, applied } = await mountSystemSettingsModule()
+
+    await act(async () => {
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('配置可信 IP'))
+        ?.click()
+    })
+    await flushEffects()
+
+    expect(document.body.textContent).toContain('可信客户端 IP')
+    expect(document.body.textContent).toContain('取消')
+    expect(document.body.textContent).toContain('应用')
+    expect(document.body.textContent).not.toContain('Close')
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }))
+    })
+    await flushEffects()
+    expect(document.body.textContent).toContain('可信客户端 IP')
+
+    await act(async () => {
+      document.querySelector<HTMLElement>('.layer-modal-overlay')?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true }),
+      )
+    })
+    await flushEffects()
+    expect(document.body.textContent).toContain('可信客户端 IP')
+
+    const textareas = Array.from(document.querySelectorAll<HTMLTextAreaElement>('textarea'))
+    expect(textareas.length).toBeGreaterThanOrEqual(2)
+
+    await act(async () => {
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === 'x-real-ip')
+        ?.click()
+    })
+    await flushEffects()
+    expect(applied.length).toBe(0)
+
+    await act(async () => {
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('取消'))
+        ?.click()
+    })
+    await flushEffects()
+    expect(document.body.textContent).not.toContain('最近请求中的字段值')
+    expect(applied.length).toBe(0)
+
+    await act(async () => {
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('配置可信 IP'))
+        ?.click()
+    })
+    await flushEffects()
+
+    const reopenedTextareas = Array.from(document.querySelectorAll<HTMLTextAreaElement>('textarea'))
+    expect(reopenedTextareas.length).toBeGreaterThanOrEqual(2)
+    await act(async () => {
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === 'x-real-ip')
+        ?.click()
+    })
+    await act(async () => {
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent?.includes('应用'))
+        ?.click()
+    })
+    await flushEffects()
+
+    expect(applied.at(-1)?.trustedClientIpHeaders).toEqual(['cf-connecting-ip', 'x-forwarded-for', 'x-real-ip'])
+    expect(document.body.textContent).not.toContain('最近请求中的字段值')
+
+    await act(async () => root.unmount())
+    restoreFetch()
+  })
+})

--- a/web/src/admin/SystemSettingsModule.render.test.ts
+++ b/web/src/admin/SystemSettingsModule.render.test.ts
@@ -67,6 +67,7 @@ describe('SystemSettingsModule rendering', () => {
     expect(markup).toContain(strings.form.currentGlobalIpLimitValue.replace('{count}', '5'))
     expect(markup).toContain(strings.form.globalIpLimitHint)
     expect(markup).toContain('配置可信 IP')
+    expect(markup).not.toContain('system-settings-apply')
     expect(markup).not.toContain(strings.description)
     expect(markup).not.toContain(strings.form.description)
     expect(markup).not.toContain(strings.form.countHint)
@@ -98,7 +99,6 @@ describe('SystemSettingsModule rendering', () => {
     )
 
     expect(markup).toContain(strings.actions.applying)
-    expect(markup).toContain('icon-spin')
   })
 
   it('shows the locked hint when rebalance is disabled', () => {

--- a/web/src/admin/SystemSettingsModule.stories.test.ts
+++ b/web/src/admin/SystemSettingsModule.stories.test.ts
@@ -20,6 +20,7 @@ describe('SystemSettingsModule Storybook proofs', () => {
     expect(systemSettingsStories.ErrorState).toMatchObject({})
     expect(systemSettingsStories.HelpBubbleOpen).toMatchObject({})
     expect(systemSettingsStories.BlockedKeyBaseConfigured).toMatchObject({})
+    expect(systemSettingsStories.AutosaveOnBlur).toMatchObject({})
     expect(systemSettingsStories.ClientIpDialogWithObservedValues).toMatchObject({})
   })
 

--- a/web/src/admin/SystemSettingsModule.stories.tsx
+++ b/web/src/admin/SystemSettingsModule.stories.tsx
@@ -1,8 +1,9 @@
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useState } from 'react'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import SystemSettingsModule from './SystemSettingsModule'
+import type { SystemSettings } from '../api'
 import { translations } from '../i18n'
 
 function SystemSettingsCanvas(props: {
@@ -18,34 +19,37 @@ function SystemSettingsCanvas(props: {
   saving?: boolean
   helpBubbleOpen?: boolean
 }): JSX.Element {
+  const [currentSettings, setCurrentSettings] = useState<SystemSettings>({
+    requestRateLimit: props.requestRateLimit ?? 100,
+    mcpSessionAffinityKeyCount: props.count ?? 5,
+    rebalanceMcpEnabled: props.rebalanceEnabled ?? false,
+    rebalanceMcpSessionPercent: props.rebalancePercent ?? 100,
+    apiRebalanceEnabled: props.apiRebalanceEnabled ?? false,
+    apiRebalancePercent: props.apiRebalancePercent ?? 0,
+    userBlockedKeyBaseLimit: props.blockedKeyBaseLimit ?? 5,
+    globalIpLimit: 5,
+    trustedProxyCidrs: ['127.0.0.0/8', '::1/128'],
+    trustedClientIpHeaders: [
+      'cf-connecting-ip',
+      'true-client-ip',
+      'x-real-ip',
+      'x-forwarded-for',
+      'cf-connecting-ipv6',
+      'eo-connecting-ip',
+    ],
+  })
   return (
     <div style={{ maxWidth: 960, margin: '0 auto' }}>
       <SystemSettingsModule
         strings={translations.zh.admin.systemSettings}
-        settings={{
-          requestRateLimit: props.requestRateLimit ?? 100,
-          mcpSessionAffinityKeyCount: props.count ?? 5,
-          rebalanceMcpEnabled: props.rebalanceEnabled ?? false,
-          rebalanceMcpSessionPercent: props.rebalancePercent ?? 100,
-          apiRebalanceEnabled: props.apiRebalanceEnabled ?? false,
-          apiRebalancePercent: props.apiRebalancePercent ?? 0,
-          userBlockedKeyBaseLimit: props.blockedKeyBaseLimit ?? 5,
-          globalIpLimit: 5,
-          trustedProxyCidrs: ['127.0.0.0/8', '::1/128'],
-          trustedClientIpHeaders: [
-            'cf-connecting-ip',
-            'true-client-ip',
-            'x-real-ip',
-            'x-forwarded-for',
-            'cf-connecting-ipv6',
-            'eo-connecting-ip',
-          ],
-        }}
+        settings={currentSettings}
         loadState={props.loadState ?? 'ready'}
         error={props.error ?? null}
         saving={props.saving ?? false}
         helpBubbleOpen={props.helpBubbleOpen}
-        onApply={() => {}}
+        onApply={(nextSettings) => {
+          setCurrentSettings(nextSettings)
+        }}
       />
     </div>
   )
@@ -56,7 +60,10 @@ function ObservedClientIpRequestsMock(): null {
     const originalFetch = window.fetch.bind(window)
 
     window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-      const request = input instanceof Request ? input : new Request(input, init)
+      const request =
+        input instanceof Request
+          ? input
+          : new Request(typeof input === 'string' && input.startsWith('/') ? `http://localhost${input}` : input, init)
       const url = new URL(request.url, window.location.origin)
 
       if (url.pathname === '/api/settings/client-ip/observed-headers') {
@@ -137,6 +144,12 @@ function ObservedClientIpRequestsMock(): null {
   return null
 }
 
+function setNativeValue<T extends HTMLInputElement | HTMLTextAreaElement>(element: T, value: string): void {
+  const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value')
+  descriptor?.set?.call(element, value)
+  element.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
 const meta = {
   title: 'Admin/SystemSettingsModule',
   component: SystemSettingsModule,
@@ -144,7 +157,8 @@ const meta = {
     layout: 'padded',
     docs: {
       description: {
-        component: 'Admin-only MCP session affinity and Rebalance MCP controls with immediate apply feedback.',
+        component:
+          'Admin-only MCP session affinity and Rebalance MCP controls with direct-save drafts and a confirmed trusted IP dialog.',
       },
     },
   },
@@ -195,13 +209,7 @@ export const ApiRebalanceDisabledSliderLocked: Story = {
 
 export const Applying: Story = {
   render: () => (
-    <SystemSettingsCanvas
-      rebalanceEnabled
-      rebalancePercent={35}
-      apiRebalanceEnabled
-      apiRebalancePercent={25}
-      saving
-    />
+    <SystemSettingsCanvas rebalanceEnabled rebalancePercent={35} apiRebalanceEnabled apiRebalancePercent={25} saving />
   ),
 }
 
@@ -223,6 +231,21 @@ export const RequestRateEdited: Story = {
       apiRebalancePercent={25}
     />
   ),
+}
+
+export const AutosaveOnBlur: Story = {
+  render: () => <SystemSettingsCanvas />,
+  play: async ({ canvasElement }) => {
+    const input = canvasElement.querySelector<HTMLInputElement>('#system-settings-request-rate-limit')
+    if (!input) throw new Error('Expected request-rate input to exist')
+    setNativeValue(input, '72')
+    input.dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+    await new Promise((resolve) => window.setTimeout(resolve, 100))
+    const text = canvasElement.textContent ?? ''
+    if (!text.includes('当前阈值：72')) {
+      throw new Error('Expected blur autosave to update the current request-rate value')
+    }
+  },
 }
 
 export const BlockedKeyBaseConfigured: Story = {
@@ -260,6 +283,8 @@ export const ClientIpDialogWithObservedValues: Story = {
     const text = canvasElement.ownerDocument.body.textContent ?? ''
     for (const expected of [
       '可信客户端 IP',
+      '取消',
+      '应用',
       '请求',
       'cf-connecting-ip',
       'true-client-ip',
@@ -273,6 +298,9 @@ export const ClientIpDialogWithObservedValues: Story = {
       if (!text.includes(expected)) {
         throw new Error(`Expected client IP dialog canvas to contain: ${expected}`)
       }
+    }
+    if (text.includes('Close')) {
+      throw new Error('Expected client IP dialog to hide the default close button')
     }
   },
 }

--- a/web/src/admin/SystemSettingsModule.tsx
+++ b/web/src/admin/SystemSettingsModule.tsx
@@ -376,7 +376,6 @@ export default function SystemSettingsModule({
   const handleCommitKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter') return
     event.preventDefault()
-    void commitNormalSettings()
     event.currentTarget.blur()
   }
 

--- a/web/src/admin/SystemSettingsModule.tsx
+++ b/web/src/admin/SystemSettingsModule.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type KeyboardEvent } from 'react'
 
 import { fetchObservedClientIpRequests, type ObservedClientIpRequest, type SystemSettings } from '../api'
 import type { QueryLoadState } from './queryLoadState'
@@ -16,7 +16,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '../components/ui/dialog'
 
 interface SystemSettingsModuleProps {
@@ -28,6 +27,20 @@ interface SystemSettingsModuleProps {
   helpBubbleOpen?: boolean
   onApply: (settings: SystemSettings) => Promise<void> | void
 }
+
+type NormalSystemSettingsOverrides = Partial<
+  Pick<
+    SystemSettings,
+    | 'requestRateLimit'
+    | 'mcpSessionAffinityKeyCount'
+    | 'rebalanceMcpEnabled'
+    | 'rebalanceMcpSessionPercent'
+    | 'apiRebalanceEnabled'
+    | 'apiRebalancePercent'
+    | 'userBlockedKeyBaseLimit'
+    | 'globalIpLimit'
+  >
+>
 
 function isValidCountDraft(value: string): value is `${number}` {
   if (!/^\d+$/.test(value)) return false
@@ -69,6 +82,13 @@ const clientIpHeaderPresets = [
     note: '通常与通用反代中的 x-forwarded-for 一起使用',
   },
 ] as const
+
+function normalizedTrustedProxyCidrsFromDraft(current: string): string[] {
+  return current
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
 
 export function parseTrustedClientIpHeaderDraft(current: string): {
   values: string[]
@@ -159,33 +179,25 @@ export default function SystemSettingsModule({
   const [draftRequestRateLimit, setDraftRequestRateLimit] = useState(() =>
     settings ? String(settings.requestRateLimit) : '100',
   )
-  const [draftCount, setDraftCount] = useState(() =>
-    settings ? String(settings.mcpSessionAffinityKeyCount) : '',
-  )
-  const [draftRebalanceEnabled, setDraftRebalanceEnabled] = useState(
-    settings?.rebalanceMcpEnabled ?? false,
-  )
+  const [draftCount, setDraftCount] = useState(() => (settings ? String(settings.mcpSessionAffinityKeyCount) : ''))
+  const [draftRebalanceEnabled, setDraftRebalanceEnabled] = useState(settings?.rebalanceMcpEnabled ?? false)
   const [draftPercent, setDraftPercent] = useState(() =>
     settings ? String(settings.rebalanceMcpSessionPercent) : '100',
   )
-  const [draftApiRebalanceEnabled, setDraftApiRebalanceEnabled] = useState(
-    settings?.apiRebalanceEnabled ?? false,
-  )
+  const [draftApiRebalanceEnabled, setDraftApiRebalanceEnabled] = useState(settings?.apiRebalanceEnabled ?? false)
   const [draftApiRebalancePercent, setDraftApiRebalancePercent] = useState(() =>
     settings ? String(settings.apiRebalancePercent) : '0',
   )
   const [draftBlockedKeyBaseLimit, setDraftBlockedKeyBaseLimit] = useState(() =>
     settings ? String(settings.userBlockedKeyBaseLimit) : '5',
   )
-  const [draftGlobalIpLimit, setDraftGlobalIpLimit] = useState(() =>
-    settings ? String(settings.globalIpLimit) : '5',
-  )
+  const [draftGlobalIpLimit, setDraftGlobalIpLimit] = useState(() => (settings ? String(settings.globalIpLimit) : '5'))
   const [clientIpDialogOpen, setClientIpDialogOpen] = useState(false)
-  const [draftTrustedProxyCidrs, setDraftTrustedProxyCidrs] = useState(() =>
-    settings?.trustedProxyCidrs?.join('\n') ?? '',
+  const [draftTrustedProxyCidrs, setDraftTrustedProxyCidrs] = useState(
+    () => settings?.trustedProxyCidrs?.join('\n') ?? '',
   )
-  const [draftTrustedClientIpHeaders, setDraftTrustedClientIpHeaders] = useState(() =>
-    settings?.trustedClientIpHeaders?.join('\n') ?? '',
+  const [draftTrustedClientIpHeaders, setDraftTrustedClientIpHeaders] = useState(
+    () => settings?.trustedClientIpHeaders?.join('\n') ?? '',
   )
   const [observedClientIpRequests, setObservedClientIpRequests] = useState<ObservedClientIpRequest[]>([])
   const [observedClientIpRequestsError, setObservedClientIpRequestsError] = useState<string | null>(null)
@@ -199,8 +211,10 @@ export default function SystemSettingsModule({
     setDraftApiRebalancePercent(settings ? String(settings.apiRebalancePercent) : '0')
     setDraftBlockedKeyBaseLimit(settings ? String(settings.userBlockedKeyBaseLimit) : '5')
     setDraftGlobalIpLimit(settings ? String(settings.globalIpLimit) : '5')
-    setDraftTrustedProxyCidrs(settings?.trustedProxyCidrs?.join('\n') ?? '')
-    setDraftTrustedClientIpHeaders(settings?.trustedClientIpHeaders?.join('\n') ?? '')
+    if (!clientIpDialogOpen) {
+      setDraftTrustedProxyCidrs(settings?.trustedProxyCidrs?.join('\n') ?? '')
+      setDraftTrustedClientIpHeaders(settings?.trustedClientIpHeaders?.join('\n') ?? '')
+    }
   }, [
     settings?.requestRateLimit,
     settings?.mcpSessionAffinityKeyCount,
@@ -212,6 +226,7 @@ export default function SystemSettingsModule({
     settings?.globalIpLimit,
     settings?.trustedProxyCidrs,
     settings?.trustedClientIpHeaders,
+    clientIpDialogOpen,
   ])
 
   useEffect(() => {
@@ -234,23 +249,18 @@ export default function SystemSettingsModule({
   const normalizedApiRebalancePercent = draftApiRebalancePercent.trim()
   const normalizedBlockedKeyBaseLimit = draftBlockedKeyBaseLimit.trim()
   const normalizedGlobalIpLimit = draftGlobalIpLimit.trim()
-  const normalizedTrustedProxyCidrs = draftTrustedProxyCidrs
-    .split(/\r?\n/)
-    .map((value) => value.trim())
-    .filter(Boolean)
+  const normalizedTrustedProxyCidrs = normalizedTrustedProxyCidrsFromDraft(draftTrustedProxyCidrs)
   const parsedTrustedClientIpHeaders = parseTrustedClientIpHeaderDraft(draftTrustedClientIpHeaders)
   const normalizedTrustedClientIpHeaders = parsedTrustedClientIpHeaders.values
   const observedHeaderColumns =
     normalizedTrustedClientIpHeaders.length > 0
       ? normalizedTrustedClientIpHeaders
-      : settings?.trustedClientIpHeaders ?? []
+      : (settings?.trustedClientIpHeaders ?? [])
   const parsedRequestRateLimit = isValidRequestRateLimitDraft(normalizedRequestRateLimit)
     ? Number.parseInt(normalizedRequestRateLimit, 10)
     : null
   const parsedCount = isValidCountDraft(normalizedCount) ? Number.parseInt(normalizedCount, 10) : null
-  const parsedPercent = isValidPercentDraft(normalizedPercent)
-    ? Number.parseInt(normalizedPercent, 10)
-    : null
+  const parsedPercent = isValidPercentDraft(normalizedPercent) ? Number.parseInt(normalizedPercent, 10) : null
   const parsedApiRebalancePercent = isValidPercentDraft(normalizedApiRebalancePercent)
     ? Number.parseInt(normalizedApiRebalancePercent, 10)
     : null
@@ -275,23 +285,134 @@ export default function SystemSettingsModule({
       draftApiRebalanceEnabled !== settings.apiRebalanceEnabled ||
       parsedApiRebalancePercent !== settings.apiRebalancePercent ||
       parsedBlockedKeyBaseLimit !== settings.userBlockedKeyBaseLimit ||
-      parsedGlobalIpLimit !== settings.globalIpLimit ||
-      normalizedTrustedProxyCidrs.join('\n') !== settings.trustedProxyCidrs.join('\n') ||
+      parsedGlobalIpLimit !== settings.globalIpLimit)
+  const trustedClientIpChanged =
+    settings != null &&
+    parsedTrustedClientIpHeaders.duplicateError == null &&
+    (normalizedTrustedProxyCidrs.join('\n') !== settings.trustedProxyCidrs.join('\n') ||
       normalizedTrustedClientIpHeaders.join('\n') !== settings.trustedClientIpHeaders.join('\n'))
-  const inlineError =
-    normalizedRequestRateLimit.length > 0 && parsedRequestRateLimit == null
-      ? strings.form.invalidRequestRateLimit
-      : normalizedCount.length > 0 && parsedCount == null
-      ? strings.form.invalidCount
-      : normalizedPercent.length > 0 && parsedPercent == null
+  const fieldErrors = {
+    requestRateLimit:
+      normalizedRequestRateLimit.length > 0 && parsedRequestRateLimit == null
+        ? strings.form.invalidRequestRateLimit
+        : null,
+    count: normalizedCount.length > 0 && parsedCount == null ? strings.form.invalidCount : null,
+    percent: normalizedPercent.length > 0 && parsedPercent == null ? strings.form.invalidPercent : null,
+    apiRebalancePercent:
+      normalizedApiRebalancePercent.length > 0 && parsedApiRebalancePercent == null
         ? strings.form.invalidPercent
-        : normalizedApiRebalancePercent.length > 0 && parsedApiRebalancePercent == null
-          ? strings.form.invalidPercent
-          : normalizedBlockedKeyBaseLimit.length > 0 && parsedBlockedKeyBaseLimit == null
-            ? strings.form.invalidBlockedKeyBaseLimit
-            : normalizedGlobalIpLimit.length > 0 && parsedGlobalIpLimit == null
-              ? strings.form.invalidGlobalIpLimit
-              : parsedTrustedClientIpHeaders.duplicateError ?? error
+        : null,
+    blockedKeyBaseLimit:
+      normalizedBlockedKeyBaseLimit.length > 0 && parsedBlockedKeyBaseLimit == null
+        ? strings.form.invalidBlockedKeyBaseLimit
+        : null,
+    globalIpLimit:
+      normalizedGlobalIpLimit.length > 0 && parsedGlobalIpLimit == null ? strings.form.invalidGlobalIpLimit : null,
+  }
+  const inlineError =
+    fieldErrors.requestRateLimit ??
+    fieldErrors.count ??
+    fieldErrors.percent ??
+    fieldErrors.apiRebalancePercent ??
+    fieldErrors.blockedKeyBaseLimit ??
+    fieldErrors.globalIpLimit ??
+    parsedTrustedClientIpHeaders.duplicateError ??
+    error
+  const requestRateLimitErrorId = 'system-settings-request-rate-limit-error'
+  const blockedKeyBaseLimitErrorId = 'system-settings-blocked-key-base-limit-error'
+  const globalIpLimitErrorId = 'system-settings-global-ip-limit-error'
+  const affinityCountErrorId = 'system-settings-affinity-count-error'
+  const rebalancePercentErrorId = 'system-settings-rebalance-percent-error'
+  const apiRebalancePercentErrorId = 'system-settings-api-rebalance-percent-error'
+
+  const buildNormalSettingsPayload = (overrides: NormalSystemSettingsOverrides = {}): SystemSettings | null => {
+    if (
+      settings == null ||
+      parsedRequestRateLimit == null ||
+      parsedCount == null ||
+      parsedPercent == null ||
+      parsedApiRebalancePercent == null ||
+      parsedBlockedKeyBaseLimit == null ||
+      parsedGlobalIpLimit == null
+    )
+      return null
+    return {
+      requestRateLimit: overrides.requestRateLimit ?? parsedRequestRateLimit,
+      mcpSessionAffinityKeyCount: overrides.mcpSessionAffinityKeyCount ?? parsedCount,
+      rebalanceMcpEnabled: overrides.rebalanceMcpEnabled ?? draftRebalanceEnabled,
+      rebalanceMcpSessionPercent: overrides.rebalanceMcpSessionPercent ?? parsedPercent,
+      apiRebalanceEnabled: overrides.apiRebalanceEnabled ?? draftApiRebalanceEnabled,
+      apiRebalancePercent: overrides.apiRebalancePercent ?? parsedApiRebalancePercent,
+      userBlockedKeyBaseLimit: overrides.userBlockedKeyBaseLimit ?? parsedBlockedKeyBaseLimit,
+      globalIpLimit: overrides.globalIpLimit ?? parsedGlobalIpLimit,
+      trustedProxyCidrs: settings.trustedProxyCidrs,
+      trustedClientIpHeaders: settings.trustedClientIpHeaders,
+    }
+  }
+
+  const normalPayloadChanged = (payload: SystemSettings): boolean =>
+    settings != null &&
+    (payload.requestRateLimit !== settings.requestRateLimit ||
+      payload.mcpSessionAffinityKeyCount !== settings.mcpSessionAffinityKeyCount ||
+      payload.rebalanceMcpEnabled !== settings.rebalanceMcpEnabled ||
+      payload.rebalanceMcpSessionPercent !== settings.rebalanceMcpSessionPercent ||
+      payload.apiRebalanceEnabled !== settings.apiRebalanceEnabled ||
+      payload.apiRebalancePercent !== settings.apiRebalancePercent ||
+      payload.userBlockedKeyBaseLimit !== settings.userBlockedKeyBaseLimit ||
+      payload.globalIpLimit !== settings.globalIpLimit)
+
+  const commitNormalSettings = (overrides: NormalSystemSettingsOverrides = {}): Promise<boolean> => {
+    if (saving) return Promise.resolve(false)
+    const payload = buildNormalSettingsPayload(overrides)
+    if (!payload || !normalPayloadChanged(payload)) return Promise.resolve(false)
+    return Promise.resolve()
+      .then(() => onApply(payload))
+      .then(
+        () => true,
+        () => false,
+      )
+  }
+
+  const handleCommitKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return
+    event.preventDefault()
+    void commitNormalSettings()
+    event.currentTarget.blur()
+  }
+
+  const openClientIpDialog = () => {
+    if (saving) return
+    setDraftTrustedProxyCidrs(settings?.trustedProxyCidrs?.join('\n') ?? '')
+    setDraftTrustedClientIpHeaders(settings?.trustedClientIpHeaders?.join('\n') ?? '')
+    setClientIpDialogOpen(true)
+  }
+
+  const cancelClientIpDialog = () => {
+    if (saving) return
+    setDraftTrustedProxyCidrs(settings?.trustedProxyCidrs?.join('\n') ?? '')
+    setDraftTrustedClientIpHeaders(settings?.trustedClientIpHeaders?.join('\n') ?? '')
+    setClientIpDialogOpen(false)
+  }
+
+  const commitTrustedClientIpSettings = async () => {
+    const normalPayload = buildNormalSettingsPayload()
+    if (saving || !normalPayload || parsedTrustedClientIpHeaders.duplicateError != null) return
+    const payload = {
+      ...normalPayload,
+      trustedProxyCidrs: normalizedTrustedProxyCidrs,
+      trustedClientIpHeaders: normalizedTrustedClientIpHeaders,
+    }
+    if (!trustedClientIpChanged && !normalPayloadChanged(payload)) {
+      setClientIpDialogOpen(false)
+      return
+    }
+    try {
+      await onApply(payload)
+      setClientIpDialogOpen(false)
+    } catch {
+      // Parent state owns the visible save error; keep the dialog draft intact.
+    }
+  }
   const observedClientIpRequestsSection = (
     <div className="grid gap-3 rounded-md border border-border/60 bg-muted/20 p-3 text-sm">
       <div className="grid gap-1">
@@ -344,6 +465,160 @@ export default function SystemSettingsModule({
       )}
     </div>
   )
+  const trustedClientIpPanel = (
+    <section className="grid gap-3 border-t border-border/60 pt-5">
+      <div>
+        <h4 className="text-sm font-semibold">可信客户端 IP</h4>
+        <p className="text-xs text-muted-foreground">
+          {settings?.trustedClientIpHeaders?.join(' -> ') ||
+            'cf-connecting-ip -> true-client-ip -> x-real-ip -> x-forwarded-for -> forwarded'}
+        </p>
+      </div>
+      <Dialog
+        open={clientIpDialogOpen}
+        onOpenChange={(open) => {
+          if (open) openClientIpDialog()
+        }}
+      >
+        <Button type="button" variant="outline" size="sm" disabled={saving} onClick={openClientIpDialog}>
+          <Icon icon="mdi:shield-account-outline" width={16} height={16} aria-hidden="true" />
+          配置可信 IP
+        </Button>
+        <DialogContent
+          hideCloseButton
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          onPointerDownOutside={(event) => event.preventDefault()}
+          className="grid max-h-[calc(100dvh-2rem)] w-[min(72rem,calc(100vw-2rem))] max-w-6xl grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0"
+        >
+          <DialogHeader className="px-6 pb-4 pr-12 pt-6">
+            <DialogTitle>可信客户端 IP</DialogTitle>
+            <DialogDescription>
+              先核对最近请求中的真实值，再用快捷按钮切换下方请求头顺序。使用应用或取消关闭弹窗。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid min-h-0 gap-4 overflow-y-auto px-6 pb-4">
+            <div className="grid gap-2 text-sm">
+              <label className="flex flex-col gap-2">
+                <span className="font-medium">可信代理 CIDR</span>
+                <textarea
+                  rows={4}
+                  className="resize-y rounded-md border border-input bg-background px-3 py-2 text-sm leading-6"
+                  value={draftTrustedProxyCidrs}
+                  disabled={saving}
+                  onChange={(event) => setDraftTrustedProxyCidrs(event.target.value)}
+                />
+              </label>
+
+              <div className="grid gap-1">
+                <span className="font-medium">客户端 IP 请求头顺序</span>
+                <p className="text-xs text-muted-foreground">点击切换。选中会出现在列表末尾，取消会从列表删除。</p>
+              </div>
+              <div className="grid gap-3">
+                <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/10 p-2">
+                  {clientIpHeaderPresets.map((preset) => (
+                    <div
+                      key={preset.group}
+                      className="inline-flex max-w-full flex-wrap items-center gap-1.5 rounded-md border border-border/50 bg-background/40 px-2 py-1.5"
+                    >
+                      <span
+                        className="mr-0.5 shrink-0 text-xs font-medium text-muted-foreground"
+                        title={'note' in preset ? preset.note : undefined}
+                      >
+                        {preset.group}
+                      </span>
+                      {preset.headers.map((header) =>
+                        (() => {
+                          const selected = normalizedTrustedClientIpHeaders.includes(header)
+                          return (
+                            <Button
+                              key={`${preset.group}-${header}`}
+                              type="button"
+                              variant="outline"
+                              size="xs"
+                              aria-pressed={selected}
+                              disabled={saving}
+                              className={
+                                selected
+                                  ? 'border-primary/65 bg-primary/10 text-primary hover:bg-primary/15'
+                                  : undefined
+                              }
+                              onClick={() =>
+                                setDraftTrustedClientIpHeaders((current) => toggleOrderedHeaderDraft(current, header))
+                              }
+                            >
+                              <Icon
+                                icon={selected ? 'mdi:check' : 'mdi:plus'}
+                                width={14}
+                                height={14}
+                                aria-hidden="true"
+                              />
+                              {header}
+                            </Button>
+                          )
+                        })(),
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <textarea
+                className="h-28 resize-y rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={draftTrustedClientIpHeaders}
+                disabled={saving}
+                onChange={(event) => setDraftTrustedClientIpHeaders(event.target.value)}
+              />
+            </div>
+            {observedClientIpRequestsSection}
+            {(parsedTrustedClientIpHeaders.duplicateError || (clientIpDialogOpen && error) || saving) && (
+              <p
+                className="text-sm font-medium"
+                role="status"
+                aria-live="polite"
+                style={{
+                  color: parsedTrustedClientIpHeaders.duplicateError || error ? 'hsl(var(--destructive))' : undefined,
+                }}
+              >
+                {parsedTrustedClientIpHeaders.duplicateError ??
+                  (clientIpDialogOpen ? error : null) ??
+                  strings.actions.applying}
+              </p>
+            )}
+          </div>
+          <DialogFooter className="border-t border-border/60 px-6 py-4">
+            <Button type="button" variant="outline" disabled={saving} onClick={cancelClientIpDialog}>
+              {strings.actions.cancel}
+            </Button>
+            <Button
+              type="button"
+              disabled={
+                saving ||
+                parsedTrustedClientIpHeaders.duplicateError != null ||
+                parsedRequestRateLimit == null ||
+                parsedCount == null ||
+                parsedPercent == null ||
+                parsedApiRebalancePercent == null ||
+                parsedBlockedKeyBaseLimit == null ||
+                parsedGlobalIpLimit == null ||
+                !trustedClientIpChanged
+              }
+              onClick={() => {
+                void commitTrustedClientIpSettings()
+              }}
+            >
+              <Icon
+                icon={saving ? 'mdi:loading' : 'mdi:check-circle-outline'}
+                width={16}
+                height={16}
+                className={saving ? 'icon-spin' : undefined}
+                aria-hidden="true"
+              />
+              {saving ? strings.actions.applying : strings.actions.apply}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
 
   return (
     <section className="surface panel">
@@ -359,407 +634,339 @@ export default function SystemSettingsModule({
         errorLabel={error ?? undefined}
         minHeight={260}
       >
-        <div
-          className="rounded-2xl border border-border/60 bg-background/55 p-5 shadow-sm backdrop-blur"
-          style={{ display: 'grid', gap: 20 }}
-        >
+        <div className="grid gap-6">
           <div>
             <h3 className="text-base font-semibold">{strings.form.title}</h3>
           </div>
 
-          <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'minmax(220px, 420px)' }}>
-            <div className="rounded-lg border border-border/70 bg-muted/20 p-4" style={{ display: 'grid', gap: 10 }}>
-              <div>
-                <h4 className="text-sm font-semibold">可信客户端 IP</h4>
-                <p className="text-xs text-muted-foreground">
-                  {settings?.trustedClientIpHeaders?.join(' -> ') || 'cf-connecting-ip -> true-client-ip -> x-real-ip -> x-forwarded-for -> forwarded'}
-                </p>
-              </div>
-              <Dialog open={clientIpDialogOpen} onOpenChange={setClientIpDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button type="button" variant="outline" size="sm" disabled={saving}>
-                    <Icon icon="mdi:shield-account-outline" width={16} height={16} aria-hidden="true" />
-                    配置可信 IP
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="grid max-h-[calc(100dvh-2rem)] w-[min(72rem,calc(100vw-2rem))] max-w-6xl grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0">
-                  <DialogHeader className="px-6 pb-4 pr-12 pt-6">
-                    <DialogTitle>可信客户端 IP</DialogTitle>
-                    <DialogDescription>
-                      先核对最近请求中的真实值，再用快捷按钮切换下方请求头顺序。
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="grid min-h-0 gap-4 overflow-y-auto px-6 pb-4">
-                    <div className="grid gap-2 text-sm">
-                      <label className="flex flex-col gap-2">
-                        <span className="font-medium">可信代理 CIDR</span>
-                        <textarea
-                          rows={4}
-                          className="resize-y rounded-md border border-input bg-background px-3 py-2 text-sm leading-6"
-                          value={draftTrustedProxyCidrs}
-                          disabled={saving}
-                          onChange={(event) => setDraftTrustedProxyCidrs(event.target.value)}
-                        />
-                      </label>
-
-                      <div className="grid gap-1">
-                        <span className="font-medium">客户端 IP 请求头顺序</span>
-                        <p className="text-xs text-muted-foreground">
-                          点击切换。选中会出现在列表末尾，取消会从列表删除。
-                        </p>
-                      </div>
-                      <div className="grid gap-3">
-                        <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/10 p-2">
-                          {clientIpHeaderPresets.map((preset) => (
-                            <div
-                              key={preset.group}
-                              className="inline-flex max-w-full flex-wrap items-center gap-1.5 rounded-md border border-border/50 bg-background/40 px-2 py-1.5"
-                            >
-                              <span
-                                className="mr-0.5 shrink-0 text-xs font-medium text-muted-foreground"
-                                title={'note' in preset ? preset.note : undefined}
-                              >
-                                {preset.group}
-                              </span>
-                              {preset.headers.map((header) => (
-                                (() => {
-                                  const selected = normalizedTrustedClientIpHeaders.includes(header)
-                                  return (
-                                    <Button
-                                      key={`${preset.group}-${header}`}
-                                      type="button"
-                                      variant="outline"
-                                      size="xs"
-                                      aria-pressed={selected}
-                                      disabled={saving}
-                                      className={
-                                        selected
-                                          ? 'border-primary/65 bg-primary/10 text-primary hover:bg-primary/15'
-                                          : undefined
-                                      }
-                                      onClick={() =>
-                                        setDraftTrustedClientIpHeaders((current) =>
-                                          toggleOrderedHeaderDraft(current, header),
-                                        )
-                                      }
-                                    >
-                                      <Icon
-                                        icon={selected ? 'mdi:check' : 'mdi:plus'}
-                                        width={14}
-                                        height={14}
-                                        aria-hidden="true"
-                                      />
-                                      {header}
-                                    </Button>
-                                  )
-                                })()
-                              ))}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                      <textarea
-                        className="h-28 resize-y rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        value={draftTrustedClientIpHeaders}
-                        disabled={saving}
-                        onChange={(event) => setDraftTrustedClientIpHeaders(event.target.value)}
-                      />
-                    </div>
-                    {observedClientIpRequestsSection}
-                  </div>
-                  <DialogFooter className="border-t border-border/60 px-6 py-4">
-                    <Button type="button" variant="outline" onClick={() => setClientIpDialogOpen(false)}>
-                      完成
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-
-            <div style={{ display: 'grid', gap: 8 }}>
-              <label className="text-sm font-medium" htmlFor="system-settings-request-rate-limit">
-                {strings.form.requestRateLimitLabel}
-              </label>
-              <Input
-                id="system-settings-request-rate-limit"
-                type="number"
-                inputMode="numeric"
-                min={1}
-                step={1}
-                value={draftRequestRateLimit}
-                disabled={saving}
-                onChange={(event) => setDraftRequestRateLimit(event.target.value)}
-                aria-invalid={inlineError ? true : undefined}
-              />
-              {settings && (
-                <p className="text-xs text-muted-foreground">
-                  {strings.form.currentRequestRateLimitValue.replace(
-                    '{count}',
-                    String(settings.requestRateLimit),
-                  )}
-                </p>
-              )}
-              <p className="text-xs text-muted-foreground">{strings.form.requestRateLimitHint}</p>
-            </div>
-
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <label className="text-sm font-medium" htmlFor="system-settings-affinity-count">
-                {strings.form.countLabel}
-              </label>
-              <SystemSettingsHelpBubble strings={strings} open={helpBubbleOpen} />
-            </div>
-            <Input
-              id="system-settings-affinity-count"
-              type="number"
-              inputMode="numeric"
-              min={1}
-              max={1000}
-              step={1}
-              value={draftCount}
-              disabled={saving}
-              onChange={(event) => setDraftCount(event.target.value)}
-              aria-invalid={inlineError ? true : undefined}
-            />
-            {settings && (
-              <p className="text-xs text-muted-foreground">
-                {strings.form.currentValue.replace('{count}', String(settings.mcpSessionAffinityKeyCount))}
-              </p>
-            )}
-
-            <div className="mt-2 flex items-start justify-between gap-4 rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div style={{ display: 'grid', gap: 4 }}>
-                <label className="text-sm font-medium" htmlFor="system-settings-rebalance-switch">
-                  {strings.form.rebalanceLabel}
+          <section className="grid gap-4">
+            <h4 className="text-sm font-semibold">{strings.form.limitsTitle}</h4>
+            <div className="grid gap-4 md:grid-cols-[minmax(220px,420px)]">
+              <div style={{ display: 'grid', gap: 8 }}>
+                <label className="text-sm font-medium" htmlFor="system-settings-request-rate-limit">
+                  {strings.form.requestRateLimitLabel}
                 </label>
-                <p className="text-xs text-muted-foreground">{strings.form.rebalanceHint}</p>
-              </div>
-              <Switch
-                aria-label={strings.form.rebalanceLabel}
-                id="system-settings-rebalance-switch"
-                checked={draftRebalanceEnabled}
-                onCheckedChange={setDraftRebalanceEnabled}
-                disabled={saving}
-              />
-            </div>
-
-            <div style={{ display: 'grid', gap: 8 }}>
-              <label className="text-sm font-medium" htmlFor="system-settings-rebalance-percent">
-                {strings.form.percentLabel}
-              </label>
-              <div className="grid gap-3 md:grid-cols-[minmax(0,1fr),96px] md:items-center">
-                <input
-                  id="system-settings-rebalance-percent"
-                  className="range"
-                  type="range"
-                  min={0}
-                  max={100}
-                  step={1}
-                  value={parsedPercent ?? 0}
-                  disabled={saving || !draftRebalanceEnabled}
-                  onChange={(event) => setDraftPercent(event.target.value)}
-                  aria-label={strings.form.percentLabel}
-                />
                 <Input
+                  id="system-settings-request-rate-limit"
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  value={draftRequestRateLimit}
+                  disabled={saving}
+                  onChange={(event) => setDraftRequestRateLimit(event.target.value)}
+                  onBlur={() => {
+                    void commitNormalSettings()
+                  }}
+                  onKeyDown={handleCommitKeyDown}
+                  aria-invalid={fieldErrors.requestRateLimit ? true : undefined}
+                  aria-describedby={fieldErrors.requestRateLimit ? requestRateLimitErrorId : undefined}
+                />
+                {fieldErrors.requestRateLimit && (
+                  <p id={requestRateLimitErrorId} className="text-xs font-medium text-destructive">
+                    {fieldErrors.requestRateLimit}
+                  </p>
+                )}
+                {settings && (
+                  <p className="text-xs text-muted-foreground">
+                    {strings.form.currentRequestRateLimitValue.replace('{count}', String(settings.requestRateLimit))}
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">{strings.form.requestRateLimitHint}</p>
+              </div>
+              <div style={{ display: 'grid', gap: 8 }}>
+                <label className="text-sm font-medium" htmlFor="system-settings-blocked-key-base-limit">
+                  {strings.form.blockedKeyBaseLimitLabel}
+                </label>
+                <Input
+                  id="system-settings-blocked-key-base-limit"
                   type="number"
                   inputMode="numeric"
                   min={0}
-                  max={100}
                   step={1}
-                  value={draftPercent}
-                  disabled={saving || !draftRebalanceEnabled}
-                  onChange={(event) => setDraftPercent(event.target.value)}
-                  aria-invalid={inlineError ? true : undefined}
+                  value={draftBlockedKeyBaseLimit}
+                  disabled={saving}
+                  onChange={(event) => setDraftBlockedKeyBaseLimit(event.target.value)}
+                  onBlur={() => {
+                    void commitNormalSettings()
+                  }}
+                  onKeyDown={handleCommitKeyDown}
+                  aria-invalid={fieldErrors.blockedKeyBaseLimit ? true : undefined}
+                  aria-describedby={fieldErrors.blockedKeyBaseLimit ? blockedKeyBaseLimitErrorId : undefined}
                 />
+                {fieldErrors.blockedKeyBaseLimit && (
+                  <p id={blockedKeyBaseLimitErrorId} className="text-xs font-medium text-destructive">
+                    {fieldErrors.blockedKeyBaseLimit}
+                  </p>
+                )}
+                {settings && (
+                  <p className="text-xs text-muted-foreground">
+                    {strings.form.currentBlockedKeyBaseLimitValue.replace(
+                      '{count}',
+                      String(settings.userBlockedKeyBaseLimit),
+                    )}
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">{strings.form.blockedKeyBaseLimitHint}</p>
               </div>
-              {settings && (
-                <p className="text-xs text-muted-foreground">
-                  {strings.form.currentPercentValue.replace(
-                    '{percent}',
-                    String(settings.rebalanceMcpSessionPercent),
-                  )}
-                </p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                {draftRebalanceEnabled ? strings.form.percentHint : strings.form.percentDisabledHint}
-              </p>
-            </div>
 
-            <div className="mt-2 flex items-start justify-between gap-4 rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div style={{ display: 'grid', gap: 4 }}>
-                <label className="text-sm font-medium" htmlFor="system-settings-api-rebalance-switch">
-                  {strings.form.apiRebalanceLabel}
+              <div style={{ display: 'grid', gap: 8 }}>
+                <label className="text-sm font-medium" htmlFor="system-settings-global-ip-limit">
+                  {strings.form.globalIpLimitLabel}
                 </label>
-                <p className="text-xs text-muted-foreground">{strings.form.apiRebalanceHint}</p>
-              </div>
-              <Switch
-                aria-label={strings.form.apiRebalanceLabel}
-                id="system-settings-api-rebalance-switch"
-                checked={draftApiRebalanceEnabled}
-                onCheckedChange={setDraftApiRebalanceEnabled}
-                disabled={saving}
-              />
-            </div>
-
-            <div style={{ display: 'grid', gap: 8 }}>
-              <label className="text-sm font-medium" htmlFor="system-settings-api-rebalance-percent">
-                {strings.form.apiRebalancePercentLabel}
-              </label>
-              <div className="grid gap-3 md:grid-cols-[minmax(0,1fr),96px] md:items-center">
-                <input
-                  id="system-settings-api-rebalance-percent"
-                  className="range"
-                  type="range"
-                  min={0}
-                  max={100}
-                  step={1}
-                  value={parsedApiRebalancePercent ?? 0}
-                  disabled={saving || !draftApiRebalanceEnabled}
-                  onChange={(event) => setDraftApiRebalancePercent(event.target.value)}
-                  aria-label={strings.form.apiRebalancePercentLabel}
-                />
                 <Input
+                  id="system-settings-global-ip-limit"
                   type="number"
                   inputMode="numeric"
                   min={0}
-                  max={100}
                   step={1}
-                  value={draftApiRebalancePercent}
-                  disabled={saving || !draftApiRebalanceEnabled}
-                  onChange={(event) => setDraftApiRebalancePercent(event.target.value)}
-                  aria-invalid={inlineError ? true : undefined}
+                  value={draftGlobalIpLimit}
+                  disabled={saving}
+                  onChange={(event) => setDraftGlobalIpLimit(event.target.value)}
+                  onBlur={() => {
+                    void commitNormalSettings()
+                  }}
+                  onKeyDown={handleCommitKeyDown}
+                  aria-invalid={fieldErrors.globalIpLimit ? true : undefined}
+                  aria-describedby={fieldErrors.globalIpLimit ? globalIpLimitErrorId : undefined}
+                />
+                {fieldErrors.globalIpLimit && (
+                  <p id={globalIpLimitErrorId} className="text-xs font-medium text-destructive">
+                    {fieldErrors.globalIpLimit}
+                  </p>
+                )}
+                {settings && (
+                  <p className="text-xs text-muted-foreground">
+                    {strings.form.currentGlobalIpLimitValue.replace('{count}', String(settings.globalIpLimit))}
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">{strings.form.globalIpLimitHint}</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-4 border-t border-border/60 pt-5">
+            <h4 className="text-sm font-semibold">{strings.form.gatewayTitle}</h4>
+            <div className="grid gap-4 md:grid-cols-[minmax(220px,420px)]">
+              <div style={{ display: 'grid', gap: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <label className="text-sm font-medium" htmlFor="system-settings-affinity-count">
+                    {strings.form.countLabel}
+                  </label>
+                  <SystemSettingsHelpBubble strings={strings} open={helpBubbleOpen} />
+                </div>
+                <Input
+                  id="system-settings-affinity-count"
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={1000}
+                  step={1}
+                  value={draftCount}
+                  disabled={saving}
+                  onChange={(event) => setDraftCount(event.target.value)}
+                  onBlur={() => {
+                    void commitNormalSettings()
+                  }}
+                  onKeyDown={handleCommitKeyDown}
+                  aria-invalid={fieldErrors.count ? true : undefined}
+                  aria-describedby={fieldErrors.count ? affinityCountErrorId : undefined}
+                />
+                {fieldErrors.count && (
+                  <p id={affinityCountErrorId} className="text-xs font-medium text-destructive">
+                    {fieldErrors.count}
+                  </p>
+                )}
+                {settings && (
+                  <p className="text-xs text-muted-foreground">
+                    {strings.form.currentValue.replace('{count}', String(settings.mcpSessionAffinityKeyCount))}
+                  </p>
+                )}
+              </div>
+
+              <div className="mt-2 flex items-start justify-between gap-4 rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div style={{ display: 'grid', gap: 4 }}>
+                  <label className="text-sm font-medium" htmlFor="system-settings-rebalance-switch">
+                    {strings.form.rebalanceLabel}
+                  </label>
+                  <p className="text-xs text-muted-foreground">{strings.form.rebalanceHint}</p>
+                </div>
+                <Switch
+                  aria-label={strings.form.rebalanceLabel}
+                  id="system-settings-rebalance-switch"
+                  checked={draftRebalanceEnabled}
+                  onCheckedChange={(checked) => {
+                    setDraftRebalanceEnabled(checked)
+                    void commitNormalSettings({
+                      rebalanceMcpEnabled: checked,
+                    }).then((saved) => {
+                      if (!saved) setDraftRebalanceEnabled(settings?.rebalanceMcpEnabled ?? false)
+                    })
+                  }}
+                  disabled={saving}
                 />
               </div>
-              {settings && (
-                <p className="text-xs text-muted-foreground">
-                  {strings.form.currentApiRebalancePercentValue.replace(
-                    '{percent}',
-                    String(settings.apiRebalancePercent),
-                  )}
-                </p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                {draftApiRebalanceEnabled
-                  ? strings.form.apiRebalancePercentHint
-                  : strings.form.apiRebalancePercentDisabledHint}
-              </p>
-            </div>
 
-            <div style={{ display: 'grid', gap: 8 }}>
-              <label className="text-sm font-medium" htmlFor="system-settings-blocked-key-base-limit">
-                {strings.form.blockedKeyBaseLimitLabel}
-              </label>
-              <Input
-                id="system-settings-blocked-key-base-limit"
-                type="number"
-                inputMode="numeric"
-                min={0}
-                step={1}
-                value={draftBlockedKeyBaseLimit}
-                disabled={saving}
-                onChange={(event) => setDraftBlockedKeyBaseLimit(event.target.value)}
-                aria-invalid={inlineError ? true : undefined}
-              />
-              {settings && (
+              <div style={{ display: 'grid', gap: 8 }}>
+                <label className="text-sm font-medium" htmlFor="system-settings-rebalance-percent">
+                  {strings.form.percentLabel}
+                </label>
+                <div className="grid gap-3 md:grid-cols-[minmax(0,1fr),96px] md:items-center">
+                  <input
+                    id="system-settings-rebalance-percent"
+                    className="range"
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={parsedPercent ?? 0}
+                    disabled={saving || !draftRebalanceEnabled}
+                    onChange={(event) => setDraftPercent(event.target.value)}
+                    onBlur={() => {
+                      void commitNormalSettings()
+                    }}
+                    aria-label={strings.form.percentLabel}
+                  />
+                  <Input
+                    id="system-settings-rebalance-percent-input"
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={draftPercent}
+                    disabled={saving || !draftRebalanceEnabled}
+                    onChange={(event) => setDraftPercent(event.target.value)}
+                    onBlur={() => {
+                      void commitNormalSettings()
+                    }}
+                    onKeyDown={handleCommitKeyDown}
+                    aria-label={strings.form.percentLabel}
+                    aria-invalid={fieldErrors.percent ? true : undefined}
+                    aria-describedby={fieldErrors.percent ? rebalancePercentErrorId : undefined}
+                  />
+                </div>
+                {fieldErrors.percent && (
+                  <p id={rebalancePercentErrorId} className="text-xs font-medium text-destructive">
+                    {fieldErrors.percent}
+                  </p>
+                )}
+                {settings && (
+                  <p className="text-xs text-muted-foreground">
+                    {strings.form.currentPercentValue.replace('{percent}', String(settings.rebalanceMcpSessionPercent))}
+                  </p>
+                )}
                 <p className="text-xs text-muted-foreground">
-                  {strings.form.currentBlockedKeyBaseLimitValue.replace(
-                    '{count}',
-                    String(settings.userBlockedKeyBaseLimit),
-                  )}
+                  {draftRebalanceEnabled ? strings.form.percentHint : strings.form.percentDisabledHint}
                 </p>
-              )}
-              <p className="text-xs text-muted-foreground">{strings.form.blockedKeyBaseLimitHint}</p>
+              </div>
             </div>
+          </section>
 
-            <div style={{ display: 'grid', gap: 8 }}>
-              <label className="text-sm font-medium" htmlFor="system-settings-global-ip-limit">
-                {strings.form.globalIpLimitLabel}
-              </label>
-              <Input
-                id="system-settings-global-ip-limit"
-                type="number"
-                inputMode="numeric"
-                min={0}
-                step={1}
-                value={draftGlobalIpLimit}
-                disabled={saving}
-                onChange={(event) => setDraftGlobalIpLimit(event.target.value)}
-                aria-invalid={inlineError ? true : undefined}
-              />
-              {settings && (
+          <section className="grid gap-4 border-t border-border/60 pt-5">
+            <h4 className="text-sm font-semibold">{strings.form.apiRebalanceTitle}</h4>
+            <div className="grid gap-4 md:grid-cols-[minmax(220px,420px)]">
+              <div className="mt-2 flex items-start justify-between gap-4 rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div style={{ display: 'grid', gap: 4 }}>
+                  <label className="text-sm font-medium" htmlFor="system-settings-api-rebalance-switch">
+                    {strings.form.apiRebalanceLabel}
+                  </label>
+                  <p className="text-xs text-muted-foreground">{strings.form.apiRebalanceHint}</p>
+                </div>
+                <Switch
+                  aria-label={strings.form.apiRebalanceLabel}
+                  id="system-settings-api-rebalance-switch"
+                  checked={draftApiRebalanceEnabled}
+                  onCheckedChange={(checked) => {
+                    setDraftApiRebalanceEnabled(checked)
+                    void commitNormalSettings({
+                      apiRebalanceEnabled: checked,
+                    }).then((saved) => {
+                      if (!saved) setDraftApiRebalanceEnabled(settings?.apiRebalanceEnabled ?? false)
+                    })
+                  }}
+                  disabled={saving}
+                />
+              </div>
+
+              <div style={{ display: 'grid', gap: 8 }}>
+                <label className="text-sm font-medium" htmlFor="system-settings-api-rebalance-percent">
+                  {strings.form.apiRebalancePercentLabel}
+                </label>
+                <div className="grid gap-3 md:grid-cols-[minmax(0,1fr),96px] md:items-center">
+                  <input
+                    id="system-settings-api-rebalance-percent"
+                    className="range"
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={parsedApiRebalancePercent ?? 0}
+                    disabled={saving || !draftApiRebalanceEnabled}
+                    onChange={(event) => setDraftApiRebalancePercent(event.target.value)}
+                    onBlur={() => {
+                      void commitNormalSettings()
+                    }}
+                    aria-label={strings.form.apiRebalancePercentLabel}
+                  />
+                  <Input
+                    id="system-settings-api-rebalance-percent-input"
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={draftApiRebalancePercent}
+                    disabled={saving || !draftApiRebalanceEnabled}
+                    onChange={(event) => setDraftApiRebalancePercent(event.target.value)}
+                    onBlur={() => {
+                      void commitNormalSettings()
+                    }}
+                    onKeyDown={handleCommitKeyDown}
+                    aria-label={strings.form.apiRebalancePercentLabel}
+                    aria-invalid={fieldErrors.apiRebalancePercent ? true : undefined}
+                    aria-describedby={fieldErrors.apiRebalancePercent ? apiRebalancePercentErrorId : undefined}
+                  />
+                </div>
+                {fieldErrors.apiRebalancePercent && (
+                  <p id={apiRebalancePercentErrorId} className="text-xs font-medium text-destructive">
+                    {fieldErrors.apiRebalancePercent}
+                  </p>
+                )}
+                {settings && (
+                  <p className="text-xs text-muted-foreground">
+                    {strings.form.currentApiRebalancePercentValue.replace(
+                      '{percent}',
+                      String(settings.apiRebalancePercent),
+                    )}
+                  </p>
+                )}
                 <p className="text-xs text-muted-foreground">
-                  {strings.form.currentGlobalIpLimitValue.replace(
-                    '{count}',
-                    String(settings.globalIpLimit),
-                  )}
+                  {draftApiRebalanceEnabled
+                    ? strings.form.apiRebalancePercentHint
+                    : strings.form.apiRebalancePercentDisabledHint}
                 </p>
-              )}
-              <p className="text-xs text-muted-foreground">{strings.form.globalIpLimitHint}</p>
+              </div>
             </div>
-          </div>
+          </section>
 
-          {(inlineError || saving) && (
+          {(error || saving) && (
             <p
               className="text-sm font-medium"
               role="status"
               aria-live="polite"
-              style={{ color: inlineError ? 'hsl(var(--destructive))' : undefined }}
+              style={{ color: error ? 'hsl(var(--destructive))' : undefined }}
             >
-              {inlineError ?? strings.actions.applying}
+              {error ?? strings.actions.applying}
             </p>
           )}
 
-          <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
-            <Button
-              type="button"
-              onClick={() => {
-                if (
-                  parsedRequestRateLimit == null ||
-                  parsedCount == null ||
-                  parsedPercent == null ||
-                  parsedApiRebalancePercent == null ||
-                  parsedBlockedKeyBaseLimit == null ||
-                  parsedGlobalIpLimit == null ||
-                  parsedTrustedClientIpHeaders.duplicateError != null ||
-                  saving ||
-                  !changed
-                ) return
-                void onApply({
-                  requestRateLimit: parsedRequestRateLimit,
-                  mcpSessionAffinityKeyCount: parsedCount,
-                  rebalanceMcpEnabled: draftRebalanceEnabled,
-                  rebalanceMcpSessionPercent: parsedPercent,
-                  apiRebalanceEnabled: draftApiRebalanceEnabled,
-                  apiRebalancePercent: parsedApiRebalancePercent,
-                  userBlockedKeyBaseLimit: parsedBlockedKeyBaseLimit,
-                  globalIpLimit: parsedGlobalIpLimit,
-                  trustedProxyCidrs: normalizedTrustedProxyCidrs,
-                  trustedClientIpHeaders: normalizedTrustedClientIpHeaders,
-                })
-              }}
-              disabled={
-                saving ||
-                !changed ||
-                parsedRequestRateLimit == null ||
-                parsedCount == null ||
-                parsedPercent == null ||
-                parsedApiRebalancePercent == null ||
-                parsedBlockedKeyBaseLimit == null ||
-                parsedGlobalIpLimit == null ||
-                parsedTrustedClientIpHeaders.duplicateError != null
-              }
-              data-testid="system-settings-apply"
-            >
-              <Icon
-                icon={saving ? 'mdi:loading' : 'mdi:check-circle-outline'}
-                width={16}
-                height={16}
-                className={saving ? 'icon-spin' : undefined}
-                aria-hidden="true"
-              />
-              <span>{saving ? strings.actions.applying : strings.actions.apply}</span>
-            </Button>
-          </div>
+          {changed && !inlineError && !saving && (
+            <p className="text-xs text-muted-foreground">{strings.form.autosaveHint}</p>
+          )}
         </div>
+
+        {trustedClientIpPanel}
       </AdminLoadingRegion>
     </section>
   )

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -23,8 +23,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { hideCloseButton?: boolean }
+>(({ className, children, hideCloseButton = false, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -36,10 +36,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {hideCloseButton ? null : (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/web/src/i18n/translations/en.ts
+++ b/web/src/i18n/translations/en.ts
@@ -574,6 +574,9 @@ export const EN: TranslationShape = {
         form: {
           title: 'MCP gateway controls',
           description: 'Manage the global request-rate threshold, the MCP session affinity pool, the Rebalance MCP rollout ratio, and the blocked-key base limit in one place.',
+          limitsTitle: 'Global limits and warnings',
+          gatewayTitle: 'MCP gateway controls',
+          apiRebalanceTitle: 'Tavily API Rebalance',
           requestRateLimitLabel: 'Max requests per 5 minutes',
           requestRateLimitHint: 'Applies to the global request-rate limiter. Saving takes effect on the next authenticated request, but keeps the current rolling-window counters intact.',
           currentRequestRateLimitValue: 'Current limit: {count}',
@@ -599,6 +602,7 @@ export const EN: TranslationShape = {
           globalIpLimitHint: 'Only highlights 24-hour IP counts in admin UI. It does not block requests.',
           currentGlobalIpLimitValue: 'Current limit: {count}',
           applyScopeHint: 'Applies immediately to newly created MCP sessions only. Existing sessions keep their current upstream key.',
+          autosaveHint: 'Changes save automatically on blur or when you press Enter.',
           invalidRequestRateLimit: 'Enter a safe integer greater than or equal to 1.',
           invalidCount: 'Enter an integer between 1 and 1000.',
           invalidPercent: 'Enter an integer between 0 and 100.',
@@ -607,8 +611,9 @@ export const EN: TranslationShape = {
           saveFailed: 'Failed to save system settings.',
         },
         actions: {
-          apply: 'Apply settings',
+          apply: 'Apply',
           applying: 'Applying…',
+          cancel: 'Cancel',
         },
       },
       users: {

--- a/web/src/i18n/translations/en.ts
+++ b/web/src/i18n/translations/en.ts
@@ -568,14 +568,12 @@ export const EN: TranslationShape = {
         },
       },
       systemSettings: {
-        title: 'System Settings',
-        description: 'Adjust the global request-rate threshold, MCP session affinity, Rebalance behavior, and blocked-key base limit without restarting.',
+        title: 'System Settings', description: 'Adjust the global request-rate threshold, MCP session affinity, Rebalance behavior, and blocked-key base limit without restarting.',
         helpLabel: 'Show system settings help',
         form: {
           title: 'MCP gateway controls',
           description: 'Manage the global request-rate threshold, the MCP session affinity pool, the Rebalance MCP rollout ratio, and the blocked-key base limit in one place.',
-          limitsTitle: 'Global limits and warnings',
-          gatewayTitle: 'MCP gateway controls',
+          limitsTitle: 'Global limits and warnings', gatewayTitle: 'MCP gateway controls',
           apiRebalanceTitle: 'Tavily API Rebalance',
           requestRateLimitLabel: 'Max requests per 5 minutes',
           requestRateLimitHint: 'Applies to the global request-rate limiter. Saving takes effect on the next authenticated request, but keeps the current rolling-window counters intact.',
@@ -611,8 +609,7 @@ export const EN: TranslationShape = {
           saveFailed: 'Failed to save system settings.',
         },
         actions: {
-          apply: 'Apply',
-          applying: 'Applying…',
+          apply: 'Apply', applying: 'Applying…',
           cancel: 'Cancel',
         },
       },

--- a/web/src/i18n/translations/zh.ts
+++ b/web/src/i18n/translations/zh.ts
@@ -573,8 +573,7 @@ export const ZH: TranslationShape = {
         form: {
           title: 'MCP 网关控制',
           description: '这里统一管理全局 request-rate 阈值、MCP session 亲和池、Rebalance MCP 灰度比例与封禁数基础值。',
-          limitsTitle: '全局限制与提示',
-          gatewayTitle: 'MCP 网关控制',
+          limitsTitle: '全局限制与提示', gatewayTitle: 'MCP 网关控制',
           apiRebalanceTitle: 'Tavily API Rebalance',
           requestRateLimitLabel: '5 分钟最大请求数',
           requestRateLimitHint: '作用于全局 request-rate limiter；保存后对下一次已鉴权请求立即生效，但不会清空当前 5 分钟窗口中的已有计数。',
@@ -610,8 +609,7 @@ export const ZH: TranslationShape = {
           saveFailed: '保存系统设置失败。',
         },
         actions: {
-          apply: '应用',
-          applying: '应用中…',
+          apply: '应用', applying: '应用中…',
           cancel: '取消',
         },
       },

--- a/web/src/i18n/translations/zh.ts
+++ b/web/src/i18n/translations/zh.ts
@@ -573,6 +573,9 @@ export const ZH: TranslationShape = {
         form: {
           title: 'MCP 网关控制',
           description: '这里统一管理全局 request-rate 阈值、MCP session 亲和池、Rebalance MCP 灰度比例与封禁数基础值。',
+          limitsTitle: '全局限制与提示',
+          gatewayTitle: 'MCP 网关控制',
+          apiRebalanceTitle: 'Tavily API Rebalance',
           requestRateLimitLabel: '5 分钟最大请求数',
           requestRateLimitHint: '作用于全局 request-rate limiter；保存后对下一次已鉴权请求立即生效，但不会清空当前 5 分钟窗口中的已有计数。',
           currentRequestRateLimitValue: '当前阈值：{count}',
@@ -598,6 +601,7 @@ export const ZH: TranslationShape = {
           globalIpLimitHint: '仅用于管理端最近 24 小时 IP 数标红提示，不会拦截请求。',
           currentGlobalIpLimitValue: '当前限制：{count}',
           applyScopeHint: '设置会立即作用于新创建的 MCP session；已有 session 会继续保持当前上游 key。',
+          autosaveHint: '更改后会在失焦或按 Enter 时自动保存。',
           invalidRequestRateLimit: '请输入大于等于 1 的安全整数。',
           invalidCount: '请输入 1 到 1000 之间的整数。',
           invalidPercent: '请输入 0 到 100 之间的整数。',
@@ -606,8 +610,9 @@ export const ZH: TranslationShape = {
           saveFailed: '保存系统设置失败。',
         },
         actions: {
-          apply: '应用设置',
+          apply: '应用',
           applying: '应用中…',
+          cancel: '取消',
         },
       },
       users: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -556,6 +556,9 @@ export interface AdminTranslationsShape {
     form: {
       title: string
       description: string
+      limitsTitle: string
+      gatewayTitle: string
+      apiRebalanceTitle: string
       requestRateLimitLabel: string
       requestRateLimitHint: string
       currentRequestRateLimitValue: string
@@ -581,6 +584,7 @@ export interface AdminTranslationsShape {
       globalIpLimitHint: string
       currentGlobalIpLimitValue: string
       applyScopeHint: string
+      autosaveHint: string
       invalidRequestRateLimit: string
       invalidCount: string
       invalidPercent: string
@@ -591,6 +595,7 @@ export interface AdminTranslationsShape {
     actions: {
       apply: string
       applying: string
+      cancel: string
     }
   }
   users: {


### PR DESCRIPTION
## Summary
- make normal system settings save on blur or Enter
- keep trusted client IP edits inside a draft dialog with Apply / Cancel only
- split the settings page into clearer sections and add field-specific validation feedback

## Validation
- cd web && bun test src/admin/SystemSettingsModule.render.test.ts src/admin/SystemSettingsModule.stories.test.ts src/admin/SystemSettingsModule.interaction.test.tsx src/api.test.ts
- cd web && bun run build

## References
- Specs: docs/specs/r7k2p-client-ip-trust-and-usage/SPEC.md, docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md, docs/specs/r7k2p-client-ip-trust-and-usage/HISTORY.md, docs/specs/tjhrr-system-request-rate-limit-setting/SPEC.md
- Solutions: -
- Project Docs: -