### PR TITLE
fix: reduce forward proxy readiness latency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ LABEL org.opencontainers.image.version=${APP_EFFECTIVE_VERSION}
 VOLUME ["/srv/app/data"]
 EXPOSE 8787
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=6 CMD curl --fail --silent http://127.0.0.1:8787/health || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=18 CMD curl --fail --silent http://127.0.0.1:8787/health || exit 1
 
 ENTRYPOINT ["tavily-hikari"]
 CMD []

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -28,6 +28,8 @@ writer to coexist, but only one writer can hold the write slot at a time.
 - Logs contain `database is locked` while `/health` remains OK.
 - Request-path messages mention `token billing lock failed` or `mcp session ... lock failed`.
 - Background messages mention `token-usage-rollup: start job error`, `quota-sync-hot: start job error`, or LinuxDo OAuth upsert failures.
+- Startup logs may show `forward-proxy startup: ...` phases taking a long time when runtime
+  snapshot persistence or subscription refresh collides with another writer.
 - WAL can be large without itself proving corruption; it is a signal to inspect writer pressure and
   long readers before performing maintenance.
 
@@ -43,6 +45,10 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
   inside the existing bounded lock wait or lease budget.
 - Retry background job bookkeeping writes before surfacing scheduler errors.
 - Retry OAuth upsert/refresh wrapper calls so login/profile sync can survive short writer collisions.
+- Retry forward-proxy runtime snapshot persistence at the startup/maintenance boundary so a short
+  writer collision does not stretch readiness.
+- Overlap startup subscription fetches where possible, but keep the refresh fail-closed if every
+  feed fails.
 - Prefer bounded retries and narrower write windows before increasing SQLite pool size.
 
 ## Guardrails / Reuse Notes

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -7,3 +7,9 @@
 - Chose bounded retry hardening as the first repair because the evidence showed short writer
   collisions, while API rebalance selection and research result key pinning were behaving as
   designed.
+
+## 2026-05-24
+
+- Extended the same lock-hardening line to forward-proxy startup: subscription refresh now fetches
+  multiple feeds concurrently, runtime snapshot persistence retries transient busy/locked writes,
+  and startup logs now break out sqlite, refresh, xray, and store-sync phases.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -9,7 +9,12 @@
   failure to background schedulers.
 - OAuth account upsert/profile refresh wrapper calls now retry transient SQLite busy/locked errors
   before returning failures to LinuxDo login or daily sync flows.
+- Forward-proxy startup now refreshes subscription-backed endpoints concurrently, syncs xray state
+  from the restored snapshot, and retries runtime snapshot persistence when SQLite briefly denies
+  the write slot.
 - Added local contention tests for quota subject lock acquisition and scheduled job start.
+- Added local contention coverage for forward-proxy startup subscription refresh and runtime
+  snapshot persistence.
 
 ## Validation
 
@@ -17,6 +22,8 @@
 - Targeted SQLite lock contention tests.
 - Existing billing/MCP/quota-sync tests relevant to the touched paths.
 - `cargo test`
+- `cargo clippy -- -D warnings`
+- Full `cargo test --locked --all-features`
 - `cargo clippy -- -D warnings`
 
 ## Operations Notes

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -4,7 +4,7 @@
 
 - Lifecycle: active
 - Created: 2026-05-07
-- Last: 2026-05-07
+- Last: 2026-05-24
 
 ## Background
 
@@ -18,6 +18,11 @@ misrouting. Billing, MCP session serialization, quota sync, scheduled job loggin
 upserts, and rollups all share the same SQLite database and can briefly compete for the single
 writer slot.
 
+Forward-proxy startup also participates in this same lock budget: it refreshes subscription-backed
+endpoints, syncs xray state, and persists runtime snapshots before the HTTP server reports itself
+ready. That startup path can amplify a short writer collision into a slow first healthy when the
+runtime snapshot write collides with other writers.
+
 ## Goals
 
 - Keep request-path billing and MCP session locks from failing on transient SQLite busy/locked
@@ -26,6 +31,8 @@ writer slot.
   and API rebalance behavior.
 - Make background job bookkeeping tolerate transient lock pressure without amplifying request-path
   failures.
