### PR TITLE
feat: unify runtime logging with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "html-escape",
  "httpdate",
  "libc",
+ "log",
  "md5",
  "mime_guess",
  "nanoid",
@@ -2426,6 +2427,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -2718,6 +2720,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,12 +2739,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,6 @@ data-encoding = "2"
 totp-rs = { version = "5.7", features = ["qr", "zeroize"] }
 zstd = "0.13"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+log = "0.4"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json", "tracing-log"] }

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The stock [`docker-compose.yml`](docker-compose.yml) exposes port 8787 and mount
 | `--bind` / `PROXY_BIND`                                                             | Listen address (default `127.0.0.1`).                                                                                |
 | `--port` / `PROXY_PORT`                                                             | Listen port (default `8787`).                                                                                        |
 | `--db-path` / `PROXY_DB_PATH`                                                       | SQLite file path (default `tavily_proxy.db`).                                                                        |
+| `--log-format` / `RUNTIME_LOG_FORMAT`                                               | Runtime log formatter (`json` by default, `text` for fallback grep workflows).                                       |
 | `--low-quota-depletion-threshold` / `LOW_QUOTA_DEPLETION_THRESHOLD`                 | Remaining-credit threshold for keeping 432-exhausted upstream keys out of normal monthly pools (default `15`).       |
 | `--static-dir` / `WEB_STATIC_DIR`                                                   | Directory for static assets; auto-detected if `web/dist` exists.                                                     |
 | `--forward-auth-header` / `FORWARD_AUTH_HEADER`                                     | Request header that carries the authenticated user identity (e.g., `Remote-Email`).                                  |
