### PR TITLE
fix(admin): page user usage sorts in sql

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -62,6 +62,10 @@ reads:
 - Replace repeated window scans with a single bounded scan that derives all needed windows, then add
   a short manager-scoped TTL cache when settings and live stats can request the same window set in
   one admin refresh cycle.
+- For list pages that need per-user request-log facts, page the user set before hydrating secondary
+  details. If a query is bounded by a small user set but SQLite chooses a broad time/visibility
+  index, reshape it or use `INDEXED BY` so it seeks by user first instead of scanning the full
+  retained window.
 
 ## Guardrails / Reuse Notes
 
@@ -75,6 +79,9 @@ reads:
   embedded in rollup triggers; prefer canonicalizing retained legacy rows before rollup rebuild,
   using a focused canonicalization trigger for legacy write-path rows, then keeping rollup triggers
   on stored canonical columns only.
+- `COUNT(DISTINCT ...)` over request logs is especially prone to temp B-trees; keep its input
+  cardinality small with user-first filtering and avoid running it over all visible rows in a recent
+  time window for every admin refresh.
 - Production stop-the-bleed actions such as single-container restart are live changes and require
   explicit owner approval.
 

--- a/docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md
+++ b/docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md
@@ -5,6 +5,7 @@
 - UI: system settings dialog, global IP limit input, trusted client IP Apply/Cancel-confirmed draft editor, user IP count badges, user detail IP chart/list, recent request diagnostics.
 - Operations: historical `request_user_id` repair is an explicit resumable
   `request_user_id_backfill` CLI batch job, not part of service startup.
+- Performance: admin user list sorting now pages in SQL before hydrating usage details; recent IP count queries use the user/IP/time index path so bounded user pages do not scan the whole recent request-log window.
 
 ## Status
 
@@ -12,6 +13,7 @@
 - Startup only applies schema-compatible changes; large historical request log
   backfills must run outside the healthcheck path.
 - Current follow-up adds 24h IP counts, global IP warning threshold, and user detail IP timeline/list on top of the original 7-day count work.