+- Keep forward-proxy startup from turning short SQLite writer contention into a long readiness
+  delay.
 - Cover the lock-contention behavior with local tests that use only local/mock state.
 
 ## Non-goals
@@ -45,6 +52,10 @@ writer slot.
   background job logging failure.
 - LinuxDo OAuth account upsert/refresh calls must retry transient SQLite write errors at the proxy
   boundary so a short writer collision does not immediately fail user login/profile sync.
+- `forward_proxy` startup runtime snapshot persistence must retry transient SQLite write errors with
+  bounded backoff so a short writer collision does not delay readiness longer than necessary.
+- Startup subscription refresh may fetch multiple subscription URLs concurrently, as long as the
+  refresh still fails closed when every subscription fetch fails.
 - Retry logs may include operation, attempt, backoff, and final error context.
 
 ## Acceptance
@@ -53,6 +64,8 @@ writer slot.
   writer releases within the existing wait budget.
 - Under a competing SQLite writer, scheduled job start retries rather than immediately returning
   `database is locked`.
+- Under a competing SQLite writer, forward-proxy startup runtime snapshot persistence retries
+  transient lock errors rather than failing the startup path immediately.
 - Existing billing tests continue to prove locked billing subject stability, pending billing
   replay, and account/token quota attribution.
 - Existing MCP/API routing behavior remains unchanged, including research result GET key pinning.

