### PR TITLE
fix(server): serialize database maintenance jobs

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -63,6 +63,11 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - Treat SQLite file shrinkage as a separate maintenance concern. Row deletes and body nulling create
   free pages; size convergence requires freelist telemetry plus a controlled compaction job after
   retention cleanup has made space reclaimable.
+- Serialize DB-backed scheduled/manual maintenance jobs through an in-process execution gate when
+  they can write SQLite. Same-job duplicate claiming is not enough when different logical jobs, such
+  as retention GC, quota sync, rollups, and compaction, can all compete for the single writer slot.
+- Do not hold that job execution gate while a catch-up scheduler is sleeping between cleanup
+  windows. Hold it for the active DB write window, then release it before throttled rechecks.
 - Provide a one-shot operational CLI for retention cleanup so production-derived database samples
   can be tested deterministically. Do not rely only on the daily scheduler when validating cleanup
   behavior.
@@ -87,6 +92,10 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
   a separate maintenance-window decision after retention cleanup has completed.
 - Automatic compaction should be threshold-gated and cooldown-limited. Triggering it on every GC
   pass can turn a cleanup backlog into a new writer-pressure loop.
+- Stale `scheduled_jobs.running` rows from a previous process lifetime are an operational restart
+  concern. The process-level gate prevents new same-process writer overlap, but a controlled restart
+  may still be needed to let startup stale-job cleanup mark old rows abandoned before operators
+  retry manual jobs.
 - If a retention table has aggregate-maintenance triggers, validate large-copy cleanup with the
   triggers in mind. For `request_logs`, GC deletes expired rollup buckets separately and suppresses
   the per-row rollup delete trigger inside each batch transaction to avoid spending minutes per

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -27,3 +27,10 @@
   and DB size convergence. Manual and automatic maintenance now share job bookkeeping semantics, and
   SQLite file shrinkage is treated as an explicit compaction concern rather than an implicit side
   effect of deleting old rows.
+
+## 2026-06-06
+
+- Added a process-wide execution gate for DB-backed scheduled/manual jobs after production evidence
+  showed stale running maintenance rows and overlapping writers across request-log GC, quota sync,
+  and compaction. Request-log GC catch-up only holds the gate during active cleanup windows, not
+  while sleeping between catch-up passes.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -39,6 +39,12 @@
   body-cleanup backlog does not repeatedly consume the SQLite writer slot.
 - DB maintenance now records size/freelist telemetry and can compact the SQLite file through a
   dedicated job, with automatic threshold-based triggering and manual admin triggering.
+- DB-backed scheduled and manual jobs now pass through a process-wide execution gate before their
+  SQLite write windows. The gate covers retention GC, compaction, quota sync, rollups, session GC,
+  backoff GC, auth-token log GC, and LinuxDo sync/refresh jobs while preserving the existing
+  scheduled-job claim/finish semantics.
+- Request-log GC catch-up releases the DB job execution gate between cleanup windows so the
+  scheduler delay does not block other DB-backed jobs.
 - Added `request_logs_gc_once` as a one-shot operational binary. It supports JSON output and
   `--run-until-complete` for deterministic low-resource validation against production-derived
   database samples.
@@ -47,6 +53,8 @@
   snapshot persistence.
 - Added request-log GC coverage for old-row deletion, recent-row preservation, partial catch-up,
   catalog rollup cleanup, and transient SQLite write-lock retry.
+- Added process-level DB job execution gate coverage that proves overlapping jobs serialize before
+  entering their write windows.
 - Added startup-order coverage for restored subscription runtime with a slow subscription endpoint,
   plus the strict no-runtime fallback where startup still waits for subscription readiness.
 
@@ -70,4 +78,8 @@
 - A later request-log body-retention backlog produced a much larger main DB file even after row
   retention was no longer the primary issue. Deleting or nulling payloads alone leaves free pages in
   SQLite, so file-size convergence is handled as a separate compaction job after retention work.
+- If production inspection shows long-lived `scheduled_jobs.running` rows from an older process,
+  restart the service under the current stale-job cleanup path before relying on manual retriggers.
+  The in-process execution gate prevents new same-process overlap; it does not rewrite stale rows
+  while the old process is still considered active.
 - The implementation does not perform production data mutation and does not alter pool size.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -4,7 +4,7 @@
 
 - Lifecycle: active
 - Created: 2026-05-07
-- Last: 2026-05-24
+- Last: 2026-06-06
 
 ## Background
 
@@ -76,6 +76,11 @@ source when a usable persisted runtime already exists.
   pass. It must delete old `request_logs` and `request_log_catalog_rollups` in bounded batches,
   yield between batches, report partial progress, and continue catch-up after a throttled delay when
   more rows remain.
+- DB-backed scheduled and manual jobs that can write SQLite must also be serialized across logical
+  job types inside one process, so maintenance catch-up, quota sync, rollups, GC, and compaction do
+  not overlap as independent SQLite writers.
+- Request-log GC catch-up may reacquire that execution gate for each actual cleanup window, but it
+  must not keep the gate while sleeping or waiting for the next catch-up recheck.
 - SQLite file size must converge after retention cleanup. The service must expose DB size/freelist
   telemetry, automatically trigger compaction when reclaimable space crosses the configured
   threshold, and provide a manual compaction trigger. Health checks must remain available while DB
@@ -102,6 +107,8 @@ source when a usable persisted runtime already exists.
 - With a large backlog of old request logs, one scheduler pass records bounded progress instead of
   running indefinitely; later catch-up passes eventually remove all rows older than the retention
   threshold.
+- Overlapping DB-backed maintenance jobs in one process run through a shared execution gate, so a
+  second job waits for the active DB job instead of competing for the SQLite writer slot.
 - Manual trigger API calls return a job id, job rows expose `trigger_source`, and duplicate active
   manual triggers return a conflict instead of starting overlapping work.
 - After request-log retention cleanup creates enough freelist pages, DB compaction runs under the

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -378,12 +378,9 @@ async fn run_manual_key_quota_sync(
     };
     let job_id = claimed_job.job_id;
     let _job_execution_gate = claimed_job._job_execution_gate;
+    drop(_job_execution_gate);
 
