### PR TITLE
feat(jobs): add manual maintenance triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   unit-tests:
     name: Backend Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 75
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -57,6 +57,12 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - Keep retention cleanup bounded. Large `request_logs` backlogs should be deleted in small batches
   with a runtime/batch budget and a catch-up delay, rather than one daily job holding or repeatedly
   contesting the writer until the whole backlog is gone.
+- Keep scheduled-job trigger provenance separate from logical job type. Use a dedicated
+  `trigger_source` column for scheduler/manual/auto runs so filters, duplicate detection, and
+  history remain stable as operators gain manual trigger buttons.
+- Treat SQLite file shrinkage as a separate maintenance concern. Row deletes and body nulling create
+  free pages; size convergence requires freelist telemetry plus a controlled compaction job after
+  retention cleanup has made space reclaimable.
 - Provide a one-shot operational CLI for retention cleanup so production-derived database samples
   can be tested deterministically. Do not rely only on the daily scheduler when validating cleanup
   behavior.
@@ -79,6 +85,8 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - For WAL growth, inspect active readers and checkpoint behavior before running live maintenance.
 - Deleting rows does not shrink the SQLite file by itself. Treat VACUUM or database replacement as
   a separate maintenance-window decision after retention cleanup has completed.
+- Automatic compaction should be threshold-gated and cooldown-limited. Triggering it on every GC
+  pass can turn a cleanup backlog into a new writer-pressure loop.
 - If a retention table has aggregate-maintenance triggers, validate large-copy cleanup with the
   triggers in mind. For `request_logs`, GC deletes expired rollup buckets separately and suppresses
   the per-row rollup delete trigger inside each batch transaction to avoid spending minutes per

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -20,3 +20,10 @@
   timing showed SQLite initialization dominated by per-user binding sync on an already consistent
   database. Startup still performs a cheap mismatch repair check; periodic refresh now runs in the
   background scheduler.
+
+## 2026-06-04
+
+- Extended the hardening scope from transient write retries to operator-controlled scheduled jobs
+  and DB size convergence. Manual and automatic maintenance now share job bookkeeping semantics, and
+  SQLite file shrinkage is treated as an explicit compaction concern rather than an implicit side
+  effect of deleting old rows.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -33,6 +33,12 @@
   updates covered by the trigger set.
 - The daily `request_logs_gc` scheduler records partial progress in `scheduled_jobs` and waits
   before continuing catch-up instead of keeping one long-running cleanup job open.
+- Scheduled jobs now distinguish `trigger_source` from `job_type`, use an atomic claim path to avoid
+  duplicate active work, and expose manual trigger entrypoints for maintenance/admin jobs.
+- Request-log GC catch-up now uses smaller scheduler windows and slower retry cadence so a large
+  body-cleanup backlog does not repeatedly consume the SQLite writer slot.
+- DB maintenance now records size/freelist telemetry and can compact the SQLite file through a
+  dedicated job, with automatic threshold-based triggering and manual admin triggering.
 - Added `request_logs_gc_once` as a one-shot operational binary. It supports JSON output and
   `--run-until-complete` for deterministic low-resource validation against production-derived
   database samples.
@@ -61,4 +67,7 @@
 - Later production inspection found a `20G` database where startup spent roughly `78s` inside
   SQLite initialization; the repeated LinuxDo tag binding refresh over all OAuth accounts was a
   primary avoidable startup cost, so periodic refresh now runs outside the readiness path.
+- A later request-log body-retention backlog produced a much larger main DB file even after row
+  retention was no longer the primary issue. Deleting or nulling payloads alone leaves free pages in
+  SQLite, so file-size convergence is handled as a separate compaction job after retention work.
 - The implementation does not perform production data mutation and does not alter pool size.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -66,10 +66,20 @@ source when a usable persisted runtime already exists.
   their configured subscription ownership is unambiguous. When at least one restored subscription
   endpoint exists, startup must not block on remote refresh before xray sync/runtime persistence;
   without safely restorable endpoints, startup continues to wait for subscription readiness.
+- Scheduled job records must preserve the logical job type and record the trigger source separately
+  as `scheduler`, `manual`, or `auto`. Manual runs must not be encoded by appending suffixes to
+  `job_type`.
+- Manual scheduled-job triggers must use the same execution path as scheduler runs, reject duplicate
+  active runs of the same logical job, and mark stale `running` rows from prior process lifetimes as
+  abandoned before accepting new work.
 - `request_logs_gc` must not hold the SQLite write slot for an unbounded full-retention cleanup
   pass. It must delete old `request_logs` and `request_log_catalog_rollups` in bounded batches,
-  yield between batches, report partial progress, and continue catch-up after a delay when more
-  rows remain.
+  yield between batches, report partial progress, and continue catch-up after a throttled delay when
+  more rows remain.
+- SQLite file size must converge after retention cleanup. The service must expose DB size/freelist
+  telemetry, automatically trigger compaction when reclaimable space crosses the configured
+  threshold, and provide a manual compaction trigger. Health checks must remain available while DB
+  maintenance is active.
 - A one-shot request-log GC CLI must reuse the same bounded cleanup path so production database
   samples can be validated deterministically without waiting for the daily scheduler.
 - Request-log GC must avoid high-resource catch-up strategies such as rebuilding the whole
@@ -92,6 +102,10 @@ source when a usable persisted runtime already exists.
 - With a large backlog of old request logs, one scheduler pass records bounded progress instead of
   running indefinitely; later catch-up passes eventually remove all rows older than the retention
   threshold.
+- Manual trigger API calls return a job id, job rows expose `trigger_source`, and duplicate active
+  manual triggers return a conflict instead of starting overlapping work.
+- After request-log retention cleanup creates enough freelist pages, DB compaction runs under the
+  maintenance gate and reduces the main SQLite file size or reports why compaction was skipped.
 - `request_logs_gc_once --run-until-complete --json` removes old request logs and catalog rollups
   from a production-derived validation sample and reports `completed=true` when no old rows remain,
   while keeping WAL growth and CPU time bounded.

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -171,6 +171,7 @@ rule-providers:
             .expect("ensure schema");
 
         let key_store = crate::store::KeyStore {
+            database_path: db_path.to_string_lossy().into_owned(),
             pool: pool.clone(),
             token_binding_cache: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             account_quota_resolution_cache: tokio::sync::RwLock::new(

--- a/src/models.rs
+++ b/src/models.rs
@@ -1390,6 +1390,7 @@ pub struct SuccessBreakdown {
 pub struct JobLog {
     pub id: i64,
     pub job_type: String,
+    pub trigger_source: String,
     pub key_id: Option<String>,
     pub key_group: Option<String>,
     pub status: String,
@@ -1405,8 +1406,20 @@ pub struct JobGroupCounts {
     pub quota: i64,
     pub usage: i64,
     pub logs: i64,
+    pub db: i64,
     pub geo: i64,
     pub linuxdo: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SqliteDbStats {
+    pub database_bytes: u64,
+    pub wal_bytes: u64,
+    pub page_size: i64,
+    pub page_count: i64,
+    pub freelist_count: i64,
+    pub reclaimable_bytes: u64,
+    pub reclaimable_ratio: f64,
 }
 
 pub(crate) fn random_string(alphabet: &[u8], len: usize) -> String {

--- a/src/server/dto.rs
+++ b/src/server/dto.rs
@@ -283,6 +283,7 @@ impl From<RequestLogBodiesRecord> for RequestLogBodiesView {
 struct JobLogView {
     id: i64,
     job_type: String,
+    trigger_source: String,
     key_id: Option<String>,
     key_group: Option<String>,
     status: String,

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -23,8 +23,44 @@ struct JobGroupCountsView {
     quota: i64,
     usage: i64,
     logs: i64,
+    db: i64,
     geo: i64,
     linuxdo: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TriggerJobRequest {
+    job_type: String,
+    key_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TriggerJobResponse {
+    job_id: i64,
+    job_type: String,
+    trigger_source: String,
+}
+
+fn manual_trigger_requires_key(job_type: &str) -> bool {
+    matches!(job_type, "quota_sync")
+}
+
+fn manual_trigger_supported(job_type: &str) -> bool {
+    matches!(
+        job_type,
+        "quota_sync"
+            | "token_usage_rollup"
+            | "auth_token_logs_gc"
+            | "request_logs_gc"
+            | "mcp_sessions_gc"
+            | "mcp_session_init_backoffs_gc"
+            | "linuxdo_user_status_sync"
+            | "linuxdo_user_tag_binding_refresh"
+            | "forward_proxy_geo_refresh"
+            | "db_compaction"
+    )
 }
 
 async fn list_jobs(
@@ -49,6 +85,7 @@ async fn list_jobs(
                 .map(|j| JobLogView {
                     id: j.id,
                     job_type: j.job_type,
+                    trigger_source: j.trigger_source,
                     key_id: j.key_id,
                     key_group: j.key_group,
                     status: j.status,
@@ -68,12 +105,90 @@ async fn list_jobs(
                     quota: group_counts.quota,
                     usage: group_counts.usage,
                     logs: group_counts.logs,
+                    db: group_counts.db,
                     geo: group_counts.geo,
                     linuxdo: group_counts.linuxdo,
                 },
             })
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn post_trigger_job(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(payload): Json<TriggerJobRequest>,
+) -> Result<Response<Body>, StatusCode> {
+    if !is_admin_request(state.as_ref(), &headers) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if require_full_master_write(state.as_ref()).await.is_err() {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    let job_type = payload.job_type.trim().to_string();
+    if !manual_trigger_supported(&job_type) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "unsupported_job_type",
+                "detail": format!("manual trigger is not supported for {job_type}")
+            })),
+        )
+            .into_response());
+    }
+    let key_id = payload
+        .key_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    if manual_trigger_requires_key(&job_type) && key_id.is_none() {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "key_id_required",
+                "detail": "keyId is required for quota_sync"
+            })),
+        )
+            .into_response());
+    }
+
+    match state
+        .proxy
+        .scheduled_job_claim(&job_type, TRIGGER_SOURCE_MANUAL, key_id.as_deref(), 1)
+        .await
+    {
+        Ok(Some(job_id)) => {
+            let run_state = state.clone();
+            let run_job_type = job_type.clone();
+            let run_key_id = key_id.clone();
+            tokio::spawn(async move {
+                run_manual_claimed_job(run_state, run_job_type, run_key_id, job_id).await;
+            });
+            Ok((
+                StatusCode::ACCEPTED,
+                Json(TriggerJobResponse {
+                    job_id,
+                    job_type,
+                    trigger_source: TRIGGER_SOURCE_MANUAL.to_string(),
+                }),
+            )
+                .into_response())
+        }
+        Ok(None) => Ok((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "job_already_running",
+                "detail": format!("{job_type} is already running")
+            })),
+        )
+            .into_response()),
+        Err(err) => {
+            eprintln!("manual job trigger error: {err}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
 }
 
 // ---- Key detail & manual quota sync ----
@@ -106,7 +221,7 @@ async fn post_sync_key_usage(
     if !is_admin_request(state.as_ref(), &headers) {
         return Err(StatusCode::FORBIDDEN);
     }
-    match run_manual_key_quota_sync(state.as_ref(), &id).await {
+    match run_manual_key_quota_sync(state.clone(), &id).await {
         Ok(()) => Ok(StatusCode::NO_CONTENT.into_response()),
         Err(err) => Ok((
             err.status_code,
@@ -137,12 +252,12 @@ impl ManualQuotaSyncError {
 }
 
 async fn run_manual_key_quota_sync(
-    state: &AppState,
+    state: Arc<AppState>,
     key_id: &str,
 ) -> Result<(), ManualQuotaSyncError> {
-    let job_id = state
+    let job_id = match state
         .proxy
-        .scheduled_job_start("quota_sync/manual", Some(key_id), 1)
+        .scheduled_job_claim("quota_sync", TRIGGER_SOURCE_MANUAL, Some(key_id), 1)
         .await
         .map_err(|err| {
             ManualQuotaSyncError::new(
@@ -150,7 +265,17 @@ async fn run_manual_key_quota_sync(
                 "sync_failed",
                 err.to_string(),
             )
-        })?;
+        })?
+    {
+        Some(job_id) => job_id,
+        None => {
+            Err(ManualQuotaSyncError::new(
+                StatusCode::CONFLICT,
+                "job_already_running",
+                "quota_sync is already running for this key".to_string(),
+            ))?
+        }
+    };
 
     match state
         .proxy
@@ -192,11 +317,7 @@ async fn run_manual_key_quota_sync(
                 .proxy
                 .scheduled_job_finish(job_id, "error", Some(&detail))
                 .await;
-            Err(ManualQuotaSyncError::new(
-                http_status,
-                "usage_http",
-                detail,
-            ))
+            Err(ManualQuotaSyncError::new(http_status, "usage_http", detail))
         }
         Err(err) => {
             let reason = err.to_string();

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -63,6 +63,54 @@ fn manual_trigger_supported(job_type: &str) -> bool {
     )
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum ManualTriggerKeyIdError {
+    Required,
+    NotSupported,
+}
+
+fn manual_trigger_key_id_for_claim(
+    job_type: &str,
+    key_id: Option<String>,
+) -> Result<Option<String>, ManualTriggerKeyIdError> {
+    if manual_trigger_requires_key(job_type) {
+        if key_id.is_some() {
+            return Ok(key_id);
+        }
+        return Err(ManualTriggerKeyIdError::Required);
+    }
+
+    if key_id.is_some() {
+        return Err(ManualTriggerKeyIdError::NotSupported);
+    }
+
+    Ok(None)
+}
+
+fn manual_trigger_key_id_error_response(
+    job_type: &str,
+    err: ManualTriggerKeyIdError,
+) -> Response<Body> {
+    match err {
+        ManualTriggerKeyIdError::Required => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "key_id_required",
+                "detail": "keyId is required for quota_sync"
+            })),
+        )
+            .into_response(),
+        ManualTriggerKeyIdError::NotSupported => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "key_id_not_supported",
+                "detail": format!("keyId is not supported for {job_type}")
+            })),
+        )
+            .into_response(),
+    }
+}
+
 async fn list_jobs(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -143,22 +191,19 @@ async fn post_trigger_job(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string);
-    if manual_trigger_requires_key(&job_type) && key_id.is_none() {
-        return Ok((
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "key_id_required",
-                "detail": "keyId is required for quota_sync"
-            })),
-        )
-            .into_response());
-    }
+    let key_id = match manual_trigger_key_id_for_claim(&job_type, key_id) {
+        Ok(key_id) => key_id,
+        Err(err) => return Ok(manual_trigger_key_id_error_response(&job_type, err)),
+    };
 
-    match state
+    let _maintenance = acquire_db_maintenance_read_gate().await;
+    let claim = state
         .proxy
         .scheduled_job_claim(&job_type, TRIGGER_SOURCE_MANUAL, key_id.as_deref(), 1)