--- a/src/forward_proxy/storage.rs
+++ b/src/forward_proxy/storage.rs
@@ -758,7 +758,28 @@ pub async fn sync_manager_runtime_to_store(
     key_store: &KeyStore,
     manager: &ForwardProxyManager,
 ) -> Result<(), ProxyError> {
-    persist_forward_proxy_runtime_snapshot(&key_store.pool, manager.snapshot_runtime()).await
+    let snapshot = manager.snapshot_runtime();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut retry_attempt = 0usize;
+    loop {
+        match persist_forward_proxy_runtime_snapshot(&key_store.pool, snapshot.clone()).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                if crate::store::sleep_before_sqlite_transient_write_retry(
+                    "forward proxy runtime snapshot sync",
+                    retry_attempt,
+                    deadline,
+                    &err,
+                )
+                .await
+                {
+                    retry_attempt += 1;
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
 }
 
 async fn load_forward_proxy_assignment_counts(

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -3,8 +3,13 @@ mod tests {
     use super::*;
     use crate::tavily_proxy::{TavilyProxy, TavilyProxyOptions};
     use crate::LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT;
+    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    use std::{
+        path::PathBuf,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn derive_probe_url_uses_public_probe_endpoint() {
@@ -85,6 +90,17 @@ rule-providers:
         assert_eq!(parsed.display_name, "example.com:8443");
     }
 
+    fn temp_db_path(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "tavily-hikari-{prefix}-{}-{unique}.db",
+            std::process::id()
+        ))
+    }
+
     #[test]
     fn parse_vless_forward_proxy_keeps_lossy_fragment_for_invalid_percent_encoding() {
         let parsed = parse_vless_forward_proxy(
@@ -134,6 +150,85 @@ rule-providers:
         };
 
         assert_eq!(endpoint_host(&endpoint).as_deref(), Some("127.0.0.1"));
+    }
+
+    #[tokio::test]
+    async fn persist_forward_proxy_runtime_snapshot_retries_transient_write_lock() {
+        let db_path = temp_db_path("forward-proxy-runtime-snapshot-retry");
+        let options = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(Duration::from_millis(1));
+        let pool = SqlitePoolOptions::new()
+            .min_connections(1)
+            .max_connections(2)
+            .connect_with(options)
+            .await
+            .expect("connect sqlite");
+        ensure_forward_proxy_schema(&pool)
+            .await
+            .expect("ensure schema");
+
+        let key_store = crate::store::KeyStore {
+            pool: pool.clone(),
+            token_binding_cache: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            account_quota_resolution_cache: tokio::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            ),
+            request_logs_catalog_cache: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            admin_heavy_read_semaphore: tokio::sync::Semaphore::new(1),
+            #[cfg(test)]
+            forced_pending_claim_miss_log_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+            forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(
+                std::collections::HashSet::new(),
+            ),
+        };
+        let manager = ForwardProxyManager::new(
+            ForwardProxySettings {
+                proxy_urls: vec!["http://198.51.100.8:8080".to_string()],
+                subscription_urls: Vec::new(),
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            Vec::new(),
+        );
+
+        let mut blocker = pool.acquire().await.expect("acquire sqlite writer");
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *blocker)
+            .await
+            .expect("begin immediate lock");
+
+        let key_store_for_write = key_store;
+        let manager_for_write = manager.clone();
+        let write_task = tokio::spawn(async move {
+            sync_manager_runtime_to_store(&key_store_for_write, &manager_for_write).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        sqlx::query("ROLLBACK")
+            .execute(&mut *blocker)
+            .await
+            .expect("release sqlite writer lock");
+        drop(blocker);
+
+        write_task
+            .await
+            .expect("runtime snapshot write task")
+            .expect("runtime snapshot write should retry and succeed");
+
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM forward_proxy_runtime")
+            .fetch_one(&pool)
+            .await
+            .expect("count runtime rows");
+        assert_eq!(row_count, 1);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+        let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
     }
 
     #[test]

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -522,7 +522,6 @@ fn low_quota_depletion_threshold_from_env() -> i64 {
 }
 
 include!("proxy_core.rs");
-include!("proxy_forward_proxy_maintenance.rs");
 include!("proxy_affinity.rs");
 include!("proxy_http_and_logs.rs");
 include!("proxy_auth_and_oauth.rs");
@@ -530,6 +529,8 @@ include!("proxy_usage_and_metrics.rs");
 include!("proxy_request_limits.rs");
 include!("proxy_alerts.rs");
 include!("proxy_admin_user_usage_series.rs");
+include!("proxy_quota_sync_and_jobs.rs");
+include!("proxy_forward_proxy_maintenance.rs");
 
 impl TokenQuota {
     pub(crate) fn new(store: Arc<KeyStore>) -> Self {
@@ -1371,5 +1372,3 @@ impl MemoryRequestRateLimitBackend {
         Self::maybe_gc(&mut state, now_ts, window_secs);
     }
 }
-
-include!("proxy_quota_sync_and_jobs.rs");

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -395,16 +395,29 @@ impl TavilyProxy {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
+        let startup_started = Instant::now();
         let sanitized: Vec<String> = keys
             .into_iter()
             .map(|k| k.into().trim().to_owned())
             .filter(|k| !k.is_empty())
             .collect();
 
+        let key_store_started = Instant::now();
         let key_store = KeyStore::new(database_path).await?;
+        eprintln!(
+            "forward-proxy startup: sqlite initialized in {}ms",
+            key_store_started.elapsed().as_millis()
+        );
         if !sanitized.is_empty() {
+            let sync_keys_started = Instant::now();
             key_store.sync_keys(&sanitized).await?;
+            eprintln!(
+                "forward-proxy startup: synced {} api keys in {}ms",
+                sanitized.len(),
+                sync_keys_started.elapsed().as_millis()
+            );
         }
+        let forward_proxy_load_started = Instant::now();
         let upstream = Url::parse(upstream).map_err(|source| ProxyError::InvalidEndpoint {
             endpoint: upstream.to_owned(),
             source,
@@ -425,6 +438,10 @@ impl TavilyProxy {
                 .keys()
                 .cloned()
                 .collect::<std::collections::HashSet<_>>(),
+        );
+        eprintln!(
+            "forward-proxy startup: loaded settings/runtime in {}ms",
+            forward_proxy_load_started.elapsed().as_millis()
         );
         let forward_proxy = Arc::new(Mutex::new(forward_proxy_manager));
         let key_store = Arc::new(key_store);
@@ -471,12 +488,21 @@ impl TavilyProxy {
             low_quota_depletion_threshold: options.low_quota_depletion_threshold,
             health_readiness_grace_until: Instant::now() + options.health_readiness_grace_period,
         };
+        eprintln!("forward-proxy startup: initializing runtime graph");
+        let runtime_init_started = Instant::now();
         proxy.initialize_forward_proxy_runtime().await?;
+        eprintln!(
+            "forward-proxy startup: runtime graph ready in {}ms; total startup {}ms",
+            runtime_init_started.elapsed().as_millis(),
+            startup_started.elapsed().as_millis()
+        );
         Ok(proxy)
     }
 
     pub(crate) async fn initialize_forward_proxy_runtime(&mut self) -> Result<(), ProxyError> {
-        if let Err(err) = self.refresh_forward_proxy_subscriptions().await {
+        let startup_started = Instant::now();
+        let refresh_started = Instant::now();
+        if let Err(err) = self.refresh_forward_proxy_subscriptions_for_startup().await {
             eprintln!("forward-proxy startup subscription refresh failed: {err}");
             let restored = {
                 let mut manager = self.forward_proxy.lock().await;
@@ -487,7 +513,14 @@ impl TavilyProxy {
                     "forward-proxy restored {restored} persisted subscription nodes after startup refresh failure"
                 );
             }
+        } else {
+            eprintln!(
+                "forward-proxy startup: refreshed subscriptions in {}ms",
+                refresh_started.elapsed().as_millis()
+            );
         }
+        let xray_started = Instant::now();
+        let persist_started = Instant::now();
         {
             let mut manager = self.forward_proxy.lock().await;
             let egress_socks5_url = manager.settings.effective_egress_socks5_url();
@@ -502,8 +535,18 @@ impl TavilyProxy {
             }
             self.sync_forward_proxy_runtime_state(&mut manager).await?;
         }
+        eprintln!(
+            "forward-proxy startup: xray sync + runtime snapshot persisted in {}ms",
+            persist_started.elapsed().as_millis()
+        );
         let manager = self.forward_proxy.lock().await;
-        forward_proxy::sync_manager_runtime_to_store(&self.key_store, &manager).await
+        forward_proxy::sync_manager_runtime_to_store(&self.key_store, &manager).await?;
+        eprintln!(
+            "forward-proxy startup: runtime store synced in {}ms (total init {}ms)",
+            xray_started.elapsed().as_millis(),
+            startup_started.elapsed().as_millis()
+        );
+        Ok(())
     }
 
     pub async fn is_forward_proxy_xray_ready(&self) -> bool {

--- a/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
+++ b/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
@@ -46,6 +46,39 @@ impl TavilyProxy {
         Ok(())
     }
 
+    pub(crate) async fn refresh_forward_proxy_subscriptions_for_startup(
+        &self,
+    ) -> Result<(), ProxyError> {
+        let settings = {
+            let manager = self.forward_proxy.lock().await;
+            manager.settings.clone()
+        };
+        let egress_socks5_url = settings.effective_egress_socks5_url();
+        let subscription_client = self
+            .forward_proxy_clients
+            .direct_client_via_egress(egress_socks5_url.as_ref())
+            .await?;
+        let fetched = Self::fetch_forward_proxy_subscription_map_parallel(
+            &subscription_client,
+            &settings.subscription_urls,
+        )
+        .await?;
+
+        let mut manager = self.forward_proxy.lock().await;
+        manager.apply_subscription_refresh(&fetched);
+        {
+            let mut xray = self.xray_supervisor.lock().await;
+            if let Err(err) = xray
+                .sync_endpoints(&mut manager.endpoints, egress_socks5_url.as_ref())
+                .await
+            {
+                eprintln!("forward-proxy startup xray prewarm failed: {err}");
+            }
+        }
+        self.sync_forward_proxy_runtime_state(&mut manager).await?;
+        Ok(())
+    }
+
     pub(crate) async fn fetch_forward_proxy_subscription_map_with_progress(
         &self,
         subscription_urls: &[String],
@@ -93,6 +126,54 @@ impl TavilyProxy {
         }
 
         if fail_when_all_fail && !subscription_urls.is_empty() && !fetched_any_subscription {
+            return Err(ProxyError::Other(
+                "all forward proxy subscriptions failed to refresh".to_string(),
+            ));
+        }
+
+        Ok(fetched)
+    }
+
+    async fn fetch_forward_proxy_subscription_map_parallel(
+        subscription_client: &Client,
+        subscription_urls: &[String],
+    ) -> Result<HashMap<String, Vec<String>>, ProxyError> {
+        let mut fetched = HashMap::new();
+        let mut fetched_any_subscription = false;
+        let mut tasks = tokio::task::JoinSet::new();
+        for subscription_url in subscription_urls.iter().cloned() {
+            let subscription_client = subscription_client.clone();
+            tasks.spawn(async move {
+                let urls = forward_proxy::fetch_subscription_proxy_urls(
+                    &subscription_client,
+                    &subscription_url,
+                    Duration::from_secs(
+                        forward_proxy::FORWARD_PROXY_SUBSCRIPTION_VALIDATION_TIMEOUT_SECS,
+                    ),
+                )
+                .await;
+                (subscription_url, urls)
+            });
+        }
+
+        while let Some(joined) = tasks.join_next().await {
+            let (subscription_url, result) = joined.map_err(|err| {
+                ProxyError::Other(format!(
+                    "forward-proxy startup subscription fetch task failed: {err}"
+                ))
+            })?;
+            match result {
+                Ok(urls) => {
+                    fetched_any_subscription = true;
+                    fetched.insert(subscription_url, urls);
+                }
+                Err(_err) => {
+                    eprintln!("failed to refresh forward proxy subscription");
+                }
+            }
+        }
+
+        if !subscription_urls.is_empty() && !fetched_any_subscription {
             return Err(ProxyError::Other(
                 "all forward proxy subscriptions failed to refresh".to_string(),
             ));
@@ -1841,6 +1922,65 @@ impl TavilyProxy {
             _local: local_guard,
             _subject_lock: QuotaSubjectLockGuard::new(self.key_store.clone(), lease),
         })
+}
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{extract::State, routing::get, Router};
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+    use tokio::time::{timeout, Duration};
+
+    #[derive(Clone)]
+    struct SubscriptionTestState {
+        barrier: Arc<Barrier>,
+        body: &'static str,
     }
 
+    async fn subscription_handler(State(state): State<SubscriptionTestState>) -> &'static str {
+        state.barrier.wait().await;
+        state.body
+    }
+
+    #[tokio::test]
+    async fn startup_subscription_refresh_fetches_subscriptions_concurrently() {
+        let barrier = Arc::new(Barrier::new(2));
+        let app = Router::new()
+            .route("/sub1", get(subscription_handler))
+            .route("/sub2", get(subscription_handler))
+            .with_state(SubscriptionTestState {
+                barrier: Arc::clone(&barrier),
+                body: "http://198.51.100.8:8080",
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind subscription test server");
+        let addr = listener.local_addr().expect("subscription test addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("run subscription test server");
+        });
+        let client = Client::new();
+        let urls = vec![
+            format!("http://{addr}/sub1"),
+            format!("http://{addr}/sub2"),
+        ];
+
+        let fetched = timeout(
+            Duration::from_secs(2),
+            TavilyProxy::fetch_forward_proxy_subscription_map_parallel(&client, &urls),
+        )
+        .await
+        .expect("startup fetch should not hang")
+        .expect("startup fetch should succeed");
+
+        assert_eq!(fetched.len(), 2);
+        assert!(fetched.values().all(|urls| urls == &vec!["http://198.51.100.8:8080".to_string()]));
+
+        server.abort();
+    }
 }

--- a/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
+++ b/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
@@ -1926,6 +1926,7 @@ impl TavilyProxy {
 
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
+++ b/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
@@ -1,3 +1,5 @@
+const FORWARD_PROXY_STARTUP_SUBSCRIPTION_FETCH_CONCURRENCY: usize = 4;
+
 impl TavilyProxy {
     pub async fn refresh_forward_proxy_subscriptions(&self) -> Result<(), ProxyError> {
         self.refresh_forward_proxy_subscriptions_with_progress(None)
@@ -140,10 +142,11 @@ impl TavilyProxy {
     ) -> Result<HashMap<String, Vec<String>>, ProxyError> {
         let mut fetched = HashMap::new();
         let mut fetched_any_subscription = false;
-        let mut tasks = tokio::task::JoinSet::new();
-        for subscription_url in subscription_urls.iter().cloned() {
-            let subscription_client = subscription_client.clone();
-            tasks.spawn(async move {
+
+        let results = futures_util::stream::iter(subscription_urls.iter().cloned().map(
+            |subscription_url| {
+                let subscription_client = subscription_client.clone();
+                async move {
                 let urls = forward_proxy::fetch_subscription_proxy_urls(
                     &subscription_client,
                     &subscription_url,
@@ -153,15 +156,14 @@ impl TavilyProxy {
                 )
                 .await;
                 (subscription_url, urls)
-            });
-        }
+                }
+            },
+        ))
+        .buffer_unordered(FORWARD_PROXY_STARTUP_SUBSCRIPTION_FETCH_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
 
-        while let Some(joined) = tasks.join_next().await {
-            let (subscription_url, result) = joined.map_err(|err| {
-                ProxyError::Other(format!(
-                    "forward-proxy startup subscription fetch task failed: {err}"
-                ))
-            })?;
+        for (subscription_url, result) in results {
             match result {
                 Ok(urls) => {
                     fetched_any_subscription = true;
@@ -1931,7 +1933,10 @@ impl TavilyProxy {
 mod tests {
     use super::*;
     use axum::{extract::State, routing::get, Router};
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
     use tokio::sync::Barrier;
     use tokio::time::{timeout, Duration};
 
@@ -1941,8 +1946,27 @@ mod tests {
         body: &'static str,
     }
 
+    #[derive(Clone)]
+    struct CountingSubscriptionTestState {
+        current: Arc<AtomicUsize>,
+        max_seen: Arc<AtomicUsize>,
+        body: &'static str,
+    }
+
     async fn subscription_handler(State(state): State<SubscriptionTestState>) -> &'static str {
         state.barrier.wait().await;
+        state.body
+    }
+
+    async fn counting_subscription_handler(
+        State(state): State<CountingSubscriptionTestState>,
+    ) -> &'static str {
+        let current = state.current.fetch_add(1, Ordering::SeqCst) + 1;
+        state
+            .max_seen
+            .fetch_max(current, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        state.current.fetch_sub(1, Ordering::SeqCst);
         state.body
     }
 
@@ -1981,6 +2005,55 @@ mod tests {
 
         assert_eq!(fetched.len(), 2);
         assert!(fetched.values().all(|urls| urls == &vec!["http://198.51.100.8:8080".to_string()]));
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn startup_subscription_refresh_bounds_fetch_concurrency() {
+        let current = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/sub0", get(counting_subscription_handler))
+            .route("/sub1", get(counting_subscription_handler))
+            .route("/sub2", get(counting_subscription_handler))
+            .route("/sub3", get(counting_subscription_handler))
+            .route("/sub4", get(counting_subscription_handler))
+            .route("/sub5", get(counting_subscription_handler))
+            .with_state(CountingSubscriptionTestState {
+                current: Arc::clone(&current),
+                max_seen: Arc::clone(&max_seen),
+                body: "http://198.51.100.8:8080",
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind subscription test server");
+        let addr = listener.local_addr().expect("subscription test addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("run subscription test server");
+        });
+        let client = Client::new();
+        let urls = (0..6)
+            .map(|index| format!("http://{addr}/sub{index}"))
+            .collect::<Vec<_>>();
+
+        let fetched = timeout(
+            Duration::from_secs(2),
+            TavilyProxy::fetch_forward_proxy_subscription_map_parallel(&client, &urls),
+        )
+        .await
+        .expect("startup fetch should not hang")
+        .expect("startup fetch should succeed");
+
+        assert_eq!(fetched.len(), 6);
+        let peak = max_seen.load(Ordering::SeqCst);
+        assert!(peak > 1, "startup fetches should still overlap");
+        assert!(
+            peak <= FORWARD_PROXY_STARTUP_SUBSCRIPTION_FETCH_CONCURRENCY,
+            "startup fetches should be bounded"
+        );
 
         server.abort();
     }


### PR DESCRIPTION
## Summary
- Parallelize startup subscription refresh.
- Retry forward-proxy runtime snapshot writes on transient SQLite lock contention.
- Add startup phase timing logs and keep Docker healthcheck probing faster.

## Validation
- `cargo test startup_subscription_refresh_fetches_subscriptions_concurrently -- --nocapture`
- `cargo test persist_forward_proxy_runtime_snapshot_retries_transient_write_lock -- --nocapture`
- `cargo test --locked --all-features`
- `cargo clippy -- -D warnings`

## References
- Specs: `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`
- Project Docs: -