### PR TITLE
fix(sqlite): add runtime db operation logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1383,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1702,6 +1729,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2014,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2372,6 +2425,8 @@ dependencies = [
  "totp-rs",
  "tower 0.4.13",
  "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "urlencoding",
  "zstd",
@@ -2408,6 +2463,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2639,6 +2703,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2739,6 +2833,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,5 @@ md5 = "0.7"
 data-encoding = "2"
 totp-rs = { version = "5.7", features = ["qr", "zeroize"] }
 zstd = "0.13"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -43,6 +43,18 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 
 ## Resolution
 
+- Add a runtime DB logging contract before changing lock semantics again. For this service, keep
+  stderr text logging, but make runtime DB phases emit one stable prefix:
+  `db operation slow:` / `db operation error:` with `operation`, `elapsed_ms`, optional `context`,
+  and optional `err`.
+- Enable SQL-level slow statement logging directly on runtime `sqlx` SQLite connect options. The
+  default threshold is `250ms` for SQL statements and `1s` for explicit DB operation phases such as
+  startup pool open, schema init, request-stats flush, scheduler enqueue, OAuth upsert, and
+  pending billing settlement.
+- Keep the historical startup line `forward-proxy startup: sqlite initialized in ...` for grep
+  continuity, but require the new DB phase logs alongside it so operators can tell whether the time
+  went into pool open, observability attach probing, `BEGIN IMMEDIATE`, schema bootstrap, or a
+  later request/worker write path.
 - Keep billing and MCP serialization fail-closed, but retry transient SQLite busy/locked writes
   inside the existing bounded lock wait or lease budget.
 - Retry background job bookkeeping writes before surfacing scheduler errors.
@@ -149,6 +161,11 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 
 ## Guardrails / Reuse Notes
 
+- Do not enable full SQL debug logging in production by default. Slow-statement logging is enough
+  for this contention class and avoids dumping every statement or bind-heavy traffic path.
+- Treat runtime DB operation logs and `sqlx::query` slow warnings as complementary:
+  `sqlx::query` answers “which statement was slow,” while `db operation ...` answers “which
+  service-layer operation or phase was slow/failing.”
 - Do not fix this class of problem by simply raising `sqlx` pool size; more concurrent writers can
   increase lock pressure.
 - Do not hand-edit production ledgers. Use repository repair binaries or controlled migrations when
@@ -178,3 +195,27 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - `src/store/key_store_users_and_oauth.rs`
 - `src/store/key_store_request_logs_and_dashboard.rs`
 - `src/tavily_proxy/proxy_auth_and_oauth.rs`
+- `src/tavily_proxy/proxy_ha.rs`
+- `src/server/schedulers.rs`
+
+## 101 Symptom Mapping
+
+For the `2026-06-19 01:00 +08:00` onward 101 sample, the runtime DB log contract should map the
+observed symptoms like this:
+
+- `forward-proxy startup: sqlite initialized in 38906ms`
+  -> keep the existing startup line and also expect `db operation slow: operation=sqlite startup ...`
+- `quota-sync-hot: enqueue job error: ... database is locked`
+  -> expect `db operation error: operation=scheduled job enqueue ...`
+- `request stats persist warning: ... database is locked`
+  -> expect `db operation error: operation=request stats persist ...`
+- `upsert linuxdo oauth account error: ... database is locked`
+  -> expect `db operation error: operation=oauth account upsert ...`
+- `oauth account upsert: transient sqlite write error (...)`
+  -> keep bounded retry logs and expect the final phase-level `oauth account upsert` slow/error log
+- `apply_pending_billing_log: transient sqlite write error (...)`
+  -> keep bounded retry logs and expect the final phase-level
+  `db operation slow|error: operation=apply_pending_billing_log ...`
+- request-path `/api/tavily/search` / MCP billing failures
+  -> correlate request warning lines with `apply_pending_billing_log`, quota/billing lock logs, and
+  `sqlx::query` warn lines for slow statements on the same wall-clock window

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -2,6 +2,31 @@
 
 ## Current Coverage
 
+- Added a runtime DB logging contract for the online service surface without migrating the whole
+  repo to structured logging. Runtime SQLite pool creation now initializes a minimal
+  `tracing_subscriber` backend once at process startup, and all runtime `SqliteConnectOptions`
+  enable `sqlx` slow statement logging at `250ms`.
+- Added shared DB operation log helpers in `src/store/mod.rs`. They emit stable stderr lines using
+  `db operation slow:` and `db operation error:` with `operation=...`, `elapsed_ms=...`, optional
+  `context=...`, and optional `err=...`, so startup, request-path, and background DB phases can be
+  grepped with one contract.
+- Runtime DB operation logs intentionally do not include SQL bind values. The SQL-level
+  `sqlx::query` slow-statement warnings keep the statement text/summary and timing, while the
+  explicit phase-level helper keeps only operation/context metadata to avoid leaking secrets.
+- Startup SQLite open / observability-attach probe / schema initialization now pass through that
+  shared helper with a `1s` slow-operation threshold. The existing
+  `forward-proxy startup: sqlite initialized in ...` line remains in place for historical grep
+  continuity, and the new `db operation slow:`/`error:` lines make it clear which startup DB phase
+  stalled or failed.
+- Request-path DB work now has unified phase logs around LinuxDo OAuth upsert/profile refresh and
+  pending billing settlement. That covers the same classes already seen in production after
+  `2026-06-19 01:00 +08:00`: `oauth account upsert`, `apply_pending_billing_log`, and the
+  downstream request-path billing failures that bubble up as `/api/tavily/search` or MCP proxy
+  errors.
+- Background scheduler/worker DB work now has unified phase logs around `scheduled job enqueue`
+  and `request stats persist`, so `quota-sync-hot enqueue`, `scheduled job finish`, and request
+  stats flush contention all have a stable DB operation prefix in addition to the existing
+  owner-facing warning lines.
 - Added a shared transient SQLite write retry helper for bounded backoff.
 - `quota_subject_locks` acquire/refresh/release now retry transient SQLite busy/locked errors within
   the existing lock timeout or lease budget.
@@ -233,6 +258,12 @@
 
 ## Validation
 
+- `cargo check -q`
+- `cargo test -q db_operation_log_format_includes_operation_context_and_error`
+- `cargo test -q sqlite_runtime_log_context_is_stable_and_grep_friendly`
+- `cargo test -q scheduled_job_enqueue`
+- `cargo test -q linuxdo_oauth_upsert_skips_missing_tags_for_new_accounts_and_recovers_after_reseed`
+- `cargo test -q pending_billing_claim_miss_is_retry_later_until_next_replay`
 - `cargo fmt --all`
 - `cargo test observability_sidecar_migrate_moves_large_legacy_request_logs_offline -- --nocapture`
 - `cargo test observability_sidecar_migrate_resumes_copy_from_preseeded_sidecar_gaps -- --nocapture`
@@ -264,6 +295,21 @@
 
 ## Operations Notes
 
+- The `2026-06-19 01:00 +08:00` to `2026-06-19 10:18 +08:00` 101 sample that motivated this pass
+  showed all three runtime responsibility surfaces at once:
+  - startup: `forward-proxy startup: sqlite initialized in 38906ms`
+  - background queueing/worker writes: `quota-sync-hot: enqueue job error`, `scheduled job finish`,
+    `request stats persist warning`
+  - request-path/user writes: `upsert linuxdo oauth account error`,
+    `oauth account upsert: transient sqlite write error`, `apply_pending_billing_log`, and
+    `/api/tavily/search` proxy failures bubbling a `database is locked`
+- The new runtime DB logging contract is designed to map those same symptoms onto stable grep keys:
+  - `db operation slow: operation=sqlite startup ...`
+  - `db operation error: operation=scheduled job enqueue ...`
+  - `db operation error: operation=request stats persist ...`
+  - `db operation error|slow: operation=oauth account upsert ...`
+  - `db operation error|slow: operation=apply_pending_billing_log ...`
+  - `sqlx::query` warn lines for statements slower than `250ms`
 - Production baseline was read-only: container healthy, version `0.46.2`, database `8.3G`, WAL
   `235M`, and the most recent one-hour lock sample only showed LinuxDo OAuth upsert contention.
 - Later production inspection found a `20G` database where startup spent roughly `78s` inside

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -87,6 +87,7 @@
         "analysis::tests::",
         "ha::tests::",
         "models::client_ip_tests::",
+        "store::tests::",
         "tavily_proxy::tests::",
         "tests::request_kind_and_core::parse_",
         "tests::proxy_affinity_and_summary::extract_",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,44 @@ use sqlx::{Executor, QueryBuilder, Sqlite, SqlitePool, Transaction};
 use thiserror::Error;
 use tokio::sync::{Mutex, Notify, RwLock, Semaphore};
 use tokio::time::Instant;
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 use url::form_urlencoded;
 
 #[cfg(test)]
 use std::sync::atomic::AtomicU64;
+
+static RUNTIME_LOGGING_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
+pub fn init_runtime_logging() {
+    RUNTIME_LOGGING_INIT.get_or_init(|| {
+        let filter = EnvFilter::try_from_default_env()
+            .or_else(|_| EnvFilter::try_new("warn,sqlx::query=warn"))
+            .unwrap_or_else(|_| EnvFilter::new("warn"));
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_target(true)
+                    .without_time()
+                    .compact(),
+            )
+            .init();
+    });
+}
+
+pub fn emit_db_operation_slow_log(operation: &str, elapsed: Duration, context: Option<&str>) {
+    store::log_slow_db_operation(operation, elapsed, context);
+}
+
+pub fn emit_db_operation_error_log(
+    operation: &str,
+    elapsed: Duration,
+    context: Option<&str>,
+    err: &ProxyError,
+) {
+    store::log_db_operation_error(operation, elapsed, context, err);
+}
 
 pub type ForwardProxyProgressCallback = dyn Fn(ForwardProxyProgressEvent) + Send + Sync;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,8 @@ pub fn init_runtime_logging() {
                     .without_time()
                     .compact(),
             )
