### PR TITLE
fix(proxy): restore persisted runtime before subscriptions

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -30,6 +30,8 @@ writer to coexist, but only one writer can hold the write slot at a time.
 - Background messages mention `token-usage-rollup: start job error`, `quota-sync-hot: start job error`, or LinuxDo OAuth upsert failures.
 - Startup logs may show `forward-proxy startup: ...` phases taking a long time when runtime
   snapshot persistence or subscription refresh collides with another writer.
+- Deploy health may remain `starting` when restart waits for remote subscription refresh before
+  restoring previously working subscription-backed proxy nodes from the local runtime table.
 - WAL can be large without itself proving corruption; it is a signal to inspect writer pressure and
   long readers before performing maintenance.
 
@@ -49,6 +51,9 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
   writer collision does not stretch readiness.
 - Overlap startup subscription fetches where possible, but keep the refresh fail-closed if every
   feed fails.
+- Restore safely attributable persisted subscription-backed proxy nodes from `forward_proxy_runtime`
+  before attempting remote subscription refresh. If that restored graph exists, use it for startup
+  readiness and leave remote subscription calibration to the maintenance scheduler.
 - Prefer bounded retries and narrower write windows before increasing SQLite pool size.
 
 ## Guardrails / Reuse Notes

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -12,9 +12,16 @@
 - Forward-proxy startup now refreshes subscription-backed endpoints concurrently, syncs xray state
   from the restored snapshot, and retries runtime snapshot persistence when SQLite briefly denies
   the write slot.
+- Forward-proxy startup now restores persisted subscription endpoints from `forward_proxy_runtime`
+  before attempting remote subscription refresh when the current settings contain one unambiguous
+  subscription source. If restored endpoints exist, startup skips the blocking remote refresh and
+  proceeds to xray sync/runtime persistence; the existing maintenance scheduler performs
+  subscription calibration after the service is running.
 - Added local contention tests for quota subject lock acquisition and scheduled job start.
 - Added local contention coverage for forward-proxy startup subscription refresh and runtime
   snapshot persistence.
+- Added startup-order coverage for restored subscription runtime with a slow subscription endpoint,
+  plus the strict no-runtime fallback where startup still waits for subscription readiness.
 
 ## Validation
 

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -23,6 +23,12 @@ endpoints, syncs xray state, and persists runtime snapshots before the HTTP serv
 ready. That startup path can amplify a short writer collision into a slow first healthy when the
 runtime snapshot write collides with other writers.
 
+Dockrev `job_01KSEPDVXF8NAQCEQGJKV33T4F` showed a related startup-order failure after the previous
+hardening: the service was healthy before restart, but startup still waited on remote subscription
+refresh before restoring the locally persisted subscription runtime. A restart should recover known
+proxy nodes from `forward_proxy_runtime` first; remote subscription refresh is only the calibration
+source when a usable persisted runtime already exists.
+
 ## Goals
 
 - Keep request-path billing and MCP session locks from failing on transient SQLite busy/locked
@@ -56,6 +62,10 @@ runtime snapshot write collides with other writers.
   bounded backoff so a short writer collision does not delay readiness longer than necessary.
 - Startup subscription refresh may fetch multiple subscription URLs concurrently, as long as the
   refresh still fails closed when every subscription fetch fails.
+- Startup must restore persisted subscription endpoints before remote subscription refresh when
+  their configured subscription ownership is unambiguous. When at least one restored subscription
+  endpoint exists, startup must not block on remote refresh before xray sync/runtime persistence;
+  without safely restorable endpoints, startup continues to wait for subscription readiness.
 - Retry logs may include operation, attempt, backoff, and final error context.
 
 ## Acceptance
@@ -66,6 +76,10 @@ runtime snapshot write collides with other writers.
   `database is locked`.
 - Under a competing SQLite writer, forward-proxy startup runtime snapshot persistence retries
   transient lock errors rather than failing the startup path immediately.
+- With safely restorable persisted subscription runtime and a slow subscription endpoint, restart
+  restores the local runtime and completes without waiting for the slow remote refresh.
+- Without persisted subscription runtime, startup remains strict and waits for subscription
+  readiness instead of reporting healthy from an empty proxy graph.
 - Existing billing tests continue to prove locked billing subject stability, pending billing
   replay, and account/token quota attribution.
 - Existing MCP/API routing behavior remains unchanged, including research result GET key pinning.

--- a/src/forward_proxy/manager.rs
+++ b/src/forward_proxy/manager.rs
@@ -3,6 +3,14 @@ impl ForwardProxyManager {
         settings: ForwardProxySettings,
         runtime_rows: Vec<ForwardProxyRuntimeState>,
     ) -> Self {
+        Self::new_with_settings_updated_at(settings, 0, runtime_rows)
+    }
+
+    pub fn new_with_settings_updated_at(
+        settings: ForwardProxySettings,
+        settings_updated_at: i64,
+        runtime_rows: Vec<ForwardProxyRuntimeState>,
+    ) -> Self {
         let runtime = runtime_rows
             .into_iter()
             .map(|entry| (entry.proxy_key.clone(), entry))
@@ -17,9 +25,11 @@ impl ForwardProxyManager {
             probe_in_flight: false,
             last_probe_at: Utc::now().timestamp() - FORWARD_PROXY_PROBE_INTERVAL_SECS,
             last_subscription_refresh_at: None,
+            settings_updated_at,
             window_stats_cache: Arc::new(RwLock::new(None)),
         };
         manager.rebuild_endpoints(Vec::new());
+        manager.restore_persisted_subscription_endpoints();
         manager
     }
 
