### PR TITLE
fix: complete observability sidecar offline

### DIFF
--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -104,3 +104,24 @@
 - Recorded the first passing shared-testbox evidence for that flow: isolated compose project build,
   explicit sidecar migration, fresh token-backed `/api/tavily/search`, `/mcp`, and migrated
   request-log reads all succeeded against the migrated snapshot.
+
+## 2026-06-18
+
+- A 101 short-maintenance cutover attempt exposed a contract bug in the first explicit migration:
+  the tool copied `request_logs` and reset derived-table rebuild markers, then service startup
+  synchronously awaited the large derived rollup rebuild before opening the HTTP listener.
+- Tightened the contract so `observability_sidecar_migrate` must complete all sidecar derived-table
+  rebuild work and write completion meta before reporting success or deleting hidden legacy
+  observability tables.
+- Tightened the finalization order again after review: the migration now drops hidden legacy
+  observability tables before writing completion meta and the explicit cutover marker, avoiding a
+  false completed state if final table deletion is interrupted.
+- Added startup protection for explicit cutovers: a sidecar with the explicit cutover marker,
+  historical rows, and missing derived completion meta now fails fast with an operator instruction
+  to rerun the offline tool instead of turning startup into an implicit migration worker. The guard
+  is scoped to the explicit marker so legacy startup and small automatic sidecar self-heal remain
+  compatible.
+- Tightened completion checks so only exact `1` meta values count as complete; stale `0` values
+  remain rebuild-needed and are recovered by rerunning the offline tool.
+- Restored `valuable_failure_429_count` in the offline `api_key_usage_buckets` rebuild path so
+  per-key upstream-429 failures survive explicit sidecar migration.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -134,19 +134,30 @@
   - forces the sibling sidecar attach target instead of reusing the startup fallback,
   - copies only `main.request_logs` into `observability.request_logs` in `id` order with bounded
     batches and `NOT EXISTS` dedupe so reruns can resume partial copies safely,
-  - rebuilds request-log soft-reference tables before dropping `main.request_logs`,
+  - rebuilds request-log soft-reference tables before removing `main.request_logs`,
   - validates preserved child references (`billing_ledger`, `api_key_maintenance_records`,
     `api_key_transient_backoffs`, and any existing `auth_token_logs.request_log_id`),
-  - removes legacy `main` observability tables (`api_key_usage_buckets`,
-    `dashboard_request_rollup_buckets`, `request_log_catalog_rollups`) and resets their rebuild
-    meta markers so the next normal startup recreates or self-heals them in the sidecar layout.
-  - resets each legacy rollup/bucket rebuild marker in the same SQLite transaction that drops the
-    corresponding legacy `main` table, so an interrupted cutover cannot strand a missing table
-    behind a stale “already rebuilt” marker.
-  - preserves `request_log_catalog_rollup_v1_retention_days` at the current retention window while
-    resetting `request_log_catalog_rollup_v1_done`, so post-cutover startup sees the intended
-    rebuild marker reset without forcing an extra catalog rebuild solely because the retention meta
-    was zeroed.
+  - temporarily hides legacy `main` observability tables while reusing the existing sidecar layout
+    rebuild routines, so unqualified rebuild SQL reads and writes the attached `observability`
+    schema instead of the legacy `main` tables,
+  - rebuilds sidecar `api_key_usage_buckets`, `dashboard_request_rollup_buckets`, and
+    `request_log_catalog_rollups` before deleting any hidden legacy table,
+  - drops the hidden legacy `main` observability tables before writing completion meta, so a
+    crash cannot leave a false completed state with temporary legacy tables still present,
+  - marks `api_key_usage_buckets_v1_done`,
+    `api_key_usage_buckets_request_value_v2_done`,
+    `dashboard_request_rollup_buckets_v1_done`,
+    `request_log_catalog_rollup_v1_done`, and
+    `request_log_catalog_rollup_v1_retention_days` complete, then writes
+    `observability_sidecar_explicit_cutover_v1_done` before reporting success,
+  - reports the derived rebuild booleans, completion-meta booleans,
+    `startup_rebuild_required`, and `derived_rebuild_elapsed_ms` in JSON output.
+- Startup now treats explicit large sidecar cutover as a completed offline operation. If
+  `observability_sidecar_explicit_cutover_v1_done` is present, `main.request_logs` is gone, sidecar
+  `request_logs` contains rows, and the derived rebuild meta is incomplete, startup fails fast with
+  an instruction to rerun `observability_sidecar_migrate` instead of awaiting full derived-table
+  rebuilds before the HTTP listener is ready. Legacy single-DB startup and small automatic sidecar
+  migration remain allowed to use their bounded startup self-heal paths.
 - Server/admin test helpers now mirror that sidecar layout instead of opening only the core DB
   file. SQLite schema assertions for `request_logs` and the other observability tables now probe
   the attached schema explicitly, which keeps migration and admin-route coverage aligned with the
@@ -197,6 +208,8 @@
   - dry-run reporting without sidecar creation,
   - idempotent reruns after a finished cutover,
   - resuming partial copies when the sidecar already contains a subset of `request_logs` ids,
+  - rejecting startup when a cutover sidecar has historical rows but derived completion meta is
+    missing,
   - preserving the large-legacy startup compatibility path and standalone `request_logs_gc_once`
     behavior until the explicit cutover is run.
 - Added request-stats coverage proving summary/key-metric reads flush pending coalesced deltas
@@ -218,6 +231,7 @@
 - `cargo fmt --all`
 - `cargo test observability_sidecar_migrate_moves_large_legacy_request_logs_offline -- --nocapture`
 - `cargo test observability_sidecar_migrate_resumes_copy_from_preseeded_sidecar_gaps -- --nocapture`
+- `cargo test observability_sidecar -- --nocapture`
 - `cargo test large_legacy_single_db_request_logs_stay_in_core_database_for_startup -- --nocapture`
 - `cargo test standalone_request_logs_gc_uses_large_legacy_single_db_layout -- --nocapture`
 - Targeted SQLite lock contention tests.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -4,7 +4,7 @@
 
 - Lifecycle: active
 - Created: 2026-05-07
-- Last: 2026-06-17
+- Last: 2026-06-18
 
 ## Background
 
@@ -145,10 +145,25 @@ source when a usable persisted runtime already exists.
 - The explicit sidecar migration contract must be resumable and idempotent. Re-running the command
   after a partial copy must preserve existing `observability.request_logs` rows by `id`, continue
   copying any missing `main.request_logs` rows in bounded batches, keep soft `request_log_id`
-  references valid, then delete the legacy `main.request_logs`. For each legacy rollup/bucket table
-  drop, the corresponding rebuild markers must be reset in the same transactional cutover step so
-  an interruption cannot leave sidecar rebuild metadata falsely marked complete after the legacy
-  table is already gone.
+  references valid, rebuild all derived observability tables in the sibling sidecar layout, delete
+  the legacy `main.request_logs` and legacy `main` rollup/bucket tables, then mark the corresponding
+  meta keys complete and write the explicit cutover marker
+  `observability_sidecar_explicit_cutover_v1_done`. The command must not report completion until a
+  normal restart can attach the sibling sidecar without running a full derived-table rebuild.
+  A DB where the legacy tables are already gone but this explicit marker or the derived completion
+  meta is missing is an interrupted cutover, not an `already_migrated` success; rerunning the tool
+  must rebuild and mark the sidecar offline.
+  Completion meta must be interpreted as complete only when the value is exactly `1`; present
+  `0` values mean rebuild-needed and must not satisfy either the offline `already_migrated` check
+  or the startup guard.
+  Offline rebuild SQL for `api_key_usage_buckets` must preserve the `valuable_failure_429_count`
+  metric, not just the aggregate success/error buckets.
+- Startup must not run large sidecar derived-table rebuilds after an explicit cutover. If a cutover
+  DB has the explicit cutover marker, `main.request_logs` removed, and sidecar `request_logs`
+  present but the derived rebuild meta is incomplete, startup must fail fast with an
+  operator-facing instruction to rerun `observability_sidecar_migrate`. Startup self-heal for
+  legacy single-DB and small automatic sidecar migration remains outside this explicit-cutover
+  fail-fast guard.
 - Sidecar-aware schema self-heal paths must probe the attached `observability` schema explicitly.
   When both `main.request_logs` and `observability.request_logs` exist during migration or repair,
   column-existence checks must not accidentally read the wrong schema and issue duplicate `ALTER TABLE` statements.
@@ -217,9 +232,10 @@ source when a usable persisted runtime already exists.
   `*-observability.db` exists, `main.request_logs` is gone, `observability.request_logs` preserves
   the original `id` coverage, child `request_log_id` / `source_request_log_id` references remain
   valid, and legacy `api_key_usage_buckets`, `dashboard_request_rollup_buckets`, and
-  `request_log_catalog_rollups` are removed from `main` with their rebuild markers reset. The
-  catalog retention meta must stay aligned with the current retention setting so the first normal
-  startup after cutover does not trigger an avoidable extra catalog rebuild.
+  `request_log_catalog_rollups` are removed from `main`. Sidecar `api_key_usage_buckets`,
+  `dashboard_request_rollup_buckets`, and `request_log_catalog_rollups` must already be rebuilt,
+  their meta keys must be marked complete, and the catalog retention meta must match the current
+  retention setting before the command reports `completed=true`.
 - The explicit migration path must refuse to run while another process still holds the sibling
   `observability-migrate.lock`; success no longer relies on WAL-mode `BEGIN EXCLUSIVE` semantics to
   infer that the live service has stopped.

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -124,16 +124,17 @@
       "serial_prefixes": [
         "tests::request_"
       ],