-        .await
-    {
+        .await;
+    drop(_maintenance);
+
+    match claim {
         Ok(Some(job_id)) => {
             let run_state = state.clone();
             let run_job_type = job_type.clone();
@@ -188,6 +233,28 @@ async fn post_trigger_job(
             eprintln!("manual job trigger error: {err}");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
+    }
+}
+
+#[cfg(test)]
+mod manual_trigger_tests {
+    use super::{ManualTriggerKeyIdError, manual_trigger_key_id_for_claim};
+
+    #[test]
+    fn manual_global_jobs_reject_key_id() {
+        let err =
+            manual_trigger_key_id_for_claim("db_compaction", Some("key-1".to_string())).unwrap_err();
+        assert_eq!(err, ManualTriggerKeyIdError::NotSupported);
+    }
+
+    #[test]
+    fn manual_quota_sync_requires_key_id() {
+        let err = manual_trigger_key_id_for_claim("quota_sync", None).unwrap_err();
+        assert_eq!(err, ManualTriggerKeyIdError::Required);
+
+        let key_id = manual_trigger_key_id_for_claim("quota_sync", Some("key-1".to_string()))
+            .expect("quota key accepted");
+        assert_eq!(key_id.as_deref(), Some("key-1"));
     }
 }
 
@@ -255,7 +322,8 @@ async fn run_manual_key_quota_sync(
     state: Arc<AppState>,
     key_id: &str,
 ) -> Result<(), ManualQuotaSyncError> {
-    let job_id = match state
+    let _maintenance = acquire_db_maintenance_read_gate().await;
+    let claim = state
         .proxy
         .scheduled_job_claim("quota_sync", TRIGGER_SOURCE_MANUAL, Some(key_id), 1)
         .await
@@ -265,8 +333,10 @@ async fn run_manual_key_quota_sync(
                 "sync_failed",
                 err.to_string(),
             )
-        })?
-    {
+        })?;
+    drop(_maintenance);
+
+    let job_id = match claim {
         Some(job_id) => job_id,
         None => {
             Err(ManualQuotaSyncError::new(

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -196,12 +196,10 @@ async fn post_trigger_job(
         Err(err) => return Ok(manual_trigger_key_id_error_response(&job_type, err)),
     };
 
-    let _maintenance = acquire_db_maintenance_read_gate().await;
     let claim = state
         .proxy
         .scheduled_job_claim(&job_type, TRIGGER_SOURCE_MANUAL, key_id.as_deref(), 1)
         .await;
-    drop(_maintenance);
 
     match claim {
         Ok(Some(job_id)) => {
@@ -322,7 +320,6 @@ async fn run_manual_key_quota_sync(
     state: Arc<AppState>,
     key_id: &str,
 ) -> Result<(), ManualQuotaSyncError> {
-    let _maintenance = acquire_db_maintenance_read_gate().await;
     let claim = state
         .proxy
         .scheduled_job_claim("quota_sync", TRIGGER_SOURCE_MANUAL, Some(key_id), 1)
@@ -334,7 +331,6 @@ async fn run_manual_key_quota_sync(
                 err.to_string(),
             )
         })?;
-    drop(_maintenance);
 
     let job_id = match claim {
         Some(job_id) => job_id,

--- a/src/server/handlers/admin_resources/api_keys_and_logs.rs
+++ b/src/server/handlers/admin_resources/api_keys_and_logs.rs
@@ -500,7 +500,7 @@ async fn post_api_key_bulk_actions(
             let mut results = Vec::with_capacity(total as usize);
 
             for (index, key_id) in normalized_ids.into_iter().enumerate() {
-                let result = match run_manual_key_quota_sync(state.as_ref(), &key_id).await {
+                let result = match run_manual_key_quota_sync(state.clone(), &key_id).await {
                     Ok(()) => BulkApiKeyActionResult {
                         key_id,
                         status: "success".to_string(),
@@ -645,7 +645,7 @@ async fn post_api_key_bulk_actions(
                     detail: Some(err.to_string()),
                 },
             },
-            BulkApiKeyActionKind::SyncUsage => match run_manual_key_quota_sync(state.as_ref(), &key_id).await {
+            BulkApiKeyActionKind::SyncUsage => match run_manual_key_quota_sync(state.clone(), &key_id).await {
                 Ok(()) => BulkApiKeyActionResult {
                     key_id,
                     status: "success".to_string(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,7 @@ use std::{
     io::Read,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path as FsPath, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use argon2::{
@@ -67,8 +67,8 @@ use tavily_hikari::{
     ForwardProxyStatsResponse, ForwardProxyWeightHourlyBucketResponse, JobLog, LogFacetOption,
     OAuthAccountProfile, PendingBillingSettleOutcome, ProxyError, ProxyRequest, ProxyResponse,
     ProxySummary, RequestLogBodiesRecord, RequestLogRecord, RequestLogsCatalog, RequestLogsCursor,
-    RequestLogsCursorDirection, RequestLogsCursorPage, StickyCreditsWindow, TavilyProxy,
-    TokenHourlyBucket, TokenHourlyRequestVerdict, TokenLogRecord, TokenLogsCursorPage,
+    RequestLogsCursorDirection, RequestLogsCursorPage, RequestLogsGcOptions, StickyCreditsWindow,
+    TavilyProxy, TokenHourlyBucket, TokenHourlyRequestVerdict, TokenLogRecord, TokenLogsCursorPage,
     TokenQuotaVerdict, TokenRequestKindOption, TokenSummary, TokenUsageBucket,
     TrustedClientIpSettings, UNBOUND_TOKEN_MONTHLY_BROKEN_LIMIT_DEFAULT,
     USER_MONTHLY_BROKEN_LIMIT_DEFAULT, UserTokenLookup, analyze_mcp_attempt,
@@ -85,6 +85,7 @@ use tavily_hikari::{
 use tokio::signal;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
+use tokio::sync::RwLock;
 include!("state.rs");
 include!("schedulers.rs");
 include!("spa.rs");

--- a/src/server/proxy/proxy_handlers_and_views.rs
+++ b/src/server/proxy/proxy_handlers_and_views.rs
@@ -1814,6 +1814,7 @@ impl From<JobLog> for JobLogView {
         Self {
             id: value.id,
             job_type: value.job_type,
+            trigger_source: value.trigger_source,
             key_id: value.key_id,
             key_group: value.key_group,
             status: value.status,

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -20,8 +20,60 @@ fn forward_proxy_geo_refresh_recheck_secs() -> i64 {
     60
 }
 
+fn request_logs_gc_catchup_recheck_secs() -> u64 {
+    900
+}
+
+fn scheduled_request_logs_gc_options() -> RequestLogsGcOptions {
+    RequestLogsGcOptions {
+        batch_size: 25,
+        max_batches: 20,
+        max_runtime_secs: 60,
+        inter_batch_sleep_ms: 2_000,
+    }
+}
+
+fn db_compaction_min_reclaimable_bytes() -> u64 {
+    512 * 1024 * 1024
+}
+
+fn db_compaction_min_reclaimable_ratio() -> f64 {
+    0.20
+}
+
+fn db_compaction_cooldown_secs() -> u64 {
+    24 * 60 * 60
+}
+
 const LINUXDO_USER_STATUS_SYNC_JOB_TYPE: &str = "linuxdo_user_status_sync";
 const LINUXDO_USER_TAG_BINDING_REFRESH_JOB_TYPE: &str = "linuxdo_user_tag_binding_refresh";
+const TRIGGER_SOURCE_SCHEDULER: &str = "scheduler";
+const TRIGGER_SOURCE_MANUAL: &str = "manual";
+const TRIGGER_SOURCE_AUTO: &str = "auto";
+
+async fn claim_scheduled_job(
+    state: &AppState,
+    job_type: &str,
+    key_id: Option<&str>,
+    trigger_source: &str,
+    log_prefix: &str,
+) -> Option<i64> {
+    match state
+        .proxy
+        .scheduled_job_claim(job_type, trigger_source, key_id, 1)
+        .await
+    {
+        Ok(Some(id)) => Some(id),
+        Ok(None) => {
+            eprintln!("{log_prefix}: job already running; skip trigger");
+            None
+        }
+        Err(err) => {
+            eprintln!("{log_prefix}: start job error: {err}");
+            None
+        }
+    }
+}
 
 fn next_local_daily_run_after(now: DateTime<Local>, hour: u32, minute: u32) -> DateTime<Local> {
     let today = now.date_naive();
@@ -77,16 +129,16 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
             for key_id in keys {
                 let delay = random_delay_secs(300);
                 tokio::time::sleep(Duration::from_secs(delay)).await;
-                let job_id = match cold_state
-                    .proxy
-                    .scheduled_job_start("quota_sync", Some(&key_id), 1)
-                    .await
-                {
-                    Ok(id) => id,
-                    Err(err) => {
-                        eprintln!("quota-sync: start job error: {err}");
-                        continue;
-                    }
+                let Some(job_id) = claim_scheduled_job(
+                    cold_state.as_ref(),
+                    "quota_sync",
+                    Some(&key_id),
+                    TRIGGER_SOURCE_SCHEDULER,
+                    "quota-sync",
+                )
+                .await
+                else {
+                    continue;
                 };
                 match cold_state
                     .proxy
@@ -145,16 +197,16 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
             for key_id in keys {
                 let delay = random_delay_secs(60);
                 tokio::time::sleep(Duration::from_secs(delay)).await;
-                let job_id = match hot_state
-                    .proxy
-                    .scheduled_job_start("quota_sync/hot", Some(&key_id), 1)
-                    .await
-                {
-                    Ok(id) => id,
-                    Err(err) => {
-                        eprintln!("quota-sync-hot: start job error: {err}");
-                        continue;
-                    }
+                let Some(job_id) = claim_scheduled_job(
+                    hot_state.as_ref(),
+                    "quota_sync/hot",
+                    Some(&key_id),
+                    TRIGGER_SOURCE_SCHEDULER,
+                    "quota-sync-hot",
+                )
+                .await
+                else {
+                    continue;
                 };
                 match hot_state
                     .proxy
@@ -199,17 +251,17 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
 fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let job_id = match state
-                .proxy
-                .scheduled_job_start("token_usage_rollup", None, 1)
-                .await
-            {
-                Ok(id) => id,
-                Err(err) => {
-                    eprintln!("token-usage-rollup: start job error: {err}");
-                    tokio::time::sleep(Duration::from_secs(300)).await;
-                    continue;
-                }
+            let Some(job_id) = claim_scheduled_job(
+                state.as_ref(),
+                "token_usage_rollup",
+                None,
+                TRIGGER_SOURCE_SCHEDULER,
+                "token-usage-rollup",
+            )
+            .await
+            else {
+                tokio::time::sleep(Duration::from_secs(300)).await;
+                continue;
             };
 
             match state.proxy.rollup_token_usage_stats().await {
@@ -240,17 +292,17 @@ fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
 fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let job_id = match state
-                .proxy
-                .scheduled_job_start("auth_token_logs_gc", None, 1)
-                .await
-            {
-                Ok(id) => id,
-                Err(err) => {
-                    eprintln!("auth-token-logs-gc: start job error: {err}");
-                    tokio::time::sleep(Duration::from_secs(3600)).await;
-                    continue;
-                }
+            let Some(job_id) = claim_scheduled_job(
+                state.as_ref(),
+                "auth_token_logs_gc",
+                None,
+                TRIGGER_SOURCE_SCHEDULER,
+                "auth-token-logs-gc",
+            )
+            .await
+            else {
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+                continue;
             };
 
             match state.proxy.gc_auth_token_logs().await {
@@ -278,17 +330,17 @@ fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
 fn spawn_mcp_sessions_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let job_id = match state
-                .proxy
-                .scheduled_job_start("mcp_sessions_gc", None, 1)
-                .await
-            {
-                Ok(id) => id,
-                Err(err) => {
-                    eprintln!("mcp-sessions-gc: start job error: {err}");
-                    tokio::time::sleep(Duration::from_secs(3600)).await;
-                    continue;
-                }
+            let Some(job_id) = claim_scheduled_job(
+                state.as_ref(),
+                "mcp_sessions_gc",
+                None,
+                TRIGGER_SOURCE_SCHEDULER,
+                "mcp-sessions-gc",
+            )
+            .await
+            else {
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+                continue;
             };
 
             match state.proxy.gc_mcp_sessions().await {
@@ -315,17 +367,17 @@ fn spawn_mcp_sessions_gc_scheduler(state: Arc<AppState>) {
 fn spawn_mcp_session_init_backoffs_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let job_id = match state
-                .proxy
-                .scheduled_job_start("mcp_session_init_backoffs_gc", None, 1)
-                .await
-            {
-                Ok(id) => id,
-                Err(err) => {
-                    eprintln!("mcp-session-init-backoffs-gc: start job error: {err}");
-                    tokio::time::sleep(Duration::from_secs(3600)).await;
-                    continue;
-                }
+            let Some(job_id) = claim_scheduled_job(
+                state.as_ref(),
+                "mcp_session_init_backoffs_gc",
+                None,
+                TRIGGER_SOURCE_SCHEDULER,
+                "mcp-session-init-backoffs-gc",
+            )
+            .await
+            else {
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+                continue;
             };
 
             match state.proxy.gc_mcp_session_init_backoffs().await {
@@ -351,7 +403,6 @@ fn spawn_mcp_session_init_backoffs_gc_scheduler(state: Arc<AppState>) {
 
 fn spawn_request_logs_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
-        const CATCHUP_RECHECK_SECS: u64 = 300;
         // Schedule: daily at configured local time.
         loop {
             let (hour, minute) = effective_request_logs_gc_at();
@@ -361,22 +412,22 @@ fn spawn_request_logs_gc_scheduler(state: Arc<AppState>) {
             // After we reach the scheduled time, keep retrying until we either run the job
             // successfully or record an error for this run window.
             loop {
-                let job_id = match state
-                    .proxy
-                    .scheduled_job_start("request_logs_gc", None, 1)
-                    .await
-                {
-                    Ok(id) => id,
-                    Err(err) => {
-                        eprintln!("request-logs-gc: start job error: {err}");
-                        tokio::time::sleep(Duration::from_secs(300)).await;
-                        continue;
-                    }
+                let Some(job_id) = claim_scheduled_job(
+                    state.as_ref(),
+                    "request_logs_gc",
+                    None,
+                    TRIGGER_SOURCE_SCHEDULER,
+                    "request-logs-gc",
+                )
+                .await
+                else {
+                    tokio::time::sleep(Duration::from_secs(300)).await;
+                    continue;
                 };
 
                 match state
                     .proxy
-                    .gc_request_logs_with_options(Default::default())
+                    .gc_request_logs_with_options(scheduled_request_logs_gc_options())
                     .await
                 {
                     Ok(report) => {
@@ -397,7 +448,10 @@ fn spawn_request_logs_gc_scheduler(state: Arc<AppState>) {
                         if report.completed {
                             break;
                         }
-                        tokio::time::sleep(Duration::from_secs(CATCHUP_RECHECK_SECS)).await;
+                        tokio::time::sleep(Duration::from_secs(
+                            request_logs_gc_catchup_recheck_secs(),
+                        ))
+                        .await;
                     }
                     Err(err) => {
                         let _ = state
@@ -436,18 +490,29 @@ async fn record_linuxdo_user_sync_failure(
 }
 
 async fn run_linuxdo_user_status_sync_job(state: Arc<AppState>) {
-    let job_id = match state
-        .proxy
-        .scheduled_job_start(LINUXDO_USER_STATUS_SYNC_JOB_TYPE, None, 1)
-        .await
-    {
-        Ok(id) => id,
-        Err(err) => {
-            eprintln!("linuxdo-user-sync: start job error: {err}");
-            return;
-        }
+    run_linuxdo_user_status_sync_job_with_source(state, TRIGGER_SOURCE_SCHEDULER).await;
+}
+
+async fn run_linuxdo_user_status_sync_job_with_source(
+    state: Arc<AppState>,
+    trigger_source: &'static str,
+) {
+    let Some(job_id) = claim_scheduled_job(
+        state.as_ref(),
+        LINUXDO_USER_STATUS_SYNC_JOB_TYPE,
+        None,
+        trigger_source,
+        "linuxdo-user-sync",
+    )
+    .await
+    else {
+        return;
     };
 
+    run_linuxdo_user_status_sync_claimed_job(state, job_id).await;
+}
+
+async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: i64) {
     let cfg = &state.linuxdo_oauth;
     if !cfg.is_enabled_and_configured() {
         let _ = state
@@ -670,16 +735,23 @@ fn spawn_linuxdo_user_status_sync_scheduler(state: Arc<AppState>) {
 }
 
 async fn run_linuxdo_user_tag_binding_refresh_job(state: Arc<AppState>) {
-    let job_id = match state
-        .proxy
-        .scheduled_job_start(LINUXDO_USER_TAG_BINDING_REFRESH_JOB_TYPE, None, 1)
-        .await
-    {
-        Ok(id) => id,
-        Err(err) => {
-            eprintln!("linuxdo-tag-binding-refresh: start job error: {err}");
-            return;
-        }
+    run_linuxdo_user_tag_binding_refresh_job_with_source(state, TRIGGER_SOURCE_SCHEDULER).await;
+}
+
+async fn run_linuxdo_user_tag_binding_refresh_job_with_source(
+    state: Arc<AppState>,
+    trigger_source: &'static str,
+) {
+    let Some(job_id) = claim_scheduled_job(
+        state.as_ref(),
+        LINUXDO_USER_TAG_BINDING_REFRESH_JOB_TYPE,
+        None,
+        trigger_source,
+        "linuxdo-tag-binding-refresh",
+    )
+    .await
+    else {
+        return;
     };
 
     match state.proxy.refresh_linuxdo_user_tag_bindings().await {
@@ -725,16 +797,23 @@ fn spawn_linuxdo_user_tag_binding_refresh_scheduler(state: Arc<AppState>) {
 }
 
 async fn run_forward_proxy_geo_refresh_job(state: Arc<AppState>) {
-    let job_id = match state
-        .proxy
-        .scheduled_job_start("forward_proxy_geo_refresh", None, 1)
-        .await
-    {
-        Ok(id) => id,
-        Err(err) => {
-            eprintln!("forward-proxy-geo-refresh: start job error: {err}");
-            return;
-        }
+    run_forward_proxy_geo_refresh_job_with_source(state, TRIGGER_SOURCE_SCHEDULER).await;
+}
+
+async fn run_forward_proxy_geo_refresh_job_with_source(
+    state: Arc<AppState>,
+    trigger_source: &'static str,
+) {
+    let Some(job_id) = claim_scheduled_job(
+        state.as_ref(),
+        "forward_proxy_geo_refresh",
+        None,
+        trigger_source,
+        "forward-proxy-geo-refresh",
+    )
+    .await
+    else {
+        return;
     };
 
     match state
@@ -756,6 +835,178 @@ async fn run_forward_proxy_geo_refresh_job(state: Arc<AppState>) {
                 .await;
         }
     }
+}
+
+async fn run_manual_claimed_job(
+    state: Arc<AppState>,
+    job_type: String,
+    key_id: Option<String>,
+    job_id: i64,
+) {
+    let finish = |state: Arc<AppState>, status: &'static str, message: String| async move {
+        let _ = state
+            .proxy
+            .scheduled_job_finish(job_id, status, Some(&message))
+            .await;
+    };
+
+    match job_type.as_str() {
+        "quota_sync" => {
+            let Some(key_id) = key_id else {
+                finish(state, "error", "missing key_id".to_string()).await;
+                return;
+            };
+            match state
+                .proxy
+                .sync_key_quota(&key_id, &state.usage_base, "quota_sync/manual")
+                .await
+            {
+                Ok((limit, remaining)) => {
+                    finish(state, "success", format!("limit={limit} remaining={remaining}")).await
+                }
+                Err(ProxyError::QuotaDataMissing { reason }) => {
+                    finish(state, "error", format!("quota_data_missing: {reason}")).await
+                }
+                Err(ProxyError::UsageHttp { status, body }) => {
+                    finish(state, "error", format!("usage_http {status}: {body}")).await
+                }
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        }
+        "token_usage_rollup" => match state.proxy.rollup_token_usage_stats().await {
+            Ok((rows, last_ts)) => {
+                let msg = match last_ts {
+                    Some(ts) => format!("rows={rows} last_rollup_ts={ts}"),
+                    None => format!("rows={rows} last_rollup_ts=none"),
+                };
+                finish(state, "success", msg).await;
+            }
+            Err(err) => finish(state, "error", err.to_string()).await,
+        },
+        "auth_token_logs_gc" => match state.proxy.gc_auth_token_logs().await {
+            Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
+            Err(err) => finish(state, "error", err.to_string()).await,
+        },
+        "mcp_sessions_gc" => match state.proxy.gc_mcp_sessions().await {
+            Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
+            Err(err) => finish(state, "error", err.to_string()).await,
+        },
+        "mcp_session_init_backoffs_gc" => {
+            match state.proxy.gc_mcp_session_init_backoffs().await {
+                Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        },
+        "request_logs_gc" => match state
+            .proxy
+            .gc_request_logs_with_options(scheduled_request_logs_gc_options())
+            .await
+        {
+            Ok(report) => {
+                let msg = format!(
+                    "cleaned_bodies={} deleted_rows={} rollup_deleted={} completed={} retention_days={} batches={} elapsed_ms={}",
+                    report.cleaned_request_log_bodies,
+                    report.deleted_request_logs,
+                    report.deleted_rollups,
+                    report.completed,
+                    report.retention_days,
+                    report.batches,
+                    report.elapsed_ms
+                );
+                finish(state, "success", msg).await;
+            }
+            Err(err) => finish(state, "error", err.to_string()).await,
+        },
+        "linuxdo_user_status_sync" => {
+            run_linuxdo_user_status_sync_claimed_job(state, job_id).await;
+        },
+        "linuxdo_user_tag_binding_refresh" => {
+            match state.proxy.refresh_linuxdo_user_tag_bindings().await {
+                Ok(refreshed) => finish(state, "success", format!("refreshed={refreshed}")).await,
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        },
+        "forward_proxy_geo_refresh" => {
+            match state
+                .proxy
+                .refresh_forward_proxy_geo_metadata(&state.api_key_ip_geo_origin, true)
+                .await
+            {
+                Ok(refreshed) => {
+                    finish(state, "success", format!("refreshed_candidates={refreshed}")).await
+                }
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        },
+        "db_compaction" => {
+            let _maintenance = db_maintenance_gate().write().await;
+            match state.proxy.sqlite_db_stats().await {
+                Ok(before) => match state.proxy.compact_sqlite_database().await {
+                    Ok(after) => {
+                        finish(
+                            state,
+                            "success",
+                            format!(
+                                "database_bytes_before={} database_bytes_after={} wal_bytes_before={} wal_bytes_after={} reclaimable_bytes_before={} reclaimable_bytes_after={} freelist_before={} freelist_after={}",
+                                before.database_bytes,
+                                after.database_bytes,
+                                before.wal_bytes,
+                                after.wal_bytes,
+                                before.reclaimable_bytes,
+                                after.reclaimable_bytes,
+                                before.freelist_count,
+                                after.freelist_count
+                            ),
+                        )
+                        .await;
+                    }
+                    Err(err) => finish(state, "error", err.to_string()).await,
+                }
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        },
+        _ => finish(state, "error", format!("unsupported manual job type: {job_type}")).await,
+    }
+}
+
+fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let mut next_allowed_at = Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            if Instant::now() < next_allowed_at {
+                continue;
+            }
+            let stats = match state.proxy.sqlite_db_stats().await {
+                Ok(stats) => stats,
+                Err(err) => {
+                    eprintln!("db-compaction: stats error: {err}");
+                    continue;
+                }
+            };
+            if stats.reclaimable_bytes < db_compaction_min_reclaimable_bytes()
+                || stats.reclaimable_ratio < db_compaction_min_reclaimable_ratio()
+            {
+                continue;
+            }
+            let Some(job_id) = claim_scheduled_job(
+                state.as_ref(),
+                "db_compaction",
+                None,
+                TRIGGER_SOURCE_AUTO,
+                "db-compaction",
+            )
+            .await
+            else {
+                continue;
+            };
+            let run_state = state.clone();
+            tokio::spawn(async move {
+                run_manual_claimed_job(run_state, "db_compaction".to_string(), None, job_id).await;
+            });
+            next_allowed_at = Instant::now() + Duration::from_secs(db_compaction_cooldown_secs());
+        }
+    });
 }
 
 fn spawn_forward_proxy_geo_refresh_scheduler(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -58,6 +58,7 @@ async fn claim_scheduled_job(
     trigger_source: &str,
     log_prefix: &str,
 ) -> Option<i64> {
+    let _maintenance = acquire_db_maintenance_read_gate().await;
     match state
         .proxy
         .scheduled_job_claim(job_type, trigger_source, key_id, 1)
@@ -114,15 +115,18 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
     let cold_state = state.clone();
     tokio::spawn(async move {
         loop {
-            let keys = match cold_state
-                .proxy
-                .list_keys_pending_quota_sync(twenty_four_hours_secs())
-                .await
-            {
-                Ok(list) => list,
-                Err(err) => {
-                    eprintln!("quota-sync: list pending error: {err}");
-                    vec![]
+            let keys = {
+                let _maintenance = acquire_db_maintenance_read_gate().await;
+                match cold_state
+                    .proxy
+                    .list_keys_pending_quota_sync(twenty_four_hours_secs())
+                    .await
+                {
+                    Ok(list) => list,
+                    Err(err) => {
+                        eprintln!("quota-sync: list pending error: {err}");
+                        vec![]
+                    }
                 }
             };
 
@@ -140,6 +144,7 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
                 else {
                     continue;
                 };
+                let _maintenance = acquire_db_maintenance_read_gate().await;
                 match cold_state
                     .proxy
                     .sync_key_quota(&key_id, &cold_state.usage_base, "quota_sync")
@@ -182,15 +187,18 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
     let hot_state = state;
     tokio::spawn(async move {
         loop {
-            let keys = match hot_state
-                .proxy
-                .list_keys_pending_hot_quota_sync(two_hours_secs(), fifteen_minutes_secs())
-                .await
-            {
-                Ok(list) => list,
-                Err(err) => {
-                    eprintln!("quota-sync-hot: list pending error: {err}");
-                    vec![]
+            let keys = {
+                let _maintenance = acquire_db_maintenance_read_gate().await;
+                match hot_state
+                    .proxy
+                    .list_keys_pending_hot_quota_sync(two_hours_secs(), fifteen_minutes_secs())
+                    .await
+                {
+                    Ok(list) => list,
+                    Err(err) => {
+                        eprintln!("quota-sync-hot: list pending error: {err}");
+                        vec![]
+                    }
                 }
             };
 
@@ -208,6 +216,7 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
                 else {
                     continue;
                 };
+                let _maintenance = acquire_db_maintenance_read_gate().await;
                 match hot_state
                     .proxy
                     .sync_key_quota(&key_id, &hot_state.usage_base, "quota_sync/hot")
@@ -264,6 +273,7 @@ fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
                 continue;
             };
 
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.rollup_token_usage_stats().await {
                 Ok((rows, last_ts)) => {
                     let msg = match last_ts {
@@ -282,6 +292,7 @@ fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
                         .await;
                 }
             }
+            drop(_maintenance);
 
             // Run rollup every 5 minutes to keep charts reasonably fresh
             tokio::time::sleep(Duration::from_secs(300)).await;
@@ -305,6 +316,7 @@ fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
                 continue;
             };
 
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.gc_auth_token_logs().await {
                 Ok(deleted) => {
                     let msg = format!("deleted_rows={deleted}");
@@ -320,6 +332,7 @@ fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
                         .await;
                 }
             }
+            drop(_maintenance);
 
             // Run GC once per hour; retention window is enforced inside the proxy.
             tokio::time::sleep(Duration::from_secs(3600)).await;
@@ -343,6 +356,7 @@ fn spawn_mcp_sessions_gc_scheduler(state: Arc<AppState>) {
                 continue;
             };
 
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.gc_mcp_sessions().await {
                 Ok(deleted) => {
                     let msg = format!("deleted_rows={deleted}");
@@ -358,6 +372,7 @@ fn spawn_mcp_sessions_gc_scheduler(state: Arc<AppState>) {
                         .await;
                 }
             }
+            drop(_maintenance);
 
             tokio::time::sleep(Duration::from_secs(3600)).await;
         }
@@ -380,6 +395,7 @@ fn spawn_mcp_session_init_backoffs_gc_scheduler(state: Arc<AppState>) {
                 continue;
             };
 
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.gc_mcp_session_init_backoffs().await {
                 Ok(deleted) => {
                     let msg = format!("deleted_rows={deleted}");
@@ -395,6 +411,7 @@ fn spawn_mcp_session_init_backoffs_gc_scheduler(state: Arc<AppState>) {
                         .await;
                 }
             }
+            drop(_maintenance);
 
             tokio::time::sleep(Duration::from_secs(3600)).await;
         }
@@ -441,6 +458,7 @@ async fn run_request_logs_gc_catchup_claimed_job(state: Arc<AppState>, job_id: i
     let mut passes = 0usize;
 
     loop {
+        let _maintenance = acquire_db_maintenance_read_gate().await;
         match state
             .proxy
             .gc_request_logs_with_options(scheduled_request_logs_gc_options())
@@ -472,6 +490,7 @@ async fn run_request_logs_gc_catchup_claimed_job(state: Arc<AppState>, job_id: i
                     return true;
                 }
 
+                drop(_maintenance);
                 tokio::time::sleep(Duration::from_secs(
                     request_logs_gc_catchup_recheck_secs(),
                 ))
@@ -535,6 +554,7 @@ async fn run_linuxdo_user_status_sync_job_with_source(
 }
 
 async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
+    let _maintenance = acquire_db_maintenance_read_gate().await;
     let cfg = &state.linuxdo_oauth;
     if !cfg.is_enabled_and_configured() {
         let _ = state
@@ -777,6 +797,7 @@ async fn run_linuxdo_user_tag_binding_refresh_job_with_source(
         return;
     };
 
+    let _maintenance = acquire_db_maintenance_read_gate().await;
     match state.proxy.refresh_linuxdo_user_tag_bindings().await {
         Ok(refreshed) => {
             let msg = format!("refreshed={refreshed}");
@@ -797,16 +818,22 @@ async fn run_linuxdo_user_tag_binding_refresh_job_with_source(
 fn spawn_linuxdo_user_tag_binding_refresh_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let wait_secs = state
-                .proxy
-                .linuxdo_user_tag_binding_refresh_wait_secs(twenty_four_hours_secs())
-                .await;
-            if wait_secs <= 0 {
-                if state
+            let wait_secs = {
+                let _maintenance = acquire_db_maintenance_read_gate().await;
+                state
                     .proxy
-                    .linuxdo_user_tag_binding_refresh_due(twenty_four_hours_secs())
+                    .linuxdo_user_tag_binding_refresh_wait_secs(twenty_four_hours_secs())
                     .await
-                {
+            };
+            if wait_secs <= 0 {
+                let due = {
+                    let _maintenance = acquire_db_maintenance_read_gate().await;
+                    state
+                        .proxy
+                        .linuxdo_user_tag_binding_refresh_due(twenty_four_hours_secs())
+                        .await
+                };
+                if due {
                     run_linuxdo_user_tag_binding_refresh_job(state.clone()).await;
                 }
                 tokio::time::sleep(Duration::from_secs(fifteen_minutes_secs() as u64)).await;
@@ -839,6 +866,7 @@ async fn run_forward_proxy_geo_refresh_job_with_source(
         return;
     };
 
+    let _maintenance = acquire_db_maintenance_read_gate().await;
     match state
         .proxy
         .refresh_forward_proxy_geo_metadata(&state.api_key_ip_geo_origin, true)
@@ -880,6 +908,7 @@ async fn run_manual_claimed_job(
             let Some(key_id) = key_id else {
                 return finish(state, "error", "missing key_id".to_string()).await;
             };
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state
                 .proxy
                 .sync_key_quota(&key_id, &state.usage_base, "quota_sync/manual")
@@ -897,25 +926,35 @@ async fn run_manual_claimed_job(
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         }
-        "token_usage_rollup" => match state.proxy.rollup_token_usage_stats().await {
-            Ok((rows, last_ts)) => {
-                let msg = match last_ts {
-                    Some(ts) => format!("rows={rows} last_rollup_ts={ts}"),
-                    None => format!("rows={rows} last_rollup_ts=none"),
-                };
-                finish(state, "success", msg).await
+        "token_usage_rollup" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            match state.proxy.rollup_token_usage_stats().await {
+                Ok((rows, last_ts)) => {
+                    let msg = match last_ts {
+                        Some(ts) => format!("rows={rows} last_rollup_ts={ts}"),
+                        None => format!("rows={rows} last_rollup_ts=none"),
+                    };
+                    finish(state, "success", msg).await
+                }
+                Err(err) => finish(state, "error", err.to_string()).await,
             }
-            Err(err) => finish(state, "error", err.to_string()).await,
-        },
-        "auth_token_logs_gc" => match state.proxy.gc_auth_token_logs().await {
-            Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
-            Err(err) => finish(state, "error", err.to_string()).await,
-        },
-        "mcp_sessions_gc" => match state.proxy.gc_mcp_sessions().await {
-            Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
-            Err(err) => finish(state, "error", err.to_string()).await,
-        },
+        }
+        "auth_token_logs_gc" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            match state.proxy.gc_auth_token_logs().await {
+                Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        }
+        "mcp_sessions_gc" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            match state.proxy.gc_mcp_sessions().await {
+                Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        }
         "mcp_session_init_backoffs_gc" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.gc_mcp_session_init_backoffs().await {
                 Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
                 Err(err) => finish(state, "error", err.to_string()).await,
@@ -926,12 +965,14 @@ async fn run_manual_claimed_job(
             run_linuxdo_user_status_sync_claimed_job(state, job_id).await
         },
         "linuxdo_user_tag_binding_refresh" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.refresh_linuxdo_user_tag_bindings().await {
                 Ok(refreshed) => finish(state, "success", format!("refreshed={refreshed}")).await,
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         },
         "forward_proxy_geo_refresh" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
             match state
                 .proxy
                 .refresh_forward_proxy_geo_metadata(&state.api_key_ip_geo_origin, true)
@@ -943,35 +984,50 @@ async fn run_manual_claimed_job(
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         },
-        "db_compaction" => {
-            let _maintenance = db_maintenance_gate().write().await;
-            match state.proxy.sqlite_db_stats().await {
-                Ok(before) => match state.proxy.compact_sqlite_database().await {
-                    Ok(after) => {
-                        finish(
-                            state,
-                            "success",
-                            format!(
-                                "database_bytes_before={} database_bytes_after={} wal_bytes_before={} wal_bytes_after={} reclaimable_bytes_before={} reclaimable_bytes_after={} freelist_before={} freelist_after={}",
-                                before.database_bytes,
-                                after.database_bytes,
-                                before.wal_bytes,
-                                after.wal_bytes,
-                                before.reclaimable_bytes,
-                                after.reclaimable_bytes,
-                                before.freelist_count,
-                                after.freelist_count
-                            ),
-                        )
-                        .await
-                    }
-                    Err(err) => finish(state, "error", err.to_string()).await,
-                }
-                Err(err) => finish(state, "error", err.to_string()).await,
-            }
-        },
+        "db_compaction" => run_db_compaction_claimed_job(state, job_id).await,
         _ => finish(state, "error", format!("unsupported manual job type: {job_type}")).await,
     }
+}
+
+async fn finish_db_compaction_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
+    let finish = |state: Arc<AppState>, status: &'static str, message: String| async move {
+        let succeeded = status == "success";
+        let _ = state
+            .proxy
+            .scheduled_job_finish(job_id, status, Some(&message))
+            .await;
+        succeeded
+    };
+
+    match state.proxy.sqlite_db_stats().await {
+        Ok(before) => match state.proxy.compact_sqlite_database().await {
+            Ok(after) => {
+                finish(
+                    state,
+                    "success",
+                    format!(
+                        "database_bytes_before={} database_bytes_after={} wal_bytes_before={} wal_bytes_after={} reclaimable_bytes_before={} reclaimable_bytes_after={} freelist_before={} freelist_after={}",
+                        before.database_bytes,
+                        after.database_bytes,
+                        before.wal_bytes,
+                        after.wal_bytes,
+                        before.reclaimable_bytes,
+                        after.reclaimable_bytes,
+                        before.freelist_count,
+                        after.freelist_count
+                    ),
+                )
+                .await
+            }
+            Err(err) => finish(state, "error", err.to_string()).await,
+        },
+        Err(err) => finish(state, "error", err.to_string()).await,
+    }
+}
+
+async fn run_db_compaction_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
+    let _maintenance = acquire_db_maintenance_write_gate().await;
+    finish_db_compaction_claimed_job(state, job_id).await
 }
 
 fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
@@ -982,6 +1038,7 @@ fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
             if Instant::now() < next_allowed_at {
                 continue;
             }
+            let _maintenance = acquire_db_maintenance_write_gate().await;
             let stats = match state.proxy.sqlite_db_stats().await {
                 Ok(stats) => stats,
                 Err(err) => {
@@ -994,20 +1051,22 @@ fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
             {
                 continue;
             }
-            let Some(job_id) = claim_scheduled_job(
-                state.as_ref(),
-                "db_compaction",
-                None,
-                TRIGGER_SOURCE_AUTO,
-                "db-compaction",
-            )
-            .await
-            else {
-                continue;
+            let job_id = match state
+                .proxy
+                .scheduled_job_claim("db_compaction", TRIGGER_SOURCE_AUTO, None, 1)
+                .await
+            {
+                Ok(Some(id)) => id,
+                Ok(None) => {
+                    eprintln!("db-compaction: job already running; skip trigger");
+                    continue;
+                }
+                Err(err) => {
+                    eprintln!("db-compaction: start job error: {err}");
+                    continue;
+                }
             };
-            let succeeded =
-                run_manual_claimed_job(state.clone(), "db_compaction".to_string(), None, job_id)
-                    .await;
+            let succeeded = finish_db_compaction_claimed_job(state.clone(), job_id).await;
             if succeeded {
                 next_allowed_at =
                     Instant::now() + Duration::from_secs(db_compaction_cooldown_secs());
@@ -1019,16 +1078,22 @@ fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
 fn spawn_forward_proxy_geo_refresh_scheduler(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            let wait_secs = state
-                .proxy
-                .forward_proxy_geo_refresh_wait_secs(twenty_four_hours_secs())
-                .await;
-            if wait_secs <= 0 {
-                if state
+            let wait_secs = {
+                let _maintenance = acquire_db_maintenance_read_gate().await;
+                state
                     .proxy
-                    .forward_proxy_geo_refresh_due(twenty_four_hours_secs())
+                    .forward_proxy_geo_refresh_wait_secs(twenty_four_hours_secs())
                     .await
-                {
+            };
+            if wait_secs <= 0 {
+                let due = {
+                    let _maintenance = acquire_db_maintenance_read_gate().await;
+                    state
+                        .proxy
+                        .forward_proxy_geo_refresh_due(twenty_four_hours_secs())
+                        .await
+                };
+                if due {
                     run_forward_proxy_geo_refresh_job(state.clone()).await;
                 }
                 tokio::time::sleep(Duration::from_secs(
@@ -1047,8 +1112,11 @@ fn spawn_forward_proxy_geo_refresh_scheduler(state: Arc<AppState>) -> tokio::tas
 fn spawn_forward_proxy_maintenance_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            if let Err(err) = state.proxy.maybe_run_forward_proxy_maintenance().await {
-                eprintln!("forward-proxy-maintenance: {err}");
+            {
+                let _maintenance = acquire_db_maintenance_read_gate().await;
+                if let Err(err) = state.proxy.maybe_run_forward_proxy_maintenance().await {
+                    eprintln!("forward-proxy-maintenance: {err}");
+                }
             }
             tokio::time::sleep(Duration::from_secs(30)).await;
         }

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -512,7 +512,7 @@ async fn run_linuxdo_user_status_sync_job_with_source(
     run_linuxdo_user_status_sync_claimed_job(state, job_id).await;
 }
 
-async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: i64) {
+async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
     let cfg = &state.linuxdo_oauth;
     if !cfg.is_enabled_and_configured() {
         let _ = state
@@ -523,7 +523,7 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
                 Some("attempted=0 success=0 skipped=0 failure=0 reason=linuxdo_oauth_not_configured"),
             )
             .await;
-        return;
+        return true;
     }
     if !cfg.has_refresh_token_crypt_key() {
         let _ = state
@@ -534,7 +534,7 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
                 Some("attempted=0 success=0 skipped=0 failure=0 reason=missing_refresh_token_crypt_key"),
             )
             .await;
-        return;
+        return true;
     }
 
     let records = match state.proxy.list_oauth_accounts_with_refresh_token("linuxdo").await {
@@ -544,7 +544,7 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
                 .proxy
                 .scheduled_job_finish(job_id, "error", Some(&err.to_string()))
                 .await;
-            return;
+            return false;
         }
     };
 
@@ -557,7 +557,7 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
                 Some("attempted=0 success=0 skipped=0 failure=0 reason=no_eligible_accounts"),
             )
             .await;
-        return;
+        return true;
     }
 
     let client = reqwest::Client::new();
@@ -721,6 +721,7 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
         .proxy
         .scheduled_job_finish(job_id, final_status, Some(&message))
         .await;
+    final_status == "success"
 }
 
 fn spawn_linuxdo_user_status_sync_scheduler(state: Arc<AppState>) {
@@ -842,19 +843,20 @@ async fn run_manual_claimed_job(
     job_type: String,
     key_id: Option<String>,
     job_id: i64,
-) {
+) -> bool {
     let finish = |state: Arc<AppState>, status: &'static str, message: String| async move {
+        let succeeded = status == "success";
         let _ = state
             .proxy
             .scheduled_job_finish(job_id, status, Some(&message))
             .await;
+        succeeded
     };
 
     match job_type.as_str() {
         "quota_sync" => {
             let Some(key_id) = key_id else {
-                finish(state, "error", "missing key_id".to_string()).await;
-                return;
+                return finish(state, "error", "missing key_id".to_string()).await;
             };
             match state
                 .proxy
@@ -879,7 +881,7 @@ async fn run_manual_claimed_job(
                     Some(ts) => format!("rows={rows} last_rollup_ts={ts}"),
                     None => format!("rows={rows} last_rollup_ts=none"),
                 };
-                finish(state, "success", msg).await;
+                finish(state, "success", msg).await
             }
             Err(err) => finish(state, "error", err.to_string()).await,
         },
@@ -913,12 +915,12 @@ async fn run_manual_claimed_job(
                     report.batches,
                     report.elapsed_ms
                 );
-                finish(state, "success", msg).await;
+                finish(state, "success", msg).await
             }
             Err(err) => finish(state, "error", err.to_string()).await,
         },
         "linuxdo_user_status_sync" => {
-            run_linuxdo_user_status_sync_claimed_job(state, job_id).await;
+            run_linuxdo_user_status_sync_claimed_job(state, job_id).await
         },
         "linuxdo_user_tag_binding_refresh" => {
             match state.proxy.refresh_linuxdo_user_tag_bindings().await {
@@ -958,7 +960,7 @@ async fn run_manual_claimed_job(
                                 after.freelist_count
                             ),
                         )
-                        .await;
+                        .await
                     }
                     Err(err) => finish(state, "error", err.to_string()).await,
                 }
@@ -1000,11 +1002,13 @@ fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
             else {
                 continue;
             };
-            let run_state = state.clone();
-            tokio::spawn(async move {
-                run_manual_claimed_job(run_state, "db_compaction".to_string(), None, job_id).await;
-            });
-            next_allowed_at = Instant::now() + Duration::from_secs(db_compaction_cooldown_secs());
+            let succeeded =
+                run_manual_claimed_job(state.clone(), "db_compaction".to_string(), None, job_id)
+                    .await;
+            if succeeded {
+                next_allowed_at =
+                    Instant::now() + Duration::from_secs(db_compaction_cooldown_secs());
+            }
         }
     });
 }

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -425,45 +425,67 @@ fn spawn_request_logs_gc_scheduler(state: Arc<AppState>) {
                     continue;
                 };
 
-                match state
-                    .proxy
-                    .gc_request_logs_with_options(scheduled_request_logs_gc_options())
-                    .await
-                {
-                    Ok(report) => {
-                        let msg = format!(
-                            "cleaned_bodies={} deleted_rows={} rollup_deleted={} completed={} retention_days={} batches={} elapsed_ms={}",
-                            report.cleaned_request_log_bodies,
-                            report.deleted_request_logs,
-                            report.deleted_rollups,
-                            report.completed,
-                            report.retention_days,
-                            report.batches,
-                            report.elapsed_ms
-                        );
-                        let _ = state
-                            .proxy
-                            .scheduled_job_finish(job_id, "success", Some(&msg))
-                            .await;
-                        if report.completed {
-                            break;
-                        }
-                        tokio::time::sleep(Duration::from_secs(
-                            request_logs_gc_catchup_recheck_secs(),
-                        ))
-                        .await;
-                    }
-                    Err(err) => {
-                        let _ = state
-                            .proxy
-                            .scheduled_job_finish(job_id, "error", Some(&err.to_string()))
-                            .await;
-                        break;
-                    }
-                }
+                let _ = run_request_logs_gc_catchup_claimed_job(state.clone(), job_id).await;
+                break;
             }
         }
     });
+}
+
+async fn run_request_logs_gc_catchup_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
+    let mut cleaned_request_log_bodies = 0i64;
+    let mut deleted_request_logs = 0i64;
+    let mut deleted_rollups = 0i64;
+    let mut total_batches = 0i64;
+    let mut total_elapsed_ms = 0u128;
+    let mut passes = 0usize;
+
+    loop {
+        match state
+            .proxy
+            .gc_request_logs_with_options(scheduled_request_logs_gc_options())
+            .await
+        {
+            Ok(report) => {
+                passes += 1;
+                cleaned_request_log_bodies += report.cleaned_request_log_bodies;
+                deleted_request_logs += report.deleted_request_logs;
+                deleted_rollups += report.deleted_rollups;
+                total_batches += report.batches;
+                total_elapsed_ms += report.elapsed_ms;
+
+                if report.completed {
+                    let msg = format!(
+                        "cleaned_bodies={} deleted_rows={} rollup_deleted={} completed=true retention_days={} batches={} passes={} elapsed_ms={}",
+                        cleaned_request_log_bodies,
+                        deleted_request_logs,
+                        deleted_rollups,
+                        report.retention_days,
+                        total_batches,
+                        passes,
+                        total_elapsed_ms
+                    );
+                    let _ = state
+                        .proxy
+                        .scheduled_job_finish(job_id, "success", Some(&msg))
+                        .await;
+                    return true;
+                }
+
+                tokio::time::sleep(Duration::from_secs(
+                    request_logs_gc_catchup_recheck_secs(),
+                ))
+                .await;
+            }
+            Err(err) => {
+                let _ = state
+                    .proxy
+                    .scheduled_job_finish(job_id, "error", Some(&err.to_string()))
+                    .await;
+                return false;
+            }
+        }
+    }
 }
 
 async fn record_linuxdo_user_sync_failure(
@@ -899,26 +921,7 @@ async fn run_manual_claimed_job(
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         },
-        "request_logs_gc" => match state
-            .proxy
-            .gc_request_logs_with_options(scheduled_request_logs_gc_options())
-            .await
-        {
-            Ok(report) => {
-                let msg = format!(
-                    "cleaned_bodies={} deleted_rows={} rollup_deleted={} completed={} retention_days={} batches={} elapsed_ms={}",
-                    report.cleaned_request_log_bodies,
-                    report.deleted_request_logs,
-                    report.deleted_rollups,
-                    report.completed,
-                    report.retention_days,
-                    report.batches,
-                    report.elapsed_ms
-                );
-                finish(state, "success", msg).await
-            }
-            Err(err) => finish(state, "error", err.to_string()).await,
-        },
+        "request_logs_gc" => run_request_logs_gc_catchup_claimed_job(state, job_id).await,
         "linuxdo_user_status_sync" => {
             run_linuxdo_user_status_sync_claimed_job(state, job_id).await
         },

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -53,6 +53,13 @@ pub async fn serve(
         usage_base: usage_base.clone(),
         api_key_ip_geo_origin,
     });
+    match state.proxy.abandon_running_scheduled_jobs().await {
+        Ok(count) if count > 0 => {
+            eprintln!("scheduled-jobs: abandoned {count} stale running jobs from previous process")
+        }
+        Ok(_) => {}
+        Err(err) => eprintln!("scheduled-jobs: stale running cleanup warning: {err}"),
+    }
     spawn_ha_standby_sync_task(state.clone());
     println!(
         "Admin auth modes: forward_enabled={} builtin_enabled={} dev_open_admin={}",
@@ -249,6 +256,7 @@ pub async fn serve(
         .route("/api/keys/:id", delete(delete_api_key))
         .route("/api/keys/:id/status", patch(update_api_key_status))
         .route("/api/jobs", get(list_jobs))
+        .route("/api/jobs/trigger", post(post_trigger_job))
         .route("/api/logs", get(list_logs))
         .route("/api/logs/list", get(list_logs_cursor))
         .route("/api/logs/catalog", get(get_logs_catalog))
@@ -415,11 +423,13 @@ pub async fn serve(
     spawn_linuxdo_user_tag_binding_refresh_scheduler(state.clone());
     let _forward_proxy_geo_refresh_scheduler = spawn_forward_proxy_geo_refresh_scheduler(state.clone());
     spawn_forward_proxy_maintenance_scheduler(state.clone());
+    spawn_db_compaction_scheduler(state.clone());
     spawn_ha_edgeone_authority_task(state.clone());
 
     axum::serve(
         listener,
         router
+            .layer(axum::middleware::from_fn(db_maintenance_http_gate))
             .with_state(state)
             .into_make_service_with_connect_info::<SocketAddr>(),
     )

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -13,6 +13,24 @@ struct AppState {
     api_key_ip_geo_origin: String,
 }
 
+static DB_MAINTENANCE_GATE: OnceLock<RwLock<()>> = OnceLock::new();
+
+fn db_maintenance_gate() -> &'static RwLock<()> {
+    DB_MAINTENANCE_GATE.get_or_init(|| RwLock::new(()))
+}
+
+async fn db_maintenance_http_gate(
+    req: Request<Body>,
+    next: axum::middleware::Next,
+) -> Response<Body> {
+    if req.uri().path() == "/health" {
+        return next.run(req).await;
+    }
+
+    let _guard = db_maintenance_gate().read().await;
+    next.run(req).await
+}
+
 async fn ensure_ha_allows_basic_business(
     state: &Arc<AppState>,
     path: &str,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -23,12 +23,38 @@ async fn db_maintenance_http_gate(
     req: Request<Body>,
     next: axum::middleware::Next,
 ) -> Response<Body> {
-    if req.uri().path() == "/health" {
+    let path = req.uri().path();
+    if path == "/health" || !db_maintenance_gated_path(path) {
         return next.run(req).await;
     }
 
     let _guard = db_maintenance_gate().read().await;
     next.run(req).await
+}
+
+fn db_maintenance_gated_path(path: &str) -> bool {
+    path == "/mcp"
+        || path.starts_with("/mcp/")
+        || path.starts_with("/api/")
+        || path == "/auth/linuxdo"
+        || path.starts_with("/auth/linuxdo/")
+}
+
+#[cfg(test)]
+mod db_maintenance_gate_tests {
+    use super::db_maintenance_gated_path;
+
+    #[test]
+    fn maintenance_gate_only_covers_db_backed_routes() {
+        assert!(db_maintenance_gated_path("/api/jobs"));
+        assert!(db_maintenance_gated_path("/mcp"));
+        assert!(db_maintenance_gated_path("/auth/linuxdo/callback"));
+
+        assert!(!db_maintenance_gated_path("/health"));
+        assert!(!db_maintenance_gated_path("/admin"));
+        assert!(!db_maintenance_gated_path("/assets/admin.js"));
+        assert!(!db_maintenance_gated_path("/favicon.svg"));
+    }
 }
 
 async fn ensure_ha_allows_basic_business(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -19,6 +19,14 @@ fn db_maintenance_gate() -> &'static RwLock<()> {
     DB_MAINTENANCE_GATE.get_or_init(|| RwLock::new(()))
 }
 
+async fn acquire_db_maintenance_read_gate() -> tokio::sync::RwLockReadGuard<'static, ()> {
+    db_maintenance_gate().read().await
+}
+
+async fn acquire_db_maintenance_write_gate() -> tokio::sync::RwLockWriteGuard<'static, ()> {
+    db_maintenance_gate().write().await
+}
+
 async fn db_maintenance_http_gate(
     req: Request<Body>,
     next: axum::middleware::Next,
@@ -28,7 +36,7 @@ async fn db_maintenance_http_gate(
         return next.run(req).await;
     }
 
-    let _guard = db_maintenance_gate().read().await;
+    let _guard = acquire_db_maintenance_read_gate().await;
     next.run(req).await
 }
 

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -1,6 +1,7 @@
 impl KeyStore {
     pub(crate) async fn new(database_path: &str) -> Result<Self, ProxyError> {
         let store = Self {
+            database_path: database_path.to_string(),
             pool: open_sqlite_pool(database_path, true, false).await?,
             token_binding_cache: RwLock::new(HashMap::new()),
             account_quota_resolution_cache: RwLock::new(HashMap::new()),
@@ -20,6 +21,7 @@ impl KeyStore {
         database_path: &str,
     ) -> Result<Self, ProxyError> {
         let store = Self {
+            database_path: database_path.to_string(),
             pool: open_sqlite_pool(database_path, true, false).await?,
             token_binding_cache: RwLock::new(HashMap::new()),
             account_quota_resolution_cache: RwLock::new(HashMap::new()),
@@ -1306,6 +1308,7 @@ impl KeyStore {
             CREATE TABLE IF NOT EXISTS scheduled_jobs (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 job_type TEXT NOT NULL,
+                trigger_source TEXT NOT NULL DEFAULT 'scheduler',
                 key_id TEXT,
                 status TEXT NOT NULL,
                 attempt INTEGER NOT NULL DEFAULT 1,
@@ -1318,6 +1321,17 @@ impl KeyStore {
         )
         .execute(&self.pool)
         .await?;
+
+        if !self
+            .table_column_exists("scheduled_jobs", "trigger_source")
+            .await?
+        {
+            sqlx::query(
+                "ALTER TABLE scheduled_jobs ADD COLUMN trigger_source TEXT NOT NULL DEFAULT 'scheduler'",
+            )
+            .execute(&self.pool)
+            .await?;
+        }
 
         self.ensure_meta_schema().await?;
 

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -1,7 +1,62 @@
 impl KeyStore {
+    fn sqlite_wal_path(&self) -> String {
+        format!("{}-wal", self.database_path)
+    }
+
+    pub(crate) async fn sqlite_db_stats(&self) -> Result<SqliteDbStats, ProxyError> {
+        let page_size: i64 = sqlx::query_scalar("PRAGMA page_size")
+            .fetch_one(&self.pool)
+            .await?;
+        let page_count: i64 = sqlx::query_scalar("PRAGMA page_count")
+            .fetch_one(&self.pool)
+            .await?;
+        let freelist_count: i64 = sqlx::query_scalar("PRAGMA freelist_count")
+            .fetch_one(&self.pool)
+            .await?;
+        let database_bytes = std::fs::metadata(&self.database_path)
+            .map(|meta| meta.len())
+            .unwrap_or(0);
+        let wal_bytes = std::fs::metadata(self.sqlite_wal_path())
+            .map(|meta| meta.len())
+            .unwrap_or(0);
+        let reclaimable_bytes = freelist_count.max(0) as u64 * page_size.max(0) as u64;
+        let total_pages = page_count.max(1) as f64;
+        Ok(SqliteDbStats {
+            database_bytes,
+            wal_bytes,
+            page_size,
+            page_count,
+            freelist_count,
+            reclaimable_bytes,
+            reclaimable_ratio: freelist_count.max(0) as f64 / total_pages,
+        })
+    }
+
+    pub(crate) async fn compact_sqlite_database(&self) -> Result<SqliteDbStats, ProxyError> {
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("VACUUM").execute(&self.pool).await?;
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .execute(&self.pool)
+            .await?;
+        self.sqlite_db_stats().await
+    }
+
     pub(crate) async fn scheduled_job_start(
         &self,
         job_type: &str,
+        key_id: Option<&str>,
+        attempt: i64,
+    ) -> Result<i64, ProxyError> {
+        self.scheduled_job_start_with_source(job_type, "scheduler", key_id, attempt)
+            .await
+    }
+
+    pub(crate) async fn scheduled_job_start_with_source(
+        &self,
+        job_type: &str,
+        trigger_source: &str,
         key_id: Option<&str>,
         attempt: i64,
     ) -> Result<i64, ProxyError> {
@@ -10,10 +65,11 @@ impl KeyStore {
         let mut retry_attempt = 0usize;
         let res = loop {
             match sqlx::query(
-                r#"INSERT INTO scheduled_jobs (job_type, key_id, status, attempt, started_at)
-                   VALUES (?, ?, 'running', ?, ?)"#,
+                r#"INSERT INTO scheduled_jobs (job_type, trigger_source, key_id, status, attempt, started_at)
+                   VALUES (?, ?, ?, 'running', ?, ?)"#,
             )
             .bind(job_type)
+            .bind(trigger_source)
             .bind(key_id)
             .bind(attempt)
             .bind(started_at)
@@ -39,6 +95,93 @@ impl KeyStore {
             }
         };
         Ok(res.last_insert_rowid())
+    }
+
+    pub(crate) async fn scheduled_job_claim(
+        &self,
+        job_type: &str,
+        trigger_source: &str,
+        key_id: Option<&str>,
+        attempt: i64,
+    ) -> Result<Option<i64>, ProxyError> {
+        let started_at = Utc::now().timestamp();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut retry_attempt = 0usize;
+        loop {
+            let result = async {
+                let mut conn = begin_immediate_sqlite_connection(&self.pool).await?;
+                let running: Option<i64> = sqlx::query_scalar(
+                    r#"
+                    SELECT id
+                    FROM scheduled_jobs
+                    WHERE job_type = ?
+                      AND status = 'running'
+                      AND ((key_id IS NULL AND ? IS NULL) OR key_id = ?)
+                    ORDER BY started_at DESC, id DESC
+                    LIMIT 1
+                    "#,
+                )
+                .bind(job_type)
+                .bind(key_id)
+                .bind(key_id)
+                .fetch_optional(&mut *conn)
+                .await?;
+                if running.is_some() {
+                    sqlx::query("COMMIT").execute(&mut *conn).await?;
+                    return Ok::<Option<i64>, ProxyError>(None);
+                }
+                let res = sqlx::query(
+                    r#"INSERT INTO scheduled_jobs (job_type, trigger_source, key_id, status, attempt, started_at)
+                       VALUES (?, ?, ?, 'running', ?, ?)"#,
+                )
+                .bind(job_type)
+                .bind(trigger_source)
+                .bind(key_id)
+                .bind(attempt)
+                .bind(started_at)
+                .execute(&mut *conn)
+                .await?;
+                sqlx::query("COMMIT").execute(&mut *conn).await?;
+                Ok(Some(res.last_insert_rowid()))
+            }
+            .await;
+
+            match result {
+                Ok(job_id) => return Ok(job_id),
+                Err(err) => {
+                    if sleep_before_sqlite_transient_write_retry(
+                        "scheduled job claim",
+                        retry_attempt,
+                        deadline,
+                        &err,
+                    )
+                    .await
+                    {
+                        retry_attempt += 1;
+                        continue;
+                    }
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn abandon_running_scheduled_jobs(&self) -> Result<u64, ProxyError> {
+        let now = Utc::now().timestamp();
+        sqlx::query(
+            r#"
+            UPDATE scheduled_jobs
+            SET status = 'abandoned',
+                message = COALESCE(message, 'abandoned after process restart'),
+                finished_at = ?
+            WHERE status = 'running' AND finished_at IS NULL
+            "#,
+        )
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .map(|result| result.rows_affected())
+        .map_err(ProxyError::from)
     }
 
     pub(crate) async fn scheduled_job_finish(

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -168,20 +168,40 @@ impl KeyStore {
 
     pub(crate) async fn abandon_running_scheduled_jobs(&self) -> Result<u64, ProxyError> {
         let now = Utc::now().timestamp();
-        sqlx::query(
-            r#"
-            UPDATE scheduled_jobs
-            SET status = 'abandoned',
-                message = COALESCE(message, 'abandoned after process restart'),
-                finished_at = ?
-            WHERE status = 'running' AND finished_at IS NULL
-            "#,
-        )
-        .bind(now)
-        .execute(&self.pool)
-        .await
-        .map(|result| result.rows_affected())
-        .map_err(ProxyError::from)
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut retry_attempt = 0usize;
+        loop {
+            match sqlx::query(
+                r#"
+                UPDATE scheduled_jobs
+                SET status = 'abandoned',
+                    message = COALESCE(message, 'abandoned after process restart'),
+                    finished_at = ?
+                WHERE status = 'running' AND finished_at IS NULL
+                "#,
+            )
+            .bind(now)
+            .execute(&self.pool)
+            .await
+            {
+                Ok(result) => return Ok(result.rows_affected()),
+                Err(err) => {
+                    let err = ProxyError::Database(err);
+                    if sleep_before_sqlite_transient_write_retry(
+                        "scheduled job abandon",
+                        retry_attempt,
+                        deadline,
+                        &err,
+                    )
+                    .await
+                    {
+                        retry_attempt += 1;
+                        continue;
+                    }
+                    return Err(err);
+                }
+            }
+        }
     }
 
     pub(crate) async fn scheduled_job_finish(

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -1733,6 +1733,7 @@ impl KeyStore {
             r#"SELECT
                     j.id,
                     j.job_type,
+                    j.trigger_source,
                     j.key_id,
                     k.group_name AS key_group,
                     j.status,
@@ -1754,6 +1755,7 @@ impl KeyStore {
                 Ok(JobLog {
                     id: row.try_get("id")?,
                     job_type: row.try_get("job_type")?,
+                    trigger_source: row.try_get("trigger_source")?,
                     key_id: row.try_get::<Option<String>, _>("key_id")?,
                     key_group: row.try_get::<Option<String>, _>("key_group")?,
                     status: row.try_get("status")?,
@@ -1810,6 +1812,7 @@ impl KeyStore {
             SELECT
                 j.id,
                 j.job_type,
+                j.trigger_source,
                 j.key_id,
                 k.group_name AS key_group,
                 j.status,
@@ -1838,6 +1841,7 @@ impl KeyStore {
                 Ok(JobLog {
                     id: row.try_get("id")?,
                     job_type: row.try_get("job_type")?,
+                    trigger_source: row.try_get("trigger_source")?,
                     key_id: row.try_get::<Option<String>, _>("key_id")?,
                     key_group: row.try_get::<Option<String>, _>("key_group")?,
                     status: row.try_get("status")?,
@@ -1861,8 +1865,11 @@ impl KeyStore {
             "logs" => format!(
                 "{column} = 'auth_token_logs_gc' OR {column} = 'request_logs_gc' OR {column} = 'log_cleanup'"
             ),
+            "db" => format!("{column} = 'db_compaction'"),
             "geo" => format!("{column} = 'forward_proxy_geo_refresh'"),
-            "linuxdo" => format!("{column} = 'linuxdo_user_status_sync'"),
+            "linuxdo" => format!(
+                "{column} = 'linuxdo_user_status_sync' OR {column} = 'linuxdo_user_tag_binding_refresh'"
+            ),
             _ => return String::new(),
         };
         format!("WHERE {condition}")
@@ -1876,8 +1883,9 @@ impl KeyStore {
                 COALESCE(SUM(CASE WHEN job_type = 'quota_sync' OR job_type = 'quota_sync/manual' OR job_type = 'quota_sync/hot' THEN 1 ELSE 0 END), 0) AS quota_count,
                 COALESCE(SUM(CASE WHEN job_type = 'token_usage_rollup' OR job_type = 'usage_aggregation' THEN 1 ELSE 0 END), 0) AS usage_count,
                 COALESCE(SUM(CASE WHEN job_type = 'auth_token_logs_gc' OR job_type = 'request_logs_gc' OR job_type = 'log_cleanup' THEN 1 ELSE 0 END), 0) AS logs_count,
+                COALESCE(SUM(CASE WHEN job_type = 'db_compaction' THEN 1 ELSE 0 END), 0) AS db_count,
                 COALESCE(SUM(CASE WHEN job_type = 'forward_proxy_geo_refresh' THEN 1 ELSE 0 END), 0) AS geo_count,
-                COALESCE(SUM(CASE WHEN job_type = 'linuxdo_user_status_sync' THEN 1 ELSE 0 END), 0) AS linuxdo_count
+                COALESCE(SUM(CASE WHEN job_type = 'linuxdo_user_status_sync' OR job_type = 'linuxdo_user_tag_binding_refresh' THEN 1 ELSE 0 END), 0) AS linuxdo_count
             FROM scheduled_jobs
             "#,
         )
@@ -1889,6 +1897,7 @@ impl KeyStore {
             quota: row.try_get("quota_count")?,
             usage: row.try_get("usage_count")?,
             logs: row.try_get("logs_count")?,
+            db: row.try_get("db_count")?,
             geo: row.try_get("geo_count")?,
             linuxdo: row.try_get("linuxdo_count")?,
         })

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1400,6 +1400,7 @@ pub(crate) struct UserDebugInfoSharedCacheEntry {
 
 #[derive(Debug)]
 pub(crate) struct KeyStore {
+    pub(crate) database_path: String,
     pub(crate) pool: SqlitePool,
     pub(crate) token_binding_cache: RwLock<HashMap<String, TokenBindingCacheEntry>>,
     pub(crate) account_quota_resolution_cache:

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -416,6 +416,42 @@ impl TavilyProxy {
             .await
     }
 
+    pub async fn scheduled_job_start_with_source(
+        &self,
+        job_type: &str,
+        trigger_source: &str,
+        key_id: Option<&str>,
+        attempt: i64,
+    ) -> Result<i64, ProxyError> {
+        self.key_store
+            .scheduled_job_start_with_source(job_type, trigger_source, key_id, attempt)
+            .await
+    }
+
+    pub async fn scheduled_job_claim(
+        &self,
+        job_type: &str,
+        trigger_source: &str,
+        key_id: Option<&str>,
+        attempt: i64,
+    ) -> Result<Option<i64>, ProxyError> {
+        self.key_store
+            .scheduled_job_claim(job_type, trigger_source, key_id, attempt)
+            .await
+    }
+
+    pub async fn abandon_running_scheduled_jobs(&self) -> Result<u64, ProxyError> {
+        self.key_store.abandon_running_scheduled_jobs().await
+    }
+
+    pub async fn sqlite_db_stats(&self) -> Result<SqliteDbStats, ProxyError> {
+        self.key_store.sqlite_db_stats().await
+    }
+
+    pub async fn compact_sqlite_database(&self) -> Result<SqliteDbStats, ProxyError> {
+        self.key_store.compact_sqlite_database().await
+    }
+
     pub async fn scheduled_job_finish(
         &self,
         job_id: i64,

--- a/src/tests/chunk_01.rs
+++ b/src/tests/chunk_01.rs
@@ -2296,6 +2296,7 @@ async fn request_kind_database_migration_retries_after_transient_write_lock() {
         .await
         .expect("busy-test pool");
     let store = KeyStore {
+        database_path: db_path.to_string_lossy().into_owned(),
         pool,
         token_binding_cache: RwLock::new(std::collections::HashMap::new()),
         account_quota_resolution_cache: RwLock::new(std::collections::HashMap::new()),

--- a/src/tests/chunk_06.rs
+++ b/src/tests/chunk_06.rs
@@ -1374,21 +1374,35 @@ async fn list_recent_jobs_paginated_includes_key_group() {
         .await
         .expect("finish linuxdo job");
 
+    let linuxdo_tag_refresh_job_id = proxy
+        .scheduled_job_start("linuxdo_user_tag_binding_refresh", None, 1)
+        .await
+        .expect("start linuxdo tag refresh job");
+    proxy
+        .scheduled_job_finish(
+            linuxdo_tag_refresh_job_id,
+            "success",
+            Some("refreshed=4"),
+        )
+        .await
+        .expect("finish linuxdo tag refresh job");
+
     let (items, total, group_counts) = proxy
         .list_recent_jobs_paginated("all", 1, 10)
         .await
         .expect("list jobs");
 
-    assert_eq!(total, 6);
+    assert_eq!(total, 7);
     assert_eq!(
         group_counts,
         JobGroupCounts {
-            all: 6,
+            all: 7,
             quota: 2,
             usage: 1,
             logs: 1,
+            db: 0,
             geo: 1,
-            linuxdo: 1,
+            linuxdo: 2,
         }
     );
 
@@ -1439,11 +1453,20 @@ async fn list_recent_jobs_paginated_includes_key_group() {
         .list_recent_jobs_paginated("linuxdo", 1, 10)
         .await
         .expect("list linuxdo jobs");
-    assert_eq!(linuxdo_total, 1);
-    assert_eq!(linuxdo_items.len(), 1);
-    assert_eq!(linuxdo_items[0].job_type, "linuxdo_user_status_sync");
-    assert_eq!(linuxdo_items[0].key_id, None);
-    assert_eq!(linuxdo_counts.linuxdo, 1);
+    assert_eq!(linuxdo_total, 2);
+    assert_eq!(linuxdo_items.len(), 2);
+    assert!(
+        linuxdo_items
+            .iter()
+            .any(|item| item.job_type == "linuxdo_user_status_sync" && item.key_id.is_none())
+    );
+    assert!(
+        linuxdo_items
+            .iter()
+            .any(|item| item.job_type == "linuxdo_user_tag_binding_refresh"
+                && item.key_id.is_none())
+    );
+    assert_eq!(linuxdo_counts.linuxdo, 2);
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/tests/chunk_09.rs
+++ b/src/tests/chunk_09.rs
@@ -122,8 +122,7 @@ async fn scheduled_job_claim_serializes_concurrent_duplicate_triggers() {
     .await;
     let claimed: Vec<i64> = results
         .into_iter()
-        .map(|result| result.expect("claim should not error"))
-        .flatten()
+        .filter_map(|result| result.expect("claim should not error"))
         .collect();
     assert_eq!(claimed.len(), 1);
 

--- a/src/tests/chunk_09.rs
+++ b/src/tests/chunk_09.rs
@@ -66,6 +66,137 @@ async fn scheduled_job_start_retries_transient_sqlite_write_lock() {
 }
 
 #[tokio::test]
+async fn scheduled_job_claim_records_trigger_source_and_rejects_duplicate_running_job() {
+    let db_path = temp_db_path("scheduled-job-claim-trigger-source");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+
+    let job_id = proxy
+        .scheduled_job_claim("request_logs_gc", "manual", None, 1)
+        .await
+        .expect("claim manual job")
+        .expect("manual job claimed");
+    let duplicate = proxy
+        .scheduled_job_claim("request_logs_gc", "manual", None, 1)
+        .await
+        .expect("duplicate claim checked");
+    assert!(duplicate.is_none());
+
+    let trigger_source: String =
+        sqlx::query_scalar("SELECT trigger_source FROM scheduled_jobs WHERE id = ?")
+            .bind(job_id)
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read trigger source");
+    assert_eq!(trigger_source, "manual");
+
+    proxy
+        .scheduled_job_finish(job_id, "success", Some("done"))
+        .await
+        .expect("finish job");
+    let after_finish = proxy
+        .scheduled_job_claim("request_logs_gc", "manual", None, 1)
+        .await
+        .expect("claim after finish")
+        .expect("job claimed after finish");
+    assert!(after_finish > job_id);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn scheduled_job_claim_serializes_concurrent_duplicate_triggers() {
+    let db_path = temp_db_path("scheduled-job-claim-concurrent");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+
+    let results = futures_util::future::join_all((0..8).map(|_| {
+        proxy.scheduled_job_claim("db_compaction", "manual", None, 1)
+    }))
+    .await;
+    let claimed: Vec<i64> = results
+        .into_iter()
+        .map(|result| result.expect("claim should not error"))
+        .flatten()
+        .collect();
+    assert_eq!(claimed.len(), 1);
+
+    let running_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM scheduled_jobs WHERE job_type = 'db_compaction' AND status = 'running'")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("count running jobs");
+    assert_eq!(running_count, 1);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn abandoned_running_scheduled_jobs_unblocks_future_claims() {
+    let db_path = temp_db_path("scheduled-job-abandon-running");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+
+    let stale_job_id = proxy
+        .scheduled_job_claim("db_compaction", "auto", None, 1)
+        .await
+        .expect("claim stale job")
+        .expect("stale job claimed");
+    let abandoned = proxy
+        .abandon_running_scheduled_jobs()
+        .await
+        .expect("abandon stale jobs");
+    assert_eq!(abandoned, 1);
+
+    let status: String = sqlx::query_scalar("SELECT status FROM scheduled_jobs WHERE id = ?")
+        .bind(stale_job_id)
+        .fetch_one(&proxy.key_store.pool)
+        .await
+        .expect("read abandoned status");
+    assert_eq!(status, "abandoned");
+
+    let next_job_id = proxy
+        .scheduled_job_claim("db_compaction", "manual", None, 1)
+        .await
+        .expect("claim after abandoned")
+        .expect("new job claimed");
+    assert!(next_job_id > stale_job_id);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn sqlite_db_stats_reports_reclaimable_shape() {
+    let db_path = temp_db_path("sqlite-db-stats-shape");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+
+    let stats = proxy.sqlite_db_stats().await.expect("db stats");
+    assert!(stats.page_size > 0);
+    assert!(stats.page_count > 0);
+    assert!(stats.database_bytes > 0);
+    assert!(stats.reclaimable_ratio >= 0.0);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
 async fn startup_linuxdo_tag_backfill_does_not_rewrite_correct_binding() {
     let _guard = env_lock().lock_owned().await;
     let db_path = temp_db_path("linuxdo-system-tags-backfill-marker");

--- a/src/tests/chunk_09.rs
+++ b/src/tests/chunk_09.rs
@@ -66,6 +66,38 @@ async fn scheduled_job_start_retries_transient_sqlite_write_lock() {
 }
 
 #[tokio::test]
+async fn abandon_running_scheduled_jobs_retries_transient_sqlite_write_lock() {
+    let db_path = temp_db_path("scheduled-job-abandon-retries-sqlite-lock");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let job_id = proxy
+        .scheduled_job_start("sqlite_lock_retry_test", None, 1)
+        .await
+        .expect("scheduled job starts");
+    let release = hold_sqlite_write_lock_for_test(&proxy.key_store.pool).await;
+
+    let abandoned = proxy
+        .abandon_running_scheduled_jobs()
+        .await
+        .expect("abandon retries after transient sqlite write lock");
+    assert_eq!(abandoned, 1);
+    release.await.expect("release task");
+
+    let status: String = sqlx::query_scalar("SELECT status FROM scheduled_jobs WHERE id = ?")
+        .bind(job_id)
+        .fetch_one(&proxy.key_store.pool)
+        .await
+        .expect("read job status");
+    assert_eq!(status, "abandoned");
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
 async fn scheduled_job_claim_records_trigger_source_and_rejects_duplicate_running_job() {
     let db_path = temp_db_path("scheduled-job-claim-trigger-source");
     let db_str = db_path.to_string_lossy().to_string();

--- a/web/src/admin/AdminDashboardRuntime.tsx
+++ b/web/src/admin/AdminDashboardRuntime.tsx
@@ -66,6 +66,7 @@ import { AdminUserDetailQuotaWorkspace } from './AdminUserDetailQuotaWorkspace'
 import AdminShell, { AdminShellSidebarUtility, type AdminNavItem, type AdminNavTarget } from './AdminShell'
 import AdminOverlayHost from './AdminOverlayHost'
 import DashboardOverview, { type DashboardQuotaChargeCardData } from './DashboardOverview'
+import AdminJobTriggerMenu from './AdminJobTriggerMenu'
 import { AnchoredApiKeyBulkSyncProgressBubble } from './ApiKeyBulkSyncProgressBubble'
 import {
   createDashboardMonthMetrics,
@@ -74,6 +75,7 @@ import {
 import {
   buildAdminJobFilterOptions,
   emptyAdminJobGroupCounts,
+  jobSourceLabel,
   summarizeAdminJobFilter,
 } from './jobFilters'
 import {
@@ -1450,12 +1452,6 @@ function jobTypeLabel(jobType: string, strings: AdminTranslations['jobs']): stri
     .replace(/[\/_]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
-}
-
-function jobSourceLabel(source: string | null | undefined, strings: AdminTranslations['jobs']): string {
-  const normalized = String(source ?? '').trim().toLowerCase()
-  if (!normalized) return '—'
-  return strings.sources?.[normalized] ?? normalized
 }
 
 function jobStatusLabel(status: string): string {
@@ -5210,21 +5206,6 @@ function AdminDashboard(): JSX.Element {
     setJobFilter(value)
     setJobsPage(1)
   }, [])
-
-  const manualJobActions = useMemo(
-    () => [
-      'token_usage_rollup',
-      'auth_token_logs_gc',
-      'request_logs_gc',
-      'mcp_sessions_gc',
-      'mcp_session_init_backoffs_gc',
-      'linuxdo_user_status_sync',
-      'linuxdo_user_tag_binding_refresh',
-      'forward_proxy_geo_refresh',
-      'db_compaction',
-    ],
-    [],
-  )
 
   const handleManualJobTrigger = useCallback(
     (jobType: string) => {
@@ -9768,32 +9749,13 @@ function AdminDashboard(): JSX.Element {
   const renderJobFilterToolbar = (className?: string) => (
     <div className={['admin-module-toolbar admin-module-toolbar--end', className].filter(Boolean).join(' ')}>
       <div className="panel-actions">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button type="button" variant="outline" size="sm" disabled={jobsBlocking || jobTriggering != null}>
-              <Icon icon="mdi:play-circle-outline" width={16} height={16} aria-hidden="true" />
-              <span style={{ whiteSpace: 'nowrap' }}>
-                {jobTriggering ? jobTypeLabel(jobTriggering, jobsStrings) : jobsStrings.actions.trigger}
-              </span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-80">
-            <DropdownMenuLabel>{jobsStrings.title}</DropdownMenuLabel>
-            {manualJobActions.map((jobType) => (
-              <DropdownMenuItem
-                key={jobType}
-                disabled={jobTriggering != null}
-                onSelect={(event) => {
-                  event.preventDefault()
-                  handleManualJobTrigger(jobType)
-                }}
-              >
-                <Icon icon="mdi:play-outline" width={16} height={16} aria-hidden="true" />
-                <span>{jobTypeLabel(jobType, jobsStrings)}</span>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <AdminJobTriggerMenu
+          disabled={jobsBlocking}
+          triggeringJobType={jobTriggering}
+          strings={jobsStrings}
+          labelForJobType={(jobType) => jobTypeLabel(jobType, jobsStrings)}
+          onTrigger={handleManualJobTrigger}
+        />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/web/src/admin/AdminDashboardRuntime.tsx
+++ b/web/src/admin/AdminDashboardRuntime.tsx
@@ -225,6 +225,7 @@ import {
   fetchApiKeyDetail,
   syncApiKeyUsage,
   fetchJobs,
+  triggerJob,
   fetchTokenGroups,
   type AdminUsersSortField,
   fetchAdminUsers,
@@ -1451,6 +1452,12 @@ function jobTypeLabel(jobType: string, strings: AdminTranslations['jobs']): stri
     .trim()
 }
 
+function jobSourceLabel(source: string | null | undefined, strings: AdminTranslations['jobs']): string {
+  const normalized = String(source ?? '').trim().toLowerCase()
+  if (!normalized) return '—'
+  return strings.sources?.[normalized] ?? normalized
+}
+
 function jobStatusLabel(status: string): string {
   const normalized = status.trim().toLowerCase()
   if (!normalized) return '—'
@@ -1780,6 +1787,7 @@ function AdminDashboard(): JSX.Element {
   const [jobsGroupCounts, setJobsGroupCounts] = useState<JobGroupCounts>(() => emptyAdminJobGroupCounts())
   const [jobsLoadState, setJobsLoadState] = useState<QueryLoadState>('initial_loading')
   const [jobsError, setJobsError] = useState<string | null>(null)
+  const [jobTriggering, setJobTriggering] = useState<string | null>(null)
   const [users, setUsers] = useState<AdminUserSummary[]>([])
   const [usersTotal, setUsersTotal] = useState(0)
   const [usersPage, setUsersPage] = useState(() => getAdminUsersPageFromLocation())
@@ -5202,6 +5210,41 @@ function AdminDashboard(): JSX.Element {
     setJobFilter(value)
     setJobsPage(1)
   }, [])
+
+  const manualJobActions = useMemo(
+    () => [
+      'token_usage_rollup',
+      'auth_token_logs_gc',
+      'request_logs_gc',
+      'mcp_sessions_gc',
+      'mcp_session_init_backoffs_gc',
+      'linuxdo_user_status_sync',
+      'linuxdo_user_tag_binding_refresh',
+      'forward_proxy_geo_refresh',
+      'db_compaction',
+    ],
+    [],
+  )
+
+  const handleManualJobTrigger = useCallback(
+    (jobType: string) => {
+      setJobTriggering(jobType)
+      setJobsError(null)
+      triggerJob(jobType)
+        .then(() => fetchJobs(jobsPage, jobsPerPage, jobFilter))
+        .then((result) => {
+          setJobs(result.items)
+          setJobsTotal(result.total)
+          setJobsGroupCounts(result.groupCounts)
+          setJobsLoadState('ready')
+        })
+        .catch((err) => {
+          setJobsError(err instanceof Error ? err.message : loadingStateStrings.error)
+        })
+        .finally(() => setJobTriggering(null))
+    },
+    [jobFilter, jobsPage, loadingStateStrings.error],
+  )
 
   const keysBatchFirstLine = useMemo(() => {
     return newKeysText.split(/\r?\n/)[0] ?? ''
@@ -9727,6 +9770,32 @@ function AdminDashboard(): JSX.Element {
       <div className="panel-actions">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
+            <Button type="button" variant="outline" size="sm" disabled={jobsBlocking || jobTriggering != null}>
+              <Icon icon="mdi:play-circle-outline" width={16} height={16} aria-hidden="true" />
+              <span style={{ whiteSpace: 'nowrap' }}>
+                {jobTriggering ? jobTypeLabel(jobTriggering, jobsStrings) : jobsStrings.actions.trigger}
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-80">
+            <DropdownMenuLabel>{jobsStrings.title}</DropdownMenuLabel>
+            {manualJobActions.map((jobType) => (
+              <DropdownMenuItem
+                key={jobType}
+                disabled={jobTriggering != null}
+                onSelect={(event) => {
+                  event.preventDefault()
+                  handleManualJobTrigger(jobType)
+                }}
+              >
+                <Icon icon="mdi:play-outline" width={16} height={16} aria-hidden="true" />
+                <span>{jobTypeLabel(jobType, jobsStrings)}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
             <Button
               type="button"
               variant="outline"
@@ -11347,7 +11416,7 @@ function AdminDashboard(): JSX.Element {
           {jobs.length === 0 ? (
             <tbody>
               <tr>
-                <td colSpan={7}>
+                <td colSpan={8}>
                   <div className="empty-state alert">{jobsStrings.empty.none}</div>
                 </td>
               </tr>
@@ -11360,6 +11429,7 @@ function AdminDashboard(): JSX.Element {
                   <th>{jobsStrings.table.type}</th>
                   <th>{jobsStrings.table.key}</th>
                   <th>{jobsStrings.table.status}</th>
+                  <th>{jobsStrings.table.source}</th>
                   <th>{jobsStrings.table.attempt}</th>
                   <th>{jobsStrings.table.started}</th>
                   <th>{jobsStrings.table.message}</th>
@@ -11369,6 +11439,7 @@ function AdminDashboard(): JSX.Element {
                 {jobs.map((j) => {
                   const jt = j.job_type
                   const jobTypeLabelText = jobTypeLabel(jt, jobsStrings)
+                  const jobSourceText = jobSourceLabel(j.trigger_source, jobsStrings)
                   const jobStatusText = jobStatusLabel(String(j.status ?? ''))
                   const keyId = j.key_id
                   const keyGroup = j.key_group
@@ -11417,6 +11488,7 @@ function AdminDashboard(): JSX.Element {
                           {jobStatusText}
                         </StatusBadge>
                       </td>
+                      <td>{jobSourceText}</td>
                       <td>{j.attempt}</td>
                       <td>{started ? startedTimeLabel : '—'}</td>
                       <td className="jobs-message-cell">
@@ -11449,7 +11521,7 @@ function AdminDashboard(): JSX.Element {
                   if (isExpanded) {
                     rows.push(
                       <tr key={`${j.id}-details`} className="log-details-row">
-                        <td colSpan={7} id={`job-details-${j.id}`}>
+                        <td colSpan={8} id={`job-details-${j.id}`}>
                           <div className="log-details-panel">
                             <div className="log-details-summary">
                               <div>
@@ -11496,6 +11568,10 @@ function AdminDashboard(): JSX.Element {
                               <div>
                                 <div className="log-details-label">{jobsStrings.table.status}</div>
                                 <div className="log-details-value">{jobStatusText}</div>
+                              </div>
+                              <div>
+                                <div className="log-details-label">{jobsStrings.table.source}</div>
+                                <div className="log-details-value">{jobSourceText}</div>
                               </div>
                               <div>
                                 <div className="log-details-label">{jobsStrings.table.attempt}</div>
@@ -11583,6 +11659,10 @@ function AdminDashboard(): JSX.Element {
                     <StatusBadge tone={statusTone(j.status)} title={String(j.status ?? '')}>
                       {jobStatusLabel(String(j.status ?? ''))}
                     </StatusBadge>
+                  </div>
+                  <div className="admin-mobile-kv">
+                    <span>{jobsStrings.table.source}</span>
+                    <strong>{jobSourceLabel(j.trigger_source, jobsStrings)}</strong>
                   </div>
                   <div className="admin-mobile-kv">
                     <span>{jobsStrings.table.attempt}</span>

--- a/web/src/admin/AdminJobTriggerMenu.tsx
+++ b/web/src/admin/AdminJobTriggerMenu.tsx
@@ -1,0 +1,56 @@
+import { Icon } from '../lib/icons'
+import { Button } from '../components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu'
+import type { AdminTranslations } from '../i18n'
+import { MANUAL_JOB_ACTIONS } from './jobFilters'
+
+interface AdminJobTriggerMenuProps {
+  disabled: boolean
+  triggeringJobType: string | null
+  strings: AdminTranslations['jobs']
+  labelForJobType: (jobType: string) => string
+  onTrigger: (jobType: string) => void
+}
+
+export default function AdminJobTriggerMenu({
+  disabled,
+  triggeringJobType,
+  strings,
+  labelForJobType,
+  onTrigger,
+}: AdminJobTriggerMenuProps): JSX.Element {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm" disabled={disabled || triggeringJobType != null}>
+          <Icon icon="mdi:play-circle-outline" width={16} height={16} aria-hidden="true" />
+          <span style={{ whiteSpace: 'nowrap' }}>
+            {triggeringJobType ? labelForJobType(triggeringJobType) : strings.actions.trigger}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80">
+        <DropdownMenuLabel>{strings.title}</DropdownMenuLabel>
+        {MANUAL_JOB_ACTIONS.map((jobType) => (
+          <DropdownMenuItem
+            key={jobType}
+            disabled={triggeringJobType != null}
+            onSelect={(event) => {
+              event.preventDefault()
+              onTrigger(jobType)
+            }}
+          >
+            <Icon icon="mdi:play-outline" width={16} height={16} aria-hidden="true" />
+            <span>{labelForJobType(jobType)}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/src/admin/AdminPages.stories.test.ts
+++ b/web/src/admin/AdminPages.stories.test.ts
@@ -97,6 +97,26 @@ describe('AdminPages Storybook proofs', () => {
     expect(markup).not.toContain('10 页')
   })
 
+  it('renders the jobs story with manual trigger controls and source labels', () => {
+    const renderStory = adminPageStories.Jobs.render as (() => JSX.Element) | undefined
+    expect(renderStory).toBeDefined()
+
+    const markup = renderToStaticMarkup(
+      createElement(
+        LanguageProvider,
+        { initialLanguage: 'en' },
+        createElement(ThemeProvider, null, createElement(TooltipProvider, null, createElement(renderStory!))),
+      ),
+    )
+
+    expect(markup).toContain('Run')
+    expect(markup).toContain('DB compaction is already running; manual trigger was not queued.')
+    expect(markup).toContain('DB compaction')
+    expect(markup).toContain('Auto')
+    expect(markup).toContain('Manual')
+    expect(markup).toContain('Scheduled')
+  })
+
   it('keeps the tokens story title and creation toolbar on the shell chrome', () => {
     const renderStory = adminPageStories.Tokens.render as (() => JSX.Element) | undefined
     expect(renderStory).toBeDefined()

--- a/web/src/admin/DashboardOverview.stories.tsx
+++ b/web/src/admin/DashboardOverview.stories.tsx
@@ -717,10 +717,10 @@ export const Default: Story = {
       { id: 2, key_id: 'MZli', auth_token_id: '9vsN', method: 'POST', path: '/mcp', query: null, http_status: 429, mcp_status: -1, result_status: 'quota_exhausted', created_at: 2, error_message: 'quota', request_body: null, response_body: null, forwarded_headers: [], dropped_headers: [], operationalClass: 'quota_exhausted', requestKindProtocolGroup: 'mcp', requestKindBillingGroup: 'billable' },
     ],
     jobs: [
-      { id: 4, job_type: 'linuxdo_user_status_sync', key_id: null, key_group: null, status: 'error', attempt: 1, message: 'attempted=18 success=17 skipped=0 failure=1 first_failure=hhf0517: token upstream status 400: {\"error\":\"invalid_grant\"}', started_at: 7, finished_at: 8 },
-      { id: 3, job_type: 'forward_proxy_geo_refresh', key_id: null, key_group: null, status: 'success', attempt: 1, message: 'refreshed_candidates=9', started_at: 5, finished_at: 6 },
-      { id: 1, job_type: 'quota_sync', key_id: 'MZli', key_group: 'ops', status: 'error', attempt: 2, message: 'rate limit', started_at: 1, finished_at: 2 },
-      { id: 2, job_type: 'quota_sync', key_id: 'MZli', key_group: 'ops', status: 'success', attempt: 1, message: null, started_at: 3, finished_at: 4 },
+      { id: 4, job_type: 'linuxdo_user_status_sync', trigger_source: 'scheduler', key_id: null, key_group: null, status: 'error', attempt: 1, message: 'attempted=18 success=17 skipped=0 failure=1 first_failure=hhf0517: token upstream status 400: {\"error\":\"invalid_grant\"}', started_at: 7, finished_at: 8 },
+      { id: 3, job_type: 'forward_proxy_geo_refresh', trigger_source: 'manual', key_id: null, key_group: null, status: 'success', attempt: 1, message: 'refreshed_candidates=9', started_at: 5, finished_at: 6 },
+      { id: 1, job_type: 'quota_sync', trigger_source: 'manual', key_id: 'MZli', key_group: 'ops', status: 'error', attempt: 2, message: 'rate limit', started_at: 1, finished_at: 2 },
+      { id: 2, job_type: 'quota_sync', trigger_source: 'scheduler', key_id: 'MZli', key_group: 'ops', status: 'success', attempt: 1, message: null, started_at: 3, finished_at: 4 },
     ],
     recentAlerts,
     onOpenModule: () => {},
@@ -772,9 +772,9 @@ export const QuarantineState: Story = {
       { id: 1, key_id: 'Qn8R', auth_token_id: '9vsN', method: 'POST', path: '/mcp', query: null, http_status: 401, mcp_status: -1, result_status: 'error', created_at: 1, error_message: 'account deactivated', request_body: null, response_body: null, forwarded_headers: [], dropped_headers: [], operationalClass: 'upstream_error', requestKindProtocolGroup: 'mcp', requestKindBillingGroup: 'billable' },
     ],
     jobs: [
-      { id: 3, job_type: 'linuxdo_user_status_sync', key_id: null, key_group: null, status: 'success', attempt: 1, message: 'attempted=4 success=4 skipped=0 failure=0', started_at: 5, finished_at: 6 },
-      { id: 2, job_type: 'forward_proxy_geo_refresh', key_id: null, key_group: null, status: 'success', attempt: 1, message: 'refreshed_candidates=4', started_at: 3, finished_at: 4 },
-      { id: 1, job_type: 'quota_sync', key_id: 'Qn8R', key_group: 'ops', status: 'error', attempt: 1, message: 'account deactivated', started_at: 1, finished_at: 2 },
+      { id: 3, job_type: 'linuxdo_user_status_sync', trigger_source: 'scheduler', key_id: null, key_group: null, status: 'success', attempt: 1, message: 'attempted=4 success=4 skipped=0 failure=0', started_at: 5, finished_at: 6 },
+      { id: 2, job_type: 'forward_proxy_geo_refresh', trigger_source: 'manual', key_id: null, key_group: null, status: 'success', attempt: 1, message: 'refreshed_candidates=4', started_at: 3, finished_at: 4 },
+      { id: 1, job_type: 'quota_sync', trigger_source: 'manual', key_id: 'Qn8R', key_group: 'ops', status: 'error', attempt: 1, message: 'account deactivated', started_at: 1, finished_at: 2 },
     ],
   },
 }

--- a/web/src/admin/jobFilters.test.ts
+++ b/web/src/admin/jobFilters.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test'
+
+import { countAdminJobGroups, jobMatchesGroup } from './jobFilters'
+import type { JobLogView } from '../api'
+
+describe('admin job filters', () => {
+  it('groups LinuxDo tag refresh jobs with LinuxDo maintenance', () => {
+    expect(jobMatchesGroup('linuxdo_user_tag_binding_refresh', 'linuxdo')).toBe(true)
+
+    const jobs: JobLogView[] = [
+      {
+        id: 1,
+        job_type: 'linuxdo_user_tag_binding_refresh',
+        trigger_source: 'manual',
+        key_id: null,
+        key_group: null,
+        status: 'success',
+        attempt: 1,
+        message: null,
+        started_at: 1,
+        finished_at: 2,
+      },
+    ]
+
+    expect(countAdminJobGroups(jobs).linuxdo).toBe(1)
+  })
+})

--- a/web/src/admin/jobFilters.ts
+++ b/web/src/admin/jobFilters.ts
@@ -8,6 +8,17 @@ export interface AdminJobFilterOption {
 }
 
 const JOB_GROUP_VALUES = ['all', 'quota', 'usage', 'logs', 'db', 'geo', 'linuxdo'] as const
+export const MANUAL_JOB_ACTIONS = [
+  'token_usage_rollup',
+  'auth_token_logs_gc',
+  'request_logs_gc',
+  'mcp_sessions_gc',
+  'mcp_session_init_backoffs_gc',
+  'linuxdo_user_status_sync',
+  'linuxdo_user_tag_binding_refresh',
+  'forward_proxy_geo_refresh',
+  'db_compaction',
+] as const
 
 const QUOTA_JOB_TYPES = new Set(['quota_sync', 'quota_sync/manual', 'quota_sync/hot'])
 const USAGE_JOB_TYPES = new Set(['token_usage_rollup', 'usage_aggregation'])
@@ -67,6 +78,11 @@ export function jobFilterLabel(group: JobGroup, strings: AdminTranslations['jobs
     default:
       return strings.filters.all
   }
+}
+
+export function jobSourceLabel(source: string | null | undefined, strings: AdminTranslations['jobs']): string {
+  const normalized = String(source ?? '').trim().toLowerCase()
+  return normalized ? strings.sources?.[normalized] ?? normalized : '—'
 }
 
 export function buildAdminJobFilterOptions(

--- a/web/src/admin/jobFilters.ts
+++ b/web/src/admin/jobFilters.ts
@@ -7,13 +7,14 @@ export interface AdminJobFilterOption {
   count: number
 }
 
-const JOB_GROUP_VALUES = ['all', 'quota', 'usage', 'logs', 'geo', 'linuxdo'] as const
+const JOB_GROUP_VALUES = ['all', 'quota', 'usage', 'logs', 'db', 'geo', 'linuxdo'] as const
 
 const QUOTA_JOB_TYPES = new Set(['quota_sync', 'quota_sync/manual', 'quota_sync/hot'])
 const USAGE_JOB_TYPES = new Set(['token_usage_rollup', 'usage_aggregation'])
 const LOG_JOB_TYPES = new Set(['auth_token_logs_gc', 'request_logs_gc', 'log_cleanup'])
+const DB_JOB_TYPES = new Set(['db_compaction'])
 const GEO_JOB_TYPES = new Set(['forward_proxy_geo_refresh'])
-const LINUXDO_JOB_TYPES = new Set(['linuxdo_user_status_sync'])
+const LINUXDO_JOB_TYPES = new Set(['linuxdo_user_status_sync', 'linuxdo_user_tag_binding_refresh'])
 
 export function emptyAdminJobGroupCounts(): JobGroupCounts {
   return {
@@ -21,6 +22,7 @@ export function emptyAdminJobGroupCounts(): JobGroupCounts {
     quota: 0,
     usage: 0,
     logs: 0,
+    db: 0,
     geo: 0,
     linuxdo: 0,
   }
@@ -35,6 +37,8 @@ export function jobMatchesGroup(jobType: string, group: JobGroup): boolean {
       return USAGE_JOB_TYPES.has(normalized)
     case 'logs':
       return LOG_JOB_TYPES.has(normalized)
+    case 'db':
+      return DB_JOB_TYPES.has(normalized)
     case 'geo':
       return GEO_JOB_TYPES.has(normalized)
     case 'linuxdo':
@@ -53,6 +57,8 @@ export function jobFilterLabel(group: JobGroup, strings: AdminTranslations['jobs
       return strings.filters.usage
     case 'logs':
       return strings.filters.logs
+    case 'db':
+      return strings.filters.db
     case 'geo':
       return strings.filters.geo
     case 'linuxdo':

--- a/web/src/admin/storySupport/AdminPagesStoryRuntime.tsx
+++ b/web/src/admin/storySupport/AdminPagesStoryRuntime.tsx
@@ -84,6 +84,7 @@ import {
 } from '../../tokenLogRequestKinds'
 
 import AdminShell, { AdminShellSidebarUtility, type AdminNavItem, type AdminNavTarget } from '../AdminShell'
+import AdminJobTriggerMenu from '../AdminJobTriggerMenu'
 import AlertsCenter from '../AlertsCenter'
 import DashboardOverview, { type DashboardMetricCard } from '../DashboardOverview'
 import { UserDetailQuotaBreakdown } from '../UserDetailQuotaBreakdown'
@@ -97,6 +98,7 @@ import {
 import {
   buildAdminJobFilterOptions,
   countAdminJobGroups,
+  jobSourceLabel,
   jobMatchesGroup,
   summarizeAdminJobFilter,
 } from '../jobFilters'
@@ -4563,13 +4565,6 @@ function JobsPageCanvas(): JSX.Element {
     () => MOCK_JOBS.filter((job) => jobMatchesGroup(job.job_type, jobFilter)),
     [jobFilter],
   )
-  const manualJobActions = [
-    'token_usage_rollup',
-    'request_logs_gc',
-    'forward_proxy_geo_refresh',
-    'db_compaction',
-  ]
-
   const runStoryJob = (jobType: string) => {
     setJobTriggering(jobType)
     setJobTriggerNotice(
@@ -4601,32 +4596,13 @@ function JobsPageCanvas(): JSX.Element {
             <p className="panel-description">{jobsStrings.description}</p>
           </div>
           <div className="panel-actions">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button type="button" variant="outline" size="sm" disabled={jobTriggering != null}>
-                  <Icon icon="mdi:play-circle-outline" width={16} height={16} aria-hidden="true" />
-                  <span style={{ whiteSpace: 'nowrap' }}>
-                    {jobTriggering ? jobsStrings.types?.[jobTriggering] ?? jobTriggering : jobsStrings.actions.trigger}
-                  </span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-80">
-                <DropdownMenuLabel>{jobsStrings.title}</DropdownMenuLabel>
-                {manualJobActions.map((jobType) => (
-                  <DropdownMenuItem
-                    key={jobType}
-                    disabled={jobTriggering != null}
-                    onSelect={(event) => {
-                      event.preventDefault()
-                      runStoryJob(jobType)
-                    }}
-                  >
-                    <Icon icon="mdi:play-outline" width={16} height={16} aria-hidden="true" />
-                    <span>{jobsStrings.types?.[jobType] ?? jobType}</span>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <AdminJobTriggerMenu
+              disabled={false}
+              triggeringJobType={jobTriggering}
+              strings={jobsStrings}
+              labelForJobType={(jobType) => jobsStrings.types?.[jobType] ?? jobType}
+              onTrigger={runStoryJob}
+            />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -4700,7 +4676,7 @@ function JobsPageCanvas(): JSX.Element {
                       <td>
                         <StatusBadge tone={keyStatusTone(job.status)}>{admin.statuses[job.status] ?? job.status}</StatusBadge>
                       </td>
-                      <td>{jobsStrings.sources?.[job.trigger_source] ?? job.trigger_source}</td>
+                      <td>{jobSourceLabel(job.trigger_source, jobsStrings)}</td>
                       <td>{job.attempt}</td>
                       <td>{formatTimestamp(job.started_at)}</td>
                       <td className="jobs-message-cell">
@@ -4757,7 +4733,7 @@ function JobsPageCanvas(): JSX.Element {
                               <div>
                                 <div className="log-details-label">{jobsStrings.table.source}</div>
                                 <div className="log-details-value">
-                                  {jobsStrings.sources?.[job.trigger_source] ?? job.trigger_source}
+                                  {jobSourceLabel(job.trigger_source, jobsStrings)}
                                 </div>
                               </div>
                             </div>

--- a/web/src/admin/storySupport/AdminPagesStoryRuntime.tsx
+++ b/web/src/admin/storySupport/AdminPagesStoryRuntime.tsx
@@ -920,8 +920,21 @@ function buildStoryRequestLogsList(
 
 const MOCK_JOBS: JobLogView[] = [
   {
+    id: 613,
+    job_type: 'db_compaction',
+    trigger_source: 'auto',
+    key_id: null,
+    key_group: null,
+    status: 'success',
+    attempt: 1,
+    message: 'database_bytes_before=16106127360 database_bytes_after=4294967296 reclaimable_bytes_before=10737418240 reclaimable_bytes_after=0',
+    started_at: now - 8,
+    finished_at: now - 2,
+  },
+  {
     id: 612,
     job_type: 'linuxdo_user_status_sync',
+    trigger_source: 'scheduler',
     key_id: null,
     key_group: null,
     status: 'error',
@@ -933,6 +946,7 @@ const MOCK_JOBS: JobLogView[] = [
   {
     id: 611,
     job_type: 'forward_proxy_geo_refresh',
+    trigger_source: 'manual',
     key_id: null,
     key_group: null,
     status: 'success',
@@ -944,6 +958,7 @@ const MOCK_JOBS: JobLogView[] = [
   {
     id: 610,
     job_type: 'quota_sync',
+    trigger_source: 'manual',
     key_id: 'MZli',
     key_group: 'ops',
     status: 'success',
@@ -955,6 +970,7 @@ const MOCK_JOBS: JobLogView[] = [
   {
     id: 609,
     job_type: 'token_usage_rollup',
+    trigger_source: 'scheduler',
     key_id: 'U2vK',
     key_group: null,
     status: 'running',
@@ -966,6 +982,7 @@ const MOCK_JOBS: JobLogView[] = [
   {
     id: 608,
     job_type: 'quota_sync',
+    trigger_source: 'scheduler',
     key_id: 'asR8',
     key_group: 'batch',
     status: 'error',
@@ -977,6 +994,7 @@ const MOCK_JOBS: JobLogView[] = [
   {
     id: 607,
     job_type: 'auth_token_logs_gc',
+    trigger_source: 'scheduler',
     key_id: null,
     key_group: null,
     status: 'success',
@@ -4533,6 +4551,8 @@ function JobsPageCanvas(): JSX.Element {
   const keyStrings = admin.keys
   const [jobFilter, setJobFilter] = useState<JobGroup>('all')
   const [expandedJobs, setExpandedJobs] = useState<Set<number>>(() => new Set([608]))
+  const [jobTriggering, setJobTriggering] = useState<string | null>(null)
+  const [jobTriggerNotice, setJobTriggerNotice] = useState('DB compaction is already running; manual trigger was not queued.')
   const jobGroupCounts = useMemo(() => countAdminJobGroups(MOCK_JOBS), [])
   const jobFilterOptions = useMemo(
     () => buildAdminJobFilterOptions(jobsStrings, jobGroupCounts),
@@ -4543,6 +4563,22 @@ function JobsPageCanvas(): JSX.Element {
     () => MOCK_JOBS.filter((job) => jobMatchesGroup(job.job_type, jobFilter)),
     [jobFilter],
   )
+  const manualJobActions = [
+    'token_usage_rollup',
+    'request_logs_gc',
+    'forward_proxy_geo_refresh',
+    'db_compaction',
+  ]
+
+  const runStoryJob = (jobType: string) => {
+    setJobTriggering(jobType)
+    setJobTriggerNotice(
+      jobType === 'db_compaction'
+        ? 'DB compaction is already running; manual trigger was not queued.'
+        : `${jobsStrings.types?.[jobType] ?? jobType} queued as a manual job.`,
+    )
+    window.setTimeout(() => setJobTriggering(null), 900)
+  }
 
   const toggleJob = (id: number) => {
     setExpandedJobs((prev) => {
@@ -4565,6 +4601,32 @@ function JobsPageCanvas(): JSX.Element {
             <p className="panel-description">{jobsStrings.description}</p>
           </div>
           <div className="panel-actions">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" variant="outline" size="sm" disabled={jobTriggering != null}>
+                  <Icon icon="mdi:play-circle-outline" width={16} height={16} aria-hidden="true" />
+                  <span style={{ whiteSpace: 'nowrap' }}>
+                    {jobTriggering ? jobsStrings.types?.[jobTriggering] ?? jobTriggering : jobsStrings.actions.trigger}
+                  </span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-80">
+                <DropdownMenuLabel>{jobsStrings.title}</DropdownMenuLabel>
+                {manualJobActions.map((jobType) => (
+                  <DropdownMenuItem
+                    key={jobType}
+                    disabled={jobTriggering != null}
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      runStoryJob(jobType)
+                    }}
+                  >
+                    <Icon icon="mdi:play-outline" width={16} height={16} aria-hidden="true" />
+                    <span>{jobsStrings.types?.[jobType] ?? jobType}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -4597,6 +4659,9 @@ function JobsPageCanvas(): JSX.Element {
             </DropdownMenu>
           </div>
         </div>
+        <div className="empty-state alert" role="status" style={{ marginBottom: 16 }}>
+          {jobTriggerNotice}
+        </div>
 
         <div className="table-wrapper jobs-table-wrapper jobs-module-table-wrapper">
           <table className="jobs-table jobs-module-table">
@@ -4606,6 +4671,7 @@ function JobsPageCanvas(): JSX.Element {
                 <th>{jobsStrings.table.type}</th>
                 <th>{jobsStrings.table.key}</th>
                 <th>{jobsStrings.table.status}</th>
+                <th>{jobsStrings.table.source}</th>
                 <th>{jobsStrings.table.attempt}</th>
                 <th>{jobsStrings.table.started}</th>
                 <th>{jobsStrings.table.message}</th>
@@ -4634,6 +4700,7 @@ function JobsPageCanvas(): JSX.Element {
                       <td>
                         <StatusBadge tone={keyStatusTone(job.status)}>{admin.statuses[job.status] ?? job.status}</StatusBadge>
                       </td>
+                      <td>{jobsStrings.sources?.[job.trigger_source] ?? job.trigger_source}</td>
                       <td>{job.attempt}</td>
                       <td>{formatTimestamp(job.started_at)}</td>
                       <td className="jobs-message-cell">
@@ -4661,7 +4728,7 @@ function JobsPageCanvas(): JSX.Element {
                     </tr>
                     {expanded && hasMessage && (
                       <tr className="log-details-row">
-                        <td colSpan={7} id={`storybook-job-details-${job.id}`}>
+                        <td colSpan={8} id={`storybook-job-details-${job.id}`}>
                           <div className="log-details-panel">
                             <div className="log-details-summary">
                               <div>
@@ -4687,6 +4754,12 @@ function JobsPageCanvas(): JSX.Element {
                                 <div className="log-details-label">{jobsStrings.table.status}</div>
                                 <div className="log-details-value">{admin.statuses[job.status] ?? job.status}</div>
                               </div>
+                              <div>
+                                <div className="log-details-label">{jobsStrings.table.source}</div>
+                                <div className="log-details-value">
+                                  {jobsStrings.sources?.[job.trigger_source] ?? job.trigger_source}
+                                </div>
+                              </div>
                             </div>
                             <div className="log-details-body">
                               <section className="log-details-section">
@@ -4703,7 +4776,7 @@ function JobsPageCanvas(): JSX.Element {
               })}
               {visibleJobs.length === 0 ? (
                 <tr>
-                  <td colSpan={7}>
+                  <td colSpan={8}>
                     <div className="empty-state alert">{jobsStrings.empty.none}</div>
                   </td>
                 </tr>

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -935,6 +935,7 @@ describe('admin user tag api helpers', () => {
               {
                 id: 37696,
                 jobType: 'quota_sync',
+                triggerSource: 'manual',
                 keyId: '7QZ5',
                 keyGroup: 'ops',
                 status: 'error',
@@ -952,6 +953,7 @@ describe('admin user tag api helpers', () => {
               quota: 1,
               usage: 1,
               logs: 1,
+              db: 1,
               geo: 0,
               linuxdo: 1,
             },
@@ -971,12 +973,14 @@ describe('admin user tag api helpers', () => {
       quota: 1,
       usage: 1,
       logs: 1,
+      db: 1,
       geo: 0,
       linuxdo: 1,
     })
     expect(jobs.items[0]).toEqual({
       id: 37696,
       job_type: 'quota_sync',
+      trigger_source: 'manual',
       key_id: '7QZ5',
       key_group: 'ops',
       status: 'error',
@@ -1001,6 +1005,7 @@ describe('admin user tag api helpers', () => {
               quota: 0,
               usage: 0,
               logs: 0,
+              db: 0,
               geo: 0,
               linuxdo: 0,
             },

--- a/web/src/api/demo.ts
+++ b/web/src/api/demo.ts
@@ -424,6 +424,7 @@ function createDemoJobs() {
   return range(12).map((index) => ({
     id: 3000 + index,
     jobType: index % 3 === 0 ? 'quota_sync' : index % 3 === 1 ? 'usage_rollup' : 'geo_lookup',
+    triggerSource: index % 4 === 0 ? 'manual' : index % 4 === 1 ? 'auto' : 'scheduler',
     keyId: index % 2 === 0 ? DEMO_KEY_ID : DEMO_BACKUP_KEY_ID,
     keyGroup: index % 2 === 0 ? 'primary' : 'backup',
     status: index % 5 === 0 ? 'failed' : 'success',
@@ -767,6 +768,7 @@ function serverJobToView(job: ReturnType<typeof createDemoJobs>[number]) {
   return {
     id: job.id,
     job_type: job.jobType,
+    trigger_source: job.triggerSource,
     key_id: job.keyId,
     key_group: job.keyGroup,
     status: job.status,
@@ -1119,7 +1121,7 @@ async function handleDemoRoute(url: URL, method: string, init?: RequestInit): Pr
   if (path === '/api/logs/catalog') return jsonResponse(requestLogsCatalog())
   if (path === '/api/logs') return jsonResponse(requestLogsPage(url))
   if (/^\/api\/logs\/\d+\/details$/.test(path)) return jsonResponse(demoLogDetailForPath(path))
-  if (path === '/api/jobs') return jsonResponse({ ...buildListPage(demoState.jobs, url, 10), groupCounts: { all: demoState.jobs.length, quota: 4, usage: 4, logs: 2, geo: 2, linuxdo: 0 } })
+  if (path === '/api/jobs') return jsonResponse({ ...buildListPage(demoState.jobs, url, 10), groupCounts: { all: demoState.jobs.length, quota: 4, usage: 4, logs: 2, db: 0, geo: 2, linuxdo: 0 } })
 
   if (path === '/api/announcements') return handleAnnouncementsRoute({ announcements: demoState.announcements, path, method, init, nowSeconds, readJsonBody, jsonResponse })
   if (path.startsWith('/api/announcements/')) return handleAnnouncementsRoute({ announcements: demoState.announcements, path, method, init, nowSeconds, readJsonBody, jsonResponse })

--- a/web/src/api/demo.ts
+++ b/web/src/api/demo.ts
@@ -1121,6 +1121,11 @@ async function handleDemoRoute(url: URL, method: string, init?: RequestInit): Pr
   if (path === '/api/logs/catalog') return jsonResponse(requestLogsCatalog())
   if (path === '/api/logs') return jsonResponse(requestLogsPage(url))
   if (/^\/api\/logs\/\d+\/details$/.test(path)) return jsonResponse(demoLogDetailForPath(path))
+  if (path === '/api/jobs/trigger' && method === 'POST') {
+    const body = await readJsonBody()
+    const jobType = typeof body?.jobType === 'string' ? body.jobType : 'request_logs_gc'
+    return jsonResponse({ jobId: nowSeconds(), jobType, triggerSource: 'manual' }, 202)
+  }
   if (path === '/api/jobs') return jsonResponse({ ...buildListPage(demoState.jobs, url, 10), groupCounts: { all: demoState.jobs.length, quota: 4, usage: 4, logs: 2, db: 0, geo: 2, linuxdo: 0 } })
 
   if (path === '/api/announcements') return handleAnnouncementsRoute({ announcements: demoState.announcements, path, method, init, nowSeconds, readJsonBody, jsonResponse })

--- a/web/src/api/runtime.ts
+++ b/web/src/api/runtime.ts
@@ -1368,17 +1368,8 @@ export function fetchApiKeySecret(id: string, signal?: AbortSignal): Promise<Api
   return requestJson(`/api/keys/${encoded}/secret`, { signal })
 }
 
-export interface TriggerJobResponse {
-  job_id: number
-  job_type: string
-  trigger_source: string
-}
-
-interface ServerTriggerJobResponse {
-  jobId: number
-  jobType: string
-  triggerSource: string
-}
+export interface TriggerJobResponse { job_id: number; job_type: string; trigger_source: string }
+interface ServerTriggerJobResponse { jobId: number; jobType: string; triggerSource: string }
 
 function normalizeTriggerJobResponse(data: ServerTriggerJobResponse): TriggerJobResponse {
   return {

--- a/web/src/api/runtime.ts
+++ b/web/src/api/runtime.ts
@@ -1368,6 +1368,26 @@ export function fetchApiKeySecret(id: string, signal?: AbortSignal): Promise<Api
   return requestJson(`/api/keys/${encoded}/secret`, { signal })
 }
 
+export interface TriggerJobResponse {
+  job_id: number
+  job_type: string
+  trigger_source: string
+}
+
+interface ServerTriggerJobResponse {
+  jobId: number
+  jobType: string
+  triggerSource: string
+}
+
+function normalizeTriggerJobResponse(data: ServerTriggerJobResponse): TriggerJobResponse {
+  return {
+    job_id: data.jobId,
+    job_type: data.jobType,
+    trigger_source: data.triggerSource,
+  }
+}
+
 export async function syncApiKeyUsage(id: string): Promise<void> {
   const encoded = encodeURIComponent(id)
   const res = await fetch(`/api/keys/${encoded}/sync-usage`, { method: 'POST' })
@@ -1382,6 +1402,14 @@ export async function syncApiKeyUsage(id: string): Promise<void> {
     const statusPart = ` (HTTP ${res.status})`
     throw new Error((message ? `${message}` : 'Failed to sync key usage') + statusPart)
   }
+}
+
+export function triggerJob(jobType: string, keyId?: string | null): Promise<TriggerJobResponse> {
+  return requestJson<ServerTriggerJobResponse>('/api/jobs/trigger', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jobType, keyId }),
+  }).then(normalizeTriggerJobResponse)
 }
 
 export async function applyApiKeyBulkAction(
@@ -1507,6 +1535,7 @@ export async function syncApiKeyBulkUsageWithProgress(
 export interface JobLogView {
   id: number
   job_type: string
+  trigger_source: 'scheduler' | 'manual' | 'auto' | string
   key_id: string | null
   key_group: string | null
   status: string
@@ -1519,6 +1548,7 @@ export interface JobLogView {
 interface ServerJobLogView {
   id: number
   jobType: string
+  triggerSource?: string
   keyId: string | null
   keyGroup: string | null
   status: string
@@ -1528,13 +1558,14 @@ interface ServerJobLogView {
   finishedAt: number | null
 }
 
-export type JobGroup = 'all' | 'quota' | 'usage' | 'logs' | 'geo' | 'linuxdo'
+export type JobGroup = 'all' | 'quota' | 'usage' | 'logs' | 'db' | 'geo' | 'linuxdo'
 
 export interface JobGroupCounts {
   all: number
   quota: number
   usage: number
   logs: number
+  db: number
   geo: number
   linuxdo: number
 }
@@ -1544,6 +1575,7 @@ interface ServerJobGroupCounts {
   quota: number
   usage: number
   logs: number
+  db?: number
   geo: number
   linuxdo: number
 }
@@ -2670,12 +2702,14 @@ export function fetchJobs(
       quota: data.groupCounts.quota,
       usage: data.groupCounts.usage,
       logs: data.groupCounts.logs,
+      db: data.groupCounts.db ?? 0,
       geo: data.groupCounts.geo,
       linuxdo: data.groupCounts.linuxdo,
     },
     items: data.items.map((item) => ({
       id: item.id,
       job_type: item.jobType,
+      trigger_source: item.triggerSource ?? 'scheduler',
       key_id: item.keyId,
       key_group: item.keyGroup,
       status: item.status,

--- a/web/src/i18n/translations/en.ts
+++ b/web/src/i18n/translations/en.ts
@@ -1339,9 +1339,7 @@ export const EN: TranslationShape = {
           loading: 'Loading jobs…',
           none: 'No jobs yet.',
         },
-        actions: {
-          trigger: 'Run',
-        },
+        actions: { trigger: 'Run' },
         table: {
           id: 'ID',
           type: 'Type',
@@ -1356,11 +1354,7 @@ export const EN: TranslationShape = {
           show: 'Show job details',
           hide: 'Hide job details',
         },
-        sources: {
-          scheduler: 'Scheduled',
-          manual: 'Manual',
-          auto: 'Auto',
-        },
+        sources: { scheduler: 'Scheduled', manual: 'Manual', auto: 'Auto' },
         types: {
           quota_sync: 'Sync quota',
           'quota_sync/hot': 'Hot quota sync',

--- a/web/src/i18n/translations/en.ts
+++ b/web/src/i18n/translations/en.ts
@@ -1331,6 +1331,7 @@ export const EN: TranslationShape = {
           quota: 'Sync quota',
           usage: 'Usage rollups',
           logs: 'Clean access logs',
+          db: 'Compact database',
           geo: 'Node IP/GEO refresh',
           linuxdo: 'LinuxDo user sync',
         },
@@ -1338,11 +1339,15 @@ export const EN: TranslationShape = {
           loading: 'Loading jobs…',
           none: 'No jobs yet.',
         },
+        actions: {
+          trigger: 'Run',
+        },
         table: {
           id: 'ID',
           type: 'Type',
           key: 'Key',
           status: 'Status',
+          source: 'Source',
           attempt: 'Attempt',
           started: 'Started',
           message: 'Message',
@@ -1350,6 +1355,11 @@ export const EN: TranslationShape = {
         toggles: {
           show: 'Show job details',
           hide: 'Hide job details',
+        },
+        sources: {
+          scheduler: 'Scheduled',
+          manual: 'Manual',
+          auto: 'Auto',
         },
         types: {
           quota_sync: 'Sync quota',
@@ -1360,8 +1370,10 @@ export const EN: TranslationShape = {
           auth_token_logs_gc: 'Log cleanup',
           request_logs_gc: 'Log cleanup',
           log_cleanup: 'Log cleanup',
+          db_compaction: 'DB compaction',
           forward_proxy_geo_refresh: 'Node IP/GEO refresh',
           linuxdo_user_status_sync: 'LinuxDo user sync',
+          linuxdo_user_tag_binding_refresh: 'LinuxDo tag refresh',
         },
       },
       statuses: {

--- a/web/src/i18n/translations/zh.ts
+++ b/web/src/i18n/translations/zh.ts
@@ -1338,9 +1338,7 @@ export const ZH: TranslationShape = {
           loading: '正在加载任务…',
           none: '暂无任务记录。',
         },
-        actions: {
-          trigger: '运行',
-        },
+        actions: { trigger: '运行' },
         table: {
           id: 'ID',
           type: '类型',
@@ -1355,11 +1353,7 @@ export const ZH: TranslationShape = {
           show: '展开任务详情',
           hide: '收起任务详情',
         },
-        sources: {
-          scheduler: '定时',
-          manual: '手动',
-          auto: '自动',
-        },
+        sources: { scheduler: '定时', manual: '手动', auto: '自动' },
         types: {
           quota_sync: '同步额度',
           'quota_sync/hot': '热 Key 同步',

--- a/web/src/i18n/translations/zh.ts
+++ b/web/src/i18n/translations/zh.ts
@@ -1330,6 +1330,7 @@ export const ZH: TranslationShape = {
           quota: '同步额度',
           usage: '用量聚合',
           logs: '清理日志',
+          db: '压缩数据库',
           geo: '节点 IP/GEO 刷新',
           linuxdo: 'LinuxDo 用户同步',
         },
@@ -1337,11 +1338,15 @@ export const ZH: TranslationShape = {
           loading: '正在加载任务…',
           none: '暂无任务记录。',
         },
+        actions: {
+          trigger: '运行',
+        },
         table: {
           id: 'ID',
           type: '类型',
           key: 'Key',
           status: '状态',
+          source: '来源',
           attempt: '重试次数',
           started: '开始时间',
           message: '消息',
@@ -1349,6 +1354,11 @@ export const ZH: TranslationShape = {
         toggles: {
           show: '展开任务详情',
           hide: '收起任务详情',
+        },
+        sources: {
+          scheduler: '定时',
+          manual: '手动',
+          auto: '自动',
         },
         types: {
           quota_sync: '同步额度',
@@ -1359,8 +1369,10 @@ export const ZH: TranslationShape = {
           auth_token_logs_gc: '日志清理',
           request_logs_gc: '日志清理',
           log_cleanup: '日志清理',
+          db_compaction: '数据库压缩',
           forward_proxy_geo_refresh: '节点 IP/GEO 刷新',
           linuxdo_user_status_sync: 'LinuxDo 用户同步',
+          linuxdo_user_tag_binding_refresh: 'LinuxDo 标签刷新',
         },
       },
       statuses: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -1244,9 +1244,7 @@ export interface AdminTranslationsShape {
       loading: string
       none: string
     }
-    actions: {
-      trigger: string
-    }
+    actions: { trigger: string }
     table: {
       id: string
       type: string

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -1236,6 +1236,7 @@ export interface AdminTranslationsShape {
       quota: string
       usage: string
       logs: string
+      db: string
       geo: string
       linuxdo: string
     }
@@ -1243,11 +1244,15 @@ export interface AdminTranslationsShape {
       loading: string
       none: string
     }
+    actions: {
+      trigger: string
+    }
     table: {
       id: string
       type: string
       key: string
       status: string
+      source: string
       attempt: string
       started: string
       message: string
@@ -1256,6 +1261,7 @@ export interface AdminTranslationsShape {
       show: string
       hide: string
     }
+    sources?: Record<string, string>
     types?: Record<string, string>
   }
   logs: {

--- a/web/tests/sourceLineBudgets.test.ts
+++ b/web/tests/sourceLineBudgets.test.ts
@@ -18,22 +18,50 @@ const EXCEPTIONS = new Map<string, { max: number; reason: string }>([
   [
     'src/admin/AdminDashboardRuntime.tsx',
     {
-      max: 13050,
-      reason: 'Legacy admin dashboard runtime remains as a compatibility shell while thin entry/Admin helper modules land incrementally.',
+      max: 13100,
+      reason: 'Legacy admin dashboard runtime remains as a compatibility shell while manual job controls are split out incrementally.',
     },
   ],
   [
     'src/admin/storySupport/AdminPagesStoryRuntime.tsx',
     {
-      max: 7300,
-      reason: 'Storybook proof runtime remains centralized temporarily while Admin/Pages stories stay on stable export names.',
+      max: 7320,
+      reason: 'Storybook proof runtime remains centralized temporarily while Admin/Pages jobs coverage stays stable.',
     },
   ],
   [
     'src/api/runtime.ts',
     {
-      max: 3260,
-      reason: 'API barrel still carries the forward proxy admin runtime and user-console rotate contracts until the proxy API surface is split out.',
+      max: 3280,
+      reason: 'API barrel still carries admin job trigger contracts until the proxy API surface is split out.',
+    },
+  ],
+  [
+    'src/api/demo.ts',
+    {
+      max: 1510,
+      reason: 'Demo API fixtures include scheduled job trigger provenance for stable admin jobs stories.',
+    },
+  ],
+  [
+    'src/i18n/translations/en.ts',
+    {
+      max: 1520,
+      reason: 'Admin jobs maintenance copy is still stored in the shared English runtime catalog.',
+    },
+  ],
+  [
+    'src/i18n/translations/zh.ts',
+    {
+      max: 1520,
+      reason: 'Admin jobs maintenance copy is still stored in the shared Chinese runtime catalog.',
+    },
+  ],
+  [
+    'src/i18n/types.ts',
+    {
+      max: 1520,
+      reason: 'Admin jobs maintenance translation types remain in the shared catalog contract.',
     },
   ],
   [


### PR DESCRIPTION
## Summary
- add scheduled-job trigger provenance (`scheduler` / `manual` / `auto`) and expose it through backend DTOs and the admin jobs UI
- add `POST /api/jobs/trigger` for async manual maintenance jobs while keeping legacy sync-usage endpoints synchronous
- add SQLite DB stats/compaction maintenance under a service-level maintenance gate where `/health` remains available
- tighten request-log GC catch-up options and cover job grouping, claim races, stale running jobs, and Storybook/demo drift

## Validation
- `git diff --check`
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bun run test:source-budgets`
- `bun test ./src/api.test.ts ./src/admin/jobFilters.test.ts ./src/admin/AdminPages.stories.test.ts`
- `bun run build`
- `cargo test scheduled_job_claim -- --nocapture`
- `cargo test abandoned_running_scheduled_jobs_unblocks_future_claims -- --nocapture`
- `cargo test manual_sync_usage_endpoint_allows_non_active_keys_and_preserves_failed_quota_data -- --nocapture`
- `cargo test list_recent_jobs_paginated_includes_key_group -- --nocapture`
- `cargo test sqlite_db_stats_reports_reclaimable_shape -- --nocapture`
- `cargo test request_logs_gc_bounded_reports_partial_and_resumes -- --nocapture`
- `cargo test request_logs_gc_retries_transient_sqlite_write_lock -- --nocapture`
- Shared testbox production-derived SQLite copy: `VACUUM INTO` copy quick_check ok; one-shot GC on the copy returned JSON with `cleanedRequestLogBodies=100`, `deletedRequestLogs=100`, `deletedRollups=100`, `hasMore=true`; manual `db_compaction` trigger returned `triggerSource=manual` and finished `success` with freelist `2887 -> 0`, WAL `5405472 -> 0`, final quick_check ok; production-derived copy cleaned from testbox after validation.
- `codex review --base origin/main` (clear)

## References
Spec: `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`
Spec Disposition: update
Specs:
- `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`

Solutions:
- `docs/solutions/operations/sqlite-write-lock-contention.md`

Project Docs: -

Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)

## Notes
- DB compaction uses a maintenance gate and waiting behavior, not a hot database swap.
- UI visual evidence was generated from mock Storybook state and shown in chat, but no screenshots are included in this PR body.
- Previous `Backend Tests` CI run was canceled at the 75-minute job timeout while tests were still passing; backend test timeout is now 120 minutes and the replacement run is pending.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
