### PR TITLE
fix(release): upload assets without git context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -636,7 +636,7 @@ jobs:
             exit 1
           fi
 
-          gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber
+          gh release upload "${RELEASE_TAG}" "${assets[@]}" --clobber --repo "${GITHUB_REPOSITORY}"
 
       - name: Upsert PR release comment
         uses: actions/github-script@v9

--- a/docs/specs/xxgfb-release-binary-assets/HISTORY.md
+++ b/docs/specs/xxgfb-release-binary-assets/HISTORY.md
@@ -7,3 +7,4 @@
 - 每个平台资产同时发布 SHA256 校验文件，便于运维审计与下载校验。
 - 外部静态目录继续保留为运行时覆盖入口；内嵌 Web 资产只作为默认发布兜底。
 - `xray` 不随主程序 binary 打包，继续由宿主环境单独安装或配置。
+- GitHub Release job 不 checkout 仓库时，`gh` CLI 必须显式指定 repository，不能依赖本地 `.git` 上下文。

--- a/docs/specs/xxgfb-release-binary-assets/IMPLEMENTATION.md
+++ b/docs/specs/xxgfb-release-binary-assets/IMPLEMENTATION.md
@@ -8,7 +8,8 @@
 - 版本检测同样保持外部静态目录优先，避免 `--static-dir` 覆盖部署时版本信息与实际服务的前端不一致。
 - `Dockerfile` 在 builder 阶段复制 `build.rs`，保证新增 Cargo build script 后容器构建路径仍可用；容器运行时继续通过 `WEB_STATIC_DIR=/srv/app/web` 使用镜像内静态目录。
 - release workflow 新增 `binary-native` matrix，在 `ubuntu-24.04` 与 `ubuntu-24.04-arm` 上构建 Web、构建 release binary、打包 `tar.gz`、生成 `.sha256` 并 smoke 解包后的 binary。
-- GitHub Release job 下载 binary artifacts 后用 `gh release upload --clobber` 上传资产，同时 PR release comment 列出 binary 资产名称。
+- GitHub Release job 下载 binary artifacts 后用 `gh release upload --clobber --repo "${GITHUB_REPOSITORY}"` 上传资产；该 job 没有 checkout，不能依赖本地 `.git` 推断仓库。PR release comment 列出 binary
+  资产名称。
 - CI workflow 增加 embedded asset contract coverage，避免无外部静态目录的 binary 路径回归。
 
 ## 验证


### PR DESCRIPTION
## Summary
- pass the repository explicitly to `gh release upload` in the GitHub Release job
- document that the release upload job has no checkout and cannot rely on `.git` context

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"'`
- `git diff --check`
- lefthook pre-commit markdown formatting

## References
- Specs: `docs/specs/xxgfb-release-binary-assets/`
- Solutions: -
- Project Docs: -
