### PR TITLE
fix: allow exact remaining quota charge

### DIFF
--- a/docs/specs/s2vd2-upstream-credits-billing/SPEC.md
+++ b/docs/specs/s2vd2-upstream-credits-billing/SPEC.md
@@ -58,7 +58,7 @@
 - `/api/tavily/research`
   - 成功发起 Research 后按请求模型固定估算扣费：`mini=40`、`auto=50`、`pro=100`。
   - 缺省 `model` 按 Tavily `auto` 处理，扣 `50`。
-  - 前置 quota 检查使用同一估算价；若 `used + estimated > limit`，直接 429 且不上游。
+  - 前置 quota 检查使用同一估算价；若 `used + estimated > limit`，直接 429 且不上游；若刚好等于 `limit`，请求必须放行并扣减到窗口上限。
   - 不再用共享 upstream key 的 `/usage.research_usage` 差分反填本地用户账单；上游实扣只作为池级运营对账指标。
 - `/mcp`
   - 白名单非业务方法不计 business quota。
@@ -72,7 +72,7 @@
 - HTTP Extract / Crawl / Map：请求体被注入 `include_usage=true`；reserved credits 超额时会先验 429，成功回包后按 `usage.credits` 扣费，`credits=0` 不扣费。
 - MCP 非工具调用继续保持 0 成本，`counts_business_quota=0`。
 - MCP `tavily-search`：支持嵌套 `usage.credits`、SSE/JSON-RPC 包装、expected cost fallback 与先验阻断。
-- Research：HTTP 与 MCP 成功发起时按模型估算价扣费（`mini=40`、缺省或 `auto=50`、`pro=100`）；前置 quota 检查使用同一估算值；上游失败、quota 拦截、validation error 与 invalid model error 不扣 business credits。
+- Research：HTTP 与 MCP 成功发起时按模型估算价扣费（`mini=40`、缺省或 `auto=50`、`pro=100`）；前置 quota 检查使用同一估算值，剩余额度刚好等于估算值时放行，低于估算值时 429；上游失败、quota 拦截、validation error 与 invalid model error 不扣 business credits。
 - 绑定账户的 token 继续只写 account counters，不回退到 token counters。
 
 ## 质量门槛（Quality Gates）
@@ -113,3 +113,4 @@
 
 - 2026-03-07: fast-flow 复跑后补齐规格同步：Research follow-up `/usage` 失败/回退改为成功回包 + warning + reserved minimum cost 兜底扣费；PR #100 checks 绿灯，可直接合并。
 - 2026-04-29: Research 本地用户计费从共享 key `/usage.research_usage` 差分归因改为模型估算价（`mini=40`、`auto=50`、`pro=100`）；`/usage` 实扣仅保留为池级运营对账指标。
+- 2026-05-17: 明确 Research 前置 quota 边界按剩余额度判断；剩余额度等于本次估算扣减时放行并扣到窗口上限。

--- a/src/server/handlers/tavily.rs
+++ b/src/server/handlers/tavily.rs
@@ -276,9 +276,12 @@ fn quota_would_exceed(verdict: &TokenQuotaVerdict, delta: i64) -> bool {
     if delta <= 0 {
         return false;
     }
-    verdict.hourly_used.saturating_add(delta) > verdict.hourly_limit
-        || verdict.daily_used.saturating_add(delta) > verdict.daily_limit
-        || verdict.monthly_used.saturating_add(delta) > verdict.monthly_limit
+
+    let hourly_remaining = verdict.hourly_limit.saturating_sub(verdict.hourly_used);
+    let daily_remaining = verdict.daily_limit.saturating_sub(verdict.daily_used);
+    let monthly_remaining = verdict.monthly_limit.saturating_sub(verdict.monthly_used);
+
+    hourly_remaining < delta || daily_remaining < delta || monthly_remaining < delta
 }
 
 #[axum::debug_handler]

--- a/src/server/tests/chunk_08.rs
+++ b/src/server/tests/chunk_08.rs
@@ -2286,6 +2286,62 @@
     }
 
     #[tokio::test]
+    async fn tavily_http_research_allows_when_remaining_equals_estimate() {
+        let db_path = temp_db_path("http-research-exact-remaining-estimate");
+        let db_str = db_path.to_string_lossy().to_string();
+
+        let _hourly_business_guard = EnvVarGuard::set("TOKEN_HOURLY_LIMIT", "200");
+
+        let expected_api_key = "tvly-http-research-exact-remaining-key";
+        let (upstream_addr, usage_calls, research_calls) =
+            spawn_http_research_mock_with_usage_diff(expected_api_key.to_string(), 10, 7).await;
+        let usage_base = format!("http://{}", upstream_addr);
+
+        let proxy = TavilyProxy::with_endpoint(
+            vec![expected_api_key.to_string()],
+            DEFAULT_UPSTREAM,
+            &db_str,
+        )
+        .await
+        .expect("proxy created");
+        let access_token = proxy
+            .create_access_token(Some("http-research-exact-remaining-estimate"))
+            .await
+            .expect("create token");
+
+        proxy
+            .charge_token_quota(&access_token.id, 150)
+            .await
+            .expect("seed prior quota usage");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), usage_base).await;
+        let client = Client::new();
+
+        let url = format!("http://{}/api/tavily/research", proxy_addr);
+        let resp = client
+            .post(url)
+            .json(&serde_json::json!({
+                "api_key": access_token.token,
+                "input": "exact remaining",
+                "model": "auto"
+            }))
+            .send()
+            .await
+            .expect("research request");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(usage_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(research_calls.load(Ordering::SeqCst), 1);
+
+        let verdict = proxy
+            .peek_token_quota(&access_token.id)
+            .await
+            .expect("peek quota");
+        assert_eq!(verdict.hourly_used, 200);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn tavily_http_research_charges_pro_estimate_without_usage_diff() {
         let db_path = temp_db_path("http-research-pro-estimate-charge");
         let db_str = db_path.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary
- Change quota precheck to compare each window's remaining credits against the requested charge.
- Add a regression test for research requests when remaining quota exactly equals the estimated charge.
- Clarify the credits-billing spec boundary for exact remaining quota.

## Validation
- cargo test tavily_http_research_allows_when_remaining_equals_estimate
- cargo test tavily_http_research_blocks_when_estimate_would_exceed_quota
- cargo clippy -- -D warnings
- spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/s2vd2-upstream-credits-billing/SPEC.md

## References
- Spec: docs/specs/s2vd2-upstream-credits-billing/SPEC.md
- Spec Disposition: update
- Solutions: -
- Project Docs: -

## Sync
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a(no solution change)
- Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->