@@ -47,11 +57,13 @@ impl ForwardProxyManager {
 
     pub fn apply_settings(&mut self, settings: ForwardProxySettings) {
         self.settings = settings;
+        self.settings_updated_at = Utc::now().timestamp();
         self.rebuild_endpoints(Vec::new());
     }
 
     pub fn update_settings_only(&mut self, settings: ForwardProxySettings) {
         self.settings = settings;
+        self.settings_updated_at = Utc::now().timestamp();
     }
 
     pub fn apply_subscription_refresh(
@@ -70,21 +82,40 @@ impl ForwardProxyManager {
     }
 
     pub fn restore_persisted_subscription_endpoints(&mut self) -> usize {
+        if self.settings.subscription_urls.len() != 1 {
+            return 0;
+        }
+        let subscription_url = &self.settings.subscription_urls[0];
         let proxy_urls = self
             .runtime
             .values()
             .filter(|entry| entry.source == FORWARD_PROXY_SOURCE_SUBSCRIPTION)
             .filter(|entry| entry.proxy_key != FORWARD_PROXY_DIRECT_KEY)
+            .filter(|entry| self.settings_updated_at <= 0 || entry.updated_at >= self.settings_updated_at)
+            .filter(|entry| {
+                entry.subscription_sources.contains(subscription_url)
+                    || entry.subscription_sources.is_empty()
+            })
             .filter(|entry| parse_forward_proxy_entry(&entry.proxy_key).is_some())
             .map(|entry| entry.proxy_key.clone())
             .collect::<Vec<_>>();
-        let subscription_endpoints =
-            normalize_subscription_endpoints_from_urls(&proxy_urls, FORWARD_PROXY_SOURCE_SUBSCRIPTION);
-        let restored = subscription_endpoints.len();
+        let subscription_endpoints = normalize_subscription_endpoints_from_urls(
+            &proxy_urls,
+            subscription_url,
+        );
+        let restored = proxy_urls.len();
         if restored > 0 {
             self.rebuild_endpoints(subscription_endpoints);
+            self.last_subscription_refresh_at = Some(Utc::now().timestamp());
         }
         restored
+    }
+
+    pub fn restored_subscription_endpoint_count(&self) -> usize {
+        self.endpoints
+            .iter()
+            .filter(|endpoint| endpoint.is_subscription_backed())
+            .count()
     }
 
     pub fn rebuild_endpoints(&mut self, subscription_endpoints: Vec<ForwardProxyEndpoint>) {
@@ -122,6 +153,8 @@ impl ForwardProxyManager {
                         .as_ref()
                         .map(Url::to_string)
                         .or_else(|| endpoint.raw_url.clone());
+                    runtime.subscription_sources =
+                        endpoint.subscription_sources.iter().cloned().collect();
                     runtime.available = endpoint.is_selectable();
                     runtime.last_error = if endpoint.is_selectable() {
                         None
@@ -239,6 +272,8 @@ impl ForwardProxyManager {
                         .as_ref()
                         .map(Url::to_string)
                         .or_else(|| endpoint.raw_url.clone());
+                    runtime.subscription_sources =
+                        endpoint.subscription_sources.iter().cloned().collect();
                     runtime.available = endpoint.is_selectable();
                     runtime.last_error = if endpoint.is_selectable() {
                         None

--- a/src/forward_proxy/manager.rs
+++ b/src/forward_proxy/manager.rs
@@ -106,7 +106,6 @@ impl ForwardProxyManager {
         let restored = proxy_urls.len();
         if restored > 0 {
             self.rebuild_endpoints(subscription_endpoints);
-            self.last_subscription_refresh_at = Some(Utc::now().timestamp());
         }
         restored
     }

--- a/src/forward_proxy/settings_and_endpoints.rs
+++ b/src/forward_proxy/settings_and_endpoints.rs
@@ -32,6 +32,12 @@ pub struct ForwardProxySettings {
     pub egress_socks5_url: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct ForwardProxySettingsSnapshot {
+    pub settings: ForwardProxySettings,
+    pub updated_at: i64,
+}
+
 impl Default for ForwardProxySettings {
     fn default() -> Self {
         Self {
@@ -432,6 +438,7 @@ pub struct ForwardProxyRuntimeState {
     pub source: String,
     pub kind: String,
     pub endpoint_url: Option<String>,
+    pub subscription_sources: Vec<String>,
     pub resolved_ip_source: String,
     pub resolved_ips: Vec<String>,
     pub resolved_regions: Vec<String>,
@@ -442,6 +449,7 @@ pub struct ForwardProxyRuntimeState {
     pub success_ema: f64,
     pub latency_ema_ms: Option<f64>,
     pub consecutive_failures: u32,
+    pub updated_at: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -473,6 +481,7 @@ impl ForwardProxyRuntimeState {
                 .as_ref()
                 .map(Url::to_string)
                 .or_else(|| endpoint.raw_url.clone()),
+            subscription_sources: endpoint.subscription_sources.iter().cloned().collect(),
             resolved_ip_source: String::new(),
             resolved_ips: Vec::new(),
             resolved_regions: Vec::new(),
@@ -491,6 +500,7 @@ impl ForwardProxyRuntimeState {
             success_ema: 0.65,
             latency_ema_ms: None,
             consecutive_failures: 0,
+            updated_at: Utc::now().timestamp(),
         }
     }
 
@@ -507,9 +517,10 @@ struct ForwardProxySettingsRow {
     insert_direct: Option<i64>,
     egress_socks5_enabled: Option<i64>,
     egress_socks5_url: Option<String>,
+    updated_at: Option<i64>,
 }
 
-impl From<ForwardProxySettingsRow> for ForwardProxySettings {
+impl From<ForwardProxySettingsRow> for ForwardProxySettingsSnapshot {
     fn from(value: ForwardProxySettingsRow) -> Self {
         let proxy_urls = decode_string_vec_json(value.proxy_urls_json.as_deref());
         let subscription_urls = decode_string_vec_json(value.subscription_urls_json.as_deref());
@@ -523,7 +534,7 @@ impl From<ForwardProxySettingsRow> for ForwardProxySettings {
             .unwrap_or_else(default_forward_proxy_insert_direct);
         let egress_socks5_enabled = value.egress_socks5_enabled.is_some_and(|value| value != 0);
         let egress_socks5_url = value.egress_socks5_url.unwrap_or_default();
-        Self {
+        let settings = ForwardProxySettings {
             proxy_urls,
             subscription_urls,
             subscription_update_interval_secs: interval,
@@ -531,7 +542,11 @@ impl From<ForwardProxySettingsRow> for ForwardProxySettings {
             egress_socks5_enabled,
             egress_socks5_url,
         }
-        .normalized()
+        .normalized();
+        Self {
+            settings,
+            updated_at: value.updated_at.unwrap_or_default(),
+        }
     }
 }
 
@@ -541,6 +556,7 @@ struct ForwardProxyRuntimeRow {
     display_name: String,
     source: String,
     endpoint_url: Option<String>,
+    subscription_sources_json: Option<String>,
     resolved_ip_source: Option<String>,
     resolved_ips_json: Option<String>,
     resolved_regions_json: Option<String>,
@@ -549,6 +565,7 @@ struct ForwardProxyRuntimeRow {
     success_ema: f64,
     latency_ema_ms: Option<f64>,
     consecutive_failures: i64,
+    updated_at: Option<i64>,
 }
 
 impl From<ForwardProxyRuntimeRow> for ForwardProxyRuntimeState {
@@ -559,6 +576,7 @@ impl From<ForwardProxyRuntimeRow> for ForwardProxyRuntimeState {
             source: value.source,
             kind: "unknown".to_string(),
             endpoint_url: value.endpoint_url,
+            subscription_sources: decode_string_vec_json(value.subscription_sources_json.as_deref()),
             resolved_ip_source: value
                 .resolved_ip_source
                 .unwrap_or_default()
@@ -577,6 +595,7 @@ impl From<ForwardProxyRuntimeRow> for ForwardProxyRuntimeState {
                 .latency_ema_ms
                 .filter(|value| value.is_finite() && *value >= 0.0),
             consecutive_failures: value.consecutive_failures.max(0) as u32,
+            updated_at: value.updated_at.unwrap_or_default(),
         }
     }
 }
@@ -592,5 +611,6 @@ pub struct ForwardProxyManager {
     pub probe_in_flight: bool,
     pub last_probe_at: i64,
     pub last_subscription_refresh_at: Option<i64>,
+    pub settings_updated_at: i64,
     pub(crate) window_stats_cache: Arc<RwLock<Option<ForwardProxyWindowStatsSetCacheEntry>>>,
 }

--- a/src/forward_proxy/storage.rs
+++ b/src/forward_proxy/storage.rs
@@ -24,6 +24,7 @@ pub async fn ensure_forward_proxy_schema(pool: &SqlitePool) -> Result<(), ProxyE
     .await?;
     ensure_forward_proxy_settings_column(pool, "egress_socks5_url", "TEXT NOT NULL DEFAULT ''")
         .await?;
+    ensure_forward_proxy_settings_column(pool, "updated_at", "INTEGER NOT NULL DEFAULT 0").await?;
 
     sqlx::query(
         r#"
@@ -60,6 +61,12 @@ pub async fn ensure_forward_proxy_schema(pool: &SqlitePool) -> Result<(), ProxyE
         .await?;
     ensure_forward_proxy_runtime_column(pool, "geo_refreshed_at", "INTEGER NOT NULL DEFAULT 0")
         .await?;
+    ensure_forward_proxy_runtime_column(
+        pool,
+        "subscription_sources_json",
+        "TEXT NOT NULL DEFAULT '[]'",
+    )
+    .await?;
 
     sqlx::query(
         r#"
@@ -168,6 +175,12 @@ pub async fn ensure_forward_proxy_schema(pool: &SqlitePool) -> Result<(), ProxyE
 pub async fn load_forward_proxy_settings(
     pool: &SqlitePool,
 ) -> Result<ForwardProxySettings, ProxyError> {
+    Ok(load_forward_proxy_settings_snapshot(pool).await?.settings)
+}
+
+pub async fn load_forward_proxy_settings_snapshot(
+    pool: &SqlitePool,
+) -> Result<ForwardProxySettingsSnapshot, ProxyError> {
     let row = sqlx::query_as::<_, ForwardProxySettingsRow>(
         r#"
         SELECT
@@ -176,7 +189,8 @@ pub async fn load_forward_proxy_settings(
             subscription_update_interval_secs,
             insert_direct,
             egress_socks5_enabled,
-            egress_socks5_url
+            egress_socks5_url,
+            updated_at
         FROM forward_proxy_settings
         WHERE id = ?1
         LIMIT 1
@@ -185,7 +199,10 @@ pub async fn load_forward_proxy_settings(
     .bind(FORWARD_PROXY_SETTINGS_SINGLETON_ID)
     .fetch_optional(pool)
     .await?;
-    Ok(row.map(Into::into).unwrap_or_default())
+    Ok(row.map(Into::into).unwrap_or_else(|| ForwardProxySettingsSnapshot {
+        settings: ForwardProxySettings::default(),
+        updated_at: 0,
+    }))
 }
 
 pub async fn save_forward_proxy_settings(
@@ -241,10 +258,12 @@ pub async fn load_forward_proxy_runtime_states(
             resolved_ips_json,
             resolved_regions_json,
             geo_refreshed_at,
+            subscription_sources_json,
             weight,
             success_ema,
             latency_ema_ms,
-            consecutive_failures
+            consecutive_failures,
+            updated_at
         FROM forward_proxy_runtime
         "#,
     )
@@ -376,6 +395,12 @@ pub async fn persist_forward_proxy_runtime_health_state(
     let resolved_regions_json = serde_json::to_string(&state.resolved_regions).map_err(|err| {
         ProxyError::Other(format!("failed to serialize forward proxy regions: {err}"))
     })?;
+    let subscription_sources_json =
+        serde_json::to_string(&state.subscription_sources).map_err(|err| {
+            ProxyError::Other(format!(
+                "failed to serialize forward proxy subscription sources: {err}"
+            ))
+        })?;
     sqlx::query(
         r#"
         INSERT INTO forward_proxy_runtime (
@@ -387,17 +412,19 @@ pub async fn persist_forward_proxy_runtime_health_state(
             resolved_ips_json,
             resolved_regions_json,
             geo_refreshed_at,
+            subscription_sources_json,
             weight,
             success_ema,
             latency_ema_ms,
             consecutive_failures,
             is_penalized,
             updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, strftime('%s', 'now'))
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, strftime('%s', 'now'))
         ON CONFLICT(proxy_key) DO UPDATE SET
             display_name = excluded.display_name,
             source = excluded.source,
             endpoint_url = excluded.endpoint_url,
+            subscription_sources_json = excluded.subscription_sources_json,
             weight = excluded.weight,
             success_ema = excluded.success_ema,
             latency_ema_ms = excluded.latency_ema_ms,
@@ -414,6 +441,7 @@ pub async fn persist_forward_proxy_runtime_health_state(
     .bind(resolved_ips_json)
     .bind(resolved_regions_json)
     .bind(state.geo_refreshed_at)
+    .bind(subscription_sources_json)
     .bind(state.weight)
     .bind(state.success_ema)
     .bind(state.latency_ema_ms)
@@ -444,6 +472,12 @@ async fn persist_forward_proxy_runtime_state_tx(
     let resolved_regions_json = serde_json::to_string(&state.resolved_regions).map_err(|err| {
         ProxyError::Other(format!("failed to serialize forward proxy regions: {err}"))
     })?;
+    let subscription_sources_json =
+        serde_json::to_string(&state.subscription_sources).map_err(|err| {
+            ProxyError::Other(format!(
+                "failed to serialize forward proxy subscription sources: {err}"
+            ))
+        })?;
     sqlx::query(
         r#"
         INSERT INTO forward_proxy_runtime (
@@ -455,13 +489,14 @@ async fn persist_forward_proxy_runtime_state_tx(
             resolved_ips_json,
             resolved_regions_json,
             geo_refreshed_at,
+            subscription_sources_json,
             weight,
             success_ema,
             latency_ema_ms,
             consecutive_failures,
             is_penalized,
             updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, strftime('%s', 'now'))
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, strftime('%s', 'now'))
         ON CONFLICT(proxy_key) DO UPDATE SET
             display_name = excluded.display_name,
             source = excluded.source,
@@ -470,6 +505,7 @@ async fn persist_forward_proxy_runtime_state_tx(
             resolved_ips_json = excluded.resolved_ips_json,
             resolved_regions_json = excluded.resolved_regions_json,
             geo_refreshed_at = excluded.geo_refreshed_at,
+            subscription_sources_json = excluded.subscription_sources_json,
             weight = excluded.weight,
             success_ema = excluded.success_ema,
             latency_ema_ms = excluded.latency_ema_ms,
@@ -486,6 +522,7 @@ async fn persist_forward_proxy_runtime_state_tx(
     .bind(resolved_ips_json)
     .bind(resolved_regions_json)
     .bind(state.geo_refreshed_at)
+    .bind(subscription_sources_json)
     .bind(state.weight)
     .bind(state.success_ema)
     .bind(state.latency_ema_ms)

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -695,6 +695,10 @@ if __name__ == "__main__":
             .endpoint_by_key(&proxy_key)
             .expect("restored subscription endpoint");
         assert!(restored.subscription_sources.contains(&subscription_url));
+        assert!(
+            manager.should_refresh_subscriptions(),
+            "restored runtime must not suppress the maintenance subscription refresh"
+        );
 
         manager.apply_incremental_settings(settings, &std::collections::HashMap::new());
         assert!(

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -614,6 +614,225 @@ if __name__ == "__main__":
     }
 
     #[test]
+    fn restore_persisted_subscription_endpoints_requires_configured_subscription() {
+        let proxy_key = sample_vless_share_link("198.51.100.7", "stale-subscription");
+        let runtime = ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+            &proxy_key,
+            "198.51.100.7",
+            "stale-subscription",
+        ));
+        let mut manager = ForwardProxyManager::new(
+            ForwardProxySettings {
+                proxy_urls: Vec::new(),
+                subscription_urls: Vec::new(),
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            vec![runtime],
+        );
+
+        assert_eq!(manager.restored_subscription_endpoint_count(), 0);
+        assert_eq!(manager.restore_persisted_subscription_endpoints(), 0);
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_none(),
+            "stale subscription runtime must not be restored when subscriptions are disabled"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_subscription_endpoints_skips_ambiguous_sources() {
+        let proxy_key = sample_vless_share_link("198.51.100.9", "ambiguous-subscription");
+        let runtime = ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+            &proxy_key,
+            "198.51.100.9",
+            "ambiguous-subscription",
+        ));
+        let mut manager = ForwardProxyManager::new(
+            ForwardProxySettings {
+                proxy_urls: Vec::new(),
+                subscription_urls: vec![
+                    "https://subscription.example.com/feed-a".to_string(),
+                    "https://subscription.example.com/feed-b".to_string(),
+                ],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            vec![runtime],
+        );
+
+        assert_eq!(manager.restored_subscription_endpoint_count(), 0);
+        assert_eq!(manager.restore_persisted_subscription_endpoints(), 0);
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_none(),
+            "multi-feed runtime cannot be restored without persisted feed ownership"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_subscription_endpoints_uses_configured_sources() {
+        let subscription_url = "https://subscription.example.com/feed".to_string();
+        let proxy_key = sample_vless_share_link("198.51.100.8", "restored-subscription");
+        let runtime = ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+            &proxy_key,
+            "198.51.100.8",
+            "restored-subscription",
+        ));
+        let settings = ForwardProxySettings {
+            proxy_urls: Vec::new(),
+            subscription_urls: vec![subscription_url.clone()],
+            subscription_update_interval_secs: 3600,
+            insert_direct: false,
+            egress_socks5_enabled: false,
+            egress_socks5_url: String::new(),
+        };
+        let mut manager = ForwardProxyManager::new(settings.clone(), vec![runtime]);
+
+        let restored = manager
+            .endpoint_by_key(&proxy_key)
+            .expect("restored subscription endpoint");
+        assert!(restored.subscription_sources.contains(&subscription_url));
+
+        manager.apply_incremental_settings(settings, &std::collections::HashMap::new());
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_some(),
+            "saving unchanged subscription settings must retain restored runtime nodes"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_subscription_endpoints_requires_runtime_after_settings_update() {
+        let subscription_url = "https://subscription.example.com/feed".to_string();
+        let proxy_key = sample_vless_share_link("198.51.100.10", "old-subscription");
+        let mut runtime =
+            ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+                &proxy_key,
+                "198.51.100.10",
+                "old-subscription",
+            ));
+        runtime.updated_at = 100;
+        runtime.subscription_sources = vec![subscription_url.clone()];
+        let manager = ForwardProxyManager::new_with_settings_updated_at(
+            ForwardProxySettings {
+                proxy_urls: Vec::new(),
+                subscription_urls: vec![subscription_url],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            200,
+            vec![runtime],
+        );
+
+        assert_eq!(manager.restored_subscription_endpoint_count(), 0);
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_none(),
+            "runtime older than the current subscription settings may belong to a previous feed"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_subscription_endpoints_allows_legacy_single_source_runtime() {
+        let subscription_url = "https://subscription.example.com/feed".to_string();
+        let proxy_key = sample_vless_share_link("198.51.100.12", "legacy-feed");
+        let mut runtime =
+            ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+                &proxy_key,
+                "198.51.100.12",
+                "legacy-feed",
+            ));
+        runtime.updated_at = 300;
+        runtime.subscription_sources.clear();
+        let manager = ForwardProxyManager::new_with_settings_updated_at(
+            ForwardProxySettings {
+                proxy_urls: Vec::new(),
+                subscription_urls: vec![subscription_url],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            200,
+            vec![runtime],
+        );
+
+        assert_eq!(manager.restored_subscription_endpoint_count(), 1);
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_some(),
+            "legacy runtimes without source attribution should recover when exactly one current feed exists"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_subscription_endpoints_allows_legacy_unknown_settings_timestamp() {
+        let subscription_url = "https://subscription.example.com/feed".to_string();
+        let proxy_key = sample_vless_share_link("198.51.100.13", "legacy-settings");
+        let mut runtime =
+            ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+                &proxy_key,
+                "198.51.100.13",
+                "legacy-settings",
+            ));
+        runtime.updated_at = 300;
+        runtime.subscription_sources.clear();
+        let manager = ForwardProxyManager::new_with_settings_updated_at(
+            ForwardProxySettings {
+                proxy_urls: Vec::new(),
+                subscription_urls: vec![subscription_url],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            0,
+            vec![runtime],
+        );
+
+        assert_eq!(manager.restored_subscription_endpoint_count(), 1);
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_some(),
+            "legacy settings rows without updated_at must not invalidate existing runtime recovery"
+        );
+    }
+
+    #[test]
+    fn restore_persisted_subscription_endpoints_requires_matching_source() {
+        let current_subscription_url = "https://subscription.example.com/feed-new".to_string();
+        let old_subscription_url = "https://subscription.example.com/feed-old".to_string();
+        let proxy_key = sample_vless_share_link("198.51.100.11", "old-feed");
+        let mut runtime =
+            ForwardProxyRuntimeState::default_for_endpoint(&subscription_vless_endpoint(
+                &proxy_key,
+                "198.51.100.11",
+                "old-feed",
+            ));
+        runtime.updated_at = 300;
+        runtime.subscription_sources = vec![old_subscription_url];
+        let manager = ForwardProxyManager::new_with_settings_updated_at(
+            ForwardProxySettings {
+                proxy_urls: Vec::new(),
+                subscription_urls: vec![current_subscription_url],
+                subscription_update_interval_secs: 3600,
+                insert_direct: false,
+                egress_socks5_enabled: false,
+                egress_socks5_url: String::new(),
+            },
+            200,
+            vec![runtime],
+        );
+
+        assert_eq!(manager.restored_subscription_endpoint_count(), 0);
+        assert!(
+            manager.endpoint_by_key(&proxy_key).is_none(),
+            "runtime from a previous feed must not be restored under a new subscription URL"
+        );
+    }
+
+    #[test]
     fn reserved_local_port_keeps_port_bound_until_release() {
         let mut reservation = reserve_unused_local_port().expect("reserve loopback port");
         let port = reservation.port();

--- a/src/server/tests/chunk_02.rs
+++ b/src/server/tests/chunk_02.rs
@@ -2208,6 +2208,30 @@ async fn spawn_forward_proxy_subscription_server(body: String) -> SocketAddr {
     addr
 }
 
+async fn spawn_forward_proxy_subscription_server_with_delay(
+    body: String,
+    delay: Duration,
+) -> SocketAddr {
+    let app = Router::new().route(
+        "/subscription",
+        get(move || {
+            let body = body.clone();
+            async move {
+                tokio::time::sleep(delay).await;
+                (StatusCode::OK, body)
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    addr
+}
+
 async fn spawn_mutable_forward_proxy_subscription_server(
     state: Arc<Mutex<(StatusCode, String)>>,
 ) -> SocketAddr {

--- a/src/server/tests/chunk_12.rs
+++ b/src/server/tests/chunk_12.rs
@@ -124,6 +124,153 @@
     }
 
     #[tokio::test]
+    async fn startup_restores_subscription_runtime_before_refreshing_slow_subscription() {
+        let db_path = temp_db_path("startup-restore-subscription-runtime");
+        let db_str = db_path.to_string_lossy().to_string();
+        let upstream_addr = spawn_forward_proxy_probe_upstream().await;
+        let upstream = format!("http://{}/mcp", upstream_addr);
+        let proxy_hits = Arc::new(AtomicUsize::new(0));
+        let fake_proxy_addr =
+            spawn_counted_fake_forward_proxy(StatusCode::NOT_FOUND, Duration::ZERO, proxy_hits)
+                .await;
+        let subscription_hits = Arc::new(AtomicUsize::new(0));
+        let subscription_addr = {
+            let hits = subscription_hits.clone();
+            let body = format!("http://{}\n", fake_proxy_addr);
+            let app = Router::new().route(
+                "/subscription",
+                get(move || {
+                    let hits = hits.clone();
+                    let body = body.clone();
+                    async move {
+                        hits.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_secs(3)).await;
+                        (StatusCode::OK, body)
+                    }
+                }),
+            );
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                axum::serve(listener, app.into_make_service())
+                    .await
+                    .unwrap();
+            });
+            addr
+        };
+
+        {
+            let proxy =
+                TavilyProxy::with_endpoint::<Vec<String>, String>(Vec::new(), &upstream, &db_str)
+                    .await
+                    .expect("create seed proxy");
+            proxy
+                .update_forward_proxy_settings(
+                    ForwardProxySettings {
+                        proxy_urls: Vec::new(),
+                        subscription_urls: vec![format!(
+                            "http://{}/subscription",
+                            subscription_addr
+                        )],
+                        subscription_update_interval_secs: 3600,
+                        insert_direct: false,
+                        egress_socks5_enabled: false,
+                        egress_socks5_url: String::new(),
+                    },
+                    true,
+                )
+                .await
+                .expect("persist subscription runtime");
+        }
+        let subscription_hits_after_seed = subscription_hits.load(Ordering::SeqCst);
+
+        let startup_started = Instant::now();
+        let proxy =
+            TavilyProxy::with_endpoint::<Vec<String>, String>(Vec::new(), &upstream, &db_str)
+                .await
+                .expect("restart proxy from restored runtime");
+        assert!(
+            startup_started.elapsed() < Duration::from_secs(3),
+            "restored runtime startup should not wait for slow subscription refresh"
+        );
+        assert!(proxy.is_forward_proxy_xray_ready().await);
+        assert_eq!(
+            subscription_hits.load(Ordering::SeqCst),
+            subscription_hits_after_seed,
+            "startup should not refresh slow subscription when restored runtime exists"
+        );
+
+        proxy
+            .maybe_run_forward_proxy_maintenance()
+            .await
+            .expect("restored runtime maintenance should not refresh immediately");
+        assert_eq!(
+            subscription_hits.load(Ordering::SeqCst),
+            subscription_hits_after_seed,
+            "first maintenance after restored startup should defer remote subscription calibration"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn startup_without_restored_runtime_still_waits_for_subscription_readiness() {
+        let db_path = temp_db_path("startup-no-restored-runtime");
+        let db_str = db_path.to_string_lossy().to_string();
+        let upstream_addr = spawn_forward_proxy_probe_upstream().await;
+        let upstream = format!("http://{}/mcp", upstream_addr);
+        let fake_proxy_addr =
+            spawn_counted_fake_forward_proxy(StatusCode::NOT_FOUND, Duration::ZERO, Arc::new(AtomicUsize::new(0)))
+                .await;
+        let subscription_addr = spawn_forward_proxy_subscription_server_with_delay(
+            format!("http://{}\n", fake_proxy_addr),
+            Duration::from_secs(3),
+        )
+        .await;
+
+        {
+            let proxy =
+                TavilyProxy::with_endpoint::<Vec<String>, String>(Vec::new(), &upstream, &db_str)
+                    .await
+                    .expect("create proxy schema");
+            drop(proxy);
+            let pool = connect_sqlite_test_pool(&db_str).await;
+            sqlx::query(
+                r#"
+                UPDATE forward_proxy_settings
+                SET subscription_urls_json = ?1,
+                    insert_direct = 0,
+                    updated_at = strftime('%s', 'now')
+                WHERE id = 1
+                "#,
+            )
+            .bind(
+                serde_json::to_string(&vec![format!(
+                    "http://{}/subscription",
+                    subscription_addr
+                )])
+                .expect("subscription url json"),
+            )
+            .execute(&pool)
+            .await
+            .expect("seed subscription settings without runtime");
+            pool.close().await;
+        }
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            TavilyProxy::with_endpoint::<Vec<String>, String>(Vec::new(), &upstream, &db_str),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "without restored runtime, startup must still wait for subscription readiness"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn admin_system_settings_reject_invalid_rebalance_percent() {
         let db_path = temp_db_path("admin-system-settings-invalid-rebalance-percent");
         let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/chunk_12.rs
+++ b/src/server/tests/chunk_12.rs
@@ -203,11 +203,11 @@
         proxy
             .maybe_run_forward_proxy_maintenance()
             .await
-            .expect("restored runtime maintenance should not refresh immediately");
+            .expect("restored runtime maintenance should refresh after startup");
         assert_eq!(
             subscription_hits.load(Ordering::SeqCst),
-            subscription_hits_after_seed,
-            "first maintenance after restored startup should defer remote subscription calibration"
+            subscription_hits_after_seed + 1,
+            "restored startup must not mark local runtime restore as a fresh remote refresh"
         );
 
         let _ = std::fs::remove_file(db_path);

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -423,16 +423,18 @@ impl TavilyProxy {
             source,
         })?;
         let upstream_origin = origin_from_url(&upstream);
-        let forward_proxy_settings =
-            forward_proxy::load_forward_proxy_settings(&key_store.pool).await?;
+        let forward_proxy_settings_snapshot =
+            forward_proxy::load_forward_proxy_settings_snapshot(&key_store.pool).await?;
         let forward_proxy_runtime =
             forward_proxy::load_forward_proxy_runtime_states(&key_store.pool).await?;
         let forward_proxy_disabled_keys =
             forward_proxy::load_forward_proxy_disabled_node_keys(&key_store.pool).await?;
-        let mut forward_proxy_manager = forward_proxy::ForwardProxyManager::new(
-            forward_proxy_settings,
-            forward_proxy_runtime,
-        );
+        let mut forward_proxy_manager =
+            forward_proxy::ForwardProxyManager::new_with_settings_updated_at(
+                forward_proxy_settings_snapshot.settings,
+                forward_proxy_settings_snapshot.updated_at,
+                forward_proxy_runtime,
+            );
         forward_proxy_manager.set_disabled_keys(
             forward_proxy_disabled_keys
                 .keys()
@@ -501,23 +503,33 @@ impl TavilyProxy {
 
     pub(crate) async fn initialize_forward_proxy_runtime(&mut self) -> Result<(), ProxyError> {
         let startup_started = Instant::now();
-        let refresh_started = Instant::now();
-        if let Err(err) = self.refresh_forward_proxy_subscriptions_for_startup().await {
-            eprintln!("forward-proxy startup subscription refresh failed: {err}");
-            let restored = {
-                let mut manager = self.forward_proxy.lock().await;
-                manager.restore_persisted_subscription_endpoints()
-            };
-            if restored > 0 {
+        let restored_subscription_endpoints = {
+            let manager = self.forward_proxy.lock().await;
+            manager.restored_subscription_endpoint_count()
+        };
+        if restored_subscription_endpoints > 0 {
+            eprintln!(
+                "forward-proxy startup: restored {restored_subscription_endpoints} persisted subscription nodes; deferred subscription refresh to maintenance"
+            );
+        } else {
+            let refresh_started = Instant::now();
+            if let Err(err) = self.refresh_forward_proxy_subscriptions_for_startup().await {
+                eprintln!("forward-proxy startup subscription refresh failed: {err}");
+                let restored = {
+                    let mut manager = self.forward_proxy.lock().await;
+                    manager.restore_persisted_subscription_endpoints()
+                };
+                if restored > 0 {
+                    eprintln!(
+                        "forward-proxy restored {restored} persisted subscription nodes after startup refresh failure"
+                    );
+                }
+            } else {
                 eprintln!(
-                    "forward-proxy restored {restored} persisted subscription nodes after startup refresh failure"
+                    "forward-proxy startup: refreshed subscriptions in {}ms",
+                    refresh_started.elapsed().as_millis()
                 );
             }
-        } else {
-            eprintln!(
-                "forward-proxy startup: refreshed subscriptions in {}ms",
-                refresh_started.elapsed().as_millis()
-            );
         }
         let xray_started = Instant::now();
         let persist_started = Instant::now();
@@ -530,7 +542,7 @@ impl TavilyProxy {
                     .sync_endpoints(&mut manager.endpoints, egress_socks5_url.as_ref())
                     .await
                 {
-                    eprintln!("forward-proxy startup xray prewarm failed");
+                    eprintln!("forward-proxy startup xray prewarm failed: {_err}");
                 }
             }
             self.sync_forward_proxy_runtime_state(&mut manager).await?;
@@ -798,12 +810,6 @@ impl TavilyProxy {
         {
             let mut manager = self.forward_proxy.lock().await;
             manager.update_settings_only(normalized.clone());
-            {
-                let mut xray = self.xray_supervisor.lock().await;
-                xray.sync_endpoints(&mut manager.endpoints, next_egress_socks5_url.as_ref())
-                    .await?;
-            }
-            self.sync_forward_proxy_runtime_state(&mut manager).await?;
         }
         let fetched_subscriptions = self
             .fetch_forward_proxy_subscription_map_with_progress(

--- a/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
+++ b/src/tavily_proxy/proxy_forward_proxy_maintenance.rs
@@ -198,6 +198,8 @@ impl TavilyProxy {
                     .as_ref()
                     .map(Url::to_string)
                     .or_else(|| endpoint.raw_url.clone());
+                runtime.subscription_sources =
+                    endpoint.subscription_sources.iter().cloned().collect();
                 runtime.available = endpoint.is_selectable();
                 if endpoint.is_direct() || endpoint.is_selectable() {
                     runtime.last_error = None;


### PR DESCRIPTION
## Summary
- Fix Dockrev job `job_01KSEPDVXF8NAQCEQGJKV33T4F` startup stall by restoring persisted subscription-backed proxy runtime before remote subscription refresh.
- Keep strict health semantics: when no restored proxy runtime exists, startup still waits for subscription readiness instead of reporting healthy from an empty proxy graph.
- Add phase-specific startup logs for restored runtime, subscription refresh, xray sync, and runtime persistence.

## Root Cause
Before this change, a restart reconstructed subscription-backed proxy nodes only after attempting remote subscription refresh. That made a previously healthy service wait on slow or unavailable subscription endpoints even though usable proxy nodes were already persisted in `forward_proxy_runtime`.

## Fix Strategy
- Restore persisted subscription endpoints during `ForwardProxyManager` initialization.
- During startup, if restored subscription endpoints exist, proceed directly to xray sync/runtime snapshot persistence and leave remote subscription calibration to maintenance.
- If no restored subscription endpoints exist, retain the strict blocking subscription refresh path.

## Validation
- `cargo fmt --all`
- `bunx --bun dprint fmt docs/solutions/operations/sqlite-write-lock-contention.md docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md`
- `cargo test -q startup_restores_subscription_runtime_before_refreshing_slow_subscription -- --nocapture`
- `cargo test -q startup_without_restored_runtime_still_waits_for_subscription_readiness -- --nocapture`
- `cargo test -q health_keeps_startup_grace_then_fails_when_xray_relay_is_not_ready -- --nocapture`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`

## References
- Specs: `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`
- Project Docs: -