+- User management and user usage list performance is optimized for large `request_logs` databases by avoiding full filtered-user hydration for DB-backed usage sorts.
 
 ## Validation
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1617,6 +1617,25 @@ pub struct TimeRangeUtc {
     pub end: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdminUserListSortField {
+    QuotaHourlyUsed,
+    QuotaDailyUsed,
+    QuotaMonthlyUsed,
+    DailySuccessRate,
+    MonthlySuccessRate,
+    MonthlyBrokenCount,
+    RecentIpCount7d,
+    LastActivity,
+    LastLoginAt,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdminListSortDirection {
+    Asc,
+    Desc,
+}
+
 #[derive(Debug, Clone)]
 pub struct AdminUserIdentity {
     pub user_id: String,

--- a/src/server/handlers/admin_resources/admin_user_views_and_sort.rs
+++ b/src/server/handlers/admin_resources/admin_user_views_and_sort.rs
@@ -5,6 +5,34 @@ impl AdminUsersSortDirection {
             Self::Desc => ordering.reverse(),
         }
     }
+
+    fn to_admin_list_sort_direction(self) -> tavily_hikari::AdminListSortDirection {
+        match self {
+            Self::Asc => tavily_hikari::AdminListSortDirection::Asc,
+            Self::Desc => tavily_hikari::AdminListSortDirection::Desc,
+        }
+    }
+}
+
+impl AdminUsersSortField {
+    fn to_paged_admin_user_sort_field(self) -> Option<tavily_hikari::AdminUserListSortField> {
+        match self {
+            Self::HourlyAnyUsed => None,
+            Self::QuotaHourlyUsed => Some(tavily_hikari::AdminUserListSortField::QuotaHourlyUsed),
+            Self::QuotaDailyUsed => Some(tavily_hikari::AdminUserListSortField::QuotaDailyUsed),
+            Self::QuotaMonthlyUsed => Some(tavily_hikari::AdminUserListSortField::QuotaMonthlyUsed),
+            Self::DailySuccessRate => Some(tavily_hikari::AdminUserListSortField::DailySuccessRate),
+            Self::MonthlySuccessRate => {
+                Some(tavily_hikari::AdminUserListSortField::MonthlySuccessRate)
+            }
+            Self::MonthlyBrokenCount => {
+                Some(tavily_hikari::AdminUserListSortField::MonthlyBrokenCount)
+            }
+            Self::RecentIpCount7d => Some(tavily_hikari::AdminUserListSortField::RecentIpCount7d),
+            Self::LastActivity => Some(tavily_hikari::AdminUserListSortField::LastActivity),
+            Self::LastLoginAt => Some(tavily_hikari::AdminUserListSortField::LastLoginAt),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/server/handlers/admin_resources/user_tag_and_token_handlers.rs
+++ b/src/server/handlers/admin_resources/user_tag_and_token_handlers.rs
@@ -177,6 +177,7 @@ async fn list_users(
             || (effective_sort_field == AdminUsersSortField::LastLoginAt
                 && effective_sort_order == AdminUsersSortDirection::Desc);
 
+    let paged_sort_field = effective_sort_field.to_paged_admin_user_sort_field();
     let (paged_rows, total) = if use_default_paged_query {
         let (users, total) = state
             .proxy
@@ -227,6 +228,83 @@ async fn list_users(
                     .copied()
                     .unwrap_or(USER_MONTHLY_BROKEN_LIMIT_DEFAULT),
                 recent_ip_count_7d: 0,
+                user,
+            })
+            .collect();
+        (rows, total)
+    } else if let Some(paged_sort_field) = paged_sort_field {
+        let (users, total) = state
+            .proxy
+            .list_admin_users_sorted_paged(
+                page,
+                per_page,
+                q.q.as_deref(),
+                q.tag_id.as_deref(),
+                paged_sort_field,
+                effective_sort_order.to_admin_list_sort_direction(),
+            )
+            .await
+            .map_err(|err| {
+                eprintln!("list admin users sorted page error: {err}");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        let user_ids: Vec<String> = users.iter().map(|user| user.user_id.clone()).collect();
+        let summaries = state
+            .proxy
+            .user_dashboard_summaries_for_users(&user_ids, None)
+            .await
+            .map_err(|err| {
+                eprintln!("list admin users sorted page dashboard summaries error: {err}");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        let monthly_broken_counts = state
+            .proxy
+            .fetch_monthly_broken_counts_for_users(&user_ids)
+            .await
+            .map_err(|err| {
+                eprintln!("list admin users sorted page monthly broken counts error: {err}");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        let monthly_broken_limits = state
+            .proxy
+            .fetch_account_monthly_broken_limits_bulk(&user_ids)
+            .await
+            .map_err(|err| {
+                eprintln!("list admin users sorted page monthly broken limits error: {err}");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        let now_ts = Utc::now().timestamp();
+        let recent_ip_counts_7d = if user_ids.is_empty() {
+            std::collections::HashMap::new()
+        } else {
+            state
+                .proxy
+                .recent_client_ip_counts_by_user(&user_ids, now_ts - 7 * 24 * 60 * 60)
+                .await
+                .map_err(|err| {
+                    eprintln!("list admin users sorted page recent ip counts error: {err}");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                })?
+        };
+        let rows: Vec<AdminUserSummaryRow> = users
+            .into_iter()
+            .map(|user| AdminUserSummaryRow {
+                summary: summaries
+                    .get(&user.user_id)
+                    .cloned()
+                    .unwrap_or_else(empty_user_dashboard_summary),
+                monthly_broken_count: monthly_broken_counts
+                    .get(&user.user_id)
+                    .copied()
+                    .unwrap_or_default(),
+                monthly_broken_limit: monthly_broken_limits
+                    .get(&user.user_id)
+                    .copied()
+                    .unwrap_or(USER_MONTHLY_BROKEN_LIMIT_DEFAULT),
+                recent_ip_count_7d: recent_ip_counts_7d
+                    .get(&user.user_id)
+                    .copied()
+                    .unwrap_or_default(),
                 user,
             })
             .collect();

--- a/src/server/tests/chunk_07.rs
+++ b/src/server/tests/chunk_07.rs
@@ -171,7 +171,7 @@
             })
             .await
             .expect("upsert bob");
-        let _charlie = proxy
+        let charlie = proxy
             .upsert_oauth_account(&OAuthAccountProfile {
                 provider: "linuxdo".to_string(),
                 provider_user_id: "admin-users-charlie".to_string(),
@@ -193,6 +193,10 @@
             .ensure_user_token_binding(&bob.user_id, Some("linuxdo:bob"))
             .await
             .expect("bind bob token");
+        let charlie_token = proxy
+            .ensure_user_token_binding(&charlie.user_id, Some("linuxdo:charlie"))
+            .await
+            .expect("bind charlie token");
         let vip_tag = proxy
             .create_user_tag(
                 "vip_plus",
@@ -210,6 +214,27 @@
             .bind_user_tag_to_user(&alice.user_id, &vip_tag.id)
             .await
             .expect("bind vip tag");
+        let legacy_logs_tag = proxy
+            .create_user_tag(
+                "legacy_logs",
+                "Legacy Logs",
+                Some("history"),
+                "quota_delta",
+                0,
+                0,
+                0,
+                0,
+            )
+            .await
+            .expect("create legacy logs tag");
+        proxy
+            .bind_user_tag_to_user(&alice.user_id, &legacy_logs_tag.id)
+            .await
+            .expect("bind legacy logs tag to alice");
+        proxy
+            .bind_user_tag_to_user(&charlie.user_id, &legacy_logs_tag.id)
+            .await
+            .expect("bind legacy logs tag to charlie");
 
         let _ = proxy
             .check_token_hourly_requests(&alice_token.id)
@@ -250,6 +275,69 @@
 
         let pool = connect_sqlite_test_pool(&db_str).await;
         let now = Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            INSERT INTO auth_token_logs (
+                token_id,
+                method,
+                path,
+                query,
+                http_status,
+                mcp_status,
+                request_kind_key,
+                request_kind_label,
+                result_status,
+                key_effect_code,
+                binding_effect_code,
+                selection_effect_code,
+                counts_business_quota,
+                billing_state,
+                created_at
+            ) VALUES
+                (?, 'POST', '/mcp', NULL, 200, 200, 'mcp:search', 'MCP | search', 'success', 'none', 'none', 'none', 1, 'none', ?),
+                (?, 'POST', '/mcp', NULL, 200, 200, 'mcp:search', 'MCP | search', 'success', 'none', 'none', 'none', 1, 'none', ?),
+                (?, 'POST', '/mcp', NULL, 200, 200, 'mcp:search', 'MCP | search', 'success', 'none', 'none', 'none', 1, 'none', ?)
+            "#,
+        )
+        .bind(&charlie_token.id)
+        .bind(now + 1)
+        .bind(&charlie_token.id)
+        .bind(now + 2)
+        .bind(&charlie_token.id)
+        .bind(now + 3)
+        .execute(&pool)
+        .await
+        .expect("insert legacy null request_user_id auth logs");
+        for token_id in [&alice_token.id, &bob_token.id] {
+            for index in 0..20 {
+                sqlx::query(
+                    r#"
+                    INSERT INTO auth_token_logs (
+                        token_id,
+                        method,
+                        path,
+                        query,
+                        http_status,
+                        mcp_status,
+                        request_kind_key,
+                        request_kind_label,
+                        result_status,
+                        key_effect_code,
+                        binding_effect_code,
+                        selection_effect_code,
+                        counts_business_quota,
+                        billing_state,
+                        created_at
+                    ) VALUES (?, 'POST', '/mcp', NULL, 500, -32001, 'mcp:search', 'MCP | search', 'error', 'none', 'none', 'none', 1, 'none', ?)
+                    "#,
+                )
+                .bind(token_id)
+                .bind(now - 10 - index)
+                .execute(&pool)
+                .await
+                .expect("insert non-charlie failure log");
+            }
+        }
         for (client_ip, created_at, visibility) in [
             ("203.0.113.7", now - 300, "visible"),
             ("198.51.100.10", now - 3_600, "visible"),
@@ -322,6 +410,36 @@
             .await
             .expect("insert high-cardinality client ip request log");
         }
+
+        let ip_count_plan_rows = sqlx::query(
+            r#"
+            EXPLAIN QUERY PLAN
+            SELECT request_user_id, COUNT(DISTINCT client_ip) AS ip_count
+            FROM request_logs INDEXED BY idx_request_logs_user_ip_time
+            WHERE visibility = ?
+              AND request_user_id IN (?, ?)
+              AND created_at >= ?
+              AND client_ip IS NOT NULL
+              AND TRIM(client_ip) != ''
+            GROUP BY request_user_id
+            "#,
+        )
+        .bind(tavily_hikari::REQUEST_LOG_VISIBILITY_VISIBLE)
+        .bind(&alice.user_id)
+        .bind(&bob.user_id)
+        .bind(now - 7 * 86_400)
+        .fetch_all(&pool)
+        .await
+        .expect("explain recent client ip count plan");
+        let ip_count_plan = ip_count_plan_rows
+            .iter()
+            .filter_map(|row| row.try_get::<String, _>("detail").ok())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            ip_count_plan.contains("idx_request_logs_user_ip_time"),
+            "recent client ip count should use the user/ip/time index, got: {ip_count_plan}"
+        );
 
         for index in 0..4 {
             let api_key_id = proxy
@@ -508,6 +626,191 @@
             Some(120)
         );
 
+        use chrono::{Datelike as _, TimeZone as _};
+
+        let now = Utc::now();
+        let month_start = Utc
+            .with_ymd_and_hms(now.year(), now.month(), 1, 0, 0, 0)
+            .single()
+            .expect("current month start")
+            .timestamp();
+        for (user_id, monthly_used) in [
+            (alice.user_id.as_str(), 15_i64),
+            (bob.user_id.as_str(), 90_i64),
+            (charlie.user_id.as_str(), 40_i64),
+        ] {
+            sqlx::query(
+                r#"
+                INSERT INTO account_monthly_quota (user_id, month_start, month_count)
+                VALUES (?, ?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET
+                    month_start = excluded.month_start,
+                    month_count = excluded.month_count
+                "#,
+            )
+            .bind(user_id)
+            .bind(month_start)
+            .bind(monthly_used)
+            .execute(&pool)
+            .await
+            .expect("seed account monthly quota");
+        }
+
+        let quota_sort_page_1_url = format!(
+            "http://{}/api/users?page=1&per_page=1&sort=quotaMonthlyUsed&order=desc",
+            addr
+        );
+        let quota_sort_page_1_resp = client
+            .get(&quota_sort_page_1_url)
+            .send()
+            .await
+            .expect("quota monthly desc sort page 1 request");
+        assert_eq!(quota_sort_page_1_resp.status(), reqwest::StatusCode::OK);
+        let quota_sort_page_1: serde_json::Value = quota_sort_page_1_resp
+            .json()
+            .await
+            .expect("quota monthly desc sort page 1 json");
+        assert_eq!(
+            quota_sort_page_1.get("total").and_then(|value| value.as_i64()),
+            Some(3)
+        );
+        let quota_sort_page_1_items = quota_sort_page_1
+            .get("items")
+            .and_then(|value| value.as_array())
+            .expect("quota monthly desc sort page 1 items array");
+        assert_eq!(quota_sort_page_1_items.len(), 1);
+        assert_eq!(
+            quota_sort_page_1_items
+                .first()
+                .and_then(|item| item.get("userId"))
+                .and_then(|value| value.as_str()),
+            Some(bob.user_id.as_str())
+        );
+        assert_eq!(
+            quota_sort_page_1_items
+                .first()
+                .and_then(|item| item.get("quotaMonthlyUsed"))
+                .and_then(|value| value.as_i64()),
+            Some(90)
+        );
+
+        let quota_sort_page_2_url = format!(
+            "http://{}/api/users?page=2&per_page=1&sort=quotaMonthlyUsed&order=desc",
+            addr
+        );
+        let quota_sort_page_2_resp = client
+            .get(&quota_sort_page_2_url)
+            .send()
+            .await
+            .expect("quota monthly desc sort page 2 request");
+        assert_eq!(quota_sort_page_2_resp.status(), reqwest::StatusCode::OK);
+        let quota_sort_page_2: serde_json::Value = quota_sort_page_2_resp
+            .json()
+            .await
+            .expect("quota monthly desc sort page 2 json");
+        let quota_sort_page_2_items = quota_sort_page_2
+            .get("items")
+            .and_then(|value| value.as_array())
+            .expect("quota monthly desc sort page 2 items array");
+        assert_eq!(quota_sort_page_2_items.len(), 1);
+        assert_eq!(
+            quota_sort_page_2_items
+                .first()
+                .and_then(|item| item.get("userId"))
+                .and_then(|value| value.as_str()),
+            Some(charlie.user_id.as_str())
+        );
+
+        let tagged_quota_sort_url = format!(
+            "http://{}/api/users?page=1&per_page=20&q={}&tagId={}&sort=quotaMonthlyUsed&order=desc",
+            addr,
+            urlencoding::encode("VIP+"),
+            urlencoding::encode(&vip_tag.id)
+        );
+        let tagged_quota_sort_resp = client
+            .get(&tagged_quota_sort_url)
+            .send()
+            .await
+            .expect("tagged quota monthly sort request");
+        assert_eq!(tagged_quota_sort_resp.status(), reqwest::StatusCode::OK);
+        let tagged_quota_sort: serde_json::Value = tagged_quota_sort_resp
+            .json()
+            .await
+            .expect("tagged quota monthly sort json");
+        assert_eq!(
+            tagged_quota_sort
+                .get("total")
+                .and_then(|value| value.as_i64()),
+            Some(1)
+        );
+        assert_eq!(
+            tagged_quota_sort
+                .get("items")
+                .and_then(|value| value.as_array())
+                .and_then(|items| items.first())
+                .and_then(|item| item.get("userId"))
+                .and_then(|value| value.as_str()),
+            Some(alice.user_id.as_str())
+        );
+
+        let daily_success_sort_url = format!(
+            "http://{}/api/users?page=1&per_page=1&tagId={}&sort=dailySuccessRate&order=desc",
+            addr,
+            urlencoding::encode(&legacy_logs_tag.id)
+        );
+        let daily_success_sort_resp = client
+            .get(&daily_success_sort_url)
+            .send()
+            .await
+            .expect("daily success desc sort request");
+        assert_eq!(daily_success_sort_resp.status(), reqwest::StatusCode::OK);
+        let daily_success_sort: serde_json::Value = daily_success_sort_resp
+            .json()
+            .await
+            .expect("daily success desc sort json");
+        let daily_success_item = daily_success_sort
+            .get("items")
+            .and_then(|value| value.as_array())
+            .and_then(|items| items.first())
+            .expect("daily success first item");
+        assert_eq!(
+            daily_success_item
+                .get("userId")
+                .and_then(|value| value.as_str()),
+            Some(charlie.user_id.as_str())
+        );
+        assert_eq!(
+            daily_success_item
+                .get("dailySuccess")
+                .and_then(|value| value.as_i64()),
+            Some(3)
+        );
+
+        let last_activity_sort_url = format!(
+            "http://{}/api/users?page=1&per_page=1&tagId={}&sort=lastActivity&order=desc",
+            addr,
+            urlencoding::encode(&legacy_logs_tag.id)
+        );
+        let last_activity_sort_resp = client
+            .get(&last_activity_sort_url)
+            .send()
+            .await
+            .expect("last activity desc sort request");
+        assert_eq!(last_activity_sort_resp.status(), reqwest::StatusCode::OK);
+        let last_activity_sort: serde_json::Value = last_activity_sort_resp
+            .json()
+            .await
+            .expect("last activity desc sort json");
+        assert_eq!(
+            last_activity_sort
+                .get("items")
+                .and_then(|value| value.as_array())
+                .and_then(|items| items.first())
+                .and_then(|item| item.get("userId"))
+                .and_then(|value| value.as_str()),
+            Some(charlie.user_id.as_str())
+        );
+
         let detail_url = format!("http://{}/api/users/{}", addr, alice.user_id);
         let detail_resp = client
             .get(&detail_url)
@@ -604,7 +907,7 @@
             .get("tags")
             .and_then(|value| value.as_array())
             .expect("detail tags array");
-        assert_eq!(detail_tags.len(), 2);
+        assert_eq!(detail_tags.len(), 3);
         let system_tag = detail_tags
             .iter()
             .find(|value| value.get("systemKey").and_then(|it| it.as_str()) == Some("linuxdo_l2"))

--- a/src/store/key_store_admin_user_listing.rs
+++ b/src/store/key_store_admin_user_listing.rs
@@ -1,0 +1,310 @@
+impl KeyStore {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn list_admin_users_sorted_paged(
+        &self,
+        page: i64,
+        per_page: i64,
+        query: Option<&str>,
+        tag_id: Option<&str>,
+        sort: AdminUserListSortField,
+        direction: AdminListSortDirection,
+        hour_window_start: i64,
+        day_window_start: i64,
+        day_window_end: i64,
+        month_start: i64,
+        recent_ip_since: i64,
+    ) -> Result<(Vec<AdminUserIdentity>, i64), ProxyError> {
+        let _permit = self
+            .admin_heavy_read_semaphore
+            .acquire()
+            .await
+            .expect("admin heavy read semaphore is never closed");
+        let page = page.max(1);
+        let per_page = per_page.clamp(1, 100);
+        let offset = (page - 1) * per_page;
+        let search = query
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| format!("%{value}%"));
+        let tag_id = tag_id.map(str::trim).filter(|value| !value.is_empty());
+
+        let mut count_builder = QueryBuilder::<Sqlite>::new("SELECT COUNT(*) FROM users u WHERE ");
+        Self::push_admin_user_filters(&mut count_builder, tag_id, search.as_deref());
+        let total = count_builder
+            .build_query_scalar::<i64>()
+            .fetch_one(&self.pool)
+            .await?;
+        let monthly_broken_base_limit = self.fetch_user_blocked_key_base_limit().await?;
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            "WITH filtered_users AS (SELECT u.id FROM users u WHERE ",
+        );
+        Self::push_admin_user_filters(&mut builder, tag_id, search.as_deref());
+        builder.push(
+            "), metric(user_id, sort_value, sort_limit, sort_total, sort_failure) AS (",
+        );
+        match sort {
+            AdminUserListSortField::QuotaHourlyUsed => {
+                builder.push(
+                    "SELECT aub.user_id, COALESCE(SUM(aub.count), 0), 0, 0, 0 \
+                     FROM account_usage_buckets aub \
+                     JOIN filtered_users fu ON fu.id = aub.user_id \
+                     WHERE aub.granularity = ",
+                );
+                builder.push_bind(GRANULARITY_MINUTE);
+                builder.push(" AND aub.bucket_start >= ");
+                builder.push_bind(hour_window_start);
+                builder.push(" GROUP BY aub.user_id");
+            }
+            AdminUserListSortField::QuotaDailyUsed => {
+                builder.push(
+                    "SELECT user_id, COALESCE(SUM(total), 0), 0, 0, 0 FROM (\
+                     SELECT aub.user_id, SUM(aub.count) AS total \
+                     FROM account_usage_buckets aub \
+                     JOIN filtered_users fu ON fu.id = aub.user_id \
+                     WHERE aub.granularity = ",
+                );
+                builder.push_bind(GRANULARITY_DAY);
+                builder.push(" AND aub.bucket_start >= ");
+                builder.push_bind(day_window_start);
+                builder.push(" GROUP BY aub.user_id UNION ALL SELECT aub.user_id, SUM(aub.count) AS total FROM account_usage_buckets aub JOIN filtered_users fu ON fu.id = aub.user_id WHERE aub.granularity = ");
+                builder.push_bind(GRANULARITY_HOUR);
+                builder.push(" AND aub.bucket_start >= ");
+                builder.push_bind(day_window_start);
+                builder.push(" AND aub.bucket_start < ");
+                builder.push_bind(day_window_end);
+                builder.push(" GROUP BY aub.user_id) GROUP BY user_id");
+            }
+            AdminUserListSortField::QuotaMonthlyUsed => {
+                builder.push("SELECT amq.user_id, CASE WHEN amq.month_start >= ");
+                builder.push_bind(month_start);
+                builder.push(
+                    " THEN amq.month_count ELSE 0 END, 0, 0, 0 \
+                     FROM account_monthly_quota amq \
+                     JOIN filtered_users fu ON fu.id = amq.user_id",
+                );
+            }
+            AdminUserListSortField::DailySuccessRate => {
+                builder.push(
+                    "SELECT b.user_id, \
+                     COALESCE(SUM(CASE WHEN l.result_status = ",
+                );
+                builder.push_bind(OUTCOME_SUCCESS);
+                builder.push(" THEN 1 ELSE 0 END), 0), 0, COUNT(*), COALESCE(SUM(CASE WHEN l.result_status = ");
+                builder.push_bind(OUTCOME_ERROR);
+                builder.push(
+                    " THEN 1 ELSE 0 END), 0) \
+                     FROM filtered_users fu \
+                     JOIN user_token_bindings b ON b.user_id = fu.id \
+                     JOIN auth_token_logs l INDEXED BY idx_token_logs_token_time ON l.token_id = b.token_id \
+                     WHERE l.created_at >= ",
+                );
+                builder.push_bind(day_window_start);
+                builder.push(" AND l.created_at < ");
+                builder.push_bind(day_window_end);
+                builder.push(" AND l.result_status IN (");
+                builder.push_bind(OUTCOME_SUCCESS);
+                builder.push(", ");
+                builder.push_bind(OUTCOME_ERROR);
+                builder.push(") GROUP BY b.user_id");
+            }
+            AdminUserListSortField::MonthlySuccessRate => {
+                builder.push(
+                    "SELECT b.user_id, \
+                     COALESCE(SUM(CASE WHEN l.result_status = ",
+                );
+                builder.push_bind(OUTCOME_SUCCESS);
+                builder.push(" THEN 1 ELSE 0 END), 0), 0, COUNT(*), COALESCE(SUM(CASE WHEN l.result_status = ");
+                builder.push_bind(OUTCOME_ERROR);
+                builder.push(
+                    " THEN 1 ELSE 0 END), 0) \
+                     FROM filtered_users fu \
+                     JOIN user_token_bindings b ON b.user_id = fu.id \
+                     JOIN auth_token_logs l INDEXED BY idx_token_logs_token_time ON l.token_id = b.token_id \
+                     WHERE l.created_at >= ",
+                );
+                builder.push_bind(month_start);
+                builder.push(" AND l.result_status IN (");
+                builder.push_bind(OUTCOME_SUCCESS);
+                builder.push(", ");
+                builder.push_bind(OUTCOME_ERROR);
+                builder.push(") GROUP BY b.user_id");
+            }
+            AdminUserListSortField::MonthlyBrokenCount => {
+                builder.push(
+                    "SELECT skb.subject_id, COUNT(*), 0, 0, 0 \
+                     FROM subject_key_breakages skb \
+                     JOIN filtered_users fu ON fu.id = skb.subject_id \
+                     JOIN api_keys ak ON ak.id = skb.key_id AND ak.deleted_at IS NULL \
+                     LEFT JOIN api_key_quarantines aq ON aq.key_id = ak.id AND aq.cleared_at IS NULL \
+                     WHERE skb.subject_kind = ",
+                );
+                builder.push_bind(BROKEN_KEY_SUBJECT_USER);
+                builder.push(" AND skb.month_start = ");
+                builder.push_bind(month_start);
+                builder.push(" AND aq.reason_code IN (");
+                builder.push_bind(BLOCKED_KEY_REASON_ACCOUNT_DEACTIVATED);
+                builder.push(", ");
+                builder.push_bind(BLOCKED_KEY_REASON_KEY_REVOKED);
+                builder.push(", ");
+                builder.push_bind(BLOCKED_KEY_REASON_INVALID_API_KEY);
+                builder.push(") AND skb.reason_code IN (");
+                builder.push_bind(BLOCKED_KEY_REASON_ACCOUNT_DEACTIVATED);
+                builder.push(", ");
+                builder.push_bind(BLOCKED_KEY_REASON_KEY_REVOKED);
+                builder.push(", ");
+                builder.push_bind(BLOCKED_KEY_REASON_INVALID_API_KEY);
+                builder.push(") GROUP BY skb.subject_id");
+            }
+            AdminUserListSortField::RecentIpCount7d => {
+                builder.push(
+                    "SELECT rl.request_user_id, COUNT(DISTINCT rl.client_ip), 0, 0, 0 \
+                     FROM request_logs rl INDEXED BY idx_request_logs_user_ip_time \
+                     JOIN filtered_users fu ON fu.id = rl.request_user_id \
+                     WHERE rl.visibility = ",
+                );
+                builder.push_bind(REQUEST_LOG_VISIBILITY_VISIBLE);
+                builder.push(" AND rl.created_at >= ");
+                builder.push_bind(recent_ip_since);
+                builder.push(
+                    " AND rl.client_ip IS NOT NULL AND TRIM(rl.client_ip) != '' \
+                     GROUP BY rl.request_user_id",
+                );
+            }
+            AdminUserListSortField::LastActivity => {
+                builder.push(
+                    "SELECT b.user_id, MAX(l.created_at), 0, 0, 0 \
+                     FROM filtered_users fu \
+                     JOIN user_token_bindings b ON b.user_id = fu.id \
+                     JOIN auth_token_logs l INDEXED BY idx_token_logs_token_time ON l.token_id = b.token_id \
+                     GROUP BY b.user_id",
+                );
+            }
+            AdminUserListSortField::LastLoginAt => {
+                builder.push("SELECT NULL, NULL, NULL, NULL, NULL WHERE 0");
+            }
+        }
+        builder.push(
+            "), quota_limits AS (\
+             SELECT fu.id AS user_id, \
+             COALESCE((SELECT s.hourly_limit FROM account_quota_limit_snapshots s WHERE s.user_id = fu.id ORDER BY s.changed_at DESC, s.id DESC LIMIT 1), 0) AS hourly_limit, \
+             COALESCE((SELECT s.daily_limit FROM account_quota_limit_snapshots s WHERE s.user_id = fu.id ORDER BY s.changed_at DESC, s.id DESC LIMIT 1), 0) AS daily_limit, \
+             COALESCE((SELECT s.monthly_limit FROM account_quota_limit_snapshots s WHERE s.user_id = fu.id ORDER BY s.changed_at DESC, s.id DESC LIMIT 1), 0) AS monthly_limit \
+             FROM filtered_users fu\
+             ), broken_limits AS (\
+             SELECT fu.id AS user_id, MAX(0, ",
+        );
+        builder.push_bind(monthly_broken_base_limit);
+        builder.push(
+            " + COALESCE(aql.monthly_blocked_key_limit_delta, aql.monthly_broken_limit - ",
+        );
+        builder.push_bind(USER_MONTHLY_BROKEN_LIMIT_DEFAULT);
+        builder.push(
+            ", 0)) AS monthly_broken_limit \
+             FROM filtered_users fu \
+             LEFT JOIN account_quota_limits aql ON aql.user_id = fu.id \
+             GROUP BY fu.id\
+             ) SELECT u.id, u.display_name, u.username, u.active, u.last_login_at, \
+             COALESCE(COUNT(b.token_id), 0) AS token_count \
+             FROM users u \
+             JOIN filtered_users fu ON fu.id = u.id \
+             LEFT JOIN user_token_bindings b ON b.user_id = u.id \
+             LEFT JOIN metric m ON m.user_id = u.id \
+             LEFT JOIN quota_limits ql ON ql.user_id = u.id \
+             LEFT JOIN broken_limits bl ON bl.user_id = u.id \
+             GROUP BY u.id, u.display_name, u.username, u.active, u.last_login_at, \
+             ql.hourly_limit, ql.daily_limit, ql.monthly_limit, bl.monthly_broken_limit",
+        );
+        let direction_sql = Self::admin_user_sort_direction_sql(direction);
+        let null_order_sql = Self::admin_user_timestamp_null_order_sql(direction);
+        match sort {
+            AdminUserListSortField::DailySuccessRate
+            | AdminUserListSortField::MonthlySuccessRate => {
+                builder.push(" ORDER BY (COALESCE(m.sort_total, 0) = 0) ASC, (CAST(COALESCE(m.sort_value, 0) AS REAL) / NULLIF(m.sort_total, 0)) ");
+                builder.push(direction_sql);
+                builder.push(", COALESCE(m.sort_failure, 0) ASC, u.id ASC");
+            }
+            AdminUserListSortField::LastActivity => {
+                builder.push(" ORDER BY (m.sort_value IS NULL) ");
+                builder.push(null_order_sql);
+                builder.push(", m.sort_value ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+            AdminUserListSortField::LastLoginAt => {
+                builder.push(" ORDER BY (u.last_login_at IS NULL) ");
+                builder.push(null_order_sql);
+                builder.push(", u.last_login_at ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+            AdminUserListSortField::QuotaHourlyUsed => {
+                builder.push(" ORDER BY COALESCE(m.sort_value, 0) ");
+                builder.push(direction_sql);
+                builder.push(", COALESCE(ql.hourly_limit, 0) ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+            AdminUserListSortField::QuotaDailyUsed => {
+                builder.push(" ORDER BY COALESCE(m.sort_value, 0) ");
+                builder.push(direction_sql);
+                builder.push(", COALESCE(ql.daily_limit, 0) ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+            AdminUserListSortField::QuotaMonthlyUsed => {
+                builder.push(" ORDER BY COALESCE(m.sort_value, 0) ");
+                builder.push(direction_sql);
+                builder.push(", COALESCE(ql.monthly_limit, 0) ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+            AdminUserListSortField::MonthlyBrokenCount => {
+                builder.push(" ORDER BY COALESCE(m.sort_value, 0) ");
+                builder.push(direction_sql);
+                builder.push(", COALESCE(bl.monthly_broken_limit, ");
+                builder.push_bind(monthly_broken_base_limit);
+                builder.push(") ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+            _ => {
+                builder.push(" ORDER BY COALESCE(m.sort_value, 0) ");
+                builder.push(direction_sql);
+                builder.push(", u.id ASC");
+            }
+        }
+        builder.push(" LIMIT ");
+        builder.push_bind(per_page);
+        builder.push(" OFFSET ");
+        builder.push_bind(offset);
+
+        let rows = builder
+            .build_query_as::<(
+                String,
+                Option<String>,
+                Option<String>,
+                i64,
+                Option<i64>,
+                i64,
+            )>()
+            .fetch_all(&self.pool)
+            .await?;
+        let items = rows
+            .into_iter()
+            .map(
+                |(user_id, display_name, username, active, last_login_at, token_count)| {
+                    AdminUserIdentity {
+                        user_id,
+                        display_name,
+                        username,
+                        active: active == 1,
+                        last_login_at,
+                        token_count,
+                    }
+                },
+            )
+            .collect();
+        Ok((items, total))
+    }
+}

--- a/src/store/key_store_keys.rs
+++ b/src/store/key_store_keys.rs
@@ -1,4 +1,42 @@
 impl KeyStore {
+    fn push_admin_user_filters<'a>(
+        builder: &mut QueryBuilder<'a, Sqlite>,
+        tag_id: Option<&'a str>,
+        search: Option<&'a str>,
+    ) {
+        builder.push("(");
+        builder.push_bind(tag_id);
+        builder.push(" IS NULL OR EXISTS (SELECT 1 FROM user_tag_bindings utb_filter WHERE utb_filter.user_id = u.id AND utb_filter.tag_id = ");
+        builder.push_bind(tag_id);
+        builder.push(")) AND (");
+        builder.push_bind(search);
+        builder.push(" IS NULL OR u.id LIKE ");
+        builder.push_bind(search);
+        builder.push(" OR COALESCE(u.display_name, '') LIKE ");
+        builder.push_bind(search);
+        builder.push(" OR COALESCE(u.username, '') LIKE ");
+        builder.push_bind(search);
+        builder.push(" OR EXISTS (SELECT 1 FROM user_tag_bindings utb_search JOIN user_tags ut_search ON ut_search.id = utb_search.tag_id WHERE utb_search.user_id = u.id AND (ut_search.name LIKE ");
+        builder.push_bind(search);
+        builder.push(" OR COALESCE(ut_search.display_name, '') LIKE ");
+        builder.push_bind(search);
+        builder.push(")))");
+    }
+
+    fn admin_user_sort_direction_sql(direction: AdminListSortDirection) -> &'static str {
+        match direction {
+            AdminListSortDirection::Asc => "ASC",
+            AdminListSortDirection::Desc => "DESC",
+        }
+    }
+
+    fn admin_user_timestamp_null_order_sql(direction: AdminListSortDirection) -> &'static str {
+        match direction {
+            AdminListSortDirection::Asc => "DESC",
+            AdminListSortDirection::Desc => "ASC",
+        }
+    }
+
     pub async fn fetch_key_summary_since(
         &self,
         key_id: &str,

--- a/src/store/key_store_token_logs.rs
+++ b/src/store/key_store_token_logs.rs
@@ -2568,7 +2568,7 @@ impl KeyStore {
         }
 
         let mut builder = QueryBuilder::<Sqlite>::new(
-            "SELECT request_user_id, COUNT(DISTINCT client_ip) AS ip_count FROM request_logs WHERE visibility = ",
+            "SELECT request_user_id, COUNT(DISTINCT client_ip) AS ip_count FROM request_logs INDEXED BY idx_request_logs_user_ip_time WHERE visibility = ",
         );
         builder.push_bind(REQUEST_LOG_VISIBILITY_VISIBLE);
         builder.push(" AND request_user_id IN (");

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1401,6 +1401,7 @@ pub(crate) struct KeyStore {
 include!("key_store_bootstrap.rs");
 include!("key_store_migrations_a.rs");
 include!("key_store_migrations_b.rs");
+include!("key_store_admin_user_listing.rs");
 include!("key_store_keys.rs");
 include!("key_store_sessions.rs");
 include!("key_store_users_and_oauth.rs");

--- a/src/tavily_proxy/proxy_auth_and_oauth.rs
+++ b/src/tavily_proxy/proxy_auth_and_oauth.rs
@@ -755,6 +755,37 @@ impl TavilyProxy {
             .await
     }
 
+    /// Admin: list users with pagination pushed below expensive usage hydration.
+    pub async fn list_admin_users_sorted_paged(
+        &self,
+        page: i64,
+        per_page: i64,
+        query: Option<&str>,
+        tag_id: Option<&str>,
+        sort: AdminUserListSortField,
+        direction: AdminListSortDirection,
+    ) -> Result<(Vec<AdminUserIdentity>, i64), ProxyError> {
+        let now = Utc::now();
+        let month_start = start_of_month(now).timestamp();
+        let server_daily_window = server_local_day_window_utc(now.with_timezone(&Local));
+        let minute_bucket = now.timestamp() - (now.timestamp() % SECS_PER_MINUTE);
+        self.key_store
+            .list_admin_users_sorted_paged(
+                page,
+                per_page,
+                query,
+                tag_id,
+                sort,
+                direction,
+                minute_bucket - 59 * SECS_PER_MINUTE,
+                server_daily_window.start,
+                server_daily_window.end,
+                month_start,
+                now.timestamp() - 7 * SECS_PER_DAY,
+            )
+            .await
+    }
+
     /// Admin: list the full filtered user set prior to sorting and pagination.
     pub async fn list_admin_users_filtered(
         &self,


### PR DESCRIPTION
## Summary
- Push admin user usage sorting into SQL so DB-backed sorts page user ids before hydrating expensive usage details.
- Force recent client IP counts onto the existing user/ip/time request-log index to avoid scanning the whole recent visibility window.
- Update the client IP usage spec and SQLite admin read containment solution with the performance guardrail.

## Validation
- `cargo fmt --check`
- `cargo test admin_user_management_lists_details_and_updates_quota -- --nocapture`
- `cargo test admin_user_tag_crud_and_system_guards_work -- --nocapture`
- `cargo clippy -- -D warnings`
- 101 read-only probe against current production `0.48.1` baseline, no deployment performed:
  - `/api/users?page=1&per_page=20`: `7.712s` cold, then `0.600s`, `0.615s`
  - `/api/users?page=1&per_page=20&sort=recentIpCount7d&order=desc`: `3.701s`, `2.374s`, `2.456s`
  - `/api/users?page=1&per_page=20&sort=quotaMonthlyUsed&order=desc`: `2.460s`, `2.434s`, `2.438s`
  - `database is locked` in last 10 minutes: `0`

## References
- Specs: `docs/specs/r7k2p-client-ip-trust-and-usage/IMPLEMENTATION.md`
- Solutions: `docs/solutions/operations/sqlite-admin-read-containment.md`
- Project Docs: `-`

## Notes
- Production was not changed. The 101 latency numbers above are the still-deployed `0.48.1` baseline for comparison after deployment approval.