-            .init();
+            .try_init()
+            .ok();
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,6 +305,7 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
+    tavily_hikari::init_runtime_logging();
     let cli = Cli::parse();
     reject_legacy_ha_origin_env_vars()?;
 

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -1,3 +1,5 @@
+use tokio::time::Instant;
+
 fn random_delay_secs(max_inclusive: u64) -> u64 {
     use rand::Rng;
     let mut rng = rand::thread_rng();
@@ -72,9 +74,27 @@ async fn enqueue_scheduled_job_logged(
     trigger_source: &str,
     log_prefix: &str,
 ) -> Option<i64> {
+    let started = Instant::now();
+    let context = format!(
+        "job_type={job_type}, trigger_source={trigger_source}, key_id={}",
+        key_id.unwrap_or("-")
+    );
     match enqueue_scheduled_job(state, job_type, key_id, trigger_source).await {
-        Ok(job_id) => Some(job_id),
+        Ok(job_id) => {
+            tavily_hikari::emit_db_operation_slow_log(
+                "scheduled job enqueue",
+                started.elapsed(),
+                Some(context.as_str()),
+            );
+            Some(job_id)
+        }
         Err(err) => {
+            tavily_hikari::emit_db_operation_error_log(
+                "scheduled job enqueue",
+                started.elapsed(),
+                Some(context.as_str()),
+                &err,
+            );
             eprintln!("{log_prefix}: enqueue job error: {err}");
             None
         }

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -540,14 +540,21 @@ impl KeyStore {
     ) -> Result<Self, ProxyError> {
         #[cfg(test)]
         let _schema_init_guard = Self::acquire_test_schema_init_guard().await;
+        let startup_started = Instant::now();
         let layout = SqliteDatabaseLayout::from_database_path(database_path);
         let observability_lock =
             acquire_observability_service_shared_lock(&layout.core_database_path)?;
-        let pool = open_sqlite_pool_with_observability(
-            &layout.core_database_path,
-            layout.observability_database_path.as_deref(),
-            true,
-            false,
+        let startup_context =
+            sqlite_runtime_log_context(&layout.core_database_path, "startup", false, true);
+        let pool = instrument_db_operation(
+            "sqlite startup open pool",
+            Some(startup_context.as_str()),
+            open_sqlite_pool_with_observability(
+                &layout.core_database_path,
+                layout.observability_database_path.as_deref(),
+                true,
+                false,
+            ),
         )
         .await?;
         let observability_database_path = attached_database_path(&pool, "observability").await?;
@@ -577,7 +584,17 @@ impl KeyStore {
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
-        store.initialize_schema().await?;
+        instrument_db_operation(
+            "sqlite startup initialize schema",
+            Some(startup_context.as_str()),
+            store.initialize_schema(),
+        )
+        .await?;
+        log_slow_db_operation(
+            "sqlite startup total",
+            startup_started.elapsed(),
+            Some(startup_context.as_str()),
+        );
         Ok(store)
     }
 
@@ -596,11 +613,17 @@ impl KeyStore {
         let layout = SqliteDatabaseLayout::from_database_path(database_path);
         let observability_lock =
             acquire_observability_service_shared_lock(&layout.core_database_path)?;
-        let pool = open_sqlite_pool_with_observability(
-            &layout.core_database_path,
-            layout.observability_database_path.as_deref(),
-            true,
-            false,
+        let gc_context =
+            sqlite_runtime_log_context(&layout.core_database_path, "request-logs-gc", false, true);
+        let pool = instrument_db_operation(
+            "sqlite request logs gc open pool",
+            Some(gc_context.as_str()),
+            open_sqlite_pool_with_observability(
+                &layout.core_database_path,
+                layout.observability_database_path.as_deref(),
+                true,
+                false,
+            ),
         )
         .await?;
         let observability_database_path = attached_database_path(&pool, "observability").await?;
@@ -630,7 +653,11 @@ impl KeyStore {
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
-        sqlx::query(
+        instrument_db_operation(
+            "sqlite request logs gc bootstrap schema",
+            Some(gc_context.as_str()),
+            async {
+                sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS observability.request_logs (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -683,14 +710,18 @@ impl KeyStore {
                 created_at INTEGER NOT NULL
             )
             "#,
+                )
+                .execute(&store.pool)
+                .await?;
+                store.ensure_meta_schema().await?;
+                store.ensure_users_debug_info_shared_column().await?;
+                store.migrate_legacy_observability_tables_to_sidecar().await?;
+                store.upgrade_request_logs_schema().await?;
+                store.ensure_request_logs_gc_support_indexes().await?;
+                Ok(())
+            },
         )
-        .execute(&store.pool)
         .await?;
-        store.ensure_meta_schema().await?;
-        store.ensure_users_debug_info_shared_column().await?;
-        store.migrate_legacy_observability_tables_to_sidecar().await?;
-        store.upgrade_request_logs_schema().await?;
-        store.ensure_request_logs_gc_support_indexes().await?;
         Ok(store)
     }
 

--- a/src/store/key_store_users_and_oauth.rs
+++ b/src/store/key_store_users_and_oauth.rs
@@ -1686,9 +1686,18 @@ impl KeyStore {
     ) -> Result<PendingBillingSettleOutcome, ProxyError> {
         let deadline = Instant::now() + Duration::from_secs(10);
         let mut retry_attempt = 0usize;
+        let operation_started = Instant::now();
+        let context = format!("log_id={log_id}");
         loop {
             match self.apply_pending_billing_log_once(log_id).await {
-                Ok(outcome) => return Ok(outcome),
+                Ok(outcome) => {
+                    log_slow_db_operation(
+                        "apply_pending_billing_log",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                    );
+                    return Ok(outcome);
+                }
                 Err(err) => {
                     if sleep_before_sqlite_transient_write_retry(
                         &self.backend_time,
@@ -1702,6 +1711,12 @@ impl KeyStore {
                         retry_attempt += 1;
                         continue;
                     }
+                    log_db_operation_error(
+                        "apply_pending_billing_log",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                        &err,
+                    );
                     return Err(err);
                 }
             }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,15 +2,20 @@ use crate::analysis::*;
 use crate::backend_time::BackendTime;
 use crate::models::*;
 use crate::*;
+use sqlx::ConnectOptions;
 use sqlx::Connection;
 use sqlx::Row;
 use sqlx::SqliteConnection;
 use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
+use tracing::log::LevelFilter;
 
 pub(crate) struct ObservabilityOfflineGuard {
     _lock_file: File,
 }
+
+pub(crate) const SQLITE_SLOW_STATEMENT_THRESHOLD: Duration = Duration::from_millis(250);
+pub(crate) const SQLITE_SLOW_OPERATION_THRESHOLD: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -110,6 +115,106 @@ pub(crate) fn sqlite_transient_write_retry_delay(attempt: usize) -> Duration {
             .get(attempt)
             .copied()
             .unwrap_or(*BACKOFF_MS.last().expect("backoff is non-empty")),
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DbLogStatus {
+    Slow,
+    Error,
+}
+
+impl DbLogStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Slow => "slow",
+            Self::Error => "error",
+        }
+    }
+}
+
+pub(crate) fn format_db_operation_log(
+    status: DbLogStatus,
+    operation: &str,
+    elapsed: Duration,
+    context: Option<&str>,
+    err: Option<&str>,
+) -> String {
+    let mut message = format!(
+        "db operation {}: operation={}, elapsed_ms={}",
+        status.as_str(),
+        operation,
+        elapsed.as_millis()
+    );
+    if let Some(context) = context.map(str::trim).filter(|value| !value.is_empty()) {
+        message.push_str(", context=");
+        message.push_str(context);
+    }
+    if let Some(err) = err.map(str::trim).filter(|value| !value.is_empty()) {
+        message.push_str(", err=");
+        message.push_str(err);
+    }
+    message
+}
+
+pub(crate) fn log_slow_db_operation(operation: &str, elapsed: Duration, context: Option<&str>) {
+    if elapsed < SQLITE_SLOW_OPERATION_THRESHOLD {
+        return;
+    }
+    eprintln!(
+        "{}",
+        format_db_operation_log(DbLogStatus::Slow, operation, elapsed, context, None)
+    );
+}
+
+pub(crate) fn log_db_operation_error(
+    operation: &str,
+    elapsed: Duration,
+    context: Option<&str>,
+    err: &ProxyError,
+) {
+    eprintln!(
+        "{}",
+        format_db_operation_log(
+            DbLogStatus::Error,
+            operation,
+            elapsed,
+            context,
+            Some(&err.to_string()),
+        )
+    );
+}
+
+pub(crate) async fn instrument_db_operation<T, F>(
+    operation: &str,
+    context: Option<&str>,
+    future: F,
+) -> Result<T, ProxyError>
+where
+    F: std::future::Future<Output = Result<T, ProxyError>>,
+{
+    let started_at = Instant::now();
+    match future.await {
+        Ok(value) => {
+            log_slow_db_operation(operation, started_at.elapsed(), context);
+            Ok(value)
+        }
+        Err(err) => {
+            log_db_operation_error(operation, started_at.elapsed(), context, &err);
+            Err(err)
+        }
+    }
+}
+
+pub(crate) fn sqlite_runtime_log_context(
+    database_path: &str,
+    mode: &str,
+    read_only: bool,
+    create_if_missing: bool,
+) -> String {
+    format!(
+        "path={}, mode={}, read_only={}, create_if_missing={}",
+        database_path, mode, read_only, create_if_missing
     )
 }
 
@@ -301,17 +406,24 @@ pub(crate) async fn open_sqlite_pool_with_observability(
         .filename(database_path)
         .create_if_missing(create_if_missing)
         .read_only(read_only)
-        .busy_timeout(Duration::from_secs(5));
+        .busy_timeout(Duration::from_secs(5))
+        .log_slow_statements(LevelFilter::Warn, SQLITE_SLOW_STATEMENT_THRESHOLD);
     if !read_only {
         options = options.journal_mode(SqliteJournalMode::Wal);
     }
 
-    let attach_plan = resolve_observability_attach_plan(
-        database_path,
-        observability_database_path,
-        create_if_missing,
-        read_only,
-        SQLITE_POOL_MAX_CONNECTIONS_DEFAULT,
+    let attach_context =
+        sqlite_runtime_log_context(database_path, "runtime", read_only, create_if_missing);
+    let attach_plan = instrument_db_operation(
+        "sqlite resolve observability attach plan",
+        Some(attach_context.as_str()),
+        resolve_observability_attach_plan(
+            database_path,
+            observability_database_path,
+            create_if_missing,
+            read_only,
+            SQLITE_POOL_MAX_CONNECTIONS_DEFAULT,
+        ),
     )
     .await?;
     let mut pool_options = SqlitePoolOptions::new()
@@ -327,10 +439,19 @@ pub(crate) async fn open_sqlite_pool_with_observability(
         });
     }
 
-    pool_options
-        .connect_with(options)
-        .await
-        .map_err(ProxyError::Database)
+    let open_context =
+        sqlite_runtime_log_context(database_path, "runtime", read_only, create_if_missing);
+    instrument_db_operation(
+        "sqlite open pool",
+        Some(open_context.as_str()),
+        async move {
+            pool_options
+                .connect_with(options)
+                .await
+                .map_err(ProxyError::Database)
+        },
+    )
+    .await
 }
 
 pub(crate) const LEGACY_REQUEST_LOGS_INLINE_SIDECAR_MIGRATION_MAX_BYTES: u64 = 32 * 1024 * 1024;
@@ -358,23 +479,50 @@ async fn resolve_observability_attach_plan(
         .filename(core_database_path)
         .create_if_missing(create_if_missing)
         .read_only(read_only)
-        .busy_timeout(Duration::from_secs(5));
+        .busy_timeout(Duration::from_secs(5))
+        .log_slow_statements(LevelFilter::Warn, SQLITE_SLOW_STATEMENT_THRESHOLD);
     if !read_only {
         options = options.journal_mode(SqliteJournalMode::Wal);
     }
 
-    let mut probe = SqliteConnection::connect_with(&options)
-        .await
-        .map_err(ProxyError::Database)?;
-    let target_path = select_observability_attach_path(
-        &mut probe,
+    let probe_context = sqlite_runtime_log_context(
         core_database_path,
-        observability_database_path,
-        create_if_missing,
+        "observability-probe",
         read_only,
+        create_if_missing,
+    );
+    let mut probe = instrument_db_operation(
+        "sqlite open observability attach probe",
+        Some(probe_context.as_str()),
+        async {
+            SqliteConnection::connect_with(&options)
+                .await
+                .map_err(ProxyError::Database)
+        },
     )
-    .await
-    .map_err(ProxyError::Database)?;
+    .await?;
+    let select_context = sqlite_runtime_log_context(
+        core_database_path,
+        "observability-probe",
+        read_only,
+        create_if_missing,
+    );
+    let target_path = instrument_db_operation(
+        "sqlite select observability attach path",
+        Some(select_context.as_str()),
+        async {
+            select_observability_attach_path(
+                &mut probe,
+                core_database_path,
+                observability_database_path,
+                create_if_missing,
+                read_only,
+            )
+            .await
+            .map_err(ProxyError::Database)
+        },
+    )
+    .await?;
     Ok(ObservabilityAttachPlan {
         target_path,
         max_connections: default_max_connections,
@@ -392,7 +540,8 @@ pub(crate) async fn open_sqlite_pool_forced_observability(
         .filename(core_database_path)
         .create_if_missing(create_if_missing)
         .read_only(read_only)
-        .busy_timeout(Duration::from_secs(5));
+        .busy_timeout(Duration::from_secs(5))
+        .log_slow_statements(LevelFilter::Warn, SQLITE_SLOW_STATEMENT_THRESHOLD);
     if !read_only {
         options = options.journal_mode(SqliteJournalMode::Wal);
     }
@@ -411,10 +560,23 @@ pub(crate) async fn open_sqlite_pool_forced_observability(
         });
     }
 
-    pool_options
-        .connect_with(options)
-        .await
-        .map_err(ProxyError::Database)
+    let forced_context = sqlite_runtime_log_context(
+        core_database_path,
+        "forced-observability",
+        read_only,
+        create_if_missing,
+    );
+    instrument_db_operation(
+        "sqlite open forced observability pool",
+        Some(forced_context.as_str()),
+        async move {
+            pool_options
+                .connect_with(options)
+                .await
+                .map_err(ProxyError::Database)
+        },
+    )
+    .await
 }
 
 async fn select_observability_attach_path(
@@ -674,12 +836,15 @@ pub(crate) fn sqlite_qualified_table_name(table: &str) -> String {
 pub(crate) async fn begin_immediate_sqlite_connection(
     pool: &SqlitePool,
 ) -> Result<sqlx::pool::PoolConnection<Sqlite>, ProxyError> {
-    let mut conn = pool.acquire().await?;
-    if let Err(err) = sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await {
-        let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
-        return Err(ProxyError::Database(err));
-    }
-    Ok(conn)
+    instrument_db_operation("sqlite begin immediate", None, async {
+        let mut conn = pool.acquire().await?;
+        if let Err(err) = sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+            return Err(ProxyError::Database(err));
+        }
+        Ok(conn)
+    })
+    .await
 }
 
 pub(crate) async fn begin_immediate_sqlite_connection_with_retry(
@@ -2254,3 +2419,31 @@ include!("key_store_jobs.rs");
 include!("key_store_account_limit_snapshots.rs");
 include!("key_store_account_usage_rollups.rs");
 include!("key_store_ha.rs");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_operation_log_format_includes_operation_context_and_error() {
+        let rendered = format_db_operation_log(
+            DbLogStatus::Error,
+            "sqlite begin immediate",
+            Duration::from_millis(1534),
+            Some("path=data/core.db, mode=startup"),
+            Some("database is locked"),
+        );
+        assert_eq!(
+            rendered,
+            "db operation error: operation=sqlite begin immediate, elapsed_ms=1534, context=path=data/core.db, mode=startup, err=database is locked"
+        );
+    }
+
+    #[test]
+    fn sqlite_runtime_log_context_is_stable_and_grep_friendly() {
+        assert_eq!(
+            sqlite_runtime_log_context("data/core.db", "startup", false, true),
+            "path=data/core.db, mode=startup, read_only=false, create_if_missing=true"
+        );
+    }
+}

--- a/src/tavily_proxy/proxy_auth_and_oauth.rs
+++ b/src/tavily_proxy/proxy_auth_and_oauth.rs
@@ -1,4 +1,13 @@
 impl TavilyProxy {
+    fn oauth_profile_log_context(profile: &OAuthAccountProfile) -> String {
+        let provider_user_id_hash = Self::sha256_hex(&profile.provider_user_id);
+        format!(
+            "provider={}, provider_user_id_sha256={}",
+            profile.provider,
+            &provider_user_id_hash[..16]
+        )
+    }
+
     // ----- Public auth token management API -----
 
     /// Validate an access token in format `th-<id>-<secret>` and record usage.
@@ -327,9 +336,18 @@ impl TavilyProxy {
     ) -> Result<UserIdentity, ProxyError> {
         let deadline = self.backend_time.deadline_after(Duration::from_secs(5));
         let mut attempt = 0usize;
+        let operation_started = Instant::now();
+        let context = Self::oauth_profile_log_context(profile);
         loop {
             match self.key_store.upsert_oauth_account(profile).await {
-                Ok(identity) => return Ok(identity),
+                Ok(identity) => {
+                    log_slow_db_operation(
+                        "oauth account upsert",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                    );
+                    return Ok(identity);
+                }
                 Err(err) => {
                     if sleep_before_sqlite_transient_write_retry(
                         &self.backend_time,
@@ -343,6 +361,12 @@ impl TavilyProxy {
                         attempt += 1;
                         continue;
                     }
+                    log_db_operation_error(
+                        "oauth account upsert",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                        &err,
+                    );
                     return Err(err);
                 }
             }
@@ -356,9 +380,18 @@ impl TavilyProxy {
     ) -> Result<UserIdentity, ProxyError> {
         let deadline = self.backend_time.deadline_after(Duration::from_secs(5));
         let mut attempt = 0usize;
+        let operation_started = Instant::now();
+        let context = Self::oauth_profile_log_context(profile);
         loop {
             match self.key_store.refresh_oauth_account_profile(profile).await {
-                Ok(identity) => return Ok(identity),
+                Ok(identity) => {
+                    log_slow_db_operation(
+                        "oauth account profile refresh",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                    );
+                    return Ok(identity);
+                }
                 Err(err) => {
                     if sleep_before_sqlite_transient_write_retry(
                         &self.backend_time,
@@ -372,6 +405,12 @@ impl TavilyProxy {
                         attempt += 1;
                         continue;
                     }
+                    log_db_operation_error(
+                        "oauth account profile refresh",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                        &err,
+                    );
                     return Err(err);
                 }
             }
@@ -387,6 +426,8 @@ impl TavilyProxy {
     ) -> Result<UserIdentity, ProxyError> {
         let deadline = self.backend_time.deadline_after(Duration::from_secs(5));
         let mut attempt = 0usize;
+        let operation_started = Instant::now();
+        let context = Self::oauth_profile_log_context(profile);
         loop {
             match self
                 .key_store
@@ -397,7 +438,14 @@ impl TavilyProxy {
                 )
                 .await
             {
-                Ok(identity) => return Ok(identity),
+                Ok(identity) => {
+                    log_slow_db_operation(
+                        "oauth account profile refresh token update",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                    );
+                    return Ok(identity);
+                }
                 Err(err) => {
                     if sleep_before_sqlite_transient_write_retry(
                         &self.backend_time,
@@ -411,6 +459,12 @@ impl TavilyProxy {
                         attempt += 1;
                         continue;
                     }
+                    log_db_operation_error(
+                        "oauth account profile refresh token update",
+                        operation_started.elapsed(),
+                        Some(context.as_str()),
+                        &err,
+                    );
                     return Err(err);
                 }
             }

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -41,9 +41,22 @@ impl TavilyProxy {
                     state.shutdown
                 };
 
+                let flush_started = Instant::now();
                 if let Err(err) = store.flush_request_stats_writes().await {
+                    log_db_operation_error(
+                        "request stats persist",
+                        flush_started.elapsed(),
+                        Some("component=request-stats-coalescer"),
+                        &err,
+                    );
                     eprintln!("request stats persist warning: {err}");
                     tokio::time::sleep(Duration::from_millis(100)).await;
+                } else {
+                    log_slow_db_operation(
+                        "request stats persist",
+                        flush_started.elapsed(),
+                        Some("component=request-stats-coalescer"),
+                    );
                 }
 
                 {


### PR DESCRIPTION
## Summary
- add a minimal runtime logging initializer and enable `sqlx` slow statement logging for runtime SQLite pools
- instrument startup, scheduler enqueue, request-stats flush, OAuth account writes, and pending billing settlement with unified DB slow/error logs
- update the SQLite lock-contention spec/solution docs with thresholds and the 101 post-`2026-06-19 01:00 +08:00` symptom mapping

## Validation
- `cargo fmt --all`
- `cargo check -q`
- `cargo test -q db_operation_log_format_includes_operation_context_and_error`
- `cargo test -q sqlite_runtime_log_context_is_stable_and_grep_friendly`
- `cargo test -q scheduled_job_enqueue`
- `cargo test -q linuxdo_oauth_upsert_skips_missing_tags_for_new_accounts_and_recovers_after_reseed`
- `cargo test -q pending_billing_claim_miss_is_retry_later_until_next_replay`
- `codex -m gpt-5.5 -c model_reasoning_effort="low" --sandbox read-only -a never review --base origin/main`

## References
Spec: `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`
Spec Disposition: `update`
Spec Sync: `done`
Spec Drift: `none`
Solutions:
- `docs/solutions/operations/sqlite-write-lock-contention.md`
Solutions Sync: `done`
Project Docs: `-`
Project Docs Sync: `n/a(no project-doc change)`

## Notes
- 101 evidence in this PR is intentionally limited to logs after `2026-06-19 01:00:00 +08:00`
- runtime DB phase logs keep stderr text output and avoid SQL bind-value logging

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
