### PR TITLE
fix(observability): require reopen verification

### DIFF
--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -110,6 +110,9 @@
 - A 101 short-maintenance cutover attempt exposed a contract bug in the first explicit migration:
   the tool copied `request_logs` and reset derived-table rebuild markers, then service startup
   synchronously awaited the large derived rollup rebuild before opening the HTTP listener.
+- The explicit migration contract now treats a successful reopen of the normal startup path as part
+  of completion, so `completed=true` only means “offline rebuild succeeded and the service can
+  reopen cleanly after the migration lock is released.”
 - Tightened the contract so `observability_sidecar_migrate` must complete all sidecar derived-table
   rebuild work and write completion meta before reporting success or deleting hidden legacy
   observability tables.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -284,9 +284,9 @@
   space crosses the threshold or operators explicitly force a maintenance window.
 - The large-legacy sidecar cutover is now a separate operator runbook instead of an automatic
   startup side effect. The validated flow is:
-  - on codex-testbox, seed a production-shaped legacy core DB snapshot, run
-    `observability_sidecar_migrate`, then start the current-branch image against the migrated files
-    and verify `/health`, `/api/version`, `/api/tavily/search`, `/mcp`, and request-log reads;
+  - on codex-testbox, seed a production-shaped legacy core DB snapshot, run the migration
+    container first, then start the current-branch service image against the migrated files and
+    verify `/health`, `/api/version`, `/api/tavily/search`, `/mcp`, and request-log reads;
   - on 101, stop `tavily-hikari`, export the pre-cutover core DB as the rollback anchor to
     codex-testbox, run `observability_sidecar_migrate` locally against
     `/srv/app/data/tavily_proxy.db`, restart, and validate the same request-log and MCP surfaces;

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -212,6 +212,11 @@
     missing,
   - preserving the large-legacy startup compatibility path and standalone `request_logs_gc_once`
     behavior until the explicit cutover is run.
+- Explicit sidecar migration completion now requires a fresh normal startup reopen after the
+  offline lock is released. The migration CLI/report surface gained
+  `startup_reopen_verified`, and the final `completed=true` contract now means “offline rebuild
+  succeeded and a normal startup reopen succeeded,” not just “the offline sidecar tables were
+  rebuilt.”
 - Added request-stats coverage proving summary/key-metric reads flush pending coalesced deltas
   before returning.
 - Added request-stats coverage proving auth-token activity reads and admin rate-5m usage-series

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -149,7 +149,8 @@ source when a usable persisted runtime already exists.
   the legacy `main.request_logs` and legacy `main` rollup/bucket tables, then mark the corresponding
   meta keys complete and write the explicit cutover marker
   `observability_sidecar_explicit_cutover_v1_done`. The command must not report completion until a
-  normal restart can attach the sibling sidecar without running a full derived-table rebuild.
+  normal restart can attach the sibling sidecar without running a full derived-table rebuild, and
+  the reopened startup path has been verified after the offline lock is released.
   A DB where the legacy tables are already gone but this explicit marker or the derived completion
   meta is missing is an interrupted cutover, not an `already_migrated` success; rerunning the tool
   must rebuild and mark the sidecar offline.
@@ -234,8 +235,9 @@ source when a usable persisted runtime already exists.
   valid, and legacy `api_key_usage_buckets`, `dashboard_request_rollup_buckets`, and
   `request_log_catalog_rollups` are removed from `main`. Sidecar `api_key_usage_buckets`,
   `dashboard_request_rollup_buckets`, and `request_log_catalog_rollups` must already be rebuilt,
-  their meta keys must be marked complete, and the catalog retention meta must match the current
-  retention setting before the command reports `completed=true`.
+  their meta keys must be marked complete, the catalog retention meta must match the current
+  retention setting, and a fresh normal startup reopen must succeed before the command reports
+  `completed=true`.
 - The explicit migration path must refuse to run while another process still holds the sibling
   `observability-migrate.lock`; success no longer relies on WAL-mode `BEGIN EXCLUSIVE` semantics to
   infer that the live service has stopped.