-      "include_prefixes": [
-        "tests::request_",
-        "tests::summary_",
-        "tests::dashboard_",
-        "tests::rollup_",
-        "tests::startup_",
-        "tests::pending_",
-        "tests::proxy_",
-        "tests::observability_",
-        "tests::mcp_",
+        "include_prefixes": [
+          "tests::request_",
+          "tests::summary_",
+          "tests::dashboard_",
+          "tests::rollup_",
+          "tests::startup_",
+          "tests::small_",
+          "tests::pending_",
+          "tests::proxy_",
+          "tests::observability_",
+          "tests::mcp_",
         "tests::public_",
         "tests::quota_",
         "tests::large_",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,14 @@ pub struct ObservabilitySidecarMigrationReport {
     pub reset_api_key_usage_buckets_meta: bool,
     pub reset_dashboard_request_rollup_buckets_meta: bool,
     pub reset_request_log_catalog_rollup_meta: bool,
+    pub rebuilt_api_key_usage_buckets: bool,
+    pub rebuilt_dashboard_request_rollup_buckets: bool,
+    pub rebuilt_request_log_catalog_rollups: bool,
+    pub marked_api_key_usage_buckets_meta_complete: bool,
+    pub marked_dashboard_request_rollup_buckets_meta_complete: bool,
+    pub marked_request_log_catalog_rollup_meta_complete: bool,
+    pub startup_rebuild_required: bool,
+    pub derived_rebuild_elapsed_ms: u128,
     pub child_reference_checks_passed: bool,
     pub batch_size: i64,
     pub batches: i64,
@@ -852,6 +860,8 @@ const META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE: &str =
 const META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE: &str = "request_log_catalog_rollup_v1_done";
 const META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS: &str =
     "request_log_catalog_rollup_v1_retention_days";
+const META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE: &str =
+    "observability_sidecar_explicit_cutover_v1_done";
 const META_KEY_ACCOUNT_QUOTA_BACKFILL_V1: &str = "account_quota_backfill_v1";
 const META_KEY_ACCOUNT_QUOTA_INHERITS_DEFAULTS_BACKFILL_V1: &str =
     "account_quota_inherits_defaults_backfill_v1";

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -1992,6 +1992,19 @@ impl KeyStore {
         }
         self.ensure_request_log_catalog_rollup_schema().await?;
         self.ensure_ha_schema().await?;
+        if !uses_legacy_single_db_observability_compatibility
+            && core_database_file_size(&self.database_path).unwrap_or(u64::MAX)
+                <= LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES
+            && self
+                .get_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+                .await?
+                .is_none()
+        {
+            self.rebuild_observability_sidecar_derived_tables_offline(false)
+                .await?;
+        }
+        self.ensure_observability_sidecar_startup_rebuild_not_required()
+            .await?;
 
         if !uses_legacy_single_db_observability_compatibility
             && self
@@ -2015,6 +2028,8 @@ impl KeyStore {
                 .await?
                 .is_some();
             if !api_key_usage_buckets_v1_done {
+                self.reject_large_sidecar_startup_rebuild("api key usage bucket rebuild")
+                    .await?;
                 self.migrate_api_key_usage_buckets_v1().await?;
                 self.set_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE, 1)
                     .await?;
@@ -2026,6 +2041,8 @@ impl KeyStore {
                     .await?
                     .is_none()
             {
+                self.reject_large_sidecar_startup_rebuild("api key usage bucket request-value backfill")
+                    .await?;
                 self.backfill_api_key_usage_bucket_request_value_counts_v2()
                     .await?;
                 self.set_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE, 1)
@@ -2036,6 +2053,8 @@ impl KeyStore {
         if !uses_legacy_single_db_observability_compatibility
             && dashboard_request_rollup_buckets_schema_changed
         {
+            self.reject_large_sidecar_startup_rebuild("dashboard request rollup schema rebuild")
+                .await?;
             self.set_meta_i64(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE, 0)
                 .await?;
         }
@@ -2046,6 +2065,8 @@ impl KeyStore {
                 .await?
                 != Some(1)
         {
+            self.reject_large_sidecar_startup_rebuild("dashboard request rollup rebuild")
+                .await?;
             self.rebuild_dashboard_request_rollup_buckets().await?;
             self.set_meta_i64(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE, 1)
                 .await?;
@@ -2066,6 +2087,8 @@ impl KeyStore {
                     .await?
                     != Some(request_log_catalog_rollup_retention_days);
             if request_log_catalog_rollup_needs_rebuild {
+                self.reject_large_sidecar_startup_rebuild("request log catalog rollup rebuild")
+                    .await?;
                 self.rebuild_request_log_catalog_rollups().await?;
                 self.set_meta_i64(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE, 1)
                     .await?;

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -1992,6 +1992,8 @@ impl KeyStore {
         }
         self.ensure_request_log_catalog_rollup_schema().await?;
         self.ensure_ha_schema().await?;
+        self.ensure_observability_sidecar_startup_rebuild_not_required()
+            .await?;
         if !uses_legacy_single_db_observability_compatibility
             && core_database_file_size(&self.database_path).unwrap_or(u64::MAX)
                 <= LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES
@@ -2003,8 +2005,6 @@ impl KeyStore {
             self.rebuild_observability_sidecar_derived_tables_offline(false)
                 .await?;
         }
-        self.ensure_observability_sidecar_startup_rebuild_not_required()
-            .await?;
 
         if !uses_legacy_single_db_observability_compatibility
             && self

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -785,6 +785,13 @@ impl KeyStore {
         if !sidecar_has_request_logs {
             return Ok(());
         }
+        let explicit_cutover_done = self
+            .get_meta_i64(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+            .await?
+            == Some(1);
+        if !explicit_cutover_done {
+            return Ok(());
+        }
         let sidecar_request_log_rows: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
                 .fetch_one(&self.pool)

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -764,8 +764,17 @@ impl KeyStore {
         if !self.observability_sidecar_has_cutover_request_logs().await? {
             return Ok(());
         }
-        if self.main_table_exists("request_logs").await? {
-            return Ok(());
+        let explicit_cutover_done = self
+            .get_meta_i64(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+            .await?
+            == Some(1);
+        let require_explicit_cutover_marker = core_database_file_size(&self.database_path)
+            .unwrap_or(u64::MAX)
+            > LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES;
+        if require_explicit_cutover_marker && !explicit_cutover_done {
+            return Err(ProxyError::Other(
+                "observability sidecar derived tables are incomplete; stop the service and run observability_sidecar_migrate before startup".to_string(),
+            ));
         }
         let sidecar_has_request_logs = sqlx::query_scalar::<_, i64>(
             "SELECT 1 FROM observability.sqlite_master WHERE type = 'table' AND name = 'request_logs' LIMIT 1",

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -1,3 +1,17 @@
+struct ObservabilitySidecarDerivedRebuildReport {
+    dropped_main_request_logs: bool,
+    dropped_legacy_api_key_usage_buckets: bool,
+    dropped_legacy_dashboard_request_rollup_buckets: bool,
+    dropped_legacy_request_log_catalog_rollups: bool,
+    rebuilt_api_key_usage_buckets: bool,
+    rebuilt_dashboard_request_rollup_buckets: bool,
+    rebuilt_request_log_catalog_rollups: bool,
+    marked_api_key_usage_buckets_meta_complete: bool,
+    marked_dashboard_request_rollup_buckets_meta_complete: bool,
+    marked_request_log_catalog_rollup_meta_complete: bool,
+    elapsed_ms: u128,
+}
+
 impl KeyStore {
     async fn rebuild_request_log_soft_reference_tables_if_needed(
         &self,
@@ -57,6 +71,54 @@ impl KeyStore {
         .fetch_optional(pool)
         .await?;
         Ok(exists.is_some())
+    }
+
+    async fn meta_i64_in_pool(pool: &SqlitePool, key: &str) -> Result<Option<i64>, ProxyError> {
+        if !Self::main_table_exists_in_pool(pool, "meta").await? {
+            return Ok(None);
+        }
+        let value = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM main.meta WHERE key = ? LIMIT 1",
+        )
+        .bind(key)
+        .fetch_optional(pool)
+        .await?;
+        Ok(value.and_then(|raw| raw.parse::<i64>().ok()))
+    }
+
+    async fn explicit_sidecar_cutover_meta_complete_in_pool(
+        pool: &SqlitePool,
+        request_log_catalog_rollup_retention_days: i64,
+    ) -> Result<bool, ProxyError> {
+        let explicit_cutover_done =
+            Self::meta_i64_in_pool(pool, META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+                .await?
+                == Some(1);
+        let api_key_usage_done =
+            Self::meta_i64_in_pool(pool, META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+                .await?
+                == Some(1)
+                && Self::meta_i64_in_pool(
+                    pool,
+                    META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE,
+                )
+                .await?
+                    == Some(1);
+        let dashboard_done =
+            Self::meta_i64_in_pool(pool, META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+                .await?
+                == Some(1);
+        let catalog_done =
+            Self::meta_i64_in_pool(pool, META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE).await?
+                == Some(1)
+                && Self::meta_i64_in_pool(
+                    pool,
+                    META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS,
+                )
+                .await?
+                    == Some(request_log_catalog_rollup_retention_days);
+
+        Ok(explicit_cutover_done && api_key_usage_done && dashboard_done && catalog_done)
     }
 
     async fn table_column_exists_in_pool(
@@ -154,6 +216,652 @@ impl KeyStore {
             sqlx::query(sql).execute(pool).await?;
         }
 
+        Ok(())
+    }
+
+    async fn ensure_observability_sidecar_derived_schema_in_pool(
+        pool: &SqlitePool,
+    ) -> Result<(), ProxyError> {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.api_key_usage_buckets (
+                api_key_id TEXT NOT NULL,
+                bucket_start INTEGER NOT NULL,
+                bucket_secs INTEGER NOT NULL,
+                total_requests INTEGER NOT NULL,
+                success_count INTEGER NOT NULL,
+                error_count INTEGER NOT NULL,
+                quota_exhausted_count INTEGER NOT NULL,
+                valuable_success_count INTEGER NOT NULL DEFAULT 0,
+                valuable_failure_count INTEGER NOT NULL DEFAULT 0,
+                valuable_failure_429_count INTEGER NOT NULL DEFAULT 0,
+                other_success_count INTEGER NOT NULL DEFAULT 0,
+                other_failure_count INTEGER NOT NULL DEFAULT 0,
+                unknown_count INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (api_key_id, bucket_start, bucket_secs)
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_api_key_usage_buckets_time
+               ON api_key_usage_buckets(bucket_start DESC)"#,
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.dashboard_request_rollup_buckets (
+                bucket_start INTEGER NOT NULL,
+                bucket_secs INTEGER NOT NULL,
+                total_requests INTEGER NOT NULL,
+                success_count INTEGER NOT NULL,
+                error_count INTEGER NOT NULL,
+                quota_exhausted_count INTEGER NOT NULL,
+                valuable_success_count INTEGER NOT NULL DEFAULT 0,
+                valuable_failure_count INTEGER NOT NULL DEFAULT 0,
+                valuable_failure_429_count INTEGER NOT NULL DEFAULT 0,
+                other_success_count INTEGER NOT NULL DEFAULT 0,
+                other_failure_count INTEGER NOT NULL DEFAULT 0,
+                unknown_count INTEGER NOT NULL DEFAULT 0,
+                mcp_non_billable INTEGER NOT NULL DEFAULT 0,
+                mcp_billable INTEGER NOT NULL DEFAULT 0,
+                api_non_billable INTEGER NOT NULL DEFAULT 0,
+                api_billable INTEGER NOT NULL DEFAULT 0,
+                local_estimated_credits INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (bucket_start, bucket_secs)
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_dashboard_request_rollup_buckets_scope_time
+               ON dashboard_request_rollup_buckets(bucket_secs, bucket_start DESC)"#,
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.request_log_catalog_rollups (
+                bucket_start INTEGER NOT NULL,
+                request_kind_key TEXT NOT NULL,
+                request_kind_label TEXT NOT NULL,
+                result_bucket TEXT NOT NULL,
+                key_effect_code TEXT NOT NULL,
+                binding_effect_code TEXT NOT NULL,
+                selection_effect_code TEXT NOT NULL,
+                auth_token_id TEXT NOT NULL,
+                api_key_id TEXT NOT NULL,
+                operational_class TEXT NOT NULL,
+                request_count INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (
+                    bucket_start,
+                    request_kind_key,
+                    request_kind_label,
+                    result_bucket,
+                    key_effect_code,
+                    binding_effect_code,
+                    selection_effect_code,
+                    auth_token_id,
+                    api_key_id,
+                    operational_class
+                )
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        for sql in [
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_request_log_catalog_rollups_kind_time
+               ON request_log_catalog_rollups(request_kind_key, bucket_start DESC)"#,
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_request_log_catalog_rollups_result_time
+               ON request_log_catalog_rollups(result_bucket, bucket_start DESC)"#,
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_request_log_catalog_rollups_token_time
+               ON request_log_catalog_rollups(auth_token_id, bucket_start DESC)"#,
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_request_log_catalog_rollups_key_time
+               ON request_log_catalog_rollups(api_key_id, bucket_start DESC)"#,
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_request_log_catalog_rollups_operational_time
+               ON request_log_catalog_rollups(operational_class, bucket_start DESC)"#,
+        ] {
+            sqlx::query(sql).execute(pool).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn mark_observability_sidecar_derived_meta_complete_in_pool(
+        pool: &SqlitePool,
+        request_log_catalog_rollup_retention_days: i64,
+        mark_explicit_cutover: bool,
+    ) -> Result<(), ProxyError> {
+        let query = sqlx::query(
+            r#"
+            INSERT INTO main.meta (key, value)
+            VALUES
+                (?, '1'),
+                (?, '1'),
+                (?, '1'),
+                (?, '1'),
+                (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            "#,
+        )
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+        .bind(request_log_catalog_rollup_retention_days.to_string());
+        query.execute(pool).await?;
+        if mark_explicit_cutover {
+            sqlx::query(
+                r#"
+                INSERT INTO main.meta (key, value)
+                VALUES (?, '1')
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                "#,
+            )
+            .bind(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+            .execute(pool)
+            .await?;
+        }
+        Ok(())
+    }
+
+    fn sidecar_local_day_bucket_start_sql(created_at_sql: &str) -> String {
+        format!(
+            "CAST(strftime('%s', date({created_at_sql}, 'unixepoch', 'localtime'), 'utc') AS INTEGER)"
+        )
+    }
+
+    fn sidecar_counts_business_quota_sql(alias: &str, request_kind_sql: &str) -> String {
+        format!(
+            "COALESCE({alias}.counts_business_quota, {})",
+            request_log_counts_business_quota_sql(request_kind_sql, &format!("{alias}.request_body"))
+        )
+    }
+
+    fn sidecar_billing_group_sql(request_kind_sql: &str, counts_business_quota_sql: &str) -> String {
+        let normalized = format!("LOWER(TRIM(COALESCE({request_kind_sql}, '')))");
+        let non_billable_mcp = token_request_kind_non_billable_mcp_sql(request_kind_sql);
+        format!(
+            r#"
+            CASE
+                WHEN {normalized} IN ('api:research-result', 'api:usage', 'api:unknown-path')
+                    THEN 'non_billable'
+                WHEN {normalized} = 'mcp:batch' AND {counts_business_quota_sql} = 0
+                    THEN 'non_billable'
+                WHEN {non_billable_mcp}
+                    THEN 'non_billable'
+                ELSE 'billable'
+            END
+            "#
+        )
+    }
+
+    async fn rebuild_observability_sidecar_api_key_usage_buckets_sql(
+        pool: &SqlitePool,
+        updated_at: i64,
+    ) -> Result<(), ProxyError> {
+        let request_kind_sql = "rl.request_kind_key";
+        let request_value_bucket_sql =
+            request_value_bucket_sql(request_kind_sql, "rl.request_body");
+        let bucket_start_sql = Self::sidecar_local_day_bucket_start_sql("rl.created_at");
+        let insert_sql = format!(
+            r#"
+            INSERT INTO observability.api_key_usage_buckets (
+                api_key_id,
+                bucket_start,
+                bucket_secs,
+                total_requests,
+                success_count,
+                error_count,
+                quota_exhausted_count,
+                valuable_success_count,
+                valuable_failure_count,
+                valuable_failure_429_count,
+                other_success_count,
+                other_failure_count,
+                unknown_count,
+                updated_at
+            )
+            SELECT
+                rl.api_key_id,
+                {bucket_start_sql} AS bucket_start,
+                86400 AS bucket_secs,
+                COUNT(*) AS total_requests,
+                SUM(CASE WHEN rl.result_status = 'success' THEN 1 ELSE 0 END) AS success_count,
+                SUM(CASE WHEN rl.result_status = 'error' THEN 1 ELSE 0 END) AS error_count,
+                SUM(CASE WHEN rl.result_status = 'quota_exhausted' THEN 1 ELSE 0 END) AS quota_exhausted_count,
+                SUM(CASE WHEN ({request_value_bucket_sql}) = 'valuable' AND rl.result_status = 'success' THEN 1 ELSE 0 END) AS valuable_success_count,
+                SUM(CASE WHEN ({request_value_bucket_sql}) = 'valuable' AND rl.result_status IN ('error', 'quota_exhausted') THEN 1 ELSE 0 END) AS valuable_failure_count,
+                SUM(CASE WHEN ({request_value_bucket_sql}) = 'valuable' AND rl.result_status IN ('error', 'quota_exhausted') AND COALESCE(rl.failure_kind, '') = '{upstream_rate_limited_429}' THEN 1 ELSE 0 END) AS valuable_failure_429_count,
+                SUM(CASE WHEN ({request_value_bucket_sql}) = 'other' AND rl.result_status = 'success' THEN 1 ELSE 0 END) AS other_success_count,
+                SUM(CASE WHEN ({request_value_bucket_sql}) = 'other' AND rl.result_status IN ('error', 'quota_exhausted') THEN 1 ELSE 0 END) AS other_failure_count,
+                SUM(CASE WHEN ({request_value_bucket_sql}) = 'unknown' THEN 1 ELSE 0 END) AS unknown_count,
+                ? AS updated_at
+            FROM observability.request_logs AS rl
+            WHERE rl.visibility = 'visible'
+              AND rl.api_key_id IS NOT NULL
+            GROUP BY rl.api_key_id, bucket_start
+            "#,
+            upstream_rate_limited_429 = FAILURE_KIND_UPSTREAM_RATE_LIMITED_429
+        );
+        let mut conn = pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+        let result = async {
+            sqlx::query("DELETE FROM observability.api_key_usage_buckets")
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query(&insert_sql)
+                .bind(updated_at)
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            Ok::<(), ProxyError>(())
+        }
+        .await;
+        if result.is_err() {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        }
+        result
+    }
+
+    async fn rebuild_observability_sidecar_dashboard_request_rollup_buckets_sql(
+        pool: &SqlitePool,
+        updated_at: i64,
+    ) -> Result<(), ProxyError> {
+        let request_kind_sql = "rl.request_kind_key";
+        let counts_business_quota_sql =
+            Self::sidecar_counts_business_quota_sql("rl", request_kind_sql);
+        let request_value_bucket_sql =
+            request_value_bucket_sql(request_kind_sql, "rl.request_body");
+        let protocol_group_sql = format!(
+            "CASE WHEN LOWER(TRIM(COALESCE({request_kind_sql}, ''))) LIKE 'mcp:%' THEN 'mcp' ELSE 'api' END"
+        );
+        let billing_group_sql =
+            Self::sidecar_billing_group_sql(request_kind_sql, &counts_business_quota_sql);
+        let select_sql = |bucket_start_sql: &str, bucket_secs: i64| {
+            format!(
+                r#"
+                SELECT
+                    {bucket_start_sql} AS bucket_start,
+                    {bucket_secs} AS bucket_secs,
+                    COUNT(*) AS total_requests,
+                    SUM(CASE WHEN rl.result_status = 'success' THEN 1 ELSE 0 END) AS success_count,
+                    SUM(CASE WHEN rl.result_status = 'error' THEN 1 ELSE 0 END) AS error_count,
+                    SUM(CASE WHEN rl.result_status = 'quota_exhausted' THEN 1 ELSE 0 END) AS quota_exhausted_count,
+                    SUM(CASE WHEN ({request_value_bucket_sql}) = 'valuable' AND rl.result_status = 'success' THEN 1 ELSE 0 END) AS valuable_success_count,
+                    SUM(CASE WHEN ({request_value_bucket_sql}) = 'valuable' AND rl.result_status IN ('error', 'quota_exhausted') THEN 1 ELSE 0 END) AS valuable_failure_count,
+                    SUM(CASE WHEN ({request_value_bucket_sql}) = 'valuable' AND rl.result_status IN ('error', 'quota_exhausted') AND COALESCE(rl.failure_kind, '') = '{upstream_rate_limited_429}' THEN 1 ELSE 0 END) AS valuable_failure_429_count,
+                    SUM(CASE WHEN ({request_value_bucket_sql}) = 'other' AND rl.result_status = 'success' THEN 1 ELSE 0 END) AS other_success_count,
+                    SUM(CASE WHEN ({request_value_bucket_sql}) = 'other' AND rl.result_status IN ('error', 'quota_exhausted') THEN 1 ELSE 0 END) AS other_failure_count,
+                    SUM(CASE WHEN ({request_value_bucket_sql}) = 'unknown' THEN 1 ELSE 0 END) AS unknown_count,
+                    SUM(CASE WHEN ({protocol_group_sql}) = 'mcp' AND ({billing_group_sql}) = 'non_billable' THEN 1 ELSE 0 END) AS mcp_non_billable,
+                    SUM(CASE WHEN ({protocol_group_sql}) = 'mcp' AND ({billing_group_sql}) = 'billable' THEN 1 ELSE 0 END) AS mcp_billable,
+                    SUM(CASE WHEN ({protocol_group_sql}) = 'api' AND ({billing_group_sql}) = 'non_billable' THEN 1 ELSE 0 END) AS api_non_billable,
+                    SUM(CASE WHEN NOT (({protocol_group_sql}) = 'mcp' AND ({billing_group_sql}) = 'non_billable')
+                              AND NOT (({protocol_group_sql}) = 'mcp' AND ({billing_group_sql}) = 'billable')
+                              AND NOT (({protocol_group_sql}) = 'api' AND ({billing_group_sql}) = 'non_billable')
+                             THEN 1 ELSE 0 END) AS api_billable,
+                    SUM(MAX(COALESCE(rl.business_credits, 0), 0)) AS local_estimated_credits,
+                    ? AS updated_at
+                FROM observability.request_logs AS rl
+                WHERE rl.visibility = 'visible'
+                GROUP BY bucket_start
+                "#,
+                upstream_rate_limited_429 = FAILURE_KIND_UPSTREAM_RATE_LIMITED_429
+            )
+        };
+        let minute_select = select_sql("(rl.created_at / 60) * 60", SECS_PER_MINUTE);
+        let day_select = select_sql(
+            &Self::sidecar_local_day_bucket_start_sql("rl.created_at"),
+            SECS_PER_DAY,
+        );
+        let insert_sql = format!(
+            r#"
+            INSERT INTO observability.dashboard_request_rollup_buckets (
+                bucket_start,
+                bucket_secs,
+                total_requests,
+                success_count,
+                error_count,
+                quota_exhausted_count,
+                valuable_success_count,
+                valuable_failure_count,
+                valuable_failure_429_count,
+                other_success_count,
+                other_failure_count,
+                unknown_count,
+                mcp_non_billable,
+                mcp_billable,
+                api_non_billable,
+                api_billable,
+                local_estimated_credits,
+                updated_at
+            )
+            {minute_select}
+            UNION ALL
+            {day_select}
+            "#
+        );
+        let mut conn = pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+        let result = async {
+            sqlx::query("DELETE FROM observability.dashboard_request_rollup_buckets")
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query(&insert_sql)
+                .bind(updated_at)
+                .bind(updated_at)
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            Ok::<(), ProxyError>(())
+        }
+        .await;
+        if result.is_err() {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        }
+        result
+    }
+
+    async fn rename_main_table_if_exists_in_pool(
+        pool: &SqlitePool,
+        table: &str,
+        temporary_table: &str,
+    ) -> Result<bool, ProxyError> {
+        if !Self::main_table_exists_in_pool(pool, table).await? {
+            if Self::main_table_exists_in_pool(pool, temporary_table).await? {
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+        if Self::main_table_exists_in_pool(pool, temporary_table).await? {
+            return Err(ProxyError::Other(format!(
+                "temporary migration table {temporary_table} already exists"
+            )));
+        }
+        sqlx::query(&format!(
+            r#"ALTER TABLE main."{table}" RENAME TO "{temporary_table}""#
+        ))
+        .execute(pool)
+        .await?;
+        Ok(true)
+    }
+
+    async fn restore_renamed_main_table_if_needed_in_pool(
+        pool: &SqlitePool,
+        table: &str,
+        temporary_table: &str,
+        renamed: bool,
+    ) -> Result<(), ProxyError> {
+        if !renamed {
+            return Ok(());
+        }
+        if Self::main_table_exists_in_pool(pool, table).await? {
+            return Err(ProxyError::Other(format!(
+                "cannot restore {temporary_table}: main table {table} already exists"
+            )));
+        }
+        sqlx::query(&format!(
+            r#"ALTER TABLE main."{temporary_table}" RENAME TO "{table}""#
+        ))
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn drop_renamed_main_table_if_needed_in_pool(
+        pool: &SqlitePool,
+        temporary_table: &str,
+        renamed: bool,
+    ) -> Result<bool, ProxyError> {
+        if !renamed {
+            return Ok(false);
+        }
+        sqlx::query(&format!(r#"DROP TABLE main."{temporary_table}""#))
+            .execute(pool)
+            .await?;
+        Ok(true)
+    }
+
+    async fn rebuild_observability_sidecar_derived_tables_offline(
+        &self,
+        mark_explicit_cutover: bool,
+    ) -> Result<ObservabilitySidecarDerivedRebuildReport, ProxyError> {
+        self.ensure_meta_schema().await?;
+        Self::ensure_observability_sidecar_derived_schema_in_pool(&self.pool).await?;
+        let started = Instant::now();
+        let temp_request_logs = "__observability_sidecar_legacy_request_logs";
+        let temp_api_key_usage = "__observability_sidecar_legacy_api_key_usage_buckets";
+        let temp_dashboard = "__observability_sidecar_legacy_dashboard_request_rollup_buckets";
+        let temp_catalog = "__observability_sidecar_legacy_request_log_catalog_rollups";
+
+        let request_logs_renamed =
+            Self::rename_main_table_if_exists_in_pool(&self.pool, "request_logs", temp_request_logs)
+                .await?;
+        let api_key_usage_renamed = Self::rename_main_table_if_exists_in_pool(
+            &self.pool,
+            "api_key_usage_buckets",
+            temp_api_key_usage,
+        )
+        .await?;
+        let dashboard_renamed = Self::rename_main_table_if_exists_in_pool(
+            &self.pool,
+            "dashboard_request_rollup_buckets",
+            temp_dashboard,
+        )
+        .await?;
+        let catalog_renamed = Self::rename_main_table_if_exists_in_pool(
+            &self.pool,
+            "request_log_catalog_rollups",
+            temp_catalog,
+        )
+        .await?;
+
+        let rebuild_result = async {
+            Self::rebuild_observability_sidecar_api_key_usage_buckets_sql(
+                &self.pool,
+                self.backend_time.now_ts(),
+            )
+            .await?;
+            Self::rebuild_observability_sidecar_dashboard_request_rollup_buckets_sql(
+                &self.pool,
+                self.backend_time.now_ts(),
+            )
+            .await?;
+            self.rebuild_request_log_catalog_rollups().await?;
+            Ok::<(), ProxyError>(())
+        }
+        .await;
+
+        if let Err(err) = rebuild_result {
+            let _ = Self::restore_renamed_main_table_if_needed_in_pool(
+                &self.pool,
+                "request_log_catalog_rollups",
+                temp_catalog,
+                catalog_renamed,
+            )
+            .await;
+            let _ = Self::restore_renamed_main_table_if_needed_in_pool(
+                &self.pool,
+                "dashboard_request_rollup_buckets",
+                temp_dashboard,
+                dashboard_renamed,
+            )
+            .await;
+            let _ = Self::restore_renamed_main_table_if_needed_in_pool(
+                &self.pool,
+                "api_key_usage_buckets",
+                temp_api_key_usage,
+                api_key_usage_renamed,
+            )
+            .await;
+            let _ = Self::restore_renamed_main_table_if_needed_in_pool(
+                &self.pool,
+                "request_logs",
+                temp_request_logs,
+                request_logs_renamed,
+            )
+            .await;
+            return Err(err);
+        }
+
+        let dropped_main_request_logs =
+            Self::drop_renamed_main_table_if_needed_in_pool(&self.pool, temp_request_logs, request_logs_renamed)
+                .await?;
+        let dropped_legacy_api_key_usage_buckets =
+            Self::drop_renamed_main_table_if_needed_in_pool(&self.pool, temp_api_key_usage, api_key_usage_renamed)
+                .await?;
+        let dropped_legacy_dashboard_request_rollup_buckets =
+            Self::drop_renamed_main_table_if_needed_in_pool(&self.pool, temp_dashboard, dashboard_renamed)
+                .await?;
+        let dropped_legacy_request_log_catalog_rollups =
+            Self::drop_renamed_main_table_if_needed_in_pool(&self.pool, temp_catalog, catalog_renamed)
+                .await?;
+
+        let request_log_catalog_rollup_retention_days = self
+            .get_system_settings()
+            .await?
+            .request_log_retention
+            .max_log_retention_days;
+        Self::mark_observability_sidecar_derived_meta_complete_in_pool(
+            &self.pool,
+            request_log_catalog_rollup_retention_days,
+            mark_explicit_cutover,
+        )
+        .await?;
+
+        Ok(ObservabilitySidecarDerivedRebuildReport {
+            dropped_main_request_logs,
+            dropped_legacy_api_key_usage_buckets,
+            dropped_legacy_dashboard_request_rollup_buckets,
+            dropped_legacy_request_log_catalog_rollups,
+            rebuilt_api_key_usage_buckets: true,
+            rebuilt_dashboard_request_rollup_buckets: true,
+            rebuilt_request_log_catalog_rollups: true,
+            marked_api_key_usage_buckets_meta_complete: true,
+            marked_dashboard_request_rollup_buckets_meta_complete: true,
+            marked_request_log_catalog_rollup_meta_complete: true,
+            elapsed_ms: started.elapsed().as_millis(),
+        })
+    }
+
+    async fn ensure_observability_sidecar_startup_rebuild_not_required(
+        &self,
+    ) -> Result<(), ProxyError> {
+        if self.uses_legacy_single_db_observability_compatibility() {
+            return Ok(());
+        }
+        if !self.observability_sidecar_has_cutover_request_logs().await? {
+            return Ok(());
+        }
+        if self.main_table_exists("request_logs").await? {
+            return Ok(());
+        }
+        let sidecar_has_request_logs = sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM observability.sqlite_master WHERE type = 'table' AND name = 'request_logs' LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some();
+        if !sidecar_has_request_logs {
+            return Ok(());
+        }
+        let sidecar_request_log_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
+                .fetch_one(&self.pool)
+                .await?;
+        if sidecar_request_log_rows == 0 {
+            return Ok(());
+        }
+        let request_log_catalog_rollup_retention_days = self
+            .get_system_settings()
+            .await?
+            .request_log_retention
+            .max_log_retention_days;
+        let api_key_usage_done = self
+            .get_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+            .await?
+            == Some(1)
+            && self
+                .get_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+                .await?
+                == Some(1);
+        let dashboard_done = self
+            .get_meta_i64(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+            .await?
+            == Some(1);
+        let catalog_done = self
+            .get_meta_i64(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+            .await?
+            == Some(1)
+            && self
+                .get_meta_i64(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+                .await?
+                == Some(request_log_catalog_rollup_retention_days);
+        if api_key_usage_done && dashboard_done && catalog_done {
+            return Ok(());
+        }
+        Err(ProxyError::Other(
+            "observability sidecar derived tables are incomplete; stop the service and run observability_sidecar_migrate before startup".to_string(),
+        ))
+    }
+
+    async fn observability_sidecar_has_cutover_request_logs(
+        &self,
+    ) -> Result<bool, ProxyError> {
+        if self.uses_legacy_single_db_observability_compatibility() {
+            return Ok(false);
+        }
+        if self.main_table_exists("request_logs").await? {
+            return Ok(false);
+        }
+        let sidecar_has_request_logs = sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM observability.sqlite_master WHERE type = 'table' AND name = 'request_logs' LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some();
+        if !sidecar_has_request_logs {
+            return Ok(false);
+        }
+        let sidecar_request_log_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(sidecar_request_log_rows > 0)
+    }
+
+    async fn reject_large_sidecar_startup_rebuild(
+        &self,
+        reason: &str,
+    ) -> Result<(), ProxyError> {
+        if self
+            .get_meta_i64(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+            .await?
+            != Some(1)
+        {
+            return Ok(());
+        }
+        if core_database_file_size(&self.database_path).unwrap_or(u64::MAX)
+            <= LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES
+        {
+            return Ok(());
+        }
+        if self.observability_sidecar_has_cutover_request_logs().await? {
+            return Err(ProxyError::Other(format!(
+                "observability sidecar derived tables require {reason}; stop the service and run observability_sidecar_migrate before startup"
+            )));
+        }
         Ok(())
     }
 
@@ -333,6 +1041,7 @@ impl KeyStore {
         };
         store.ensure_meta_schema().await?;
         Self::ensure_request_logs_schema_in_pool(&store.pool).await?;
+        Self::ensure_observability_sidecar_derived_schema_in_pool(&store.pool).await?;
         store.upgrade_request_logs_schema().await?;
         store.ensure_request_logs_gc_support_indexes().await?;
         Ok(store)
@@ -367,7 +1076,11 @@ impl KeyStore {
             Some(acquire_observability_offline_guard(&layout.core_database_path)?)
         };
         let offline_probe = probe_observability_offline_state(&layout.core_database_path).await?;
-        let offline_lock_acquired = offline_probe.service_lock_held_exclusively;
+        let offline_lock_acquired = if dry_run {
+            offline_probe.service_lock_held_exclusively
+        } else {
+            true
+        };
 
         let core_file_bytes = core_database_file_size(&layout.core_database_path)?;
         let available_bytes_before = available_disk_bytes_for_path(&layout.core_database_path)?;
@@ -394,6 +1107,39 @@ impl KeyStore {
             Self::main_table_exists_in_pool(&core_probe, "dashboard_request_rollup_buckets").await?;
         let legacy_request_log_catalog_rollups_exists =
             Self::main_table_exists_in_pool(&core_probe, "request_log_catalog_rollups").await?;
+        let request_log_catalog_rollup_retention_days = Self::meta_i64_in_pool(
+            &core_probe,
+            META_KEY_REQUEST_LOG_RETENTION_MAX_DAYS_V1,
+        )
+        .await?
+        .unwrap_or_else(|| {
+            effective_request_logs_retention_days().min(REQUEST_LOG_RETENTION_DAYS_MAX)
+        })
+        .clamp(REQUEST_LOG_RETENTION_DAYS_MIN, REQUEST_LOG_RETENTION_DAYS_MAX);
+        let explicit_cutover_meta_complete = Self::explicit_sidecar_cutover_meta_complete_in_pool(
+            &core_probe,
+            request_log_catalog_rollup_retention_days,
+        )
+        .await?;
+        let temporary_legacy_request_logs_exists =
+            Self::main_table_exists_in_pool(&core_probe, "__observability_sidecar_legacy_request_logs").await?;
+        let temporary_legacy_api_key_usage_buckets_exists = Self::main_table_exists_in_pool(
+            &core_probe,
+            "__observability_sidecar_legacy_api_key_usage_buckets",
+        )
+        .await?;
+        let temporary_legacy_dashboard_request_rollup_buckets_exists =
+            Self::main_table_exists_in_pool(
+                &core_probe,
+                "__observability_sidecar_legacy_dashboard_request_rollup_buckets",
+            )
+            .await?;
+        let temporary_legacy_request_log_catalog_rollups_exists =
+            Self::main_table_exists_in_pool(
+                &core_probe,
+                "__observability_sidecar_legacy_request_log_catalog_rollups",
+            )
+            .await?;
         let attached_default = planned_observability_attach_path(
             &layout.core_database_path,
             layout.observability_database_path.as_deref(),
@@ -446,9 +1192,14 @@ impl KeyStore {
         let already_migrated = !legacy_request_logs_exists
             && !legacy_api_key_usage_buckets_exists
             && !legacy_dashboard_request_rollup_buckets_exists
-            && !legacy_request_log_catalog_rollups_exists;
+            && !legacy_request_log_catalog_rollups_exists
+            && !temporary_legacy_request_logs_exists
+            && !temporary_legacy_api_key_usage_buckets_exists
+            && !temporary_legacy_dashboard_request_rollup_buckets_exists
+            && !temporary_legacy_request_log_catalog_rollups_exists
+            && explicit_cutover_meta_complete;
 
-        let (attached_observability_path, sidecar_request_log_rows_before, sidecar_request_log_rows_after, copied_request_logs, batches, dropped_main_request_logs, dropped_legacy_api_key_usage_buckets, dropped_legacy_dashboard_request_rollup_buckets, dropped_legacy_request_log_catalog_rollups, reset_api_key_usage_buckets_meta, reset_dashboard_request_rollup_buckets_meta, reset_request_log_catalog_rollup_meta, child_reference_checks_passed) =
+        let (attached_observability_path, sidecar_request_log_rows_before, sidecar_request_log_rows_after, copied_request_logs, batches, dropped_main_request_logs, dropped_legacy_api_key_usage_buckets, dropped_legacy_dashboard_request_rollup_buckets, dropped_legacy_request_log_catalog_rollups, reset_api_key_usage_buckets_meta, reset_dashboard_request_rollup_buckets_meta, reset_request_log_catalog_rollup_meta, rebuilt_api_key_usage_buckets, rebuilt_dashboard_request_rollup_buckets, rebuilt_request_log_catalog_rollups, marked_api_key_usage_buckets_meta_complete, marked_dashboard_request_rollup_buckets_meta_complete, marked_request_log_catalog_rollup_meta_complete, startup_rebuild_required, derived_rebuild_elapsed_ms, child_reference_checks_passed) =
             if dry_run {
                 let attached_observability_path = attached_default
                     .clone()
@@ -467,6 +1218,14 @@ impl KeyStore {
                     false,
                     false,
                     false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    !already_migrated && sidecar_request_log_rows_before_probe > 0,
+                    0,
+                    false,
                 )
             } else {
                 let store = Self::open_for_observability_sidecar_migration(database_path).await?;
@@ -480,133 +1239,104 @@ impl KeyStore {
                             .fetch_one(&store.pool)
                             .await?;
 
-                    let request_log_catalog_rollup_retention_days = store
-                        .get_system_settings()
-                        .await?
-                        .request_log_retention
-                        .max_log_retention_days;
-                    let mut copied_request_logs = 0_i64;
-                    let mut batches = 0_i64;
-                    let mut dropped_main_request_logs = false;
-                    let mut dropped_legacy_api_key_usage_buckets = false;
-                    let mut dropped_legacy_dashboard_request_rollup_buckets = false;
-                    let mut dropped_legacy_request_log_catalog_rollups = false;
-                    let mut reset_api_key_usage_buckets_meta = false;
-                    let mut reset_dashboard_request_rollup_buckets_meta = false;
-                    let mut reset_request_log_catalog_rollup_meta = false;
-                    let child_reference_checks_passed;
-
-                    if legacy_request_logs_exists {
+                    if already_migrated {
                         store
-                            .rebuild_request_log_soft_reference_tables_if_needed()
+                            .ensure_observability_sidecar_startup_rebuild_not_required()
                             .await?;
-                        let (copied, copied_batches) =
-                            Self::copy_legacy_request_logs_into_observability_batched_in_pool(
+                        let sidecar_request_log_rows_after: i64 =
+                            sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
+                                .fetch_one(&store.pool)
+                                .await?;
+                        (
+                            attached_observability_path,
+                            sidecar_request_log_rows_before,
+                            sidecar_request_log_rows_after,
+                            0,
+                            0,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            0,
+                            true,
+                        )
+                    } else {
+                        let mut copied_request_logs = 0_i64;
+                        let mut batches = 0_i64;
+                        let child_reference_checks_passed;
+
+                        if legacy_request_logs_exists {
+                            store
+                                .rebuild_request_log_soft_reference_tables_if_needed()
+                                .await?;
+                            let (copied, copied_batches) =
+                                Self::copy_legacy_request_logs_into_observability_batched_in_pool(
+                                    &store.pool,
+                                    batch_size,
+                                )
+                                .await?;
+                            copied_request_logs = copied;
+                            batches = copied_batches;
+                            Self::ensure_request_logs_rebuild_references_valid_in_pool(
                                 &store.pool,
-                                batch_size,
+                                "request_logs schema migration produced invalid preserved references",
                             )
                             .await?;
-                        copied_request_logs = copied;
-                        batches = copied_batches;
-                        Self::ensure_request_logs_rebuild_references_valid_in_pool(
-                            &store.pool,
-                            "request_logs schema migration produced invalid preserved references",
-                        )
-                        .await?;
-                        sqlx::query("DROP TABLE request_logs")
-                            .execute(&store.pool)
+                            child_reference_checks_passed = true;
+                        } else {
+                            Self::ensure_request_logs_rebuild_references_valid_in_pool(
+                                &store.pool,
+                                "request_logs schema migration produced invalid preserved references",
+                            )
                             .await?;
-                        dropped_main_request_logs = true;
-                        child_reference_checks_passed = true;
-                    } else {
-                        Self::ensure_request_logs_rebuild_references_valid_in_pool(
-                            &store.pool,
-                            "request_logs schema migration produced invalid preserved references",
-                        )
-                        .await?;
-                        child_reference_checks_passed = true;
-                    }
+                            child_reference_checks_passed = true;
+                        }
 
-                    if legacy_api_key_usage_buckets_exists {
-                        let mut tx = store.pool.begin().await?;
-                        sqlx::query(
-                            r#"
-                            INSERT INTO meta (key, value)
-                            VALUES (?, '0'), (?, '0')
-                            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-                            "#,
-                        )
-                        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
-                        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
-                        .execute(&mut *tx)
-                        .await?;
-                        sqlx::query("DROP TABLE api_key_usage_buckets")
-                            .execute(&mut *tx)
+                        let derived_report = store
+                            .rebuild_observability_sidecar_derived_tables_offline(true)
                             .await?;
-                        tx.commit().await?;
-                        dropped_legacy_api_key_usage_buckets = true;
-                        reset_api_key_usage_buckets_meta = true;
-                    }
-                    if legacy_dashboard_request_rollup_buckets_exists {
-                        let mut tx = store.pool.begin().await?;
-                        sqlx::query(
-                            r#"
-                            INSERT INTO meta (key, value)
-                            VALUES (?, '0')
-                            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-                            "#,
-                        )
-                        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
-                        .execute(&mut *tx)
-                        .await?;
-                        sqlx::query("DROP TABLE dashboard_request_rollup_buckets")
-                            .execute(&mut *tx)
+                        store
+                            .ensure_observability_sidecar_startup_rebuild_not_required()
                             .await?;
-                        tx.commit().await?;
-                        dropped_legacy_dashboard_request_rollup_buckets = true;
-                        reset_dashboard_request_rollup_buckets_meta = true;
-                    }
-                    if legacy_request_log_catalog_rollups_exists {
-                        let mut tx = store.pool.begin().await?;
-                        sqlx::query(
-                            r#"
-                            INSERT INTO meta (key, value)
-                            VALUES (?, '0'), (?, ?)
-                            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-                            "#,
-                        )
-                        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
-                        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
-                        .bind(request_log_catalog_rollup_retention_days.to_string())
-                        .execute(&mut *tx)
-                        .await?;
-                        sqlx::query("DROP TABLE request_log_catalog_rollups")
-                            .execute(&mut *tx)
-                            .await?;
-                        tx.commit().await?;
-                        dropped_legacy_request_log_catalog_rollups = true;
-                        reset_request_log_catalog_rollup_meta = true;
-                    }
 
-                    let sidecar_request_log_rows_after: i64 =
-                        sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
-                            .fetch_one(&store.pool)
-                            .await?;
-                    (
-                        attached_observability_path,
-                        sidecar_request_log_rows_before,
-                        sidecar_request_log_rows_after,
-                        copied_request_logs,
-                        batches,
-                        dropped_main_request_logs,
-                        dropped_legacy_api_key_usage_buckets,
-                        dropped_legacy_dashboard_request_rollup_buckets,
-                        dropped_legacy_request_log_catalog_rollups,
-                        reset_api_key_usage_buckets_meta,
-                        reset_dashboard_request_rollup_buckets_meta,
-                        reset_request_log_catalog_rollup_meta,
-                        child_reference_checks_passed,
-                    )
+                        let sidecar_request_log_rows_after: i64 =
+                            sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
+                                .fetch_one(&store.pool)
+                                .await?;
+                        (
+                            attached_observability_path,
+                            sidecar_request_log_rows_before,
+                            sidecar_request_log_rows_after,
+                            copied_request_logs,
+                            batches,
+                            derived_report.dropped_main_request_logs,
+                            derived_report.dropped_legacy_api_key_usage_buckets,
+                            derived_report.dropped_legacy_dashboard_request_rollup_buckets,
+                            derived_report.dropped_legacy_request_log_catalog_rollups,
+                            false,
+                            false,
+                            false,
+                            derived_report.rebuilt_api_key_usage_buckets,
+                            derived_report.rebuilt_dashboard_request_rollup_buckets,
+                            derived_report.rebuilt_request_log_catalog_rollups,
+                            derived_report.marked_api_key_usage_buckets_meta_complete,
+                            derived_report.marked_dashboard_request_rollup_buckets_meta_complete,
+                            derived_report.marked_request_log_catalog_rollup_meta_complete,
+                            false,
+                            derived_report.elapsed_ms,
+                            child_reference_checks_passed,
+                        )
+                    }
                 };
                 store.pool.close().await;
                 result
@@ -651,18 +1381,34 @@ impl KeyStore {
             reset_api_key_usage_buckets_meta,
             reset_dashboard_request_rollup_buckets_meta,
             reset_request_log_catalog_rollup_meta,
+            rebuilt_api_key_usage_buckets,
+            rebuilt_dashboard_request_rollup_buckets,
+            rebuilt_request_log_catalog_rollups,
+            marked_api_key_usage_buckets_meta_complete,
+            marked_dashboard_request_rollup_buckets_meta_complete,
+            marked_request_log_catalog_rollup_meta_complete,
+            startup_rebuild_required,
+            derived_rebuild_elapsed_ms,
             child_reference_checks_passed,
             batch_size,
             batches,
             completed: !dry_run
                 && child_reference_checks_passed
-                && (!legacy_request_logs_exists || dropped_main_request_logs)
-                && (!legacy_api_key_usage_buckets_exists
-                    || dropped_legacy_api_key_usage_buckets)
-                && (!legacy_dashboard_request_rollup_buckets_exists
-                    || dropped_legacy_dashboard_request_rollup_buckets)
-                && (!legacy_request_log_catalog_rollups_exists
-                    || dropped_legacy_request_log_catalog_rollups),
+                && !startup_rebuild_required
+                && (already_migrated
+                    || (rebuilt_api_key_usage_buckets
+                        && rebuilt_dashboard_request_rollup_buckets
+                        && rebuilt_request_log_catalog_rollups
+                        && marked_api_key_usage_buckets_meta_complete
+                        && marked_dashboard_request_rollup_buckets_meta_complete
+                        && marked_request_log_catalog_rollup_meta_complete
+                        && (!legacy_request_logs_exists || dropped_main_request_logs)
+                        && (!legacy_api_key_usage_buckets_exists
+                            || dropped_legacy_api_key_usage_buckets)
+                        && (!legacy_dashboard_request_rollup_buckets_exists
+                            || dropped_legacy_dashboard_request_rollup_buckets)
+                        && (!legacy_request_log_catalog_rollups_exists
+                            || dropped_legacy_request_log_catalog_rollups))),
             elapsed_ms: started.elapsed().as_millis(),
         })
     }
@@ -697,30 +1443,11 @@ impl KeyStore {
             drop(conn);
             sqlx::query("DROP TABLE request_logs")
                 .execute(&self.pool)
-                .await?;
+            .await?;
         }
 
-        if legacy_api_key_usage_buckets {
-            sqlx::query("DROP TABLE api_key_usage_buckets")
-                .execute(&self.pool)
-                .await?;
-            self.set_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE, 0)
-                .await?;
-            self.set_meta_i64(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE, 0)
-                .await?;
-        }
-        if legacy_dashboard_rollups {
-            sqlx::query("DROP TABLE dashboard_request_rollup_buckets")
-                .execute(&self.pool)
-                .await?;
-            self.set_meta_i64(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE, 0)
-                .await?;
-        }
-        if legacy_catalog_rollups {
-            sqlx::query("DROP TABLE request_log_catalog_rollups")
-                .execute(&self.pool)
-                .await?;
-            self.set_meta_i64(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE, 0)
+        if legacy_api_key_usage_buckets || legacy_dashboard_rollups || legacy_catalog_rollups {
+            self.rebuild_observability_sidecar_derived_tables_offline(false)
                 .await?;
         }
 

--- a/src/tests/chunk_04_tail.rs
+++ b/src/tests/chunk_04_tail.rs
@@ -1567,6 +1567,95 @@ async fn observability_sidecar_rejects_startup_when_explicit_marker_missing_but_
 }
 
 #[tokio::test]
+async fn observability_sidecar_rejects_explicit_cutover_before_small_self_heal() {
+    let db_path = temp_db_path("observability-sidecar-cutover-self-heal-order");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (method, path, created_at) VALUES ('POST', '/api/tavily/search', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let meta_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    sqlx::query("DELETE FROM meta WHERE key IN (?, ?, ?, ?, ?, ?)")
+        .bind(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+        .execute(&meta_pool)
+        .await
+        .expect("clear completion meta");
+    drop(meta_pool);
+
+    let startup_err = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect_err("startup should reject interrupted cutover before self-heal");
+    assert!(
+        startup_err
+            .to_string()
+            .contains("observability sidecar derived tables are incomplete"),
+        "unexpected startup error: {startup_err}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
 async fn observability_sidecar_rejects_large_startup_schema_drift_rebuild() {
     let db_path = temp_db_path("observability-sidecar-cutover-schema-drift");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/tests/chunk_04_tail.rs
+++ b/src/tests/chunk_04_tail.rs
@@ -352,6 +352,133 @@ async fn legacy_request_logs_backfill_uses_main_schema_when_sidecar_table_alread
 }
 
 #[tokio::test]
+async fn small_legacy_sidecar_migration_rebuilds_partial_derived_tables() {
+    let db_path = temp_db_path("observability-sidecar-partial-derived-auto");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let mut conn = sqlx::SqliteConnection::connect_with(
+        &sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open partial legacy sqlite");
+    sqlx::query(
+        r#"
+        CREATE TABLE api_keys (
+            id TEXT PRIMARY KEY,
+            api_key TEXT NOT NULL UNIQUE,
+            created_at INTEGER NOT NULL DEFAULT 0,
+            last_used_at INTEGER NOT NULL DEFAULT 0
+        )
+        "#,
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create api_keys");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            api_key_id TEXT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            request_kind_key TEXT,
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (api_key_id) REFERENCES api_keys(id)
+        )
+        "#,
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        r#"
+        CREATE TABLE api_key_usage_buckets (
+            api_key_id TEXT NOT NULL,
+            bucket_start INTEGER NOT NULL,
+            bucket_secs INTEGER NOT NULL,
+            total_requests INTEGER NOT NULL,
+            success_count INTEGER NOT NULL,
+            error_count INTEGER NOT NULL,
+            quota_exhausted_count INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (api_key_id, bucket_start, bucket_secs)
+        )
+        "#,
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create only one legacy derived table");
+    sqlx::query(
+        "INSERT INTO api_keys (id, api_key, created_at, last_used_at) VALUES ('k1', 'tvly-partial-derived-auto', 1, 1)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("insert api key");
+    sqlx::query(
+        r#"
+        INSERT INTO request_logs (api_key_id, method, path, result_status, request_kind_key, visibility, created_at)
+        VALUES ('k1', 'POST', '/api/tavily/search', 'success', 'api:search', 'visible', 1710000000)
+        "#,
+    )
+    .execute(&mut conn)
+    .await
+    .expect("insert legacy request log");
+    drop(conn);
+
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy should migrate partial legacy derived tables");
+
+    let main_request_logs_exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'request_logs' LIMIT 1",
+    )
+    .fetch_optional(&proxy.key_store.pool)
+    .await
+    .expect("check main request_logs");
+    assert!(main_request_logs_exists.is_none());
+
+    let main_api_key_usage_exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'api_key_usage_buckets' LIMIT 1",
+    )
+    .fetch_optional(&proxy.key_store.pool)
+    .await
+    .expect("check main partial legacy derived table");
+    assert!(main_api_key_usage_exists.is_none());
+
+    let sidecar_api_key_usage_exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM observability.sqlite_master WHERE type = 'table' AND name = 'api_key_usage_buckets' LIMIT 1",
+    )
+    .fetch_optional(&proxy.key_store.pool)
+    .await
+    .expect("check sidecar api key usage table");
+    assert_eq!(sidecar_api_key_usage_exists, Some(1));
+
+    let api_key_usage_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM observability.api_key_usage_buckets")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("count rebuilt api key usage rows");
+    assert_eq!(api_key_usage_rows, 1);
+
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
 async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline() {
     let db_path = temp_db_path("observability-sidecar-explicit-migrate-large-legacy");
     let db_str = db_path.to_string_lossy().to_string();
@@ -389,6 +516,8 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
             method TEXT NOT NULL,
             path TEXT NOT NULL,
             result_status TEXT NOT NULL DEFAULT 'success',
+            failure_kind TEXT,
+            request_kind_key TEXT,
             visibility TEXT NOT NULL DEFAULT 'visible',
             created_at INTEGER NOT NULL,
             FOREIGN KEY (api_key_id) REFERENCES api_keys(id)
@@ -473,8 +602,8 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
     for (id, created_at) in [(1_i64, 100_i64), (2, 200), (4, 400)] {
         sqlx::query(
             r#"
-            INSERT INTO request_logs (id, api_key_id, method, path, result_status, visibility, created_at)
-            VALUES (?, 'k1', 'POST', '/api/tavily/search', 'success', 'visible', ?)
+            INSERT INTO request_logs (id, api_key_id, method, path, result_status, failure_kind, request_kind_key, visibility, created_at)
+            VALUES (?, 'k1', 'POST', '/api/tavily/search', 'success', NULL, 'api:search', 'visible', ?)
             "#,
         )
         .bind(id)
@@ -483,6 +612,12 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         .await
         .expect("seed request log");
     }
+    sqlx::query(
+        "INSERT INTO request_logs (id, api_key_id, method, path, result_status, failure_kind, request_kind_key, visibility, created_at) VALUES (3, 'k1', 'POST', '/api/tavily/search', 'error', 'upstream_rate_limited_429', 'api:search', 'visible', 300)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed 429 request log");
     sqlx::query(
         "INSERT INTO api_key_maintenance_records (id, key_id, source, operation_code, operation_summary, request_log_id, created_at) VALUES ('m1', 'k1', 'auto', 'noop', 'noop', 2, 1)",
     )
@@ -523,11 +658,39 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         .await
         .expect("offline migration succeeds");
     assert!(report.completed);
-    assert_eq!(report.copied_request_logs, 3);
+    assert_eq!(report.copied_request_logs, 4);
     assert_eq!(report.batches, 2);
     assert!(report.dropped_main_request_logs);
+    assert!(report.rebuilt_api_key_usage_buckets);
+    assert!(report.rebuilt_dashboard_request_rollup_buckets);
+    assert!(report.rebuilt_request_log_catalog_rollups);
+    assert!(report.marked_api_key_usage_buckets_meta_complete);
+    assert!(report.marked_dashboard_request_rollup_buckets_meta_complete);
+    assert!(report.marked_request_log_catalog_rollup_meta_complete);
+    assert!(!report.startup_rebuild_required);
+    assert!(report.derived_rebuild_elapsed_ms > 0);
     assert!(report.child_reference_checks_passed);
     assert!(std::path::Path::new(&observability_path).exists());
+
+    let migrated_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&observability_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open migrated observability sidecar pool");
+    let api_key_usage_429_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(valuable_failure_429_count), 0)
+        FROM api_key_usage_buckets
+        WHERE api_key_id = 'k1'
+        "#,
+    )
+    .fetch_one(&migrated_pool)
+    .await
+    .expect("query api key usage 429 count");
+    assert_eq!(api_key_usage_429_count, 1);
+    drop(migrated_pool);
 
     let rerun = run_observability_sidecar_migrate(&db_str, 2, false)
         .await
@@ -550,6 +713,14 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         effective_request_logs_retention_days(),
         "migration should preserve the current catalog retention window after resetting rebuild markers"
     );
+    let explicit_cutover_done = sqlx::query_scalar::<_, i64>(
+        "SELECT CAST(value AS INTEGER) FROM meta WHERE key = ? LIMIT 1",
+    )
+    .bind(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read explicit sidecar cutover marker");
+    assert_eq!(explicit_cutover_done, 1);
     let attached_path = proxy
         .sqlite_observability_database_path()
         .expect("observability database attached");
@@ -561,7 +732,7 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         .fetch_one(&proxy.key_store.pool)
         .await
         .expect("count migrated rows");
-    assert_eq!(migrated_rows, 3);
+    assert_eq!(migrated_rows, 4);
     let main_request_logs_exists: Option<i64> = sqlx::query_scalar(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'request_logs' LIMIT 1",
     )
@@ -857,12 +1028,18 @@ async fn observability_sidecar_migrate_resumes_copy_from_preseeded_sidecar_gaps(
     assert_eq!(report.sidecar_request_log_rows_after, 3);
     assert_eq!(report.batches, 2);
     assert!(report.dropped_main_request_logs);
+    assert!(report.rebuilt_api_key_usage_buckets);
+    assert!(report.rebuilt_dashboard_request_rollup_buckets);
+    assert!(report.rebuilt_request_log_catalog_rollups);
+    assert!(!report.startup_rebuild_required);
 
     let rerun = run_observability_sidecar_migrate(&db_str, 1, false)
         .await
         .expect("rerun stays idempotent");
     assert_eq!(rerun.copied_request_logs, 0);
     assert!(rerun.already_migrated);
+    assert!(rerun.completed);
+    assert!(!rerun.startup_rebuild_required);
 
     let reopened = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
         .await
@@ -875,6 +1052,598 @@ async fn observability_sidecar_migrate_resumes_copy_from_preseeded_sidecar_gaps(
     .expect("fetch migrated ids");
     assert_eq!(ids, vec![1, 2, 4]);
     drop(reopened);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_migrate_recovers_temporary_legacy_tables() {
+    let db_path = temp_db_path("observability-sidecar-temp-legacy-recovery");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (id, method, path, created_at) VALUES (7, 'POST', '/api/tavily/search', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    sqlx::query(
+        r#"CREATE TABLE "__observability_sidecar_legacy_request_logs" (id INTEGER PRIMARY KEY)"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create leftover temp request_logs table");
+    sqlx::query(
+        r#"INSERT INTO "__observability_sidecar_legacy_request_logs" (id) VALUES (7)"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("seed leftover temp request_logs table");
+    sqlx::query("DELETE FROM meta WHERE key IN (?, ?, ?, ?, ?, ?)")
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+        .bind(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+        .execute(&pool)
+        .await
+        .expect("clear completion meta");
+    drop(pool);
+
+    let recovered = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration recovers temp table");
+    assert!(recovered.completed);
+    assert!(!recovered.already_migrated);
+    assert_eq!(recovered.copied_request_logs, 0);
+    assert!(recovered.dropped_main_request_logs);
+    assert!(!recovered.startup_rebuild_required);
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool after recovery");
+    let temp_exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '__observability_sidecar_legacy_request_logs'",
+    )
+    .fetch_optional(&pool)
+    .await
+    .expect("check temp table");
+    assert_eq!(temp_exists, None);
+    drop(pool);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_migrate_rebuilds_after_legacy_tables_dropped_before_meta() {
+    let db_path = temp_db_path("observability-sidecar-dropped-before-meta");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            api_key_id TEXT,
+            request_kind_key TEXT,
+            request_body BLOB,
+            business_credits INTEGER,
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (id, method, path, api_key_id, request_kind_key, business_credits, created_at) VALUES (11, 'POST', '/api/tavily/search', 'key-a', 'api:search', 1, 120)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let meta_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    sqlx::query("DELETE FROM meta WHERE key IN (?, ?, ?, ?, ?, ?)")
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+        .bind(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+        .execute(&meta_pool)
+        .await
+        .expect("clear completion meta");
+    drop(meta_pool);
+
+    let recovered = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration rebuilds dropped-before-meta state");
+    assert!(recovered.completed);
+    assert!(!recovered.already_migrated);
+    assert_eq!(recovered.copied_request_logs, 0);
+    assert!(recovered.rebuilt_api_key_usage_buckets);
+    assert!(recovered.rebuilt_dashboard_request_rollup_buckets);
+    assert!(recovered.rebuilt_request_log_catalog_rollups);
+    assert!(recovered.marked_api_key_usage_buckets_meta_complete);
+    assert!(recovered.marked_dashboard_request_rollup_buckets_meta_complete);
+    assert!(recovered.marked_request_log_catalog_rollup_meta_complete);
+    assert!(!recovered.startup_rebuild_required);
+
+    let restarted = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("startup accepts recovered cutover");
+    drop(restarted);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_migrate_rebuilds_when_completion_meta_is_zero() {
+    let db_path = temp_db_path("observability-sidecar-zero-meta");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            api_key_id TEXT,
+            request_kind_key TEXT,
+            request_body BLOB,
+            business_credits INTEGER,
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (id, method, path, api_key_id, request_kind_key, business_credits, created_at) VALUES (13, 'POST', '/api/tavily/search', 'key-a', 'api:search', 1, 120)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let meta_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    for key in [
+        META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE,
+        META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE,
+        META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE,
+        META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE,
+    ] {
+        sqlx::query("UPDATE meta SET value = '0' WHERE key = ?")
+            .bind(key)
+            .execute(&meta_pool)
+            .await
+            .expect("zero completion meta");
+    }
+    drop(meta_pool);
+
+    let startup_err = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect_err("startup should reject zero completion meta");
+    assert!(
+        startup_err
+            .to_string()
+            .contains("observability sidecar derived tables are incomplete"),
+        "unexpected startup error: {startup_err}"
+    );
+
+    let recovered = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration rebuilds zero-meta state");
+    assert!(recovered.completed);
+    assert!(!recovered.already_migrated);
+    assert!(recovered.marked_api_key_usage_buckets_meta_complete);
+    assert!(recovered.marked_dashboard_request_rollup_buckets_meta_complete);
+    assert!(recovered.marked_request_log_catalog_rollup_meta_complete);
+    assert!(!recovered.startup_rebuild_required);
+
+    let restarted = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("startup accepts recovered zero-meta cutover");
+    drop(restarted);
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_rejects_startup_when_cutover_completed_but_meta_missing() {
+    let db_path = temp_db_path("observability-sidecar-cutover-meta-missing");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (method, path, created_at) VALUES ('POST', '/api/tavily/search', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let meta_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    sqlx::query("DELETE FROM meta WHERE key IN (?, ?, ?, ?, ?)")
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+        .execute(&meta_pool)
+        .await
+        .expect("clear completion meta");
+    drop(meta_pool);
+
+    let startup_err = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect_err("startup should reject missing completion meta");
+    assert!(
+        startup_err
+            .to_string()
+            .contains("observability sidecar derived tables are incomplete"),
+        "unexpected startup error: {startup_err}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_rejects_startup_when_explicit_marker_missing_but_cutover_visible() {
+    let db_path = temp_db_path("observability-sidecar-cutover-marker-missing");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (method, path, created_at) VALUES ('POST', '/api/tavily/search', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let meta_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    sqlx::query("DELETE FROM meta WHERE key IN (?, ?, ?, ?, ?, ?)")
+        .bind(META_KEY_OBSERVABILITY_SIDECAR_EXPLICIT_CUTOVER_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_V1_DONE)
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .bind(META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE)
+        .bind(META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS)
+        .execute(&meta_pool)
+        .await
+        .expect("clear explicit marker and completion meta");
+    drop(meta_pool);
+
+    let startup_err = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect_err("startup should reject visible cutover without explicit marker");
+    assert!(
+        startup_err
+            .to_string()
+            .contains("observability sidecar derived tables are incomplete"),
+        "unexpected startup error: {startup_err}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_rejects_large_startup_schema_drift_rebuild() {
+    let db_path = temp_db_path("observability-sidecar-cutover-schema-drift");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (method, path, created_at) VALUES ('POST', '/api/tavily/search', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+
+    let meta_pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open core pool");
+    sqlx::query("DELETE FROM meta WHERE key = ?")
+        .bind(META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE)
+        .execute(&meta_pool)
+        .await
+        .expect("clear request-value completion meta");
+    drop(meta_pool);
+
+    let startup_err = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect_err("startup should reject large schema-drift rebuild");
+    assert!(
+        startup_err
+            .to_string()
+            .contains("observability sidecar derived tables are incomplete")
+            || startup_err
+                .to_string()
+                .contains("observability sidecar derived tables require"),
+        "unexpected startup error: {startup_err}"
+    );
 
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));

--- a/tests/sidecar-migration/docker-compose.yml
+++ b/tests/sidecar-migration/docker-compose.yml
@@ -6,6 +6,14 @@ services:
     volumes:
       - ./scripts:/work/scripts:ro
 
+  prepare-db:
+    image: python:3.12-slim
+    working_dir: /work
+    command: ["python", "/work/scripts/prepare_smoke_db.py"]
+    volumes:
+      - ./scripts:/work/scripts:ro
+      - ./runtime:/srv/app/runtime
+
   app:
     build:
       context: ../..
@@ -22,7 +30,10 @@ services:
     volumes:
       - ./runtime:/srv/app/runtime
     depends_on:
-      - upstream-mock
+      upstream-mock:
+        condition: service_started
+      prepare-db:
+        condition: service_completed_successfully
 
   verify:
     image: python:3.12-slim

--- a/tests/sidecar-migration/scripts/prepare_smoke_db.py
+++ b/tests/sidecar-migration/scripts/prepare_smoke_db.py
@@ -1,0 +1,48 @@
+import os
+import sqlite3
+import time
+
+
+CORE_DB = "/srv/app/runtime/data/tavily_proxy.db"
+
+
+def table_exists(conn, name):
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def main():
+    now = int(time.time())
+    os.makedirs(os.path.dirname(CORE_DB), exist_ok=True)
+    with sqlite3.connect(CORE_DB) as conn:
+        if table_exists(conn, "forward_proxy_settings"):
+            conn.execute(
+                """
+                UPDATE forward_proxy_settings
+                SET proxy_urls_json = '[]',
+                    subscription_urls_json = '[]',
+                    insert_direct = 1,
+                    egress_socks5_enabled = 0,
+                    egress_socks5_url = '',
+                    updated_at = ?
+                """,
+                (now,),
+            )
+        for table in (
+            "forward_proxy_runtime",
+            "forward_proxy_node_overrides",
+            "forward_proxy_attempts",
+            "forward_proxy_key_affinity",
+            "forward_proxy_weight_hourly",
+        ):
+            if table_exists(conn, table):
+                conn.execute(f"DELETE FROM {table}")
+        conn.commit()
+    print("prepared sidecar smoke database")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sidecar-migration/scripts/run_sidecar_smoke.py
+++ b/tests/sidecar-migration/scripts/run_sidecar_smoke.py
@@ -10,6 +10,7 @@ import urllib.request
 APP_URL = os.environ.get("APP_URL", "http://app:8787")
 CORE_DB = "/srv/app/runtime/data/tavily_proxy.db"
 SIDECAR_DB = "/srv/app/runtime/data/tavily_proxy-observability.db"
+MIGRATION_REPORT = "/srv/app/runtime/migrate-report.json"
 
 
 def request(method, url, body=None, headers=None, timeout=15):
@@ -34,6 +35,20 @@ def request(method, url, body=None, headers=None, timeout=15):
         except json.JSONDecodeError:
             parsed = raw
         return err.code, parsed
+
+
+def parse_sse_json_message(value):
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        raise AssertionError(f"unexpected response body type: {type(value)!r}")
+    for line in value.splitlines():
+        if not line.startswith("data:"):
+            continue
+        data = line.removeprefix("data:").strip()
+        if data:
+            return json.loads(data)
+    raise AssertionError(f"missing SSE data message: {value[:200]}")
 
 
 def wait_ok(path, timeout=90):
@@ -86,6 +101,13 @@ def sqlite_rows(path, sql, params=()):
     return rows
 
 
+def load_migration_report():
+    if not os.path.exists(MIGRATION_REPORT):
+        return None
+    with open(MIGRATION_REPORT, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
 def main():
     wait_ok("/health")
     version = wait_ok("/api/version")
@@ -112,6 +134,7 @@ def main():
         timeout=20,
     )
     assert_status("mcp tools/list", status, 200)
+    body = parse_sse_json_message(body)
     if body.get("jsonrpc") != "2.0":
         raise AssertionError(f"unexpected mcp body: {body}")
 
@@ -135,22 +158,47 @@ def main():
     if main_request_logs_exists is not None:
         raise AssertionError("core DB still owns main.request_logs after migration")
 
-    sidecar_rows = sqlite_rows(
+    report = load_migration_report()
+    sidecar_count, sidecar_min_id, sidecar_max_id = sqlite_rows(
         SIDECAR_DB,
-        "SELECT id, path FROM request_logs ORDER BY id ASC",
+        "SELECT COUNT(*), MIN(id), MAX(id) FROM request_logs",
+    )[0]
+    if report:
+        source_rows = int(report.get("sourceRequestLogRows") or 0)
+        source_min = report.get("sourceMinRequestLogId")
+        source_max = report.get("sourceMaxRequestLogId")
+        if sidecar_count < source_rows + 2:
+            raise AssertionError(
+                f"expected migrated history plus fresh rows, got {sidecar_count} < {source_rows + 2}"
+            )
+        if source_min is not None and sidecar_min_id != source_min:
+            raise AssertionError(f"sidecar min id changed: {sidecar_min_id} != {source_min}")
+        if source_max is not None and sidecar_max_id < source_max:
+            raise AssertionError(f"sidecar max id regressed: {sidecar_max_id} < {source_max}")
+    elif sidecar_count < 4:
+        raise AssertionError(f"expected migrated plus smoke rows, got {sidecar_count}")
+
+    sidecar_path_counts = dict(
+        sqlite_rows(
+            SIDECAR_DB,
+            """
+            SELECT path, COUNT(*)
+            FROM request_logs
+            WHERE path IN ('/api/tavily/search', '/mcp')
+            GROUP BY path
+            """,
+        )
     )
-    if len(sidecar_rows) < 4:
-        raise AssertionError(f"expected migrated plus smoke rows, got {len(sidecar_rows)}")
-    if sidecar_rows[0][0] != 1 or sidecar_rows[0][1] != "/api/tavily/search":
-        raise AssertionError(f"unexpected seed row 1: {sidecar_rows[0]}")
-    if sidecar_rows[1][0] != 2 or sidecar_rows[1][1] != "/mcp":
-        raise AssertionError(f"unexpected seed row 2: {sidecar_rows[1]}")
+    if sidecar_path_counts.get("/api/tavily/search", 0) < 1 or sidecar_path_counts.get("/mcp", 0) < 1:
+        raise AssertionError(f"missing expected sidecar log paths: {sidecar_path_counts}")
 
     payload = {
         "backend": version["backend"],
         "tokenId": token_id,
         "logPaths": sorted(paths),
-        "sidecarRowCount": len(sidecar_rows),
+        "sidecarRowCount": sidecar_count,
+        "sidecarMinId": sidecar_min_id,
+        "sidecarMaxId": sidecar_max_id,
     }
     print(json.dumps(payload))
 


### PR DESCRIPTION
## Summary
- Move large observability sidecar derived-table rebuilds back into the offline migration tool.
- Make startup fail fast for interrupted explicit cutovers instead of blocking on heavy rebuild work.
- Add shared-testbox smoke coverage for the migration path.

## Validation
- cargo fmt --check
- python3 -m py_compile tests/sidecar-migration/scripts/prepare_smoke_db.py tests/sidecar-migration/scripts/run_sidecar_smoke.py
- cargo test observability_sidecar -- --nocapture
- cargo test request_logs_gc_once -- --nocapture
- cargo test db_compaction_once -- --nocapture
- cargo test startup_request_value_backfill -- --nocapture
- shared testbox smoke on 101 cold backup snapshot completed successfully

## References
- Specs: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md, docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md, docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
- Solutions: -
- Project Docs: -