-    match state
-        .proxy
-        .sync_key_quota(key_id, &state.usage_base, "quota_sync/manual")
-        .await
-    {
+    match sync_key_quota_with_db_job_gate(state.as_ref(), key_id, "quota_sync/manual").await {
         Ok((limit, remaining)) => {
             let msg = format!("limit={limit} remaining={remaining}");
             let _ = state

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -196,13 +196,30 @@ async fn post_trigger_job(
         Err(err) => return Ok(manual_trigger_key_id_error_response(&job_type, err)),
     };
 
-    let claim = claim_scheduled_job_without_gate(
-        state.as_ref(),
-        &job_type,
-        key_id.as_deref(),
-        TRIGGER_SOURCE_MANUAL,
+    let claim = tokio::time::timeout(
+        Duration::from_secs(5),
+        claim_scheduled_job_with_gate(
+            state.as_ref(),
+            &job_type,
+            key_id.as_deref(),
+            TRIGGER_SOURCE_MANUAL,
+        ),
     )
     .await;
+
+    let claim = match claim {
+        Ok(claim) => claim,
+        Err(_) => {
+            return Ok((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({
+                    "error": "db_job_execution_busy",
+                    "detail": "another DB-backed maintenance job is active"
+                })),
+            )
+                .into_response());
+        }
+    };
 
     match claim {
         Ok(Some(claimed_job)) => {

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -196,7 +196,7 @@ async fn post_trigger_job(
         Err(err) => return Ok(manual_trigger_key_id_error_response(&job_type, err)),
     };
 
-    let claim = claim_scheduled_job_with_gate(
+    let claim = claim_scheduled_job_without_gate(
         state.as_ref(),
         &job_type,
         key_id.as_deref(),

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -341,13 +341,23 @@ async fn run_manual_key_quota_sync(
     state: Arc<AppState>,
     key_id: &str,
 ) -> Result<(), ManualQuotaSyncError> {
-    let claim = claim_scheduled_job_with_gate(
-        state.as_ref(),
-        "quota_sync",
-        Some(key_id),
-        TRIGGER_SOURCE_MANUAL,
+    let claim = tokio::time::timeout(
+        Duration::from_secs(5),
+        claim_scheduled_job_with_gate(
+            state.as_ref(),
+            "quota_sync",
+            Some(key_id),
+            TRIGGER_SOURCE_MANUAL,
+        ),
     )
     .await
+    .map_err(|_| {
+        ManualQuotaSyncError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "db_job_execution_busy",
+            "another DB-backed maintenance job is active".to_string(),
+        )
+    })?
     .map_err(|err| {
             ManualQuotaSyncError::new(
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -196,18 +196,22 @@ async fn post_trigger_job(
         Err(err) => return Ok(manual_trigger_key_id_error_response(&job_type, err)),
     };
 
-    let claim = state
-        .proxy
-        .scheduled_job_claim(&job_type, TRIGGER_SOURCE_MANUAL, key_id.as_deref(), 1)
-        .await;
+    let claim = claim_scheduled_job_with_gate(
+        state.as_ref(),
+        &job_type,
+        key_id.as_deref(),
+        TRIGGER_SOURCE_MANUAL,
+    )
+    .await;
 
     match claim {
-        Ok(Some(job_id)) => {
+        Ok(Some(claimed_job)) => {
+            let job_id = claimed_job.job_id;
             let run_state = state.clone();
             let run_job_type = job_type.clone();
             let run_key_id = key_id.clone();
             tokio::spawn(async move {
-                run_manual_claimed_job(run_state, run_job_type, run_key_id, job_id).await;
+                run_manual_claimed_job(run_state, run_job_type, run_key_id, claimed_job).await;
             });
             Ok((
                 StatusCode::ACCEPTED,

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -324,11 +324,14 @@ async fn run_manual_key_quota_sync(
     state: Arc<AppState>,
     key_id: &str,
 ) -> Result<(), ManualQuotaSyncError> {
-    let claim = state
-        .proxy
-        .scheduled_job_claim("quota_sync", TRIGGER_SOURCE_MANUAL, Some(key_id), 1)
-        .await
-        .map_err(|err| {
+    let claim = claim_scheduled_job_with_gate(
+        state.as_ref(),
+        "quota_sync",
+        Some(key_id),
+        TRIGGER_SOURCE_MANUAL,
+    )
+    .await
+    .map_err(|err| {
             ManualQuotaSyncError::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "sync_failed",
@@ -336,8 +339,8 @@ async fn run_manual_key_quota_sync(
             )
         })?;
 
-    let job_id = match claim {
-        Some(job_id) => job_id,
+    let claimed_job = match claim {
+        Some(claimed_job) => claimed_job,
         None => {
             Err(ManualQuotaSyncError::new(
                 StatusCode::CONFLICT,
@@ -346,6 +349,8 @@ async fn run_manual_key_quota_sync(
             ))?
         }
     };
+    let job_id = claimed_job.job_id;
+    let _job_execution_gate = claimed_job._job_execution_gate;
 
     match state
         .proxy

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -85,7 +85,7 @@ use tavily_hikari::{
 use tokio::signal;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 include!("state.rs");
 include!("schedulers.rs");
 include!("spa.rs");

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -98,6 +98,43 @@ async fn claim_scheduled_job(
     }
 }
 
+async fn sync_key_quota_with_db_job_gate(
+    state: &AppState,
+    key_id: &str,
+    source: &str,
+) -> Result<(i64, i64), ProxyError> {
+    let secret = {
+        let _job_execution_gate = acquire_db_job_execution_gate_for_state(state).await;
+        let _maintenance = acquire_db_maintenance_read_gate().await;
+        state.proxy.quota_sync_api_key_secret(key_id).await?
+    };
+
+    let (limit, remaining) = match state
+        .proxy
+        .fetch_usage_quota_for_sync_secret(&secret, &state.usage_base, key_id)
+        .await
+    {
+        Ok(quota) => quota,
+        Err(err) => {
+            let _job_execution_gate = acquire_db_job_execution_gate_for_state(state).await;
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            state.proxy.record_quota_sync_usage_error(key_id, &err).await?;
+            return Err(err);
+        }
+    };
+
+    {
+        let _job_execution_gate = acquire_db_job_execution_gate_for_state(state).await;
+        let _maintenance = acquire_db_maintenance_read_gate().await;
+        state
+            .proxy
+            .record_quota_sync_result(key_id, limit, remaining, source)
+            .await?;
+    }
+
+    Ok((limit, remaining))
+}
+
 fn next_local_daily_run_after(now: DateTime<Local>, hour: u32, minute: u32) -> DateTime<Local> {
     let today = now.date_naive();
     let scheduled_naive = today
@@ -169,10 +206,8 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
                 else {
                     continue;
                 };
-                let _maintenance = acquire_db_maintenance_read_gate().await;
-                match cold_state
-                    .proxy
-                    .sync_key_quota(&key_id, &cold_state.usage_base, "quota_sync")
+                drop(_job_execution_gate);
+                match sync_key_quota_with_db_job_gate(cold_state.as_ref(), &key_id, "quota_sync")
                     .await
                 {
                     Ok((limit, remaining)) => {
@@ -244,10 +279,8 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
                 else {
                     continue;
                 };
-                let _maintenance = acquire_db_maintenance_read_gate().await;
-                match hot_state
-                    .proxy
-                    .sync_key_quota(&key_id, &hot_state.usage_base, "quota_sync/hot")
+                drop(_job_execution_gate);
+                match sync_key_quota_with_db_job_gate(hot_state.as_ref(), &key_id, "quota_sync/hot")
                     .await
                 {
                     Ok((limit, remaining)) => {
@@ -1039,10 +1072,8 @@ async fn run_manual_claimed_job(
             let Some(key_id) = key_id else {
                 return finish(state, "error", "missing key_id".to_string()).await;
             };
-            let _maintenance = acquire_db_maintenance_read_gate().await;
-            match state
-                .proxy
-                .sync_key_quota(&key_id, &state.usage_base, "quota_sync/manual")
+            drop(_job_execution_gate);
+            match sync_key_quota_with_db_job_gate(state.as_ref(), &key_id, "quota_sync/manual")
                 .await
             {
                 Ok((limit, remaining)) => {

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -981,7 +981,6 @@ async fn run_forward_proxy_geo_refresh_job_with_source(
         return;
     };
 
-    drop(_job_execution_gate);
     let _maintenance = acquire_db_maintenance_read_gate().await;
     match state
         .proxy
@@ -1102,7 +1101,6 @@ async fn run_manual_claimed_job(
             }
         },
         "forward_proxy_geo_refresh" => {
-            drop(_job_execution_gate);
             let _maintenance = acquire_db_maintenance_read_gate().await;
             match state
                 .proxy

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -78,27 +78,6 @@ async fn claim_scheduled_job_with_gate(
     }
 }
 
-async fn claim_scheduled_job_without_gate(
-    state: &AppState,
-    job_type: &str,
-    key_id: Option<&str>,
-    trigger_source: &str,
-) -> Result<Option<ClaimedScheduledJob>, ProxyError> {
-    let _maintenance = acquire_db_maintenance_read_gate().await;
-    match state
-        .proxy
-        .scheduled_job_claim(job_type, trigger_source, key_id, 1)
-        .await
-    {
-        Ok(Some(job_id)) => Ok(Some(ClaimedScheduledJob {
-            job_id,
-            _job_execution_gate: None,
-        })),
-        Ok(None) => Ok(None),
-        Err(err) => Err(err),
-    }
-}
-
 async fn claim_scheduled_job(
     state: &AppState,
     job_type: &str,

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -51,20 +51,42 @@ const TRIGGER_SOURCE_SCHEDULER: &str = "scheduler";
 const TRIGGER_SOURCE_MANUAL: &str = "manual";
 const TRIGGER_SOURCE_AUTO: &str = "auto";
 
-async fn claim_scheduled_job(
+struct ClaimedScheduledJob {
+    job_id: i64,
+    _job_execution_gate: OwnedMutexGuard<()>,
+}
+
+async fn claim_scheduled_job_with_gate(
     state: &AppState,
     job_type: &str,
     key_id: Option<&str>,
     trigger_source: &str,
-    log_prefix: &str,
-) -> Option<i64> {
+) -> Result<Option<ClaimedScheduledJob>, ProxyError> {
+    let job_execution_gate = acquire_db_job_execution_gate().await;
     let _maintenance = acquire_db_maintenance_read_gate().await;
     match state
         .proxy
         .scheduled_job_claim(job_type, trigger_source, key_id, 1)
         .await
     {
-        Ok(Some(id)) => Some(id),
+        Ok(Some(job_id)) => Ok(Some(ClaimedScheduledJob {
+            job_id,
+            _job_execution_gate: job_execution_gate,
+        })),
+        Ok(None) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+async fn claim_scheduled_job(
+    state: &AppState,
+    job_type: &str,
+    key_id: Option<&str>,
+    trigger_source: &str,
+    log_prefix: &str,
+) -> Option<ClaimedScheduledJob> {
+    match claim_scheduled_job_with_gate(state, job_type, key_id, trigger_source).await {
+        Ok(Some(job)) => Some(job),
         Ok(None) => {
             eprintln!("{log_prefix}: job already running; skip trigger");
             None
@@ -133,7 +155,10 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
             for key_id in keys {
                 let delay = random_delay_secs(300);
                 tokio::time::sleep(Duration::from_secs(delay)).await;
-                let Some(job_id) = claim_scheduled_job(
+                let Some(ClaimedScheduledJob {
+                    job_id,
+                    _job_execution_gate,
+                }) = claim_scheduled_job(
                     cold_state.as_ref(),
                     "quota_sync",
                     Some(&key_id),
@@ -205,7 +230,10 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
             for key_id in keys {
                 let delay = random_delay_secs(60);
                 tokio::time::sleep(Duration::from_secs(delay)).await;
-                let Some(job_id) = claim_scheduled_job(
+                let Some(ClaimedScheduledJob {
+                    job_id,
+                    _job_execution_gate,
+                }) = claim_scheduled_job(
                     hot_state.as_ref(),
                     "quota_sync/hot",
                     Some(&key_id),
@@ -260,7 +288,10 @@ fn spawn_quota_sync_scheduler(state: Arc<AppState>) {
 fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let Some(job_id) = claim_scheduled_job(
+            let Some(ClaimedScheduledJob {
+                job_id,
+                _job_execution_gate,
+            }) = claim_scheduled_job(
                 state.as_ref(),
                 "token_usage_rollup",
                 None,
@@ -303,7 +334,10 @@ fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
 fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let Some(job_id) = claim_scheduled_job(
+            let Some(ClaimedScheduledJob {
+                job_id,
+                _job_execution_gate,
+            }) = claim_scheduled_job(
                 state.as_ref(),
                 "auth_token_logs_gc",
                 None,
@@ -343,7 +377,10 @@ fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
 fn spawn_mcp_sessions_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let Some(job_id) = claim_scheduled_job(
+            let Some(ClaimedScheduledJob {
+                job_id,
+                _job_execution_gate,
+            }) = claim_scheduled_job(
                 state.as_ref(),
                 "mcp_sessions_gc",
                 None,
@@ -382,7 +419,10 @@ fn spawn_mcp_sessions_gc_scheduler(state: Arc<AppState>) {
 fn spawn_mcp_session_init_backoffs_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            let Some(job_id) = claim_scheduled_job(
+            let Some(ClaimedScheduledJob {
+                job_id,
+                _job_execution_gate,
+            }) = claim_scheduled_job(
                 state.as_ref(),
                 "mcp_session_init_backoffs_gc",
                 None,
@@ -429,7 +469,7 @@ fn spawn_request_logs_gc_scheduler(state: Arc<AppState>) {
             // After we reach the scheduled time, keep retrying until we either run the job
             // successfully or record an error for this run window.
             loop {
-                let Some(job_id) = claim_scheduled_job(
+                let Some(claimed_job) = claim_scheduled_job(
                     state.as_ref(),
                     "request_logs_gc",
                     None,
@@ -442,14 +482,22 @@ fn spawn_request_logs_gc_scheduler(state: Arc<AppState>) {
                     continue;
                 };
 
-                let _ = run_request_logs_gc_catchup_claimed_job(state.clone(), job_id).await;
+                let _ = run_request_logs_gc_catchup_claimed_job(state.clone(), claimed_job).await;
                 break;
             }
         }
     });
 }
 
-async fn run_request_logs_gc_catchup_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
+async fn run_request_logs_gc_catchup_claimed_job(
+    state: Arc<AppState>,
+    claimed_job: ClaimedScheduledJob,
+) -> bool {
+    let ClaimedScheduledJob {
+        job_id,
+        _job_execution_gate,
+    } = claimed_job;
+    drop(_job_execution_gate);
     let mut cleaned_request_log_bodies = 0i64;
     let mut deleted_request_logs = 0i64;
     let mut deleted_rollups = 0i64;
@@ -458,12 +506,15 @@ async fn run_request_logs_gc_catchup_claimed_job(state: Arc<AppState>, job_id: i
     let mut passes = 0usize;
 
     loop {
+        let _job_execution_gate = acquire_db_job_execution_gate().await;
         let _maintenance = acquire_db_maintenance_read_gate().await;
-        match state
+        let result = state
             .proxy
             .gc_request_logs_with_options(scheduled_request_logs_gc_options())
-            .await
-        {
+            .await;
+        drop(_maintenance);
+
+        match result {
             Ok(report) => {
                 passes += 1;
                 cleaned_request_log_bodies += report.cleaned_request_log_bodies;
@@ -490,7 +541,7 @@ async fn run_request_logs_gc_catchup_claimed_job(state: Arc<AppState>, job_id: i
                     return true;
                 }
 
-                drop(_maintenance);
+                drop(_job_execution_gate);
                 tokio::time::sleep(Duration::from_secs(
                     request_logs_gc_catchup_recheck_secs(),
                 ))
@@ -538,7 +589,10 @@ async fn run_linuxdo_user_status_sync_job_with_source(
     state: Arc<AppState>,
     trigger_source: &'static str,
 ) {
-    let Some(job_id) = claim_scheduled_job(
+    let Some(ClaimedScheduledJob {
+        job_id,
+        _job_execution_gate,
+    }) = claim_scheduled_job(
         state.as_ref(),
         LINUXDO_USER_STATUS_SYNC_JOB_TYPE,
         None,
@@ -785,7 +839,10 @@ async fn run_linuxdo_user_tag_binding_refresh_job_with_source(
     state: Arc<AppState>,
     trigger_source: &'static str,
 ) {
-    let Some(job_id) = claim_scheduled_job(
+    let Some(ClaimedScheduledJob {
+        job_id,
+        _job_execution_gate,
+    }) = claim_scheduled_job(
         state.as_ref(),
         LINUXDO_USER_TAG_BINDING_REFRESH_JOB_TYPE,
         None,
@@ -854,7 +911,10 @@ async fn run_forward_proxy_geo_refresh_job_with_source(
     state: Arc<AppState>,
     trigger_source: &'static str,
 ) {
-    let Some(job_id) = claim_scheduled_job(
+    let Some(ClaimedScheduledJob {
+        job_id,
+        _job_execution_gate,
+    }) = claim_scheduled_job(
         state.as_ref(),
         "forward_proxy_geo_refresh",
         None,
@@ -892,8 +952,16 @@ async fn run_manual_claimed_job(
     state: Arc<AppState>,
     job_type: String,
     key_id: Option<String>,
-    job_id: i64,
+    claimed_job: ClaimedScheduledJob,
 ) -> bool {
+    if job_type == "request_logs_gc" {
+        return run_request_logs_gc_catchup_claimed_job(state, claimed_job).await;
+    }
+
+    let ClaimedScheduledJob {
+        job_id,
+        _job_execution_gate,
+    } = claimed_job;
     let finish = |state: Arc<AppState>, status: &'static str, message: String| async move {
         let succeeded = status == "success";
         let _ = state
@@ -960,7 +1028,7 @@ async fn run_manual_claimed_job(
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         },
-        "request_logs_gc" => run_request_logs_gc_catchup_claimed_job(state, job_id).await,
+        "request_logs_gc" => unreachable!("request_logs_gc handled above"),
         "linuxdo_user_status_sync" => {
             run_linuxdo_user_status_sync_claimed_job(state, job_id).await
         },

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -604,6 +604,7 @@ async fn run_linuxdo_user_status_sync_job_with_source(
         return;
     };
 
+    drop(_job_execution_gate);
     run_linuxdo_user_status_sync_claimed_job(state, job_id).await;
 }
 
@@ -926,6 +927,7 @@ async fn run_forward_proxy_geo_refresh_job_with_source(
         return;
     };
 
+    drop(_job_execution_gate);
     let _maintenance = acquire_db_maintenance_read_gate().await;
     match state
         .proxy
@@ -1035,8 +1037,9 @@ async fn run_manual_claimed_job(
         },
         "request_logs_gc" => unreachable!("request_logs_gc handled above"),
         "linuxdo_user_status_sync" => {
+            drop(_job_execution_gate);
             run_linuxdo_user_status_sync_claimed_job(state, job_id).await
-        },
+        }
         "linuxdo_user_tag_binding_refresh" => {
             let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.refresh_linuxdo_user_tag_bindings().await {
@@ -1045,6 +1048,7 @@ async fn run_manual_claimed_job(
             }
         },
         "forward_proxy_geo_refresh" => {
+            drop(_job_execution_gate);
             let _maintenance = acquire_db_maintenance_read_gate().await;
             match state
                 .proxy

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -53,7 +53,7 @@ const TRIGGER_SOURCE_AUTO: &str = "auto";
 
 struct ClaimedScheduledJob {
     job_id: i64,
-    _job_execution_gate: OwnedMutexGuard<()>,
+    _job_execution_gate: Option<OwnedMutexGuard<()>>,
 }
 
 async fn claim_scheduled_job_with_gate(
@@ -71,7 +71,28 @@ async fn claim_scheduled_job_with_gate(
     {
         Ok(Some(job_id)) => Ok(Some(ClaimedScheduledJob {
             job_id,
-            _job_execution_gate: job_execution_gate,
+            _job_execution_gate: Some(job_execution_gate),
+        })),
+        Ok(None) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+async fn claim_scheduled_job_without_gate(
+    state: &AppState,
+    job_type: &str,
+    key_id: Option<&str>,
+    trigger_source: &str,
+) -> Result<Option<ClaimedScheduledJob>, ProxyError> {
+    let _maintenance = acquire_db_maintenance_read_gate().await;
+    match state
+        .proxy
+        .scheduled_job_claim(job_type, trigger_source, key_id, 1)
+        .await
+    {
+        Ok(Some(job_id)) => Ok(Some(ClaimedScheduledJob {
+            job_id,
+            _job_execution_gate: None,
         })),
         Ok(None) => Ok(None),
         Err(err) => Err(err),
@@ -952,10 +973,14 @@ async fn run_manual_claimed_job(
     state: Arc<AppState>,
     job_type: String,
     key_id: Option<String>,
-    claimed_job: ClaimedScheduledJob,
+    mut claimed_job: ClaimedScheduledJob,
 ) -> bool {
     if job_type == "request_logs_gc" {
         return run_request_logs_gc_catchup_claimed_job(state, claimed_job).await;
+    }
+
+    if claimed_job._job_execution_gate.is_none() {
+        claimed_job._job_execution_gate = Some(acquire_db_job_execution_gate().await);
     }
 
     let ClaimedScheduledJob {

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -564,6 +564,18 @@ async fn record_linuxdo_user_sync_failure(
     attempted_at: i64,
     error: &str,
 ) {
+    let _job_execution_gate = acquire_db_job_execution_gate_for_state(state).await;
+    let _maintenance = acquire_db_maintenance_read_gate().await;
+    record_linuxdo_user_sync_failure_in_db_window(state, provider_user_id, attempted_at, error)
+        .await;
+}
+
+async fn record_linuxdo_user_sync_failure_in_db_window(
+    state: &AppState,
+    provider_user_id: &str,
+    attempted_at: i64,
+    error: &str,
+) {
     if let Err(mark_err) = state
         .proxy
         .record_oauth_account_profile_sync_failure(
@@ -581,6 +593,20 @@ async fn record_linuxdo_user_sync_failure(
     }
 }
 
+async fn finish_scheduled_job_with_db_gate(
+    state: &AppState,
+    job_id: i64,
+    status: &str,
+    message: &str,
+) {
+    let _job_execution_gate = acquire_db_job_execution_gate_for_state(state).await;
+    let _maintenance = acquire_db_maintenance_read_gate().await;
+    let _ = state
+        .proxy
+        .scheduled_job_finish(job_id, status, Some(message))
+        .await;
+}
+
 async fn run_linuxdo_user_status_sync_job(state: Arc<AppState>) {
     run_linuxdo_user_status_sync_job_with_source(state, TRIGGER_SOURCE_SCHEDULER).await;
 }
@@ -589,10 +615,7 @@ async fn run_linuxdo_user_status_sync_job_with_source(
     state: Arc<AppState>,
     trigger_source: &'static str,
 ) {
-    let Some(ClaimedScheduledJob {
-        job_id,
-        _job_execution_gate,
-    }) = claim_scheduled_job(
+    let Some(claimed_job) = claim_scheduled_job(
         state.as_ref(),
         LINUXDO_USER_STATUS_SYNC_JOB_TYPE,
         None,
@@ -604,58 +627,79 @@ async fn run_linuxdo_user_status_sync_job_with_source(
         return;
     };
 
-    drop(_job_execution_gate);
-    run_linuxdo_user_status_sync_claimed_job(state, job_id).await;
+    run_linuxdo_user_status_sync_claimed_job(state, claimed_job).await;
 }
 
-async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: i64) -> bool {
-    let _maintenance = acquire_db_maintenance_read_gate().await;
-    let cfg = &state.linuxdo_oauth;
-    if !cfg.is_enabled_and_configured() {
-        let _ = state
-            .proxy
-            .scheduled_job_finish(
-                job_id,
-                "success",
-                Some("attempted=0 success=0 skipped=0 failure=0 reason=linuxdo_oauth_not_configured"),
-            )
-            .await;
-        return true;
-    }
-    if !cfg.has_refresh_token_crypt_key() {
-        let _ = state
-            .proxy
-            .scheduled_job_finish(
-                job_id,
-                "success",
-                Some("attempted=0 success=0 skipped=0 failure=0 reason=missing_refresh_token_crypt_key"),
-            )
-            .await;
-        return true;
+async fn run_linuxdo_user_status_sync_claimed_job(
+    state: Arc<AppState>,
+    mut claimed_job: ClaimedScheduledJob,
+) -> bool {
+    if claimed_job._job_execution_gate.is_none() {
+        claimed_job._job_execution_gate =
+            Some(acquire_db_job_execution_gate_for_state(state.as_ref()).await);
     }
 
-    let records = match state.proxy.list_oauth_accounts_with_refresh_token("linuxdo").await {
-        Ok(records) => records,
-        Err(err) => {
+    let job_id = claimed_job.job_id;
+    let cfg = &state.linuxdo_oauth;
+
+    let records = {
+        let _job_execution_gate = claimed_job
+            ._job_execution_gate
+            .take()
+            .expect("claimed linuxdo job has execution gate");
+        let _maintenance = acquire_db_maintenance_read_gate().await;
+        if !cfg.is_enabled_and_configured() {
             let _ = state
                 .proxy
-                .scheduled_job_finish(job_id, "error", Some(&err.to_string()))
+                .scheduled_job_finish(
+                    job_id,
+                    "success",
+                    Some("attempted=0 success=0 skipped=0 failure=0 reason=linuxdo_oauth_not_configured"),
+                )
                 .await;
-            return false;
+            return true;
         }
-    };
+        if !cfg.has_refresh_token_crypt_key() {
+            let _ = state
+                .proxy
+                .scheduled_job_finish(
+                    job_id,
+                    "success",
+                    Some("attempted=0 success=0 skipped=0 failure=0 reason=missing_refresh_token_crypt_key"),
+                )
+                .await;
+            return true;
+        }
 
-    if records.is_empty() {
-        let _ = state
+        let records = match state
             .proxy
-            .scheduled_job_finish(
-                job_id,
-                "success",
-                Some("attempted=0 success=0 skipped=0 failure=0 reason=no_eligible_accounts"),
-            )
-            .await;
-        return true;
-    }
+            .list_oauth_accounts_with_refresh_token("linuxdo")
+            .await
+        {
+            Ok(records) => records,
+            Err(err) => {
+                let _ = state
+                    .proxy
+                    .scheduled_job_finish(job_id, "error", Some(&err.to_string()))
+                    .await;
+                return false;
+            }
+        };
+
+        if records.is_empty() {
+            let _ = state
+                .proxy
+                .scheduled_job_finish(
+                    job_id,
+                    "success",
+                    Some("attempted=0 success=0 skipped=0 failure=0 reason=no_eligible_accounts"),
+                )
+                .await;
+            return true;
+        }
+
+        records
+    };
 
     let client = reqwest::Client::new();
     let attempted = records.len();
@@ -730,79 +774,92 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
             continue;
         }
 
-        let upsert_result = if let Some(rotated_refresh_token) = token_payload
-            .refresh_token
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
+        let mut upsert_failure_message = None;
         {
-            match encrypt_linuxdo_refresh_token(cfg, rotated_refresh_token) {
-                Ok(Some((refresh_token_ciphertext, refresh_token_nonce))) => {
-                    state
-                        .proxy
-                        .refresh_oauth_account_profile_with_refresh_token(
-                            &profile,
-                            &refresh_token_ciphertext,
-                            &refresh_token_nonce,
-                        )
-                        .await
-                }
-                Ok(None) => state.proxy.refresh_oauth_account_profile(&profile).await,
-                Err(err) => {
-                    let message = format!("encrypt rotated refresh token error: {err}");
-                    failure += 1;
-                    first_failure.get_or_insert_with(|| format!("{record_label}: {message}"));
-                    record_linuxdo_user_sync_failure(
-                        state.as_ref(),
-                        &record.provider_user_id,
-                        attempted_at,
-                        &message,
-                    )
-                    .await;
-                    continue;
-                }
-            }
-        } else {
-            state.proxy.refresh_oauth_account_profile(&profile).await
-        };
-
-        if let Err(err) = upsert_result {
-            let mut message = format!("upsert oauth account error: {err}");
-            if !profile.active
-                && let Err(deactivate_err) = state
-                    .proxy
-                    .set_user_active_status(&record.user_id, false)
-                    .await
+            let _job_execution_gate = acquire_db_job_execution_gate_for_state(state.as_ref()).await;
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            let upsert_result = if let Some(rotated_refresh_token) = token_payload
+                .refresh_token
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
             {
-                message.push_str(&format!(
-                    "; deactivate local user error: {deactivate_err}"
-                ));
+                match encrypt_linuxdo_refresh_token(cfg, rotated_refresh_token) {
+                    Ok(Some((refresh_token_ciphertext, refresh_token_nonce))) => {
+                        state
+                            .proxy
+                            .refresh_oauth_account_profile_with_refresh_token(
+                                &profile,
+                                &refresh_token_ciphertext,
+                                &refresh_token_nonce,
+                            )
+                            .await
+                    }
+                    Ok(None) => state.proxy.refresh_oauth_account_profile(&profile).await,
+                    Err(err) => {
+                        let message = format!("encrypt rotated refresh token error: {err}");
+                        failure += 1;
+                        first_failure.get_or_insert_with(|| format!("{record_label}: {message}"));
+                        record_linuxdo_user_sync_failure_in_db_window(
+                            state.as_ref(),
+                            &record.provider_user_id,
+                            attempted_at,
+                            &message,
+                        )
+                        .await;
+                        continue;
+                    }
+                }
+            } else {
+                state.proxy.refresh_oauth_account_profile(&profile).await
+            };
+
+            if let Err(err) = upsert_result {
+                let mut message = format!("upsert oauth account error: {err}");
+                if !profile.active
+                    && let Err(deactivate_err) = state
+                        .proxy
+                        .set_user_active_status(&record.user_id, false)
+                        .await
+                {
+                    message.push_str(&format!(
+                        "; deactivate local user error: {deactivate_err}"
+                    ));
+                }
+                record_linuxdo_user_sync_failure_in_db_window(
+                    state.as_ref(),
+                    &record.provider_user_id,
+                    attempted_at,
+                    &message,
+                )
+                .await;
+                upsert_failure_message = Some(message);
             }
+        }
+
+        if let Some(message) = upsert_failure_message {
             failure += 1;
             first_failure.get_or_insert_with(|| format!("{record_label}: {message}"));
-            record_linuxdo_user_sync_failure(
-                state.as_ref(),
-                &record.provider_user_id,
-                attempted_at,
-                &message,
-            )
-            .await;
             continue;
         }
 
-        if let Err(err) = state
-            .proxy
-            .record_oauth_account_profile_sync_success(
-                "linuxdo",
-                &record.provider_user_id,
-                attempted_at,
-            )
-            .await
         {
-            eprintln!(
-                "linuxdo-user-sync: record success metadata error for {} (user_id={}): {}",
-                record.provider_user_id, record.user_id, err
-            );
+            let _job_execution_gate = acquire_db_job_execution_gate_for_state(state.as_ref()).await;
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            if let Err(err) = state
+                .proxy
+                .record_oauth_account_profile_sync_success(
+                    "linuxdo",
+                    &record.provider_user_id,
+                    attempted_at,
+                )
+                .await
+            {
+                eprintln!(
+                    "linuxdo-user-sync: record success metadata error for {} (user_id={}): {}",
+                    record.provider_user_id, record.user_id, err
+                );
+            }
         }
 
         success += 1;
@@ -814,10 +871,7 @@ async fn run_linuxdo_user_status_sync_claimed_job(state: Arc<AppState>, job_id: 
         message.push_str(&format!(" first_failure={first_failure}"));
     }
     let final_status = if failure > 0 { "error" } else { "success" };
-    let _ = state
-        .proxy
-        .scheduled_job_finish(job_id, final_status, Some(&message))
-        .await;
+    finish_scheduled_job_with_db_gate(state.as_ref(), job_id, final_status, &message).await;
     final_status == "success"
 }
 
@@ -959,6 +1013,9 @@ async fn run_manual_claimed_job(
     if job_type == "request_logs_gc" {
         return run_request_logs_gc_catchup_claimed_job(state, claimed_job).await;
     }
+    if job_type == LINUXDO_USER_STATUS_SYNC_JOB_TYPE {
+        return run_linuxdo_user_status_sync_claimed_job(state, claimed_job).await;
+    }
 
     if claimed_job._job_execution_gate.is_none() {
         claimed_job._job_execution_gate =
@@ -1036,10 +1093,7 @@ async fn run_manual_claimed_job(
             }
         },
         "request_logs_gc" => unreachable!("request_logs_gc handled above"),
-        "linuxdo_user_status_sync" => {
-            drop(_job_execution_gate);
-            run_linuxdo_user_status_sync_claimed_job(state, job_id).await
-        }
+        "linuxdo_user_status_sync" => unreachable!("linuxdo_user_status_sync handled above"),
         "linuxdo_user_tag_binding_refresh" => {
             let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.refresh_linuxdo_user_tag_bindings().await {

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -62,7 +62,7 @@ async fn claim_scheduled_job_with_gate(
     key_id: Option<&str>,
     trigger_source: &str,
 ) -> Result<Option<ClaimedScheduledJob>, ProxyError> {
-    let job_execution_gate = acquire_db_job_execution_gate().await;
+    let job_execution_gate = acquire_db_job_execution_gate_for_state(state).await;
     let _maintenance = acquire_db_maintenance_read_gate().await;
     match state
         .proxy
@@ -527,7 +527,7 @@ async fn run_request_logs_gc_catchup_claimed_job(
     let mut passes = 0usize;
 
     loop {
-        let _job_execution_gate = acquire_db_job_execution_gate().await;
+        let _job_execution_gate = acquire_db_job_execution_gate_for_state(state.as_ref()).await;
         let _maintenance = acquire_db_maintenance_read_gate().await;
         let result = state
             .proxy
@@ -980,7 +980,8 @@ async fn run_manual_claimed_job(
     }
 
     if claimed_job._job_execution_gate.is_none() {
-        claimed_job._job_execution_gate = Some(acquire_db_job_execution_gate().await);
+        claimed_job._job_execution_gate =
+            Some(acquire_db_job_execution_gate_for_state(state.as_ref()).await);
     }
 
     let ClaimedScheduledJob {
@@ -1131,7 +1132,7 @@ fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
             if Instant::now() < next_allowed_at {
                 continue;
             }
-            let _job_execution_gate = acquire_db_job_execution_gate().await;
+            let _job_execution_gate = acquire_db_job_execution_gate_for_state(state.as_ref()).await;
             let _maintenance = acquire_db_maintenance_write_gate().await;
             let stats = match state.proxy.sqlite_db_stats().await {
                 Ok(stats) => stats,

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -1106,6 +1106,7 @@ fn spawn_db_compaction_scheduler(state: Arc<AppState>) {
             if Instant::now() < next_allowed_at {
                 continue;
             }
+            let _job_execution_gate = acquire_db_job_execution_gate().await;
             let _maintenance = acquire_db_maintenance_write_gate().await;
             let stats = match state.proxy.sqlite_db_stats().await {
                 Ok(stats) => stats,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -14,9 +14,14 @@ struct AppState {
 }
 
 static DB_MAINTENANCE_GATE: OnceLock<RwLock<()>> = OnceLock::new();
+static DB_JOB_EXECUTION_GATE: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
 
 fn db_maintenance_gate() -> &'static RwLock<()> {
     DB_MAINTENANCE_GATE.get_or_init(|| RwLock::new(()))
+}
+
+fn db_job_execution_gate() -> &'static Arc<Mutex<()>> {
+    DB_JOB_EXECUTION_GATE.get_or_init(|| Arc::new(Mutex::new(())))
 }
 
 async fn acquire_db_maintenance_read_gate() -> tokio::sync::RwLockReadGuard<'static, ()> {
@@ -25,6 +30,10 @@ async fn acquire_db_maintenance_read_gate() -> tokio::sync::RwLockReadGuard<'sta
 
 async fn acquire_db_maintenance_write_gate() -> tokio::sync::RwLockWriteGuard<'static, ()> {
     db_maintenance_gate().write().await
+}
+
+pub(crate) async fn acquire_db_job_execution_gate() -> tokio::sync::OwnedMutexGuard<()> {
+    db_job_execution_gate().clone().lock_owned().await
 }
 
 async fn db_maintenance_http_gate(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -14,14 +14,23 @@ struct AppState {
 }
 
 static DB_MAINTENANCE_GATE: OnceLock<RwLock<()>> = OnceLock::new();
-static DB_JOB_EXECUTION_GATE: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
+static DB_JOB_EXECUTION_GATES: OnceLock<std::sync::Mutex<HashMap<usize, std::sync::Weak<Mutex<()>>>>> =
+    OnceLock::new();
 
 fn db_maintenance_gate() -> &'static RwLock<()> {
     DB_MAINTENANCE_GATE.get_or_init(|| RwLock::new(()))
 }
 
-fn db_job_execution_gate() -> &'static Arc<Mutex<()>> {
-    DB_JOB_EXECUTION_GATE.get_or_init(|| Arc::new(Mutex::new(())))
+fn db_job_execution_gate_for_state(state: &AppState) -> Arc<Mutex<()>> {
+    let key = state as *const AppState as usize;
+    let gates = DB_JOB_EXECUTION_GATES.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut gates = gates.lock().expect("db job execution gate map lock");
+    if let Some(gate) = gates.get(&key).and_then(std::sync::Weak::upgrade) {
+        return gate;
+    }
+    let gate = Arc::new(Mutex::new(()));
+    gates.insert(key, Arc::downgrade(&gate));
+    gate
 }
 
 async fn acquire_db_maintenance_read_gate() -> tokio::sync::RwLockReadGuard<'static, ()> {
@@ -32,8 +41,20 @@ async fn acquire_db_maintenance_write_gate() -> tokio::sync::RwLockWriteGuard<'s
     db_maintenance_gate().write().await
 }
 
+async fn acquire_db_job_execution_gate_for_state(
+    state: &AppState,
+) -> tokio::sync::OwnedMutexGuard<()> {
+    db_job_execution_gate_for_state(state).lock_owned().await
+}
+
+#[cfg(test)]
 pub(crate) async fn acquire_db_job_execution_gate() -> tokio::sync::OwnedMutexGuard<()> {
-    db_job_execution_gate().clone().lock_owned().await
+    static TEST_DB_JOB_EXECUTION_GATE: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
+    TEST_DB_JOB_EXECUTION_GATE
+        .get_or_init(|| Arc::new(Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
 }
 
 async fn db_maintenance_http_gate(

--- a/src/server/tests/chunk_09.rs
+++ b/src/server/tests/chunk_09.rs
@@ -2498,3 +2498,25 @@
 
         let _ = std::fs::remove_file(db_path);
     }
+
+    #[tokio::test]
+    async fn db_job_execution_gate_serializes_overlapping_jobs() {
+        let gate = acquire_db_job_execution_gate().await;
+        let entered = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let entered_waiter = entered.clone();
+
+        let waiter = tokio::spawn(async move {
+            let _gate = acquire_db_job_execution_gate().await;
+            entered_waiter.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(!entered.load(std::sync::atomic::Ordering::SeqCst));
+
+        drop(gate);
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter completed")
+            .expect("waiter join");
+        assert!(entered.load(std::sync::atomic::Ordering::SeqCst));
+    }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -204,7 +204,10 @@ pub(crate) async fn begin_immediate_sqlite_connection(
     pool: &SqlitePool,
 ) -> Result<sqlx::pool::PoolConnection<Sqlite>, ProxyError> {
     let mut conn = pool.acquire().await?;
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+    if let Err(err) = sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await {
+        let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        return Err(ProxyError::Database(err));
+    }
     Ok(conn)
 }
 

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -56,6 +56,55 @@ impl TavilyProxy {
         Ok((limit, remaining))
     }
 
+    pub async fn quota_sync_api_key_secret(&self, key_id: &str) -> Result<String, ProxyError> {
+        self.key_store
+            .fetch_api_key_secret(key_id)
+            .await?
+            .ok_or_else(|| ProxyError::Database(sqlx::Error::RowNotFound))
+    }
+
+    pub async fn fetch_usage_quota_for_sync_secret(
+        &self,
+        secret: &str,
+        usage_base: &str,
+        key_id: &str,
+    ) -> Result<(i64, i64), ProxyError> {
+        self.fetch_usage_quota_for_secret(
+            secret,
+            usage_base,
+            None,
+            Some(key_id),
+            None,
+            "quota_sync",
+        )
+        .await
+    }
+
+    pub async fn record_quota_sync_usage_error(
+        &self,
+        key_id: &str,
+        err: &ProxyError,
+    ) -> Result<(), ProxyError> {
+        self.maybe_quarantine_usage_error(key_id, "/api/tavily/usage", err)
+            .await
+    }
+
+    pub async fn record_quota_sync_result(
+        &self,
+        key_id: &str,
+        limit: i64,
+        remaining: i64,
+        source: &str,
+    ) -> Result<(), ProxyError> {
+        let now = Utc::now().timestamp();
+        self.key_store
+            .record_quota_sync_sample(key_id, limit, remaining, now, source)
+            .await?;
+        self.clear_transient_backoffs_after_success(key_id, source, None)
+            .await?;
+        Ok(())
+    }
+
     /// Probe usage/quota for an API key secret via Tavily Usage API base (e.g., https://api.tavily.com).
     /// This performs *no* database mutation and is safe to use for admin validation flows.
     pub async fn probe_api_key_quota(


### PR DESCRIPTION
## Summary

- Add a process-wide execution gate for DB-backed scheduled/manual jobs so maintenance work does not overlap as independent SQLite writers.
- Keep request-log GC catch-up from holding the gate while it sleeps between cleanup windows.
- Route manual quota sync and automatic DB compaction through the same execution gate.
- Sync the SQLite write-lock spec and solution notes for the new execution-gate behavior.

## Validation

- `cargo test db_job_execution_gate_serializes_overlapping_jobs -- --nocapture`
- `cargo test manual_sync_usage_endpoint_allows_non_active_keys_and_preserves_failed_quota_data -- --nocapture`
- `cargo test request_logs_gc_body_cleanup_retries_transient_sqlite_write_lock -- --nocapture`
- `cargo test scheduled_job_claim_records_trigger_source_and_rejects_duplicate_running_job -- --nocapture`
- `cargo clippy -- -D warnings`
- `bunx --bun dprint fmt docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md docs/solutions/operations/sqlite-write-lock-contention.md`

## References

- Spec: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions:
  - docs/solutions/operations/sqlite-write-lock-contention.md
- Solutions Sync: done
- Project Docs: -
- Project Docs Sync: n/a(no project-doc change)

## Notes

- Visual evidence: n/a(non-UI change)
- Production note: existing stale `scheduled_jobs.running` rows may still need a controlled service restart so startup stale-job cleanup can mark them abandoned.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