@@ -190,6 +191,9 @@ For the full HTTP proxy design and acceptance criteria, see [`docs/tavily-http-a
 - `exhausted` status is triggered automatically when upstream returns 432; scheduler skips those keys until UTC month rollover or manual recovery.
 - Each access token maintains a soft affinity to a single API key for a short time window. Within that window, the proxy prefers the same key when it remains active; when affinity expires or the key becomes exhausted/disabled, the next key is chosen by a global least‑recently‑used scheduler to keep load balanced across healthy keys. If all are disabled, the proxy falls back to the oldest disabled entries.
 - `request_logs` captures request metadata, upstream payloads, and dropped/forwarded header sets for postmortem analysis.
+- Runtime process logs are separate from `request_logs`. By default Hikari emits JSON lines on stderr via `tracing`; use `RUNTIME_LOG_FORMAT=text` (or `--log-format text`) only when you explicitly need grep-friendly local fallback output.
+- Stable runtime event fields include `component`, `event`, and per-path fields such as `operation`, `job_type`, `attempt`, `backoff_ms`, `path`, `method`, and `err`. Secrets, full tokens, cookies, and raw sensitive headers are intentionally excluded.
+- `RUST_LOG` still controls filtering. Typical operator flows are `docker logs ... | jq -c` in JSON mode and `RUNTIME_LOG_FORMAT=text RUST_LOG=info cargo run ... | rg "component=db|event=operation_"` in fallback text mode.
 - High-anonymity behavior (header allowlist, origin rewrite, etc.) is detailed in [`docs/high-anonymity-proxy.md`](docs/high-anonymity-proxy.md).
 
 ## ForwardAuth Integration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,6 +107,7 @@ curl -X POST http://127.0.0.1:8787/api/keys \
 | `--bind` / `PROXY_BIND`                                                             | 监听地址，默认 `127.0.0.1`。                                                                                                 |
 | `--port` / `PROXY_PORT`                                                             | 监听端口，默认 `8787`。建议开发期使用高位端口（如 `58087`）。                                                                |
 | `--db-path` / `PROXY_DB_PATH`                                                       | SQLite 文件路径，默认 `tavily_proxy.db`。                                                                                    |
+| `--log-format` / `RUNTIME_LOG_FORMAT`                                               | 运行期日志格式，默认 `json`；需要本地 `grep`/迁移期排障时可显式切到 `text`。                                                 |
 | `--static-dir` / `WEB_STATIC_DIR`                                                   | Web 静态目录，若缺省且存在 `web/dist` 会自动挂载。                                                                           |
 | `--forward-auth-header` / `FORWARD_AUTH_HEADER`                                     | 指定 ForwardAuth 注入的“用户标识”请求头（如 `Remote-Email`）。                                                               |
 | `--forward-auth-admin-value` / `FORWARD_AUTH_ADMIN_VALUE`                           | 匹配到该值时视为管理员，可访问 `/api/keys/*` 接口。                                                                          |
@@ -184,6 +185,10 @@ Tavily Hikari 通过 `/api/tavily/search` 为 Tavily HTTP API 提供代理与密
 - **额度感知**：当 Tavily 返回 432 时会自动将 Key 标记为 `exhausted`，轮询器将跳过该 Key，直到 UTC 月初或手动恢复。
 - **调度算法**：优先选择最久未使用的 `active` Key；若全部被禁用则按照禁用时间回退，避免请求被直接拒绝。
 - **日志字段**：`request_logs` 记录 method/path/query、上游响应体、状态码、错误堆栈、透传/丢弃头部，便于配额排障。
+- **运行日志与审计分层**：`request_logs` / token logs 继续承担业务审计与 owner-facing 查询；进程级 runtime logging 默认改为 `tracing` 的 JSON 行输出，写入 stderr，供容器/平台侧聚合。
+- **默认 JSON，显式 text 回退**：默认使用 `RUNTIME_LOG_FORMAT=json`；只有在本地 grep、迁移窗口或临时排障时，才显式设置 `RUNTIME_LOG_FORMAT=text`（或 `--log-format text`）。
+- **稳定字段契约**：运行日志稳定字段包括 `component`、`event`，以及按场景补充的 `operation`、`job_type`、`attempt`、`backoff_ms`、`path`、`method`、`err` 等；不会输出完整 Tavily key、Hikari token secret、cookie 或原始敏感头。
+- **过滤方式不变**：继续使用 `RUST_LOG` 控制日志级别；JSON 模式建议配合 `jq`，text 回退模式建议配合 `rg`/`grep`。
 - **匿名策略**：详见 [`docs/high-anonymity-proxy.md`](docs/high-anonymity-proxy.md)，包括允许/丢弃的头部列表、主机名改写策略等。
 
 ## ForwardAuth 配置

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -43,18 +43,19 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 
 ## Resolution
 
-- Add a runtime DB logging contract before changing lock semantics again. For this service, keep
-  stderr text logging, but make runtime DB phases emit one stable prefix:
-  `db operation slow:` / `db operation error:` with `operation`, `elapsed_ms`, optional `context`,
-  and optional `err`.
+- Add a runtime DB logging contract before changing lock semantics again. For this service, default
+  runtime logging to JSON lines on stderr via `tracing`, and keep a documented `text` fallback for
+  grep-oriented local workflows. Runtime DB phases must still emit stable fields for
+  `component=db`, `event=operation_slow|operation_error`, `operation`, `elapsed_ms`, optional
+  `context`, and optional `err`.
 - Enable SQL-level slow statement logging directly on runtime `sqlx` SQLite connect options. The
   default threshold is `250ms` for SQL statements and `1s` for explicit DB operation phases such as
   startup pool open, schema init, request-stats flush, scheduler enqueue, OAuth upsert, and
   pending billing settlement.
-- Keep the historical startup line `forward-proxy startup: sqlite initialized in ...` for grep
-  continuity, but require the new DB phase logs alongside it so operators can tell whether the time
-  went into pool open, observability attach probing, `BEGIN IMMEDIATE`, schema bootstrap, or a
-  later request/worker write path.
+- Keep stable startup/runtime event names so operators can tell whether the time went into pool
+  open, observability attach probing, `BEGIN IMMEDIATE`, schema bootstrap, or a later
+  request/worker write path. In JSON mode this comes from structured `component/event/...` fields;
+  in fallback text mode the same fields remain grep-friendly.
 - Keep billing and MCP serialization fail-closed, but retry transient SQLite busy/locked writes
   inside the existing bounded lock wait or lease budget.
 - Retry background job bookkeeping writes before surfacing scheduler errors.
@@ -204,18 +205,19 @@ For the `2026-06-19 01:00 +08:00` onward 101 sample, the runtime DB log contract
 observed symptoms like this:
 
 - `forward-proxy startup: sqlite initialized in 38906ms`
-  -> keep the existing startup line and also expect `db operation slow: operation=sqlite startup ...`
+  -> keep the startup lifecycle event and expect
+  `component=db event=operation_slow operation="sqlite startup" ...`
 - `quota-sync-hot: enqueue job error: ... database is locked`
-  -> expect `db operation error: operation=scheduled job enqueue ...`
+  -> expect `component=db event=operation_error operation="scheduled job enqueue" ...`
 - `request stats persist warning: ... database is locked`
-  -> expect `db operation error: operation=request stats persist ...`
+  -> expect `component=db event=operation_error operation="request stats persist" ...`
 - `upsert linuxdo oauth account error: ... database is locked`
-  -> expect `db operation error: operation=oauth account upsert ...`
+  -> expect `component=db event=operation_error operation="oauth account upsert" ...`
 - `oauth account upsert: transient sqlite write error (...)`
   -> keep bounded retry logs and expect the final phase-level `oauth account upsert` slow/error log
 - `apply_pending_billing_log: transient sqlite write error (...)`
   -> keep bounded retry logs and expect the final phase-level
-  `db operation slow|error: operation=apply_pending_billing_log ...`
+  `component=db event=operation_slow|operation_error operation="apply_pending_billing_log" ...`
 - request-path `/api/tavily/search` / MCP billing failures
   -> correlate request warning lines with `apply_pending_billing_log`, quota/billing lock logs, and
   `sqlx::query` warn lines for slow statements on the same wall-clock window

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -2,22 +2,21 @@
 
 ## Current Coverage
 
-- Added a runtime DB logging contract for the online service surface without migrating the whole
-  repo to structured logging. Runtime SQLite pool creation now initializes a minimal
-  `tracing_subscriber` backend once at process startup, and all runtime `SqliteConnectOptions`
-  enable `sqlx` slow statement logging at `250ms`.
-- Added shared DB operation log helpers in `src/store/mod.rs`. They emit stable stderr lines using
-  `db operation slow:` and `db operation error:` with `operation=...`, `elapsed_ms=...`, optional
-  `context=...`, and optional `err=...`, so startup, request-path, and background DB phases can be
-  grepped with one contract.
+- Added a runtime logging contract for the online service surface based on `tracing` +
+  `tracing-subscriber`. Runtime logging now defaults to JSON lines on stderr, exposes a documented
+  `RUNTIME_LOG_FORMAT=text` fallback for grep-oriented workflows, and keeps `RUST_LOG` filtering
+  intact. All runtime `SqliteConnectOptions` still enable `sqlx` slow statement logging at `250ms`.
+- Added shared DB operation log helpers in `src/store/mod.rs`. They emit stable structured events
+  with `component=db`, `event=operation_slow|operation_error`, `operation=...`,
+  `elapsed_ms=...`, optional `context=...`, and optional `err=...`, so startup, request-path, and
+  background DB phases can be filtered with one contract in both JSON and fallback text mode.
 - Runtime DB operation logs intentionally do not include SQL bind values. The SQL-level
   `sqlx::query` slow-statement warnings keep the statement text/summary and timing, while the
   explicit phase-level helper keeps only operation/context metadata to avoid leaking secrets.
 - Startup SQLite open / observability-attach probe / schema initialization now pass through that
-  shared helper with a `1s` slow-operation threshold. The existing
-  `forward-proxy startup: sqlite initialized in ...` line remains in place for historical grep
-  continuity, and the new `db operation slow:`/`error:` lines make it clear which startup DB phase
-  stalled or failed.
+  shared helper with a `1s` slow-operation threshold. Startup/shutdown/HA/forward-proxy paths also
+  emit named runtime events (`component`, `event`, and path-specific fields), so operators can tell
+  which startup DB phase stalled or failed without depending on ad hoc stderr text.
 - Request-path DB work now has unified phase logs around LinuxDo OAuth upsert/profile refresh and
   pending billing settlement. That covers the same classes already seen in production after
   `2026-06-19 01:00 +08:00`: `oauth account upsert`, `apply_pending_billing_log`, and the
@@ -303,12 +302,12 @@
   - request-path/user writes: `upsert linuxdo oauth account error`,
     `oauth account upsert: transient sqlite write error`, `apply_pending_billing_log`, and
     `/api/tavily/search` proxy failures bubbling a `database is locked`
-- The new runtime DB logging contract is designed to map those same symptoms onto stable grep keys:
-  - `db operation slow: operation=sqlite startup ...`
-  - `db operation error: operation=scheduled job enqueue ...`
-  - `db operation error: operation=request stats persist ...`
-  - `db operation error|slow: operation=oauth account upsert ...`
-  - `db operation error|slow: operation=apply_pending_billing_log ...`
+- The new runtime DB logging contract is designed to map those same symptoms onto stable fields:
+  - `component=db event=operation_slow operation="sqlite startup" ...`
+  - `component=db event=operation_error operation="scheduled job enqueue" ...`
+  - `component=db event=operation_error operation="request stats persist" ...`
+  - `component=db event=operation_error|operation_slow operation="oauth account upsert" ...`
+  - `component=db event=operation_error|operation_slow operation="apply_pending_billing_log" ...`
   - `sqlx::query` warn lines for statements slower than `250ms`
 - Production baseline was read-only: container healthy, version `0.46.2`, database `8.3G`, WAL
   `235M`, and the most recent one-hour lock sample only showed LinuxDo OAuth upsert contention.

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -87,6 +87,7 @@
         "analysis::tests::",
         "ha::tests::",
         "models::client_ip_tests::",
+        "runtime_logging::tests::",
         "store::tests::",
         "tavily_proxy::tests::",
         "tests::request_kind_and_core::parse_",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+mod runtime_logging;
 mod admin_token_filters;
 mod analysis;
 mod backend_time;
@@ -38,9 +40,13 @@ pub use forward_proxy::{
 pub use ha::*;
 pub use linuxdo_credit_recharge::*;
 pub use models::*;
+pub use runtime_logging::{
+    LegacyStdIoLevel, RuntimeLogFormat, emit_legacy_stdio_event, init_runtime_logging,
+};
 pub use tavily_proxy::*;
 
 use std::{
+    cell::Cell,
     cmp::min,
     collections::{BTreeMap, HashMap, HashSet},
     future::Future,
@@ -68,32 +74,10 @@ use sqlx::{Executor, QueryBuilder, Sqlite, SqlitePool, Transaction};
 use thiserror::Error;
 use tokio::sync::{Mutex, Notify, RwLock, Semaphore};
 use tokio::time::Instant;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 use url::form_urlencoded;
 
 #[cfg(test)]
 use std::sync::atomic::AtomicU64;
-
-static RUNTIME_LOGGING_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-
-pub fn init_runtime_logging() {
-    RUNTIME_LOGGING_INIT.get_or_init(|| {
-        let filter = EnvFilter::try_from_default_env()
-            .or_else(|_| EnvFilter::try_new("warn,sqlx::query=warn"))
-            .unwrap_or_else(|_| EnvFilter::new("warn"));
-        tracing_subscriber::registry()
-            .with(filter)
-            .with(
-                fmt::layer()
-                    .with_writer(std::io::stderr)
-                    .with_target(true)
-                    .without_time()
-                    .compact(),
-            )
-            .try_init()
-            .ok();
-    });
-}
 
 pub fn emit_db_operation_slow_log(operation: &str, elapsed: Duration, context: Option<&str>) {
     store::log_slow_db_operation(operation, elapsed, context);
@@ -934,6 +918,50 @@ const META_KEY_ADMIN_TOTP_FAILURE_COUNT_V1: &str = "admin_totp_failure_count_v1"
 const META_KEY_ADMIN_TOTP_LOCKED_UNTIL_V1: &str = "admin_totp_locked_until_v1";
 const META_KEY_REQUEST_RATE_LIMIT_V1: &str = "request_rate_limit_v1";
 const META_KEY_AUTH_TOKEN_LOG_RETENTION_DAYS_V1: &str = "auth_token_log_retention_days_v1";
+
+static PROCESS_ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+thread_local! {
+    static PROCESS_ENV_LOCK_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+pub struct ProcessEnvLockGuard {
+    _guard: Option<std::sync::MutexGuard<'static, ()>>,
+}
+
+pub fn lock_process_env() -> ProcessEnvLockGuard {
+    let nested = PROCESS_ENV_LOCK_DEPTH.with(|depth| {
+        let current = depth.get();
+        depth.set(current + 1);
+        current > 0
+    });
+    if nested {
+        ProcessEnvLockGuard { _guard: None }
+    } else {
+        let guard = PROCESS_ENV_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        ProcessEnvLockGuard {
+            _guard: Some(guard),
+        }
+    }
+}
+
+impl Drop for ProcessEnvLockGuard {
+    fn drop(&mut self) {
+        PROCESS_ENV_LOCK_DEPTH.with(|depth| {
+            let current = depth.get();
+            debug_assert!(current > 0, "process env lock depth underflow");
+            depth.set(current.saturating_sub(1));
+        });
+    }
+}
+
+fn with_process_env_lock<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = lock_process_env();
+    f()
+}
 const META_KEY_MCP_SESSION_AFFINITY_KEY_COUNT_V1: &str = "mcp_session_affinity_key_count_v1";
 const META_KEY_REBALANCE_MCP_ENABLED_V1: &str = "rebalance_mcp_enabled_v1";
 const META_KEY_REBALANCE_MCP_SESSION_PERCENT_V1: &str = "rebalance_mcp_session_percent_v1";
@@ -1113,7 +1141,7 @@ pub fn normalize_auth_token_log_retention_days(value: i64) -> Option<i64> {
 }
 
 fn parse_auth_token_log_retention_days_env() -> Result<Option<i64>, String> {
-    match std::env::var("AUTH_TOKEN_LOG_RETENTION_DAYS") {
+    with_process_env_lock(|| match std::env::var("AUTH_TOKEN_LOG_RETENTION_DAYS") {
         Ok(raw) => {
             let trimmed = raw.trim();
             if trimmed.is_empty() {
@@ -1134,7 +1162,7 @@ fn parse_auth_token_log_retention_days_env() -> Result<Option<i64>, String> {
                 })
         }
         Err(_) => Ok(None),
-    }
+    })
 }
 
 pub fn default_auth_token_log_retention_days() -> i64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,29 @@
+#[allow(unused_macros)]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        tavily_hikari::emit_legacy_stdio_event(
+            tavily_hikari::LegacyStdIoLevel::Info,
+            module_path!(),
+            file!(),
+            line!(),
+            format_args!($($arg)*),
+        )
+    }};
+}
+
+#[allow(unused_macros)]
+macro_rules! eprintln {
+    ($($arg:tt)*) => {{
+        tavily_hikari::emit_legacy_stdio_event(
+            tavily_hikari::LegacyStdIoLevel::Warn,
+            module_path!(),
+            file!(),
+            line!(),
+            format_args!($($arg)*),
+        )
+    }};
+}
+
 mod server;
 
 use std::{
@@ -9,9 +35,10 @@ use argon2::password_hash::PasswordHash;
 use clap::Parser;
 use dotenvy::dotenv;
 use tavily_hikari::{
-    DEFAULT_UPSTREAM, HaConfig, HaMode, LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT, TavilyProxy,
-    TavilyProxyOptions,
+    DEFAULT_UPSTREAM, HaConfig, HaMode, LOW_QUOTA_DEPLETION_THRESHOLD_DEFAULT, RuntimeLogFormat,
+    TavilyProxy, TavilyProxyOptions,
 };
+use tracing::{info, warn};
 
 #[derive(Debug, Parser)]
 #[command(author, version, about = "Tavily reverse proxy with key rotation")]
@@ -300,13 +327,17 @@ struct Cli {
     /// HA standby pull sync interval in seconds, clamped to 5-15.
     #[arg(long, env = "HA_SYNC_INTERVAL_SECS", default_value_t = 15)]
     ha_sync_interval_secs: u64,
+
+    /// Runtime log formatter (`json` by default, `text` for fallback grep workflows).
+    #[arg(long, env = "RUNTIME_LOG_FORMAT", value_enum, default_value_t = RuntimeLogFormat::Json)]
+    log_format: RuntimeLogFormat,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
-    tavily_hikari::init_runtime_logging();
     let cli = Cli::parse();
+    tavily_hikari::init_runtime_logging(cli.log_format);
     reject_legacy_ha_origin_env_vars()?;
 
     // Ensure parent directory for database exists when using nested path like data/tavily_proxy.db
@@ -316,7 +347,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         std::fs::create_dir_all(parent)?;
     }
-    println!("Using database: {}", db_path.display());
+    info!(
+        component = "startup",
+        event = "database_path_resolved",
+        path = %db_path.display(),
+        log_format = %cli.log_format,
+        "resolved runtime database path"
+    );
 
     let proxy_options = TavilyProxyOptions {
         xray_binary: cli.xray_binary,
@@ -381,11 +418,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if cli.admin_auth_builtin_enabled {
         match (&builtin_password_hash, &builtin_password) {
-            (Some(_), Some(_)) => println!(
-                "Built-in auth: both password and password hash are set; using password hash"
+            (Some(_), Some(_)) => info!(
+                component = "startup",
+                event = "builtin_auth_configured",
+                mode = "password_hash_preferred",
+                "built-in auth configured with both password and password hash; preferring hash"
             ),
-            (None, Some(_)) => println!(
-                "Built-in auth: using plaintext password (not recommended); prefer ADMIN_AUTH_BUILTIN_PASSWORD_HASH"
+            (None, Some(_)) => warn!(
+                component = "startup",
+                event = "builtin_auth_configured",
+                mode = "plaintext_password",
+                "built-in auth configured with plaintext password; prefer ADMIN_AUTH_BUILTIN_PASSWORD_HASH"
             ),
             _ => {}
         }
@@ -418,17 +461,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             scope.to_string()
         }
     };
-    let linuxdo_oauth_refresh_token_crypt_key = match parse_linuxdo_refresh_token_crypt_key(
-        cli.linuxdo_oauth_refresh_token_crypt_key,
-    ) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!(
-                "warning: {err}; LinuxDo refresh-token persistence and daily user sync will stay disabled"
-            );
-            None
-        }
-    };
+    let linuxdo_oauth_refresh_token_crypt_key =
+        match parse_linuxdo_refresh_token_crypt_key(cli.linuxdo_oauth_refresh_token_crypt_key) {
+            Ok(value) => value,
+            Err(err) => {
+                warn!(
+                    component = "startup",
+                    event = "linuxdo_refresh_token_key_invalid",
+                    err = %err,
+                    "linuxdo refresh-token persistence and daily user sync stay disabled"
+                );
+                None
+            }
+        };
     let linuxdo_oauth_user_sync_at =
         parse_hhmm(&cli.linuxdo_oauth_user_sync_at).ok_or_else(|| {
             format!(

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,6 +7,7 @@ use std::{
     collections::HashSet,
     net::{IpAddr, SocketAddr},
 };
+use tracing::{error, info};
 
 pub const DEFAULT_TRUSTED_PROXY_CIDRS: &[&str] = &["127.0.0.0/8", "::1/128"];
 
@@ -2930,7 +2931,15 @@ pub(crate) fn log_success(
 ) {
     let key_preview = preview_key(key);
     let full_path = compose_path(path, query);
-    println!("[{key_preview}] {method} {full_path} -> {status}");
+    info!(
+        component = "proxy",
+        event = "upstream_request_succeeded",
+        key_preview,
+        method = %method,
+        path = %full_path,
+        status = status.as_u16(),
+        "[{key_preview}] {method} {full_path} -> {status}"
+    );
 }
 
 pub(crate) fn log_error(
@@ -2942,7 +2951,15 @@ pub(crate) fn log_error(
 ) {
     let key_preview = preview_key(key);
     let full_path = compose_path(path, query);
-    eprintln!("[{key_preview}] {method} {full_path} !! {err}");
+    error!(
+        component = "proxy",
+        event = "upstream_request_failed",
+        key_preview,
+        method = %method,
+        path = %full_path,
+        err = %err,
+        "[{key_preview}] {method} {full_path} !! {err}"
+    );
 }
 
 pub(crate) fn log_proxy_error(
@@ -2957,7 +2974,15 @@ pub(crate) fn log_proxy_error(
         _ => {
             let key_preview = preview_key(key);
             let full_path = compose_path(path, query);
-            eprintln!("[{key_preview}] {method} {full_path} !! {err}");
+            error!(
+                component = "proxy",
+                event = "proxy_request_failed",
+                key_preview,
+                method = %method,
+                path = %full_path,
+                err = %err,
+                "[{key_preview}] {method} {full_path} !! {err}"
+            );
         }
     }
 }

--- a/src/runtime_logging.rs
+++ b/src/runtime_logging.rs
@@ -4,7 +4,7 @@ use clap::ValueEnum;
 use tracing::Dispatch;
 use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
 
-const DEFAULT_RUNTIME_LOG_FILTER: &str = "warn,sqlx::query=warn";
+const DEFAULT_RUNTIME_LOG_FILTER: &str = "warn,tavily_hikari=info,sqlx::query=warn";
 
 static RUNTIME_LOGGING_INIT: OnceLock<()> = OnceLock::new();
 static LOG_TRACER_INIT: OnceLock<()> = OnceLock::new();
@@ -260,6 +260,31 @@ mod tests {
         assert_eq!(payload["event"], "startup");
         assert_eq!(payload["message"], "json-ready");
         assert!(payload.get("level").is_some());
+    }
+
+    #[test]
+    fn default_runtime_log_filter_keeps_crate_info_visible() {
+        let output = capture_tracing_output(
+            RuntimeLogFormat::Json,
+            EnvFilter::new(DEFAULT_RUNTIME_LOG_FILTER),
+            || {
+                emit_legacy_stdio_event(
+                    LegacyStdIoLevel::Info,
+                    "tavily_hikari::runtime_logging::tests",
+                    file!(),
+                    line!(),
+                    format_args!("startup-visible"),
+                );
+                tracing::info!(
+                    target: "external_lib",
+                    component = "foreign",
+                    event = "filtered",
+                    message = "noise"
+                );
+            },
+        );
+        assert!(output.contains("startup-visible"));
+        assert!(!output.contains("\"target\":\"external_lib\""));
     }
 
     #[test]

--- a/src/runtime_logging.rs
+++ b/src/runtime_logging.rs
@@ -1,0 +1,317 @@
+use std::{fmt as stdfmt, io, sync::OnceLock};
+
+use clap::ValueEnum;
+use tracing::Dispatch;
+use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
+
+const DEFAULT_RUNTIME_LOG_FILTER: &str = "warn,sqlx::query=warn";
+
+static RUNTIME_LOGGING_INIT: OnceLock<()> = OnceLock::new();
+static LOG_TRACER_INIT: OnceLock<()> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum RuntimeLogFormat {
+    #[default]
+    Json,
+    Text,
+}
+
+impl RuntimeLogFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Text => "text",
+        }
+    }
+}
+
+impl stdfmt::Display for RuntimeLogFormat {
+    fn fmt(&self, f: &mut stdfmt::Formatter<'_>) -> stdfmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LegacyStdIoLevel {
+    Info,
+    Warn,
+}
+
+pub fn init_runtime_logging(format: RuntimeLogFormat) {
+    RUNTIME_LOGGING_INIT.get_or_init(|| {
+        let dispatch = build_runtime_log_dispatch(format, runtime_log_env_filter(), io::stderr);
+        if tracing::dispatcher::set_global_default(dispatch).is_ok() {
+            install_log_tracer();
+        }
+    });
+}
+
+pub fn emit_legacy_stdio_event(
+    level: LegacyStdIoLevel,
+    module_path: &'static str,
+    file: &'static str,
+    line: u32,
+    args: stdfmt::Arguments<'_>,
+) {
+    let component = component_for_module_path(module_path);
+    match level {
+        LegacyStdIoLevel::Info => {
+            tracing::info!(
+                component,
+                event = "legacy_stdio",
+                stream = "stdout",
+                module_path,
+                file,
+                line,
+                message = %args,
+            );
+        }
+        LegacyStdIoLevel::Warn => {
+            tracing::warn!(
+                component,
+                event = "legacy_stdio",
+                stream = "stderr",
+                module_path,
+                file,
+                line,
+                message = %args,
+            );
+        }
+    }
+}
+
+pub(crate) fn component_for_module_path(module_path: &str) -> &'static str {
+    if module_path.contains("::store") {
+        "db"
+    } else if module_path.contains("::server::schedulers") {
+        "scheduler"
+    } else if module_path.contains("::server::proxy") {
+        "proxy"
+    } else if module_path.contains("::server::handlers") {
+        "http_handler"
+    } else if module_path.contains("::server::serve") || module_path.contains("::proxy_ha") {
+        "ha"
+    } else if module_path.contains("::proxy_core")
+        || module_path.contains("::proxy_forward_proxy_maintenance")
+    {
+        "forward_proxy"
+    } else if module_path.contains("::tavily_proxy") {
+        "proxy_runtime"
+    } else {
+        "runtime"
+    }
+}
+
+fn runtime_log_env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(DEFAULT_RUNTIME_LOG_FILTER))
+        .unwrap_or_else(|_| EnvFilter::new("warn"))
+}
+
+fn build_runtime_log_dispatch<W>(format: RuntimeLogFormat, filter: EnvFilter, writer: W) -> Dispatch
+where
+    W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
+{
+    match format {
+        RuntimeLogFormat::Json => Dispatch::new(
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_writer(writer)
+                .json()
+                .flatten_event(true)
+                .with_current_span(false)
+                .with_span_list(false)
+                .with_target(true)
+                .finish(),
+        ),
+        RuntimeLogFormat::Text => Dispatch::new(
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_writer(writer)
+                .compact()
+                .with_ansi(false)
+                .with_target(true)
+                .finish(),
+        ),
+    }
+}
+
+fn install_log_tracer() {
+    LOG_TRACER_INIT.get_or_init(|| {
+        let _ = tracing_log::LogTracer::builder()
+            .with_max_level(log::LevelFilter::Trace)
+            .init();
+    });
+}
+
+#[allow(unused_macros)]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        $crate::runtime_logging::emit_legacy_stdio_event(
+            $crate::runtime_logging::LegacyStdIoLevel::Info,
+            module_path!(),
+            file!(),
+            line!(),
+            format_args!($($arg)*),
+        )
+    }};
+}
+
+#[allow(unused_macros)]
+macro_rules! eprintln {
+    ($($arg:tt)*) => {{
+        $crate::runtime_logging::emit_legacy_stdio_event(
+            $crate::runtime_logging::LegacyStdIoLevel::Warn,
+            module_path!(),
+            file!(),
+            line!(),
+            format_args!($($arg)*),
+        )
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::{
+        io::Write,
+        sync::{Arc, Mutex},
+    };
+
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static LOG_BRIDGE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[derive(Clone)]
+    struct SharedWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedWriter {
+        fn new() -> (Self, Arc<Mutex<Vec<u8>>>) {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    buffer: buffer.clone(),
+                },
+                buffer,
+            )
+        }
+    }
+
+    struct SharedWriterGuard {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl<'a> MakeWriter<'a> for SharedWriter {
+        type Writer = SharedWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedWriterGuard {
+                buffer: self.buffer.clone(),
+            }
+        }
+    }
+
+    impl Write for SharedWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer
+                .lock()
+                .expect("writer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn captured_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(buffer.lock().expect("buffer lock").clone()).expect("utf8 log output")
+    }
+
+    fn capture_tracing_output<F>(format: RuntimeLogFormat, filter: EnvFilter, emit: F) -> String
+    where
+        F: FnOnce(),
+    {
+        let (writer, buffer) = SharedWriter::new();
+        let dispatch = build_runtime_log_dispatch(format, filter, writer);
+        tracing::dispatcher::with_default(&dispatch, emit);
+        captured_output(&buffer)
+    }
+
+    #[test]
+    fn default_runtime_log_format_is_json() {
+        let output =
+            capture_tracing_output(RuntimeLogFormat::default(), EnvFilter::new("info"), || {
+                tracing::info!(
+                    component = "test",
+                    event = "startup",
+                    message = "json-ready"
+                );
+            });
+        let line = output
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .unwrap_or("");
+        let payload: Value = serde_json::from_str(line).expect("valid json log line");
+        assert_eq!(payload["component"], "test");
+        assert_eq!(payload["event"], "startup");
+        assert_eq!(payload["message"], "json-ready");
+        assert!(payload.get("level").is_some());
+    }
+
+    #[test]
+    fn explicit_text_fallback_format_is_supported() {
+        let output = capture_tracing_output(RuntimeLogFormat::Text, EnvFilter::new("info"), || {
+            tracing::info!(
+                component = "test",
+                event = "text-fallback",
+                message = "plain"
+            );
+        });
+        assert!(serde_json::from_str::<Value>(output.trim()).is_err());
+        assert!(output.contains("text-fallback"));
+        assert!(output.contains("plain"));
+    }
+
+    #[test]
+    fn rust_log_env_filter_still_controls_runtime_logs() {
+        let _guard = ENV_TEST_LOCK.lock().expect("env test lock");
+        let previous = std::env::var("RUST_LOG").ok();
+        unsafe {
+            std::env::set_var("RUST_LOG", "error");
+        }
+        let output =
+            capture_tracing_output(RuntimeLogFormat::Json, runtime_log_env_filter(), || {
+                tracing::warn!(component = "test", event = "filtered-out", message = "warn");
+                tracing::error!(component = "test", event = "kept", message = "error");
+            });
+        match previous {
+            Some(value) => unsafe { std::env::set_var("RUST_LOG", value) },
+            None => unsafe { std::env::remove_var("RUST_LOG") },
+        }
+        assert!(!output.contains("filtered-out"));
+        assert!(output.contains("\"event\":\"kept\""));
+    }
+
+    #[test]
+    fn log_crate_records_are_bridged_into_runtime_subscriber() {
+        let _guard = LOG_BRIDGE_TEST_LOCK.lock().expect("log bridge lock");
+        install_log_tracer();
+        let (writer, buffer) = SharedWriter::new();
+        let dispatch =
+            build_runtime_log_dispatch(RuntimeLogFormat::Json, EnvFilter::new("warn"), writer);
+        tracing::dispatcher::with_default(&dispatch, || {
+            log::warn!("log-bridge-ok");
+        });
+        let output = captured_output(&buffer);
+        let line = output
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .unwrap_or("");
+        let payload: Value = serde_json::from_str(line).expect("valid json log line");
+        assert_eq!(payload["message"], "log-bridge-ok");
+    }
+}

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -1,5 +1,4 @@
 use tokio::time::Instant;
-
 fn random_delay_secs(max_inclusive: u64) -> u64 {
     use rand::Rng;
     let mut rng = rand::thread_rng();
@@ -95,7 +94,15 @@ async fn enqueue_scheduled_job_logged(
                 Some(context.as_str()),
                 &err,
             );
-            eprintln!("{log_prefix}: enqueue job error: {err}");
+            tracing::warn!(
+                component = "scheduler",
+                event = "job_enqueue_failed",
+                job_type,
+                trigger_source,
+                key_id = key_id.unwrap_or("-"),
+                err = %err,
+                "{log_prefix}: enqueue job error: {err}"
+            );
             None
         }
     }
@@ -137,11 +144,26 @@ async fn claim_scheduled_job(
     match claim_scheduled_job_with_gate(state, job_type, key_id, trigger_source).await {
         Ok(Some(job)) => Some(job),
         Ok(None) => {
-            eprintln!("{log_prefix}: job already running; skip trigger");
+            tracing::info!(
+                component = "scheduler",
+                event = "job_trigger_skipped_already_running",
+                job_type,
+                trigger_source,
+                key_id = key_id.unwrap_or("-"),
+                "{log_prefix}: job already running; skip trigger"
+            );
             None
         }
         Err(err) => {
-            eprintln!("{log_prefix}: start job error: {err}");
+            tracing::warn!(
+                component = "scheduler",
+                event = "job_start_failed",
+                job_type,
+                trigger_source,
+                key_id = key_id.unwrap_or("-"),
+                err = %err,
+                "{log_prefix}: start job error: {err}"
+            );
             None
         }
     }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -25,11 +25,11 @@ pub async fn serve(
     );
     let ha = tavily_hikari::HaRuntime::new(ha_config);
     let previous_ha_role = proxy.get_persisted_ha_node_role().await.unwrap_or_else(|err| {
-        eprintln!("HA persisted role lookup warning: {err}");
+        tracing::warn!(component = "ha", event = "persisted_role_lookup_failed", err = %err, "HA persisted role lookup warning");
         None
     });
     let persisted_ha_source_settings = proxy.get_ha_source_settings().await.unwrap_or_else(|err| {
-        eprintln!("HA source settings lookup warning: {err}");
+        tracing::warn!(component = "ha", event = "source_settings_lookup_failed", err = %err, "HA source settings lookup warning");
         None
     });
     let startup_ha_status = reconcile_ha_startup_role(&ha, previous_ha_role).await;
@@ -38,7 +38,7 @@ pub async fn serve(
             .set_local_source_settings(Some(settings.clone()))
             .await
     {
-        eprintln!("HA source settings restore warning: {err}");
+        tracing::warn!(component = "ha", event = "source_settings_restore_failed", err = %err, "HA source settings restore warning");
     }
     if let Err(err) = async {
         proxy
@@ -54,7 +54,7 @@ pub async fn serve(
     }
     .await
     {
-        eprintln!("HA startup node state persist warning: {err}");
+        tracing::warn!(component = "ha", event = "startup_node_state_persist_failed", err = %err, "HA startup node state persist warning");
     }
     let state = Arc::new(AppState {
         proxy,
@@ -71,68 +71,97 @@ pub async fn serve(
     });
     match state.proxy.abandon_active_scheduled_jobs().await {
         Ok(count) if count > 0 => {
-            eprintln!("scheduled-jobs: abandoned {count} stale queued/running jobs from previous process")
+            tracing::warn!(
+                component = "scheduler",
+                event = "stale_jobs_abandoned",
+                count,
+                "scheduled-jobs: abandoned stale queued/running jobs from previous process"
+            )
         }
         Ok(_) => {}
-        Err(err) => eprintln!("scheduled-jobs: stale queued/running cleanup warning: {err}"),
+        Err(err) => tracing::warn!(
+            component = "scheduler",
+            event = "stale_jobs_cleanup_failed",
+            err = %err,
+            "scheduled-jobs: stale queued/running cleanup warning"
+        ),
     }
     spawn_ha_standby_sync_task(state.clone());
-    println!(
-        "Admin auth modes: forward_enabled={} builtin_enabled={} dev_open_admin={}",
-        state.forward_auth_enabled,
-        state.builtin_admin.is_enabled(),
-        state.dev_open_admin
+    tracing::info!(
+        component = "startup",
+        event = "admin_auth_modes",
+        forward_enabled = state.forward_auth_enabled,
+        builtin_enabled = state.builtin_admin.is_enabled(),
+        dev_open_admin = state.dev_open_admin,
+        "configured admin auth modes"
     );
 
     if !state.forward_auth_enabled {
-        println!("Forward-Auth: disabled (ADMIN_AUTH_FORWARD_ENABLED=false)");
+        tracing::info!(
+            component = "startup",
+            event = "forward_auth_configuration",
+            enabled = false,
+            reason = "ADMIN_AUTH_FORWARD_ENABLED=false",
+            "forward auth disabled"
+        );
     } else if let Some(h) = state.forward_auth.user_header() {
-        println!(
-            "Forward-Auth: header='{}' admin_value='{}'",
-            h,
-            state.forward_auth.admin_value().unwrap_or("<none>")
+        tracing::info!(
+            component = "startup",
+            event = "forward_auth_configuration",
+            enabled = true,
+            header = %h,
+            admin_value_present = state.forward_auth.admin_value().is_some(),
+            "forward auth enabled"
         );
     } else {
-        println!(
-            "Forward-Auth: disabled (no user header), admin_override={} dev_open_admin={}",
-            state.forward_auth.admin_override_name().unwrap_or("<none>"),
-            state.dev_open_admin
+        tracing::warn!(
+            component = "startup",
+            event = "forward_auth_configuration",
+            enabled = false,
+            reason = "missing_user_header",
+            admin_override_present = state.forward_auth.admin_override_name().is_some(),
+            dev_open_admin = state.dev_open_admin,
+            "forward auth disabled because no user header is configured"
         );
     }
 
-    println!(
-        "LinuxDo OAuth: enabled={} configured={} redirect={}",
-        state.linuxdo_oauth.enabled,
-        state.linuxdo_oauth.is_enabled_and_configured(),
-        state
-            .linuxdo_oauth
-            .redirect_url
-            .as_deref()
-            .unwrap_or("<none>")
+    tracing::info!(
+        component = "startup",
+        event = "linuxdo_oauth_configuration",
+        enabled = state.linuxdo_oauth.enabled,
+        configured = state.linuxdo_oauth.is_enabled_and_configured(),
+        redirect_configured = state.linuxdo_oauth.redirect_url.is_some(),
+        "linuxdo oauth configuration loaded"
     );
     let (linuxdo_user_sync_hour, linuxdo_user_sync_minute) = state.linuxdo_oauth.user_sync_time();
-    println!(
-        "LinuxDo user sync: scheduler_enabled={} oauth_ready={} refresh_token_key={} at={:02}:{:02}",
-        state.linuxdo_oauth.is_user_sync_scheduler_enabled(),
-        state.linuxdo_oauth.is_enabled_and_configured(),
-        state.linuxdo_oauth.has_refresh_token_crypt_key(),
-        linuxdo_user_sync_hour,
-        linuxdo_user_sync_minute,
+    tracing::info!(
+        component = "startup",
+        event = "linuxdo_user_sync_configuration",
+        scheduler_enabled = state.linuxdo_oauth.is_user_sync_scheduler_enabled(),
+        oauth_ready = state.linuxdo_oauth.is_enabled_and_configured(),
+        refresh_token_key = state.linuxdo_oauth.has_refresh_token_crypt_key(),
+        sync_hour = linuxdo_user_sync_hour,
+        sync_minute = linuxdo_user_sync_minute,
+        "linuxdo user sync configuration loaded"
     );
-    println!(
-        "LinuxDo Credit: enabled={} configured={} submit_url={}",
-        state.linuxdo_credit.enabled,
-        state.linuxdo_credit.is_enabled_and_configured(),
-        state.linuxdo_credit.submit_url
+    tracing::info!(
+        component = "startup",
+        event = "linuxdo_credit_configuration",
+        enabled = state.linuxdo_credit.enabled,
+        configured = state.linuxdo_credit.is_enabled_and_configured(),
+        submit_url = %state.linuxdo_credit.submit_url,
+        "linuxdo credit configuration loaded"
     );
     let ha_status = state.ha.status().await;
-    println!(
-        "HA: mode={:?} node={} role={:?} origin={:?} edgeone_domain={:?}",
-        ha_status.mode,
-        ha_status.node_id,
-        ha_status.role,
-        ha_status.edgeone_origin,
-        ha_status.edgeone_domain
+    tracing::info!(
+        component = "ha",
+        event = "startup_status",
+        mode = ?ha_status.mode,
+        node_id = %ha_status.node_id,
+        role = ?ha_status.role,
+        origin = ?ha_status.edgeone_origin,
+        edgeone_domain = ?ha_status.edgeone_domain,
+        "ha startup status loaded"
     );
 
     let mut router = Router::new()
@@ -432,7 +461,12 @@ pub async fn serve(
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let bound_addr = listener.local_addr()?;
-    println!("Tavily proxy listening on http://{bound_addr}");
+    tracing::info!(
+        component = "startup",
+        event = "server_listening",
+        bind_addr = %bound_addr,
+        "tavily proxy listening"
+    );
 
     // Spawn background schedulers
     spawn_maintenance_worker(state.clone());
@@ -460,7 +494,11 @@ pub async fn serve(
     )
     .with_graceful_shutdown(shutdown_signal())
     .await?;
-    println!("Server shut down gracefully.");
+    tracing::info!(
+        component = "shutdown",
+        event = "server_shutdown_complete",
+        "server shut down gracefully"
+    );
     Ok(())
 }
 
@@ -471,7 +509,12 @@ async fn reconcile_ha_startup_role(
     let startup_role_checked = match ha.refresh_startup_role().await {
         Ok(()) => true,
         Err(err) => {
-            eprintln!("HA startup role check warning: {err}");
+            tracing::warn!(
+                component = "ha",
+                event = "startup_role_check_failed",
+                err = %err,
+                "HA startup role check warning"
+            );
             false
         }
     };
@@ -502,8 +545,12 @@ fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
         return;
     };
     let Some(internal_token) = state.ha.internal_token() else {
-        eprintln!(
-            "HA standby sync disabled: HA_INTERNAL_TOKEN is required when HA_SYNC_SOURCE_URL is set"
+        tracing::warn!(
+            component = "ha",
+            event = "standby_sync_disabled",
+            reason = "missing_internal_token",
+            source_url = source_url,
+            "HA standby sync disabled because HA_INTERNAL_TOKEN is required when HA_SYNC_SOURCE_URL is set"
         );
         return;
     };
@@ -515,7 +562,13 @@ fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
                 && let Err(err) =
                     run_ha_standby_sync_once(&state, &client, &source_url, &internal_token).await
             {
-                eprintln!("HA standby sync failed: {err}");
+                tracing::warn!(
+                    component = "ha",
+                    event = "standby_sync_failed",
+                    source_url = source_url,
+                    err = %err,
+                    "HA standby sync failed"
+                );
             }
             state.proxy.backend_time().sleep(interval).await;
         }
@@ -695,11 +748,21 @@ fn spawn_ha_edgeone_authority_task(state: Arc<AppState>) {
                     }
                     .await
                     {
-                        eprintln!("HA authority state persist failed: {err}");
+                        tracing::warn!(
+                            component = "ha",
+                            event = "authority_state_persist_failed",
+                            err = %err,
+                            "HA authority state persist failed"
+                        );
                     }
                 }
                 Err(err) => {
-                    eprintln!("HA authority refresh failed: {err}");
+                    tracing::warn!(
+                        component = "ha",
+                        event = "authority_refresh_failed",
+                        err = %err,
+                        "HA authority refresh failed"
+                    );
                 }
             }
         }
@@ -710,7 +773,12 @@ async fn wait_for_ctrl_c() -> &'static str {
     match signal::ctrl_c().await {
         Ok(()) => "ctrl_c",
         Err(err) => {
-            eprintln!("Failed to listen for Ctrl+C: {err}");
+            tracing::error!(
+                component = "shutdown",
+                event = "ctrl_c_listener_failed",
+                err = %err,
+                "Failed to listen for Ctrl+C"
+            );
             "ctrl_c_error"
         }
     }
@@ -724,7 +792,12 @@ async fn wait_for_sigterm() -> &'static str {
             "sigterm"
         }
         Err(err) => {
-            eprintln!("Failed to listen for SIGTERM: {err}");
+            tracing::error!(
+                component = "shutdown",
+                event = "sigterm_listener_failed",
+                err = %err,
+                "Failed to listen for SIGTERM"
+            );
             wait_for_ctrl_c().await
         }
     }
@@ -746,7 +819,12 @@ async fn shutdown_signal() {
         }
     };
 
-    println!("Shutdown signal ({signal}) received, waiting for in-flight requests to finish...");
+    tracing::info!(
+        component = "shutdown",
+        event = "shutdown_signal_received",
+        signal,
+        "shutdown signal received, waiting for in-flight requests to finish"
+    );
 }
 
 const BODY_LIMIT: usize = 16 * 1024 * 1024; // 16 MiB 默认限制

--- a/src/server/tests/api_keys_and_registration.rs
+++ b/src/server/tests/api_keys_and_registration.rs
@@ -2204,8 +2204,22 @@ colo=LAX
 
         let refreshed_snapshot_chunk = read_sse_event_until(
             &mut response,
-            |chunk| chunk.contains("event: snapshot"),
-            "user dashboard events refreshed snapshot",
+            |chunk| {
+                if !chunk.contains("event: snapshot") {
+                    return false;
+                }
+                let snapshot_data = chunk
+                    .lines()
+                    .filter_map(|line| line.strip_prefix("data:"))
+                    .map(str::trim)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                serde_json::from_str::<serde_json::Value>(&snapshot_data)
+                    .ok()
+                    .and_then(|snapshot| snapshot["summary"]["debugInfoShared"].as_bool())
+                    == Some(true)
+            },
+            "user dashboard events refreshed snapshot with debug sharing enabled",
         )
         .await;
         let refreshed_snapshot_data = refreshed_snapshot_chunk

--- a/src/server/tests/core_support_and_parsing.rs
+++ b/src/server/tests/core_support_and_parsing.rs
@@ -12,7 +12,7 @@
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+    use std::sync::{Arc, Mutex, OnceLock};
     use std::time::Duration;
     use tokio::net::TcpListener;
     use tokio::sync::Notify;
@@ -462,22 +462,15 @@
         .expect("insert maintenance reference");
     }
 
-    pub(super) fn env_var_test_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     pub(super) struct EnvVarGuard {
         key: &'static str,
         previous: Option<String>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: tavily_hikari::ProcessEnvLockGuard,
     }
 
     impl EnvVarGuard {
         pub(super) fn set(key: &'static str, value: &str) -> Self {
-            let lock = env_var_test_lock()
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let lock = tavily_hikari::lock_process_env();
             let previous = std::env::var(key).ok();
             unsafe {
                 std::env::set_var(key, value);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -9,6 +9,7 @@ use sqlx::SqliteConnection;
 use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
 use tracing::log::LevelFilter;
+use tracing::{error, warn};
 
 pub(crate) struct ObservabilityOfflineGuard {
     _lock_file: File,
@@ -161,7 +162,12 @@ pub(crate) fn log_slow_db_operation(operation: &str, elapsed: Duration, context:
     if elapsed < SQLITE_SLOW_OPERATION_THRESHOLD {
         return;
     }
-    eprintln!(
+    warn!(
+        component = "db",
+        event = "operation_slow",
+        operation,
+        elapsed_ms = elapsed.as_millis() as u64,
+        context = context.unwrap_or(""),
         "{}",
         format_db_operation_log(DbLogStatus::Slow, operation, elapsed, context, None)
     );
@@ -173,7 +179,13 @@ pub(crate) fn log_db_operation_error(
     context: Option<&str>,
     err: &ProxyError,
 ) {
-    eprintln!(
+    error!(
+        component = "db",
+        event = "operation_error",
+        operation,
+        elapsed_ms = elapsed.as_millis() as u64,
+        context = context.unwrap_or(""),
+        err = %err,
         "{}",
         format_db_operation_log(
             DbLogStatus::Error,
@@ -236,10 +248,16 @@ pub(crate) async fn sleep_before_sqlite_transient_write_retry(
 
     let remaining = deadline.saturating_duration_since(now);
     let backoff = sqlite_transient_write_retry_delay(attempt).min(remaining);
-    eprintln!(
+    warn!(
+        component = "db",
+        event = "sqlite_transient_write_retry",
+        operation,
+        attempt = attempt + 1,
+        backoff_ms = backoff.as_millis() as u64,
+        err = %err,
         "{operation}: transient sqlite write error (attempt={}, backoff={}ms): {err}",
         attempt + 1,
-        backoff.as_millis()
+        backoff.as_millis(),
     );
     backend_time.sleep(backoff).await;
     true

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -536,13 +536,19 @@ impl TavilyProxy {
         proxy.spawn_ha_state_coalescer();
         proxy.spawn_request_stats_coalescer();
         proxy.user_business_calls_1h_window.backfill_recent().await?;
-        eprintln!("forward-proxy startup: initializing runtime graph");
+        info!(
+            component = "forward_proxy",
+            event = "startup_runtime_graph_init",
+            "forward-proxy startup: initializing runtime graph"
+        );
         let runtime_init_started = Instant::now();
         proxy.initialize_forward_proxy_runtime().await?;
-        eprintln!(
-            "forward-proxy startup: runtime graph ready in {}ms; total startup {}ms",
-            runtime_init_started.elapsed().as_millis(),
-            startup_started.elapsed().as_millis()
+        info!(
+            component = "forward_proxy",
+            event = "startup_runtime_graph_ready",
+            phase_elapsed_ms = runtime_init_started.elapsed().as_millis() as u64,
+            total_elapsed_ms = startup_started.elapsed().as_millis() as u64,
+            "forward-proxy startup: runtime graph ready"
         );
         Ok(proxy)
     }
@@ -554,26 +560,39 @@ impl TavilyProxy {
             manager.restored_subscription_endpoint_count()
         };
         if restored_subscription_endpoints > 0 {
-            eprintln!(
-                "forward-proxy startup: restored {restored_subscription_endpoints} persisted subscription nodes; deferred subscription refresh to maintenance"
+            info!(
+                component = "forward_proxy",
+                event = "startup_subscription_restore",
+                restored_count = restored_subscription_endpoints,
+                "forward-proxy startup restored persisted subscription nodes; deferred refresh to maintenance"
             );
         } else {
             let refresh_started = Instant::now();
             if let Err(err) = self.refresh_forward_proxy_subscriptions_for_startup().await {
-                eprintln!("forward-proxy startup subscription refresh failed: {err}");
+                warn!(
+                    component = "forward_proxy",
+                    event = "startup_subscription_refresh_failed",
+                    err = %err,
+                    "forward-proxy startup subscription refresh failed"
+                );
                 let restored = {
                     let mut manager = self.forward_proxy.lock().await;
                     manager.restore_persisted_subscription_endpoints()
                 };
                 if restored > 0 {
-                    eprintln!(
-                        "forward-proxy restored {restored} persisted subscription nodes after startup refresh failure"
+                    warn!(
+                        component = "forward_proxy",
+                        event = "startup_subscription_restore_after_failure",
+                        restored_count = restored,
+                        "forward-proxy restored persisted subscription nodes after startup refresh failure"
                     );
                 }
             } else {
-                eprintln!(
-                    "forward-proxy startup: refreshed subscriptions in {}ms",
-                    refresh_started.elapsed().as_millis()
+                info!(
+                    component = "forward_proxy",
+                    event = "startup_subscription_refresh_succeeded",
+                    elapsed_ms = refresh_started.elapsed().as_millis() as u64,
+                    "forward-proxy startup refreshed subscriptions"
                 );
             }
         }
@@ -588,21 +607,30 @@ impl TavilyProxy {
                     .sync_endpoints(&mut manager.endpoints, egress_socks5_url.as_ref())
                     .await
                 {
-                    eprintln!("forward-proxy startup xray prewarm failed: {_err}");
+                    warn!(
+                        component = "forward_proxy",
+                        event = "startup_xray_prewarm_failed",
+                        err = %_err,
+                        "forward-proxy startup xray prewarm failed"
+                    );
                 }
             }
             self.sync_forward_proxy_runtime_state(&mut manager).await?;
         }
-        eprintln!(
-            "forward-proxy startup: xray sync + runtime snapshot persisted in {}ms",
-            persist_started.elapsed().as_millis()
+        info!(
+            component = "forward_proxy",
+            event = "startup_runtime_snapshot_persisted",
+            elapsed_ms = persist_started.elapsed().as_millis() as u64,
+            "forward-proxy startup persisted xray sync and runtime snapshot"
         );
         let manager = self.forward_proxy.lock().await;
         forward_proxy::sync_manager_runtime_to_store(&self.key_store, &manager).await?;
-        eprintln!(
-            "forward-proxy startup: runtime store synced in {}ms (total init {}ms)",
-            xray_started.elapsed().as_millis(),
-            startup_started.elapsed().as_millis()
+        info!(
+            component = "forward_proxy",
+            event = "startup_runtime_store_synced",
+            phase_elapsed_ms = xray_started.elapsed().as_millis() as u64,
+            total_elapsed_ms = startup_started.elapsed().as_millis() as u64,
+            "forward-proxy startup synced runtime store"
         );
         Ok(())
     }
@@ -1535,3 +1563,4 @@ impl TavilyProxy {
     }
 
 }
+use tracing::{info, warn};


### PR DESCRIPTION
Summary:
- switch backend runtime logging to a unified `tracing` contract with JSON-first output
- bridge legacy stdio-style runtime messages into the shared subscriber and structure key startup/db/proxy/scheduler events
- update operator-facing docs and lock-contention guidance for the new runtime logging contract

Test Plan:
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test`
- `codex review --base origin/main` (pre-PR local proof, no discrete regression found)

Spec: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
Spec Disposition: update
Solutions: docs/solutions/operations/sqlite-write-lock-contention.md
Project Docs: README.md, README.zh-CN.md
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: done

Notes:
- Runtime process logs are now JSON-first by default, with explicit `--log-format text` / `RUNTIME_LOG_FORMAT=text` fallback for local grep-oriented workflows.
