### PR TITLE
ci: upgrade GitHub Actions majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ permissions:
 jobs:
   lint:
     name: Lint & Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
@@ -37,7 +37,7 @@ jobs:
         run: rustup component add rustfmt clippy
 
       - name: Cache cargo directories
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -57,11 +57,11 @@ jobs:
 
   unit-tests:
     name: Backend Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
@@ -72,7 +72,7 @@ jobs:
           toolchain: 1.91.0
 
       - name: Cache cargo directories
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -86,11 +86,11 @@ jobs:
 
   frontend-checks:
     name: Frontend Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -115,7 +115,7 @@ jobs:
 
   compose-smoke-forwardauth-caddy:
     name: Compose Smoke (ForwardAuth + Caddy)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [lint, unit-tests, frontend-checks]
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     timeout-minutes: 20
@@ -127,7 +127,7 @@ jobs:
       IMAGE_TAG: tavily-hikari:ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -242,13 +242,13 @@ jobs:
 
   build:
     name: Build (Release)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     needs: [lint, unit-tests, frontend-checks]
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
@@ -259,7 +259,7 @@ jobs:
           toolchain: 1.91.0
 
       - name: Cache cargo directories
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -30,10 +30,10 @@ concurrency:
 
 jobs:
   build-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -63,7 +63,7 @@ jobs:
           DOCS_BASE="${DOCS_BASE}" bun run build
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-site-build
           path: docs-site/doc_build
@@ -71,13 +71,13 @@ jobs:
           if-no-files-found: error
 
   build-storybook:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       STORYBOOK_DISABLE_TELEMETRY: '1'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -93,7 +93,7 @@ jobs:
           node ./node_modules/.bin/storybook build --disable-telemetry --quiet
 
       - name: Upload Storybook artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: storybook-static-build
           path: web/storybook-static
@@ -101,20 +101,20 @@ jobs:
           if-no-files-found: error
 
   assemble-pages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-docs, build-storybook]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-site-build
           path: .tmp/docs-site
 
       - name: Download Storybook artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: storybook-static-build
           path: .tmp/storybook-static
@@ -137,7 +137,7 @@ jobs:
           grep -q './sb-manager/runtime.js' .tmp/pages-site/storybook/index.html
 
       - name: Upload assembled Pages artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pages-site-build
           path: .tmp/pages-site
@@ -146,7 +146,7 @@ jobs:
 
   deploy:
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [assemble-pages]
     permissions:
       contents: read
@@ -157,19 +157,19 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download assembled Pages site artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pages-site-build
           path: .tmp/pages-site
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: .tmp/pages-site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/label-gate.yml
+++ b/.github/workflows/label-gate.yml
@@ -17,10 +17,10 @@ permissions:
 jobs:
   label-gate:
     name: Release intent label gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Validate release intent label (exactly one)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/notify-release-failure.yml
+++ b/.github/workflows/notify-release-failure.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   resolve_release_context:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   prepare:
     name: Prepare (intent + version + tag)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     if: >-
       (github.event_name == 'workflow_run' &&
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.tagmeta.outputs.tag }}
     steps:
       - name: Checkout (workflow_run)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_HEAD_SHA }}
@@ -198,7 +198,7 @@ jobs:
       APP_EFFECTIVE_VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Checkout (workflow_run)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_HEAD_SHA }}
 
@@ -222,7 +222,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libsqlite3-dev
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.91.0
 
@@ -252,17 +252,17 @@ jobs:
           echo "image_name_lower=${lower}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build local Docker image for MCP billing smoke
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -285,13 +285,13 @@ jobs:
 
       - name: Extract metadata labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}
 
       - name: Build and push Docker image by digest
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -317,7 +317,7 @@ jobs:
           printf '%s\n' "${digest}" > "${DIGEST_FILE}"
 
       - name: Upload image digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-digest-${{ matrix.arch }}
           path: ${{ env.DIGEST_FILE }}
@@ -358,25 +358,25 @@ jobs:
           echo "image_name_lower=${lower}" >> "$GITHUB_OUTPUT"
 
       - name: Download image digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-digest-*
           path: ${{ runner.temp }}/release-digests
           merge-multiple: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name_lower }}
           tags: |
@@ -443,7 +443,7 @@ jobs:
 
   github-release:
     name: GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [prepare, docker-manifest]
     if: ${{ needs.prepare.outputs.should_release == 'true' }}
@@ -464,7 +464,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upsert PR release comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TARGET_SHA: ${{ env.RELEASE_HEAD_SHA }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
Spec: -
Spec Disposition: not_needed
Solutions: -
Project Docs: -
Spec Sync: n/a(spec-free)
Spec Drift: none
Solutions Sync: n/a(no-solution-change)
Project Docs Sync: n/a(workflows-only)

## Summary
- Upgrade GitHub-hosted JavaScript actions to their latest major aliases so workflows use Node 24 runtimes where available.
- Upgrade Docker and Pages actions to current major aliases.
- Pin standard hosted runners from `ubuntu-latest` to `ubuntu-24.04` while preserving the existing `ubuntu-24.04-arm` release matrix entry.
- Switch the release workflow Rust toolchain action from `dtolnay/rust-toolchain@master` to `@v1`.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml`
- Residual old-reference scan for previous action majors and `ubuntu-latest`
- Artifact handoff scan for docs Pages and release digest names/paths
- GitHub Actions checks passed for PR head `1b042a652fd99667397e3db2ab9c76fba0be9eeb`

## References
- Specs: -
- Solutions: -
- Project Docs: -

## Notes
- This PR is labeled `type:skip` to avoid producing a release for workflow maintenance only.
- No production Tavily endpoint or release backfill was triggered.