--- a/src/bin/observability_sidecar_migrate.rs
+++ b/src/bin/observability_sidecar_migrate.rs
@@ -54,9 +54,10 @@ fn write_plain_report(
 ) -> io::Result<()> {
     writeln!(
         writer,
-        "observability_sidecar_migrate: dry_run={} completed={} offline_lock={} sqlite_write_probe_ok={} copied_request_logs={} batches={} already_migrated={} resumed_copy={} core_path={} sidecar_path={} lock_path={} attached_observability_path={}",
+        "observability_sidecar_migrate: dry_run={} completed={} startup_reopen_verified={} offline_lock={} sqlite_write_probe_ok={} copied_request_logs={} batches={} already_migrated={} resumed_copy={} core_path={} sidecar_path={} lock_path={} attached_observability_path={}",
         report.dry_run,
         report.completed,
+        report.startup_reopen_verified,
         report.offline_lock_acquired,
         report.sqlite_write_probe_ok,
         report.copied_request_logs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,7 @@ pub struct ObservabilitySidecarMigrationReport {
     pub marked_api_key_usage_buckets_meta_complete: bool,
     pub marked_dashboard_request_rollup_buckets_meta_complete: bool,
     pub marked_request_log_catalog_rollup_meta_complete: bool,
+    pub startup_reopen_verified: bool,
     pub startup_rebuild_required: bool,
     pub derived_rebuild_elapsed_ms: u128,
     pub child_reference_checks_passed: bool,
@@ -399,6 +400,17 @@ pub async fn run_observability_sidecar_migrate(
 ) -> Result<ObservabilitySidecarMigrationReport, ProxyError> {
     crate::store::KeyStore::run_observability_sidecar_migrate(database_path, batch_size, dry_run)
         .await
+}
+
+pub async fn verify_observability_sidecar_reopen(database_path: &str) -> Result<(), ProxyError> {
+    let _store = crate::store::KeyStore::new_with_time(database_path, BackendTime::system())
+        .await
+        .map_err(|err| {
+            ProxyError::Other(format!(
+                "observability sidecar migration completed but reopen verification failed: {err}"
+            ))
+        })?;
+    Ok(())
 }
 
 impl ForwardProxyProgressEvent {

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -12,6 +12,32 @@ struct ObservabilitySidecarDerivedRebuildReport {
     elapsed_ms: u128,
 }
 
+#[derive(Debug, Default)]
+struct ObservabilitySidecarMigrationState {
+    attached_observability_path: String,
+    sidecar_request_log_rows_before: i64,
+    sidecar_request_log_rows_after: i64,
+    copied_request_logs: i64,
+    batches: i64,
+    dropped_main_request_logs: bool,
+    dropped_legacy_api_key_usage_buckets: bool,
+    dropped_legacy_dashboard_request_rollup_buckets: bool,
+    dropped_legacy_request_log_catalog_rollups: bool,
+    reset_api_key_usage_buckets_meta: bool,
+    reset_dashboard_request_rollup_buckets_meta: bool,
+    reset_request_log_catalog_rollup_meta: bool,
+    rebuilt_api_key_usage_buckets: bool,
+    rebuilt_dashboard_request_rollup_buckets: bool,
+    rebuilt_request_log_catalog_rollups: bool,
+    marked_api_key_usage_buckets_meta_complete: bool,
+    marked_dashboard_request_rollup_buckets_meta_complete: bool,
+    marked_request_log_catalog_rollup_meta_complete: bool,
+    startup_reopen_verified: bool,
+    startup_rebuild_required: bool,
+    derived_rebuild_elapsed_ms: u128,
+    child_reference_checks_passed: bool,
+}
+
 impl KeyStore {
     async fn rebuild_request_log_soft_reference_tables_if_needed(
         &self,
@@ -1086,11 +1112,6 @@ impl KeyStore {
                 layout.core_database_path
             )));
         }
-        let _offline_guard = if dry_run {
-            None
-        } else {
-            Some(acquire_observability_offline_guard(&layout.core_database_path)?)
-        };
         let offline_probe = probe_observability_offline_state(&layout.core_database_path).await?;
         let offline_lock_acquired = if dry_run {
             offline_probe.service_lock_held_exclusively
@@ -1215,148 +1236,125 @@ impl KeyStore {
             && !temporary_legacy_request_log_catalog_rollups_exists
             && explicit_cutover_meta_complete;
 
-        let (attached_observability_path, sidecar_request_log_rows_before, sidecar_request_log_rows_after, copied_request_logs, batches, dropped_main_request_logs, dropped_legacy_api_key_usage_buckets, dropped_legacy_dashboard_request_rollup_buckets, dropped_legacy_request_log_catalog_rollups, reset_api_key_usage_buckets_meta, reset_dashboard_request_rollup_buckets_meta, reset_request_log_catalog_rollup_meta, rebuilt_api_key_usage_buckets, rebuilt_dashboard_request_rollup_buckets, rebuilt_request_log_catalog_rollups, marked_api_key_usage_buckets_meta_complete, marked_dashboard_request_rollup_buckets_meta_complete, marked_request_log_catalog_rollup_meta_complete, startup_rebuild_required, derived_rebuild_elapsed_ms, child_reference_checks_passed) =
-            if dry_run {
-                let attached_observability_path = attached_default
+        let mut migration_state = ObservabilitySidecarMigrationState::default();
+        if dry_run {
+            migration_state.attached_observability_path = attached_default
+                .clone()
+                .unwrap_or_else(|| sidecar_path.clone());
+            migration_state.sidecar_request_log_rows_before = sidecar_request_log_rows_before_probe;
+            migration_state.sidecar_request_log_rows_after = sidecar_request_log_rows_before_probe;
+            migration_state.startup_rebuild_required =
+                !already_migrated && sidecar_request_log_rows_before_probe > 0;
+        } else {
+            let _offline_guard = acquire_observability_offline_guard(&layout.core_database_path)?;
+            let store = Self::open_for_observability_sidecar_migration(database_path).await?;
+            let result = async {
+                migration_state.attached_observability_path = store
+                    .observability_database_path
                     .clone()
-                    .unwrap_or_else(|| sidecar_path.clone());
-                (
-                    attached_observability_path,
-                    sidecar_request_log_rows_before_probe,
-                    sidecar_request_log_rows_before_probe,
-                    0,
-                    0,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    !already_migrated && sidecar_request_log_rows_before_probe > 0,
-                    0,
-                    false,
-                )
-            } else {
-                let store = Self::open_for_observability_sidecar_migration(database_path).await?;
-                let result = {
-                    let attached_observability_path = store
-                        .observability_database_path
-                        .clone()
-                        .unwrap_or_else(|| layout.core_database_path.clone());
-                    let sidecar_request_log_rows_before: i64 =
+                    .unwrap_or_else(|| layout.core_database_path.clone());
+                migration_state.sidecar_request_log_rows_before =
+                    sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
+                        .fetch_one(&store.pool)
+                        .await?;
+
+                if already_migrated {
+                    store
+                        .ensure_observability_sidecar_startup_rebuild_not_required()
+                        .await?;
+                    migration_state.sidecar_request_log_rows_after =
                         sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
                             .fetch_one(&store.pool)
                             .await?;
-
-                    if already_migrated {
+                    migration_state.startup_reopen_verified = true;
+                    migration_state.child_reference_checks_passed = true;
+                    Ok::<(), ProxyError>(())
+                } else {
+                    if legacy_request_logs_exists {
                         store
-                            .ensure_observability_sidecar_startup_rebuild_not_required()
+                            .rebuild_request_log_soft_reference_tables_if_needed()
                             .await?;
-                        let sidecar_request_log_rows_after: i64 =
-                            sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
-                                .fetch_one(&store.pool)
-                                .await?;
-                        (
-                            attached_observability_path,
-                            sidecar_request_log_rows_before,
-                            sidecar_request_log_rows_after,
-                            0,
-                            0,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            false,
-                            0,
-                            true,
-                        )
-                    } else {
-                        let mut copied_request_logs = 0_i64;
-                        let mut batches = 0_i64;
-                        let child_reference_checks_passed;
-
-                        if legacy_request_logs_exists {
-                            store
-                                .rebuild_request_log_soft_reference_tables_if_needed()
-                                .await?;
-                            let (copied, copied_batches) =
-                                Self::copy_legacy_request_logs_into_observability_batched_in_pool(
-                                    &store.pool,
-                                    batch_size,
-                                )
-                                .await?;
-                            copied_request_logs = copied;
-                            batches = copied_batches;
-                            Self::ensure_request_logs_rebuild_references_valid_in_pool(
+                        let (copied, copied_batches) =
+                            Self::copy_legacy_request_logs_into_observability_batched_in_pool(
                                 &store.pool,
-                                "request_logs schema migration produced invalid preserved references",
+                                batch_size,
                             )
                             .await?;
-                            child_reference_checks_passed = true;
-                        } else {
-                            Self::ensure_request_logs_rebuild_references_valid_in_pool(
-                                &store.pool,
-                                "request_logs schema migration produced invalid preserved references",
-                            )
-                            .await?;
-                            child_reference_checks_passed = true;
-                        }
+                        migration_state.copied_request_logs = copied;
+                        migration_state.batches = copied_batches;
+                    }
+                    Self::ensure_request_logs_rebuild_references_valid_in_pool(
+                        &store.pool,
+                        "request_logs schema migration produced invalid preserved references",
+                    )
+                    .await?;
+                    migration_state.child_reference_checks_passed = true;
 
                         let derived_report = store
                             .rebuild_observability_sidecar_derived_tables_offline(true)
                             .await?;
-                        store
-                            .ensure_observability_sidecar_startup_rebuild_not_required()
-                            .await?;
 
-                        let sidecar_request_log_rows_after: i64 =
+                        migration_state.sidecar_request_log_rows_after =
                             sqlx::query_scalar("SELECT COUNT(*) FROM observability.request_logs")
                                 .fetch_one(&store.pool)
                                 .await?;
-                        (
-                            attached_observability_path,
-                            sidecar_request_log_rows_before,
-                            sidecar_request_log_rows_after,
-                            copied_request_logs,
-                            batches,
-                            derived_report.dropped_main_request_logs,
-                            derived_report.dropped_legacy_api_key_usage_buckets,
-                            derived_report.dropped_legacy_dashboard_request_rollup_buckets,
-                            derived_report.dropped_legacy_request_log_catalog_rollups,
-                            false,
-                            false,
-                            false,
-                            derived_report.rebuilt_api_key_usage_buckets,
-                            derived_report.rebuilt_dashboard_request_rollup_buckets,
-                            derived_report.rebuilt_request_log_catalog_rollups,
-                            derived_report.marked_api_key_usage_buckets_meta_complete,
-                            derived_report.marked_dashboard_request_rollup_buckets_meta_complete,
-                            derived_report.marked_request_log_catalog_rollup_meta_complete,
-                            false,
-                            derived_report.elapsed_ms,
-                            child_reference_checks_passed,
-                        )
-                    }
-                };
-                store.pool.close().await;
-                result
-            };
+                    migration_state.dropped_main_request_logs =
+                        derived_report.dropped_main_request_logs;
+                    migration_state.dropped_legacy_api_key_usage_buckets =
+                        derived_report.dropped_legacy_api_key_usage_buckets;
+                    migration_state.dropped_legacy_dashboard_request_rollup_buckets =
+                        derived_report.dropped_legacy_dashboard_request_rollup_buckets;
+                    migration_state.dropped_legacy_request_log_catalog_rollups =
+                        derived_report.dropped_legacy_request_log_catalog_rollups;
+                    migration_state.rebuilt_api_key_usage_buckets =
+                        derived_report.rebuilt_api_key_usage_buckets;
+                    migration_state.rebuilt_dashboard_request_rollup_buckets =
+                        derived_report.rebuilt_dashboard_request_rollup_buckets;
+                    migration_state.rebuilt_request_log_catalog_rollups =
+                        derived_report.rebuilt_request_log_catalog_rollups;
+                    migration_state.marked_api_key_usage_buckets_meta_complete =
+                        derived_report.marked_api_key_usage_buckets_meta_complete;
+                    migration_state.marked_dashboard_request_rollup_buckets_meta_complete =
+                        derived_report.marked_dashboard_request_rollup_buckets_meta_complete;
+                    migration_state.marked_request_log_catalog_rollup_meta_complete =
+                        derived_report.marked_request_log_catalog_rollup_meta_complete;
+                    migration_state.startup_reopen_verified = true;
+                    migration_state.derived_rebuild_elapsed_ms = derived_report.elapsed_ms;
+                    Ok::<(), ProxyError>(())
+                }
+            }
+            .await;
+            store.pool.close().await;
+            drop(_offline_guard);
+            if result.is_ok() && !already_migrated {
+                crate::verify_observability_sidecar_reopen(&layout.core_database_path).await?;
+            }
+            result?;
+        }
+        let ObservabilitySidecarMigrationState {
+            attached_observability_path,
+            sidecar_request_log_rows_before,
+            sidecar_request_log_rows_after,
+            copied_request_logs,
+            batches,
+            dropped_main_request_logs,
+            dropped_legacy_api_key_usage_buckets,
+            dropped_legacy_dashboard_request_rollup_buckets,
+            dropped_legacy_request_log_catalog_rollups,
+            reset_api_key_usage_buckets_meta,
+            reset_dashboard_request_rollup_buckets_meta,
+            reset_request_log_catalog_rollup_meta,
+            rebuilt_api_key_usage_buckets,
+            rebuilt_dashboard_request_rollup_buckets,
+            rebuilt_request_log_catalog_rollups,
+            marked_api_key_usage_buckets_meta_complete,
+            marked_dashboard_request_rollup_buckets_meta_complete,
+            marked_request_log_catalog_rollup_meta_complete,
+            startup_reopen_verified,
+            startup_rebuild_required,
+            derived_rebuild_elapsed_ms,
+            child_reference_checks_passed,
+        } = migration_state;
         let available_bytes_after = available_disk_bytes_for_path(&layout.core_database_path)?;
         let sidecar_file_bytes_after = std::fs::metadata(&sidecar_path)
             .map(|metadata| metadata.len())
@@ -1403,6 +1401,7 @@ impl KeyStore {
             marked_api_key_usage_buckets_meta_complete,
             marked_dashboard_request_rollup_buckets_meta_complete,
             marked_request_log_catalog_rollup_meta_complete,
+            startup_reopen_verified,
             startup_rebuild_required,
             derived_rebuild_elapsed_ms,
             child_reference_checks_passed,
@@ -1410,6 +1409,7 @@ impl KeyStore {
             batches,
             completed: !dry_run
                 && child_reference_checks_passed
+                && startup_reopen_verified
                 && !startup_rebuild_required
                 && (already_migrated
                     || (rebuilt_api_key_usage_buckets

--- a/src/tests/chunk_04_tail.rs
+++ b/src/tests/chunk_04_tail.rs
@@ -658,6 +658,7 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         .await
         .expect("offline migration succeeds");
     assert!(report.completed);
+    assert!(report.startup_reopen_verified);
     assert_eq!(report.copied_request_logs, 4);
     assert_eq!(report.batches, 2);
     assert!(report.dropped_main_request_logs);
@@ -1468,6 +1469,72 @@ async fn observability_sidecar_rejects_startup_when_cutover_completed_but_meta_m
             .contains("observability sidecar derived tables are incomplete"),
         "unexpected startup error: {startup_err}"
     );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(&observability_path);
+    let _ = std::fs::remove_file(format!("{observability_path}-shm"));
+    let _ = std::fs::remove_file(format!("{observability_path}-wal"));
+}
+
+#[tokio::test]
+async fn observability_sidecar_migrate_reports_reopen_verification_before_completion() {
+    let db_path = temp_db_path("observability-sidecar-reopen-verified");
+    let db_str = db_path.to_string_lossy().to_string();
+    let layout = SqliteDatabaseLayout::from_database_path(&db_str);
+    let observability_path = layout
+        .observability_database_path
+        .clone()
+        .expect("sidecar path");
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            result_status TEXT NOT NULL DEFAULT 'success',
+            visibility TEXT NOT NULL DEFAULT 'visible',
+            created_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy request_logs");
+    sqlx::query(
+        "INSERT INTO request_logs (method, path, created_at) VALUES ('POST', '/api/tavily/search', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed request log");
+    drop(pool);
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .expect("open sqlite file for resize")
+        .set_len(LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES + 4096)
+        .expect("expand sqlite file");
+
+    let report = run_observability_sidecar_migrate(&db_str, 1, false)
+        .await
+        .expect("offline migration succeeds");
+    assert!(report.completed);
+    assert!(report.startup_reopen_verified);
+
+    let restarted = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("startup accepts reopened cutover");
+    drop(restarted);
 
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));

--- a/tests/sidecar-migration/docker-compose.yml
+++ b/tests/sidecar-migration/docker-compose.yml
@@ -14,6 +14,27 @@ services:
       - ./scripts:/work/scripts:ro
       - ./runtime:/srv/app/runtime
 
+  migrate:
+    build:
+      context: ../..
+      dockerfile: tests/ha/Dockerfile.app
+    entrypoint: ["observability_sidecar_migrate"]
+    command:
+      - --db-path
+      - /srv/app/runtime/data/tavily_proxy.db
+      - --batch-size
+      - "1"
+      - --json
+    environment:
+      PROXY_DB_PATH: /srv/app/runtime/data/tavily_proxy.db
+    volumes:
+      - ./runtime:/srv/app/runtime
+    depends_on:
+      upstream-mock:
+        condition: service_started
+      prepare-db:
+        condition: service_completed_successfully
+
   app:
     build:
       context: ../..
@@ -33,6 +54,8 @@ services:
       upstream-mock:
         condition: service_started
       prepare-db:
+        condition: service_completed_successfully
+      migrate:
         condition: service_completed_successfully
 
   verify:

--- a/tests/sidecar-migration/scripts/run_testbox_sidecar_migration.py
+++ b/tests/sidecar-migration/scripts/run_testbox_sidecar_migration.py
@@ -28,21 +28,11 @@ def compose_args():
 def main():
     os.makedirs(os.path.join(RUNTIME_DIR, "data"), exist_ok=True)
     run(sys.executable, os.path.join(ROOT, "scripts", "seed_large_legacy_db.py"), DB_PATH)
-    run(
-        "cargo",
-        "run",
-        "--quiet",
-        "--bin",
-        "observability_sidecar_migrate",
-        "--",
-        "--db-path",
-        DB_PATH,
-        "--batch-size",
-        "1",
-    )
 
-    run(*compose_args(), "up", "-d", "--build")
+    run(*compose_args(), "up", "-d", "--build", "upstream-mock", "prepare-db")
     try:
+        run(*compose_args(), "run", "--rm", "migrate")
+        run(*compose_args(), "up", "-d", "--build", "app")
         time.sleep(5)
         run(
             *compose_args(),


### PR DESCRIPTION
Spec: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md\nSpec Disposition: update\nSpecs: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md\nSpec Sync: done\nSpec Drift: none\nSolutions: -\nProject Docs: -\nProject Docs Sync: n/a(no project-doc change)\n\nNotes:\n- Explicit cutover completion now requires a successful normal startup reopen after offline migration.\n- Startup remains fail-fast for explicit cutover gaps; it no longer retries the same derived-table rebuild path.\n- Shared-testbox validation now runs the migration inside compose first, then starts the service image against the migrated files.