### PR TITLE
fix: repair HA outbox growth with multichannel cleanup

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -111,6 +111,19 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
   rebuildable/eventually consistent views rather than HA-trigger-replicated truth. SQLite attached
   database triggers cannot safely write back into `main`, so the HA outbox should stay focused on
   core control-plane and billing truth tables.
+- Do not reuse one HA whitelist for both baseline export and change-event triggers. In this codebase
+  that caused `billing_ledger` and runtime quota tables to bloat `ha_outbox` even in effectively
+  single-node production. Keep HA channels explicit: `control` small-state, `billing` dedicated
+  ledger truth, and `runtime` minimal correctness state.
+- Keep `HA_MODE=single` truly silent for HA replication writes. Leaving replication triggers enabled
+  on a single live node creates unbounded local-only backlog with no standby consumer.
+- Treat large retained HA event cleanup like request-log cleanup: bounded online GC for freshness,
+  explicit offline one-shot cleanup for backlog removal, and optional later compaction only when
+  reclaimable bytes justify it.
+- When offline maintenance proof depends on a production-derived SQLite copy, define the input as a
+  full DB set instead of a single file. In this service that means the core DB plus the
+  observability sibling sidecar; copying only `tavily_proxy.db` would miss the attached
+  request-log/read-model layout that production actually serves.
 - Once observability tables move into a sidecar, test helpers and admin/read paths must become
   sidecar-aware too. Unqualified schema probes or direct core-only SQLite opens can silently stop
   covering `request_logs` even though production still reads that table through the attached
@@ -149,6 +162,12 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - Provide the same offline path for compaction. Manual HTTP trigger endpoints are still useful, but
   operators need a `db_compaction_once`-style bypass for maintenance windows when the online job
   gate is busy.
+- For HA maintenance windows, the safe order is `ha_outbox_cleanup_once` first, `db_compaction_once`
+  second. Reversing that order vacuums retained dead rows too early and can waste I/O without
+  reclaiming the real backlog yet.
+- If the live system stores the main DB and observability data in sibling SQLite files, export the
+  offline validation input with SQLite `.backup` per file and carry forward SHA-256 plus
+  `PRAGMA integrity_check` evidence for each member of the set.
 - Avoid high-resource retention catch-up tactics such as rebuilding large log tables or producing a
   large WAL. If the backlog is very large, run repeated bounded cleanup windows and verify progress
   with row counts and resource telemetry.
@@ -193,6 +212,8 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 
 - `src/store/mod.rs`
 - `src/bin/request_logs_gc_once.rs`
+- `src/bin/ha_outbox_cleanup_once.rs`
+- `scripts/export-live-db-snapshot-to-testbox.sh`
 - `src/store/key_store_users_and_oauth.rs`
 - `src/store/key_store_request_logs_and_dashboard.rs`
 - `src/tavily_proxy/proxy_auth_and_oauth.rs`

--- a/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
@@ -20,6 +20,45 @@ Single-active reduces quota, rebalance, conversation remapping, and upstream key
 
 Production validation showed that full SQLite snapshot sync is unsafe for the current data shape because request logs and response bodies can make the database tens of GiB. The accepted replacement is standby-pulled, zstd-compressed NDJSON state sync over explicit whitelisted resources plus a 72-hour `ha_outbox` event stream. HA sync is now forbidden from transporting full database files or raw request/auth-token log records.
 
+## Multi-Channel HA Revision
+
+Production `ha_outbox` growth showed that the old single whitelist simultaneously controlled
+baseline export, event emission, and trigger install, so hot tables such as `billing_ledger` and
+runtime quota state could silently flood the same `ha_outbox`. The accepted replacement splits HA
+into explicit `control`, `billing`, and `runtime` channels with independent baselines, event
+streams, and peer watermarks.
+
+- `control` stays a small control-plane event stream in `ha_outbox`.
+- `billing` gets dedicated `billing_ledger` replication through `ha_billing_outbox`.
+- `runtime` carries only minimal API/MCP correctness state through `ha_runtime_outbox`.
+- Mixed-version HA is no longer supported. A future standby must cold start from the same build and
+  then join using the new channel-aware contract.
+
+## HA Outbox Maintenance Revision
+
+Large historical `ha_outbox` cleanup is now an explicit maintenance action, not a startup side
+effect. The accepted sequence is:
+
+1. stop new HA writes or keep the node in `HA_MODE=single`
+2. run the offline `ha_outbox_cleanup_once` / `scripts/ha-outbox-maintenance.sh`
+3. run `db_compaction_once` only if reclaimable space justifies it
+
+The scheduler still performs bounded online `ha_outbox_gc`, but that path is intentionally limited
+to per-channel expired-row cleanup plus a passive WAL checkpoint so it cannot recreate the previous
+SWAP spike failure mode.
+
+## Full Live Snapshot Validation Revision
+
+Merge-ready validation for the HA outbox fix now requires a complete production-shaped SQLite input
+copied from 101 into `codex-testbox`. “Complete” is explicitly the core DB plus the observability
+sidecar sibling, not the main `.db` file alone.
+
+- The accepted source path on 101 remains the Docker volume backing `/srv/app/data`.
+- The accepted transfer shape is a read-only SQLite `.backup` snapshot set, not sampled tables and
+  not a hand-picked subset of rows.
+- Offline HA cleanup and optional compaction proof now runs against that copied snapshot set inside
+  one isolated testbox run directory.
+
 ## Admin IA Revision
 
 The full HA node inventory is an operations setting, not global business-page chrome. Admin business pages stay silent in normal `full_master` state and show only a compact attention link during abnormal HA states; promote/finalize remains confined to the System Settings high-availability subpage.

--- a/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
@@ -10,7 +10,35 @@
 - Added per-node HA source settings persistence and admin API so the current instance can store a private source override, switch between direct origin and source group, and optionally apply the saved source to EdgeOne immediately. The startup config now also accepts `HA_SOURCE_KIND` and `HA_SOURCE_ORIGIN_GROUP_ID` as per-node defaults, while `EDGEONE_EXPECTED_ORIGIN_*` stays direct-origin only.
 - Locked the HA source settings request/response wire contract to lowercase `directOriginScheme` values (`http|https|follow`) by adding serde lowercase support on the shared Rust enum, while preserving the existing uppercase conversion for outbound EdgeOne payloads.
 - Added standby pull-based sync controlled by `HA_SYNC_SOURCE_URL`, `HA_INTERNAL_TOKEN`, and `HA_SYNC_INTERVAL_SECS`; active nodes no longer push snapshots.
-- Added `ha_outbox` and peer watermark storage so standby nodes can apply small, whitelisted state changes by seq.
+- Replaced the old implicit single-channel HA contract with explicit `control` / `billing` /
+  `runtime` channels carried over the same `/api/admin/ha/baseline`, `/api/admin/ha/events`, and
+  `/api/admin/ha/events/ack` endpoints via a required `channel` contract.
+- Narrowed `ha_outbox` to the `control` channel only. `billing_ledger` now emits into
+  `ha_billing_outbox`, while minimal runtime state emits into `ha_runtime_outbox`.
+- `HA_MODE=single` now drops all HA replication triggers at startup and does not emit new HA
+  events, while preserving schema compatibility for future `active_standby` cold start.
+- Added per-channel peer watermark storage keyed by `(peer_node_id, channel)` and a compatibility
+  rebuild for old single-column `ha_peer_watermarks` schemas.
+- Added bounded `ha_outbox_gc` maintenance with scheduler/manual-job support. The online path only
+  deletes expired rows from `control` / `billing` / `runtime` outboxes within their own retention
+  windows, then runs `PRAGMA wal_checkpoint(PASSIVE)`; it never runs full `VACUUM`.
+- Added offline `ha_outbox_cleanup_once` and `scripts/ha-outbox-maintenance.sh` so large retained
+  historical `ha_outbox` rows can be cleaned explicitly during a maintenance window before an
+  optional `db_compaction_once`.
+- Added `scripts/export-live-db-snapshot-to-testbox.sh` so operators can export the full live
+  SQLite validation input from 101 into an isolated `codex-testbox` run directory. The script is
+  intentionally sidecar-aware and treats the validation input as a set:
+  - core DB snapshot for `tavily_proxy.db`
+  - observability sibling snapshot for `tavily_proxy-observability.db`
+  - per-run manifest with source paths, byte counts, SHA-256 sums, and integrity-check results
+- The accepted offline validation sequence is now explicit:
+  1. create a full read-only snapshot set on 101
+  2. upload that full set into one `codex-testbox` run directory
+  3. run `ha_outbox_cleanup_once` / `scripts/ha-outbox-maintenance.sh` there
+  4. run `db_compaction_once` only if the threshold gate says reclaimable space is large enough
+- “Full live DB validation input” does not mean “copy the main `.db` file only.” For this service
+  it means the core DB plus the observability sibling sidecar; otherwise offline verification can
+  silently miss the production request-log/read-model layout.
 - Added recovery batch idempotency, HA sync watermarks, failover operation persistence, EdgeOne request/response audit persistence, and node state persistence.
 - Adjusted EdgeOne origin switching to require explicit origin protocol, host, and port configuration, send them as top-level EdgeOne API fields, and normalize EdgeOne describe responses that omit default ports.
 - Added full-master fencing for system settings, upstream key creation, user token management, user quota changes, registration settings, OAuth login start, recharge order creation, and payment notify.
@@ -41,9 +69,9 @@
 
 - `cargo fmt --check`
 - `cargo check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test ha_ -- --nocapture`
+- `cargo test alerts_and_ha -- --nocapture`
 - `cargo test ha_source_endpoint_accepts_lowercase_direct_origin_scheme`
+- `cargo test standalone_ha_outbox_gc_deletes_expired_rows_across_channels_in_bounded_batches -- --nocapture`
 - `cd web && bun run build`
 - `cd web && bun test src/admin/HaSourceSettingsDialog.interaction.test.tsx src/components/HaStatusBanner.stories.test.tsx`
 - `python3 -m py_compile tests/ha/scripts/*.py`

--- a/docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
@@ -39,9 +39,12 @@ Tavily Hikari 的高可用方案采用单活主备热备，而不是一主多从
 - standby 每 5-15 秒从 active 拉取状态基线或 outbox 增量事件，目标 RPO `<=15s`。
 - 禁止通过 HA 同步传输全量 SQLite 数据库文件。
 - 状态基线与事件流使用 versioned zstd NDJSON，基线压缩后上限 `64MiB`，事件批次压缩后上限 `4MiB`。
-- active 持久化 `ha_outbox` 事件，standby 按递增 seq 幂等应用并回报 peer watermark；outbox 保留窗口为 72 小时，超过窗口必须重新拉状态基线。
-- 基线和事件只允许同步接管基础 API/MCP 所需状态：API keys、auth tokens、用户身份、token/key/user 绑定、MCP 当前会话必要状态、quota 当前状态与聚合 bucket、控制面配置、公告、LinuxDo 充值订单/权益、账本历史、forward proxy 配置、代理节点 override、上游 key 与代理节点绑定/亲和关系。
-- 禁止同步 `request_logs`、`auth_token_logs`、请求体、响应体、path/query/IP/header 明细、dashboard recent logs、OAuth login 临时态、Web session、forward proxy runtime/attempts/hourly weight 和节点本地观测噪声。
+- HA wire contract 按三个正式 channel 拆分：`control`、`billing`、`runtime`。每个 channel 独立导出 baseline、独立拉取 events、独立记录 peer watermark，不支持 mixed-version HA。
+- `control` 只同步控制面小状态，事件流写入 `ha_outbox`，保留窗口为 72 小时；超过窗口必须重新拉取该 channel 的状态基线。
+- `billing` 只同步 `billing_ledger` 完整账本行历史，事件流写入 `ha_billing_outbox`，不再通过 `ha_outbox` 复制账本。
+- `runtime` 只同步 failover 后若不恢复就会影响基础 API/MCP 正确性的最小运行态，事件流写入 `ha_runtime_outbox`。允许的最小运行态包括 quota 当前状态与 bucket、token/account 月额度、MCP 当前会话必要状态、forward proxy 亲和与节点 override、以及主/次 API key affinity。
+- `control`/`billing`/`runtime` 三个 channel 的 baseline 和 events 都禁止包含 `request_logs`、`auth_token_logs`、请求体、响应体、path/query/IP/header 明细、dashboard recent logs、OAuth login 临时态、Web session、forward proxy runtime/attempts/hourly weight、维护审计、调度队列、请求限流快照和节点本地观测噪声。
+- `HA_MODE=single` 下不得产生新的 HA 事件写入；仅保留 schema 兼容、显式 one-shot 维护工具与后续切回 `active_standby` 的启动能力。
 - recovery 只允许导入幂等账本事件，不导入调用记录，不覆盖新主当前权威状态。
 - recovery 完成后 quota 与 usage 聚合必须可继续滚动更新。
 
@@ -53,9 +56,9 @@ Tavily Hikari 的高可用方案采用单活主备热备，而不是一主多从
 - `PUT /api/admin/ha/source` 保存当前服务节点私有源站配置，可在 `IP/域名` 与 `源站组` 间切换，并可选择保存后立即应用到 EdgeOne。
 - HA 源站设置的 `directOriginScheme` JSON wire 值固定为小写 `http|https|follow`。`PUT /api/admin/ha/source` 请求体、成功响应以及后续 `GET /api/admin/ha/status` 返回值都必须维持同一套小写语义；仅下游 EdgeOne 控制面 payload 可以继续映射成 `HTTP|HTTPS|FOLLOW`。
 - `GET`/`PUT /api/admin/ha/snapshot` 是废弃接口，必须返回 `410 Gone`，不得读写 SQLite 数据库文件。
-- `GET /api/admin/ha/baseline` 仅内部或管理员认证可调用，在 active/provisional 节点输出 zstd NDJSON 状态基线，并在响应头返回 high watermark。
-- `GET /api/admin/ha/events?after=<seq>&limit=<n>` 仅内部或管理员认证可调用，输出 `after` 之后的 zstd NDJSON outbox 事件。
-- `POST /api/admin/ha/events/ack` 仅内部或管理员认证可调用，记录 standby 已应用的 outbox seq。
+- `GET /api/admin/ha/baseline?channel=<control|billing|runtime>` 仅内部或管理员认证可调用，在 active/provisional 节点输出对应 channel 的 zstd NDJSON 状态基线，并在响应头返回该 channel 的 high watermark。
+- `GET /api/admin/ha/events?channel=<control|billing|runtime>&after=<seq>&limit=<n>` 仅内部或管理员认证可调用，输出对应 channel 在 `after` 之后且仍位于 retention 窗口内的 zstd NDJSON outbox 事件；该读路径不得隐式删行，若 `after` 已落到 retention 窗口之外则返回 `410 Gone` 并要求先重拉该 channel baseline。
+- `POST /api/admin/ha/events/ack` 仅内部或管理员认证可调用，请求体必须显式携带 `channel`，用于记录 standby 已应用的该 channel outbox seq。
 - `POST /api/admin/ha/promote` 将当前 standby 切为 `provisional_master`，可带 `force` 用于强制接管。
 - `POST /api/admin/ha/finalize` 管理员确认后进入 `full_master`。
 - `POST /api/admin/ha/recovery/import` 导入旧主 recovery 账本批次，仅允许内部或管理员认证调用；调用记录字段必须被拒绝。

--- a/scripts/export-live-db-snapshot-to-testbox.sh
+++ b/scripts/export-live-db-snapshot-to-testbox.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: scripts/export-live-db-snapshot-to-testbox.sh
+
+Create a full read-only SQLite snapshot set on machine 101 and upload it into an isolated
+codex-testbox run directory for offline validation.
+
+Environment variables:
+  SOURCE_HOST                 Defaults to 192.168.31.11
+  SOURCE_SSH_TARGET           Defaults to SOURCE_HOST
+  TESTBOX_HOST                Defaults to codex-testbox
+  SOURCE_DB_DIR               Defaults to /var/lib/docker/volumes/ai-tavily-hikari-data/_data
+  SOURCE_CORE_DB_NAME         Defaults to tavily_proxy.db
+  SOURCE_OBSERVABILITY_DB_NAME Defaults to tavily_proxy-observability.db
+  SOURCE_SNAPSHOT_DIR         Defaults to /tmp/<repo>-<run-id>
+  RUN_ID                      Optional explicit run id
+  KEEP_SOURCE_SNAPSHOTS       true/false, defaults to false
+
+Outputs:
+  Prints the remote run directory and writes manifests under:
+    <remote-run>/live-db/manifest.env
+    <remote-run>/live-db/sha256sums.txt
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  show_help
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_HOST="${SOURCE_HOST:-192.168.31.11}"
+SOURCE_SSH_TARGET="${SOURCE_SSH_TARGET:-$SOURCE_HOST}"
+TESTBOX_HOST="${TESTBOX_HOST:-codex-testbox}"
+SOURCE_DB_DIR="${SOURCE_DB_DIR:-/var/lib/docker/volumes/ai-tavily-hikari-data/_data}"
+SOURCE_CORE_DB_NAME="${SOURCE_CORE_DB_NAME:-tavily_proxy.db}"
+SOURCE_OBSERVABILITY_DB_NAME="${SOURCE_OBSERVABILITY_DB_NAME:-tavily_proxy-observability.db}"
+KEEP_SOURCE_SNAPSHOTS="${KEEP_SOURCE_SNAPSHOTS:-false}"
+
+if REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  REPO_ROOT="$ROOT_DIR"
+fi
+REPO_ROOT="$(python3 - "$REPO_ROOT" <<'PY'
+import os
+import sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+
+REPO_NAME="$(basename "$REPO_ROOT")"
+PATH_HASH8="$(python3 - "$REPO_ROOT" <<'PY'
+import hashlib
+import os
+import sys
+path = os.path.realpath(sys.argv[1]).encode()
+print(hashlib.sha256(path).hexdigest()[:8])
+PY
+)"
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo nogit)"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%d_%H%M%S)_${GIT_SHA}_ha_outbox}"
+WORKSPACE_SLUG="${REPO_NAME}__${PATH_HASH8}"
+REMOTE_BASE="/srv/codex/workspaces/$USER"
+REMOTE_WORKSPACE="$REMOTE_BASE/$WORKSPACE_SLUG"
+REMOTE_RUN="$REMOTE_WORKSPACE/runs/$RUN_ID"
+REMOTE_REPO_DIR="$REMOTE_RUN/repo"
+REMOTE_DB_DIR="$REMOTE_RUN/live-db"
+
+SOURCE_TMP_DIR="${SOURCE_SNAPSHOT_DIR:-/tmp/${REPO_NAME}-${RUN_ID}}"
+SOURCE_CORE_LIVE="$SOURCE_DB_DIR/$SOURCE_CORE_DB_NAME"
+SOURCE_SIDECAR_LIVE="$SOURCE_DB_DIR/$SOURCE_OBSERVABILITY_DB_NAME"
+SOURCE_CORE_SNAPSHOT="$SOURCE_TMP_DIR/$SOURCE_CORE_DB_NAME"
+SOURCE_SIDECAR_SNAPSHOT="$SOURCE_TMP_DIR/$SOURCE_OBSERVABILITY_DB_NAME"
+
+manifest_get() {
+  local key="$1"
+  printf '%s\n' "$SOURCE_MANIFEST" | awk -F= -v target="$key" '$1 == target { sub($1"=",""); print; exit }'
+}
+
+printf 'Preparing isolated codex-testbox run dir: %s\n' "$REMOTE_RUN"
+ssh -o BatchMode=yes "$TESTBOX_HOST" "mkdir -p '$REMOTE_DB_DIR' '$REMOTE_REPO_DIR' '$REMOTE_WORKSPACE'"
+
+CREATED_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+ssh -o BatchMode=yes "$TESTBOX_HOST" "cat > '$REMOTE_WORKSPACE/workspace.txt'" <<TXT
+local_repo_root=$REPO_ROOT
+created_utc=$CREATED_UTC
+source_host=$SOURCE_HOST
+source_db_dir=$SOURCE_DB_DIR
+TXT
+
+printf 'Syncing repo to codex-testbox run dir...\n'
+rsync -az --delete \
+  --exclude '.git/' \
+  --exclude 'node_modules/' \
+  --exclude 'target/' \
+  --exclude 'dist/' \
+  --exclude 'build/' \
+  --exclude '.next/' \
+  --exclude '.venv/' \
+  --exclude '*.db' \
+  --exclude '*.db-*' \
+  "$REPO_ROOT/" "$TESTBOX_HOST:$REMOTE_REPO_DIR/"
+
+printf 'Creating read-only SQLite backups on %s ...\n' "$SOURCE_SSH_TARGET"
+SOURCE_MANIFEST="$(ssh -o BatchMode=yes "$SOURCE_SSH_TARGET" "bash -s" -- \
+  "$SOURCE_TMP_DIR" \
+  "$SOURCE_CORE_LIVE" \
+  "$SOURCE_SIDECAR_LIVE" \
+  "$SOURCE_CORE_SNAPSHOT" \
+  "$SOURCE_SIDECAR_SNAPSHOT" <<'EOS'
+set -euo pipefail
+
+tmp_dir="$1"
+core_live="$2"
+sidecar_live="$3"
+core_snapshot="$4"
+sidecar_snapshot="$5"
+
+mkdir -p "$tmp_dir"
+test -f "$core_live"
+test -f "$sidecar_live"
+
+core_live_bytes="$(stat -c %s "$core_live")"
+core_live_wal_bytes="$(stat -c %s "${core_live}-wal" 2>/dev/null || echo 0)"
+sidecar_live_bytes="$(stat -c %s "$sidecar_live")"
+available_tmp_bytes="$(df -B1 --output=avail "$tmp_dir" | tail -n1 | tr -d ' ')"
+required_tmp_bytes="$((core_live_bytes + core_live_wal_bytes + sidecar_live_bytes + 1073741824))"
+
+if (( available_tmp_bytes < required_tmp_bytes )); then
+  echo "insufficient temporary free space for snapshot: available=${available_tmp_bytes} required=${required_tmp_bytes}" >&2
+  exit 2
+fi
+
+rm -f "$core_snapshot" "$sidecar_snapshot"
+sqlite3 "$core_live" ".timeout 10000" ".backup '$core_snapshot'"
+sqlite3 "$sidecar_live" ".timeout 10000" ".backup '$sidecar_snapshot'"
+
+core_integrity="$(sqlite3 "$core_snapshot" 'PRAGMA integrity_check;' | tr -d '\r')"
+sidecar_integrity="$(sqlite3 "$sidecar_snapshot" 'PRAGMA integrity_check;' | tr -d '\r')"
+
+if [[ "$core_integrity" != "ok" ]]; then
+  echo "core snapshot integrity_check failed: $core_integrity" >&2
+  exit 3
+fi
+if [[ "$sidecar_integrity" != "ok" ]]; then
+  echo "sidecar snapshot integrity_check failed: $sidecar_integrity" >&2
+  exit 4
+fi
+
+printf 'source_tmp_dir=%s\n' "$tmp_dir"
+printf 'core_live_path=%s\n' "$core_live"
+printf 'sidecar_live_path=%s\n' "$sidecar_live"
+printf 'core_live_bytes=%s\n' "$core_live_bytes"
+printf 'core_live_wal_bytes=%s\n' "$core_live_wal_bytes"
+printf 'sidecar_live_bytes=%s\n' "$sidecar_live_bytes"
+printf 'available_tmp_bytes=%s\n' "$available_tmp_bytes"
+printf 'required_tmp_bytes=%s\n' "$required_tmp_bytes"
+printf 'core_snapshot_path=%s\n' "$core_snapshot"
+printf 'sidecar_snapshot_path=%s\n' "$sidecar_snapshot"
+printf 'core_snapshot_bytes=%s\n' "$(stat -c %s "$core_snapshot")"
+printf 'sidecar_snapshot_bytes=%s\n' "$(stat -c %s "$sidecar_snapshot")"
+printf 'core_snapshot_sha256=%s\n' "$(sha256sum "$core_snapshot" | awk '{print $1}')"
+printf 'sidecar_snapshot_sha256=%s\n' "$(sha256sum "$sidecar_snapshot" | awk '{print $1}')"
+printf 'core_snapshot_integrity=%s\n' "$core_integrity"
+printf 'sidecar_snapshot_integrity=%s\n' "$sidecar_integrity"
+EOS
+)"
+
+SOURCE_TMP_DIR_REMOTE="$(manifest_get source_tmp_dir)"
+CORE_LIVE_PATH_REMOTE="$(manifest_get core_live_path)"
+SIDECAR_LIVE_PATH_REMOTE="$(manifest_get sidecar_live_path)"
+CORE_LIVE_BYTES="$(manifest_get core_live_bytes)"
+CORE_LIVE_WAL_BYTES="$(manifest_get core_live_wal_bytes)"
+SIDECAR_LIVE_BYTES="$(manifest_get sidecar_live_bytes)"
+AVAILABLE_TMP_BYTES="$(manifest_get available_tmp_bytes)"
+REQUIRED_TMP_BYTES="$(manifest_get required_tmp_bytes)"
+CORE_SNAPSHOT_PATH_REMOTE="$(manifest_get core_snapshot_path)"
+SIDECAR_SNAPSHOT_PATH_REMOTE="$(manifest_get sidecar_snapshot_path)"
+CORE_SNAPSHOT_BYTES="$(manifest_get core_snapshot_bytes)"
+SIDECAR_SNAPSHOT_BYTES="$(manifest_get sidecar_snapshot_bytes)"
+CORE_SNAPSHOT_SHA256="$(manifest_get core_snapshot_sha256)"
+SIDECAR_SNAPSHOT_SHA256="$(manifest_get sidecar_snapshot_sha256)"
+CORE_SNAPSHOT_INTEGRITY="$(manifest_get core_snapshot_integrity)"
+SIDECAR_SNAPSHOT_INTEGRITY="$(manifest_get sidecar_snapshot_integrity)"
+
+printf 'Streaming full snapshot set to codex-testbox ...\n'
+ssh -o BatchMode=yes "$SOURCE_SSH_TARGET" "cat '$CORE_SNAPSHOT_PATH_REMOTE'" \
+  | ssh -o BatchMode=yes "$TESTBOX_HOST" "cat > '$REMOTE_DB_DIR/$SOURCE_CORE_DB_NAME'"
+ssh -o BatchMode=yes "$SOURCE_SSH_TARGET" "cat '$SIDECAR_SNAPSHOT_PATH_REMOTE'" \
+  | ssh -o BatchMode=yes "$TESTBOX_HOST" "cat > '$REMOTE_DB_DIR/$SOURCE_OBSERVABILITY_DB_NAME'"
+
+ssh -o BatchMode=yes "$TESTBOX_HOST" "cat > '$REMOTE_DB_DIR/manifest.env'" <<EOF
+run_id=$RUN_ID
+created_utc=$CREATED_UTC
+source_host=$SOURCE_HOST
+source_ssh_target=$SOURCE_SSH_TARGET
+source_db_dir=$SOURCE_DB_DIR
+core_live_path=$CORE_LIVE_PATH_REMOTE
+sidecar_live_path=$SIDECAR_LIVE_PATH_REMOTE
+core_live_bytes=$CORE_LIVE_BYTES
+core_live_wal_bytes=$CORE_LIVE_WAL_BYTES
+sidecar_live_bytes=$SIDECAR_LIVE_BYTES
+available_tmp_bytes=$AVAILABLE_TMP_BYTES
+required_tmp_bytes=$REQUIRED_TMP_BYTES
+core_snapshot_bytes=$CORE_SNAPSHOT_BYTES
+sidecar_snapshot_bytes=$SIDECAR_SNAPSHOT_BYTES
+core_snapshot_sha256=$CORE_SNAPSHOT_SHA256
+sidecar_snapshot_sha256=$SIDECAR_SNAPSHOT_SHA256
+core_snapshot_integrity=$CORE_SNAPSHOT_INTEGRITY
+sidecar_snapshot_integrity=$SIDECAR_SNAPSHOT_INTEGRITY
+remote_run=$REMOTE_RUN
+remote_repo_dir=$REMOTE_REPO_DIR
+remote_db_dir=$REMOTE_DB_DIR
+EOF
+
+ssh -o BatchMode=yes "$TESTBOX_HOST" "cat > '$REMOTE_DB_DIR/sha256sums.txt'" <<EOF
+$CORE_SNAPSHOT_SHA256  $SOURCE_CORE_DB_NAME
+$SIDECAR_SNAPSHOT_SHA256  $SOURCE_OBSERVABILITY_DB_NAME
+EOF
+
+printf 'Verifying uploaded files on codex-testbox ...\n'
+ssh -o BatchMode=yes "$TESTBOX_HOST" "cd '$REMOTE_DB_DIR' \
+  && sha256sum -c sha256sums.txt \
+  && test \"\$(sqlite3 '$SOURCE_CORE_DB_NAME' 'PRAGMA integrity_check;')\" = ok \
+  && test \"\$(sqlite3 '$SOURCE_OBSERVABILITY_DB_NAME' 'PRAGMA integrity_check;')\" = ok"
+
+if [[ "$KEEP_SOURCE_SNAPSHOTS" != "true" && "$KEEP_SOURCE_SNAPSHOTS" != "1" ]]; then
+  printf 'Cleaning temporary backups on %s ...\n' "$SOURCE_SSH_TARGET"
+  ssh -o BatchMode=yes "$SOURCE_SSH_TARGET" "rm -f '$CORE_SNAPSHOT_PATH_REMOTE' '$SIDECAR_SNAPSHOT_PATH_REMOTE' && rmdir '$SOURCE_TMP_DIR_REMOTE' 2>/dev/null || true"
+fi
+
+printf '\nSnapshot export complete.\n'
+printf 'REMOTE_RUN=%s\n' "$REMOTE_RUN"
+printf 'REMOTE_REPO_DIR=%s\n' "$REMOTE_REPO_DIR"
+printf 'REMOTE_DB_DIR=%s\n' "$REMOTE_DB_DIR"
+printf 'CORE_SHA256=%s\n' "$CORE_SNAPSHOT_SHA256"
+printf 'SIDECAR_SHA256=%s\n' "$SIDECAR_SNAPSHOT_SHA256"

--- a/scripts/ha-outbox-maintenance.sh
+++ b/scripts/ha-outbox-maintenance.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DB_PATH="${DB_PATH:-tavily_proxy.db}"
+RUN_UNTIL_COMPLETE="${RUN_UNTIL_COMPLETE:-true}"
+JSON="${JSON:-true}"
+COMPACT_AFTER="${COMPACT_AFTER:-false}"
+FORCE_COMPACTION="${FORCE_COMPACTION:-false}"
+BATCH_SIZE="${BATCH_SIZE:-20000}"
+MAX_BATCHES="${MAX_BATCHES:-8}"
+MAX_RUNTIME_SECS="${MAX_RUNTIME_SECS:-20}"
+INTER_BATCH_SLEEP_MS="${INTER_BATCH_SLEEP_MS:-0}"
+
+pushd "$ROOT_DIR" >/dev/null
+
+cleanup_cmd=(
+  cargo run --bin ha_outbox_cleanup_once --
+  --db-path "$DB_PATH"
+  --batch-size "$BATCH_SIZE"
+  --max-batches "$MAX_BATCHES"
+  --max-runtime-secs "$MAX_RUNTIME_SECS"
+  --inter-batch-sleep-ms "$INTER_BATCH_SLEEP_MS"
+)
+
+if [[ "$RUN_UNTIL_COMPLETE" == "true" || "$RUN_UNTIL_COMPLETE" == "1" ]]; then
+  cleanup_cmd+=(--run-until-complete)
+fi
+
+if [[ "$JSON" == "true" || "$JSON" == "1" ]]; then
+  cleanup_cmd+=(--json)
+fi
+
+echo "Running HA outbox cleanup against $DB_PATH ..."
+"${cleanup_cmd[@]}"
+
+if [[ "$COMPACT_AFTER" == "true" || "$COMPACT_AFTER" == "1" ]]; then
+  compaction_cmd=(cargo run --bin db_compaction_once -- --db-path "$DB_PATH")
+  if [[ "$FORCE_COMPACTION" == "true" || "$FORCE_COMPACTION" == "1" ]]; then
+    compaction_cmd+=(--force)
+  fi
+  if [[ "$JSON" == "true" || "$JSON" == "1" ]]; then
+    compaction_cmd+=(--json)
+  fi
+  echo "Running SQLite compaction against $DB_PATH ..."
+  "${compaction_cmd[@]}"
+fi
+
+popd >/dev/null

--- a/src/bin/ha_outbox_cleanup_once.rs
+++ b/src/bin/ha_outbox_cleanup_once.rs
@@ -1,0 +1,169 @@
+use std::io::{self, Write};
+
+use clap::Parser;
+use dotenvy::dotenv;
+use serde::Serialize;
+use tavily_hikari::{
+    HaOutboxGcChannelReport, HaOutboxGcOptions, HaOutboxGcReport,
+    format_ha_outbox_gc_report_message, run_ha_outbox_gc_once,
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    author,
+    version,
+    about = "Run bounded HA control outbox GC once, or repeatedly until complete"
+)]
+struct Cli {
+    /// SQLite database path to mutate.
+    #[arg(long, env = "PROXY_DB_PATH", default_value = "data/tavily_proxy.db")]
+    db_path: String,
+
+    /// Maximum ha_outbox rows to delete per batch.
+    #[arg(long, default_value_t = HaOutboxGcOptions::default().batch_size, value_parser = positive_i64)]
+    batch_size: i64,
+
+    /// Maximum batches per GC pass.
+    #[arg(long, default_value_t = HaOutboxGcOptions::default().max_batches, value_parser = positive_i64)]
+    max_batches: i64,
+
+    /// Maximum seconds per GC pass.
+    #[arg(long, default_value_t = HaOutboxGcOptions::default().max_runtime_secs, value_parser = positive_u64)]
+    max_runtime_secs: u64,
+
+    /// Sleep between batches to reduce write pressure.
+    #[arg(long, default_value_t = HaOutboxGcOptions::default().inter_batch_sleep_ms)]
+    inter_batch_sleep_ms: u64,
+
+    /// Continue running bounded passes until no retained control outbox rows remain.
+    #[arg(long, default_value_t = false)]
+    run_until_complete: bool,
+
+    /// Emit JSON output. Plain output is retained for interactive use.
+    #[arg(long, default_value_t = false)]
+    json: bool,
+}
+
+fn positive_i64(value: &str) -> Result<i64, String> {
+    let parsed = value
+        .parse::<i64>()
+        .map_err(|err| format!("expected a positive integer: {err}"))?;
+    if parsed > 0 {
+        Ok(parsed)
+    } else {
+        Err("expected a positive integer".to_string())
+    }
+}
+
+fn positive_u64(value: &str) -> Result<u64, String> {
+    let parsed = value
+        .parse::<u64>()
+        .map_err(|err| format!("expected a positive integer: {err}"))?;
+    if parsed > 0 {
+        Ok(parsed)
+    } else {
+        Err("expected a positive integer".to_string())
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CliReport {
+    run_until_complete: bool,
+    passes: usize,
+    batch_size: i64,
+    max_batches: i64,
+    deleted_rows: i64,
+    batches: i64,
+    completed: bool,
+    has_more: bool,
+    channels: Vec<HaOutboxGcChannelReport>,
+    wal_checkpoint_busy: bool,
+    wal_checkpoint_log_frames: i64,
+    wal_checkpoint_checkpointed_frames: i64,
+    elapsed_ms: u128,
+    pass_reports: Vec<HaOutboxGcReport>,
+}
+
+impl CliReport {
+    fn from_passes(run_until_complete: bool, reports: Vec<HaOutboxGcReport>) -> Self {
+        let last = reports
+            .last()
+            .expect("ha outbox cleanup cli always records at least one pass");
+        Self {
+            run_until_complete,
+            passes: reports.len(),
+            batch_size: last.batch_size,
+            max_batches: last.max_batches,
+            deleted_rows: reports.iter().map(|report| report.deleted_rows).sum(),
+            batches: reports.iter().map(|report| report.batches).sum(),
+            completed: last.completed,
+            has_more: last.has_more,
+            channels: last.channels.clone(),
+            wal_checkpoint_busy: last.wal_checkpoint_busy,
+            wal_checkpoint_log_frames: last.wal_checkpoint_log_frames,
+            wal_checkpoint_checkpointed_frames: last.wal_checkpoint_checkpointed_frames,
+            elapsed_ms: reports.iter().map(|report| report.elapsed_ms).sum(),
+            pass_reports: reports,
+        }
+    }
+}
+
+fn write_json_report(mut writer: impl Write, report: &CliReport) -> io::Result<()> {
+    serde_json::to_writer_pretty(&mut writer, report)?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+fn write_plain_report(mut writer: impl Write, report: &CliReport) -> io::Result<()> {
+    let aggregate = HaOutboxGcReport {
+        batch_size: report.batch_size,
+        max_batches: report.max_batches,
+        deleted_rows: report.deleted_rows,
+        batches: report.batches,
+        completed: report.completed,
+        has_more: report.has_more,
+        channels: report.channels.clone(),
+        wal_checkpoint_busy: report.wal_checkpoint_busy,
+        wal_checkpoint_log_frames: report.wal_checkpoint_log_frames,
+        wal_checkpoint_checkpointed_frames: report.wal_checkpoint_checkpointed_frames,
+        elapsed_ms: report.elapsed_ms,
+    };
+    writeln!(
+        writer,
+        "ha_outbox_gc: {}",
+        format_ha_outbox_gc_report_message(&aggregate, report.passes)
+    )?;
+    writer.flush()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv().ok();
+    let cli = Cli::parse();
+    let options = HaOutboxGcOptions {
+        batch_size: cli.batch_size,
+        max_batches: cli.max_batches,
+        max_runtime_secs: cli.max_runtime_secs,
+        inter_batch_sleep_ms: cli.inter_batch_sleep_ms,
+    };
+    let mut reports = Vec::new();
+
+    loop {
+        let report = run_ha_outbox_gc_once(&cli.db_path, options).await?;
+        let completed = report.completed;
+        reports.push(report);
+        if completed || !cli.run_until_complete {
+            break;
+        }
+    }
+
+    let cli_report = CliReport::from_passes(cli.run_until_complete, reports);
+    if cli.json {
+        write_json_report(io::stdout().lock(), &cli_report)?;
+    } else {
+        write_plain_report(io::stdout().lock(), &cli_report)?;
+    }
+
+    Ok(())
+}

--- a/src/bin/mcp_search_billing_repair.rs
+++ b/src/bin/mcp_search_billing_repair.rs
@@ -378,6 +378,7 @@ async fn repair_candidates(
                 request_log_id,
                 result_status,
                 created_at,
+                updated_at,
                 settled_at,
                 error_message
             )
@@ -391,6 +392,7 @@ async fn repair_candidates(
                 atl.api_key_id,
                 atl.request_log_id,
                 atl.result_status,
+                atl.created_at,
                 atl.created_at,
                 NULL,
                 atl.error_message
@@ -406,6 +408,7 @@ async fn repair_candidates(
                 request_log_id = excluded.request_log_id,
                 result_status = excluded.result_status,
                 created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
                 settled_at = NULL,
                 error_message = excluded.error_message
             "#,

--- a/src/ha.rs
+++ b/src/ha.rs
@@ -26,6 +26,33 @@ impl HaMode {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HaSyncChannel {
+    Control,
+    Billing,
+    Runtime,
+}
+
+impl HaSyncChannel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Control => "control",
+            Self::Billing => "billing",
+            Self::Runtime => "runtime",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "control" => Some(Self::Control),
+            "billing" => Some(Self::Billing),
+            "runtime" => Some(Self::Runtime),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HaNodeRole {
@@ -661,6 +688,11 @@ impl HaRuntime {
             recovery_status: state.recovery_status.clone(),
             message: state.message.clone(),
         }
+    }
+
+    pub async fn mark_sync_success(&self) {
+        let mut state = self.state.write().await;
+        state.last_sync_at = Some(self.backend_time.now_ts());
     }
 
     pub async fn set_local_source_settings_view(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,9 @@ pub const QUOTA_SYNC_STALE_RUNNING_SECS: i64 = 40;
 pub const DB_COMPACTION_MIN_RECLAIMABLE_BYTES: u64 = 512 * 1024 * 1024;
 pub const DB_COMPACTION_MIN_RECLAIMABLE_RATIO: f64 = 0.20;
 pub const DB_COMPACTION_COOLDOWN_SECS: u64 = 24 * 60 * 60;
+pub const HA_OUTBOX_GC_DEFAULT_BATCH_SIZE: i64 = 20_000;
+pub const HA_OUTBOX_GC_DEFAULT_MAX_BATCHES: i64 = 8;
+pub const HA_OUTBOX_GC_DEFAULT_MAX_RUNTIME_SECS: u64 = 20;
 
 pub async fn run_db_compaction_once(
     database_path: &str,
@@ -412,6 +415,88 @@ pub async fn run_db_compaction_once(
     })
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct HaOutboxGcOptions {
+    pub batch_size: i64,
+    pub max_batches: i64,
+    pub max_runtime_secs: u64,
+    pub inter_batch_sleep_ms: u64,
+}
+
+impl Default for HaOutboxGcOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: HA_OUTBOX_GC_DEFAULT_BATCH_SIZE,
+            max_batches: HA_OUTBOX_GC_DEFAULT_MAX_BATCHES,
+            max_runtime_secs: HA_OUTBOX_GC_DEFAULT_MAX_RUNTIME_SECS,
+            inter_batch_sleep_ms: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HaOutboxGcChannelReport {
+    pub channel: HaSyncChannel,
+    pub retention_secs: i64,
+    pub threshold: i64,
+    pub deleted_rows: i64,
+    pub batches: i64,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HaOutboxGcReport {
+    pub batch_size: i64,
+    pub max_batches: i64,
+    pub deleted_rows: i64,
+    pub batches: i64,
+    pub completed: bool,
+    pub has_more: bool,
+    pub channels: Vec<HaOutboxGcChannelReport>,
+    pub wal_checkpoint_busy: bool,
+    pub wal_checkpoint_log_frames: i64,
+    pub wal_checkpoint_checkpointed_frames: i64,
+    pub elapsed_ms: u128,
+}
+
+pub fn format_ha_outbox_gc_report_message(report: &HaOutboxGcReport, passes: usize) -> String {
+    format!(
+        "deleted_rows={} completed={} has_more={} channels={} batches={} passes={} wal_busy={} wal_log_frames={} wal_checkpointed_frames={} elapsed_ms={}",
+        report.deleted_rows,
+        report.completed,
+        report.has_more,
+        report
+            .channels
+            .iter()
+            .map(|channel| format!(
+                "{}:{}:{}:{}:{}",
+                channel.channel.as_str(),
+                channel.deleted_rows,
+                channel.retention_secs,
+                channel.batches,
+                channel.has_more
+            ))
+            .collect::<Vec<_>>()
+            .join(","),
+        report.batches,
+        passes,
+        report.wal_checkpoint_busy,
+        report.wal_checkpoint_log_frames,
+        report.wal_checkpoint_checkpointed_frames,
+        report.elapsed_ms
+    )
+}
+
+pub async fn run_ha_outbox_gc_once(
+    database_path: &str,
+    options: HaOutboxGcOptions,
+) -> Result<HaOutboxGcReport, ProxyError> {
+    let key_store = crate::store::KeyStore::open_for_request_logs_gc(database_path).await?;
+    key_store.gc_ha_outbox_with_options(options).await
+}
+
 pub async fn run_observability_sidecar_migrate(
     database_path: &str,
     batch_size: i64,
@@ -430,6 +515,11 @@ pub async fn verify_observability_sidecar_reopen(database_path: &str) -> Result<
             ))
         })?;
     Ok(())
+}
+
+pub async fn configure_ha_write_mode(database_path: &str, mode: HaMode) -> Result<(), ProxyError> {
+    let store = crate::store::KeyStore::new_with_time(database_path, BackendTime::system()).await?;
+    store.configure_ha_event_writes(mode).await
 }
 
 impl ForwardProxyProgressEvent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,8 +368,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ),
         health_readiness_grace_period: std::time::Duration::from_secs(90),
     };
-    let proxy =
-        TavilyProxy::with_options(cli.keys, &cli.upstream, &cli.db_path, proxy_options).await?;
+    let ha_mode = HaMode::parse(&cli.ha_mode);
+    let proxy = TavilyProxy::with_options_in_ha_mode(
+        cli.keys,
+        &cli.upstream,
+        &cli.db_path,
+        proxy_options,
+        ha_mode,
+    )
+    .await?;
     let addr: SocketAddr = format!("{}:{}", cli.bind, cli.port).parse()?;
 
     let forward_auth_header = parse_header_name(cli.forward_auth_header, "FORWARD_AUTH_HEADER")?;
@@ -534,7 +541,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         test_price_enabled: cli.linuxdo_credit_test_price_enabled,
     };
     let ha_config = HaConfig {
-        mode: HaMode::parse(&cli.ha_mode),
+        mode: ha_mode,
         node_id: cli.node_id.trim().to_string(),
         database_path: Some(cli.db_path.clone()),
         source_kind: cli

--- a/src/server/handlers/admin_auth.rs
+++ b/src/server/handlers/admin_auth.rs
@@ -56,6 +56,7 @@ fn manual_trigger_supported(job_type: &str) -> bool {
         "quota_sync"
             | "token_usage_rollup"
             | "auth_token_logs_gc"
+            | "ha_outbox_gc"
             | "request_logs_gc"
             | "mcp_sessions_gc"
             | "mcp_session_init_backoffs_gc"

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -51,7 +51,12 @@ const HA_BASELINE_MAX_COMPRESSED_BYTES: usize = 64 * 1024 * 1024;
 const HA_EVENTS_MAX_COMPRESSED_BYTES: usize = 4 * 1024 * 1024;
 
 fn parse_ha_channel(raw: Option<&str>) -> Result<tavily_hikari::HaSyncChannel, (StatusCode, String)> {
-    let value = raw.unwrap_or("control");
+    let Some(value) = raw else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "missing required HA channel".to_string(),
+        ));
+    };
     tavily_hikari::HaSyncChannel::parse(value).ok_or_else(|| {
         (
             StatusCode::BAD_REQUEST,

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -28,6 +28,7 @@ struct HaRecoveryImportRequest {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct HaEventsQuery {
+    channel: Option<String>,
     after: Option<i64>,
     limit: Option<i64>,
 }
@@ -35,6 +36,7 @@ struct HaEventsQuery {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct HaEventsAckRequest {
+    channel: String,
     peer_node_id: String,
     acked_seq: i64,
 }
@@ -47,6 +49,16 @@ struct HaEventResponseItem {
 
 const HA_BASELINE_MAX_COMPRESSED_BYTES: usize = 64 * 1024 * 1024;
 const HA_EVENTS_MAX_COMPRESSED_BYTES: usize = 4 * 1024 * 1024;
+
+fn parse_ha_channel(raw: Option<&str>) -> Result<tavily_hikari::HaSyncChannel, (StatusCode, String)> {
+    let value = raw.unwrap_or("control");
+    tavily_hikari::HaSyncChannel::parse(value).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid HA channel: {value}"),
+        )
+    })
+}
 
 fn is_ha_admin_or_internal(state: &AppState, headers: &HeaderMap) -> bool {
     if is_admin_request(state, headers) {
@@ -192,6 +204,7 @@ fn gone_ha_snapshot_response() -> Result<Response<Body>, (StatusCode, String)> {
 async fn get_admin_ha_baseline(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    Query(query): Query<HaEventsQuery>,
 ) -> Result<Response<Body>, (StatusCode, String)> {
     if !is_ha_admin_or_internal(state.as_ref(), &headers) {
         return Err((StatusCode::FORBIDDEN, "forbidden".to_string()));
@@ -206,9 +219,10 @@ async fn get_admin_ha_baseline(
             ),
         ));
     }
+    let channel = parse_ha_channel(query.channel.as_deref())?;
     let export = state
         .proxy
-        .export_ha_baseline_ndjson(&status.node_id)
+        .export_ha_baseline_ndjson(channel, &status.node_id)
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
     let compressed = encode_zstd_limited(&export.ndjson, HA_BASELINE_MAX_COMPRESSED_BYTES)?;
@@ -216,7 +230,8 @@ async fn get_admin_ha_baseline(
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/x-ndjson")
         .header("content-encoding", "zstd")
-        .header("x-ha-schema-version", "1")
+        .header("x-ha-schema-version", "2")
+        .header("x-ha-channel", channel.as_str())
         .header("x-ha-high-watermark", export.high_watermark.to_string())
         .header("x-ha-row-count", export.row_count.to_string())
         .body(Body::from(compressed))
@@ -241,11 +256,12 @@ async fn get_admin_ha_events(
             ),
         ));
     }
+    let channel = parse_ha_channel(query.channel.as_deref())?;
     let after = query.after.unwrap_or(0).max(0);
     let limit = query.limit.unwrap_or(100).clamp(1, 1000);
     let events = state
         .proxy
-        .list_ha_outbox_events_after(after, limit)
+        .list_ha_events_after(channel, after, limit)
         .await
         .map_err(|err| {
             let message = err.to_string();
@@ -260,18 +276,21 @@ async fn get_admin_ha_events(
         .map(|event| HaEventResponseItem {
             seq: event.seq,
             value: json!({
-                "schemaVersion": 1,
+                "schemaVersion": 2,
                 "kind": "event",
+                "channel": channel,
                 "event": event
             }),
         })
         .collect::<Vec<_>>();
-    let encoded = encode_ha_events_limited(after, limit, &event_items, HA_EVENTS_MAX_COMPRESSED_BYTES)?;
+    let encoded =
+        encode_ha_events_limited(channel, after, limit, &event_items, HA_EVENTS_MAX_COMPRESSED_BYTES)?;
     Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/x-ndjson")
         .header("content-encoding", "zstd")
-        .header("x-ha-schema-version", "1")
+        .header("x-ha-schema-version", "2")
+        .header("x-ha-channel", channel.as_str())
         .header("x-ha-last-seq", encoded.last_seq.to_string())
         .header("x-ha-event-count", encoded.event_count.to_string())
         .body(Body::from(encoded.compressed))
@@ -285,6 +304,7 @@ struct EncodedHaEvents {
 }
 
 fn encode_ha_events_limited(
+    channel: tavily_hikari::HaSyncChannel,
     after: i64,
     limit: i64,
     events: &[HaEventResponseItem],
@@ -295,7 +315,7 @@ fn encode_ha_events_limited(
         let selected = &events[..event_count];
         let mut ndjson = String::new();
         let mut last_seq = after;
-        append_ha_events_ndjson(&mut ndjson, after, limit, selected, &mut last_seq)?;
+        append_ha_events_ndjson(&mut ndjson, channel, after, limit, selected, &mut last_seq)?;
         let compressed = zstd::stream::encode_all(ndjson.as_bytes(), 3)
             .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
         if compressed.len() <= max_compressed_bytes {
@@ -320,6 +340,7 @@ fn encode_ha_events_limited(
 
 fn append_ha_events_ndjson(
     ndjson: &mut String,
+    channel: tavily_hikari::HaSyncChannel,
     after: i64,
     limit: i64,
     events: &[HaEventResponseItem],
@@ -327,8 +348,9 @@ fn append_ha_events_ndjson(
 ) -> Result<(), (StatusCode, String)> {
     ndjson.push_str(
         &serde_json::to_string(&json!({
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "kind": "events_start",
+            "channel": channel,
             "after": after,
             "limit": limit
         }))
@@ -345,8 +367,9 @@ fn append_ha_events_ndjson(
     }
     ndjson.push_str(
         &serde_json::to_string(&json!({
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "kind": "events_end",
+            "channel": channel,
             "lastSeq": *last_seq,
             "eventCount": events.len()
         }))
@@ -364,13 +387,15 @@ async fn post_admin_ha_events_ack(
     if !is_ha_admin_or_internal(state.as_ref(), &headers) {
         return Err((StatusCode::FORBIDDEN, "forbidden".to_string()));
     }
+    let channel = parse_ha_channel(Some(payload.channel.as_str()))?;
     state
         .proxy
-        .ack_ha_peer_watermark(&payload.peer_node_id, payload.acked_seq)
+        .ack_ha_peer_watermark(channel, &payload.peer_node_id, payload.acked_seq)
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
     Ok(Json(json!({
         "ok": true,
+        "channel": channel,
         "peerNodeId": payload.peer_node_id,
         "ackedSeq": payload.acked_seq.max(0)
     })))

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -1,3 +1,6 @@
+use tavily_hikari::{
+    HaOutboxGcOptions, format_ha_outbox_gc_report_message, run_ha_outbox_gc_once,
+};
 use tokio::time::Instant;
 fn random_delay_secs(max_inclusive: u64) -> u64 {
     use rand::Rng;
@@ -458,6 +461,27 @@ fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
             };
 
             // Run GC once per hour; retention window is enforced inside the proxy.
+            state.proxy.backend_time().sleep(Duration::from_secs(3600)).await;
+        }
+    });
+}
+
+fn spawn_ha_outbox_gc_scheduler(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        loop {
+            let Some(_) = enqueue_scheduled_job_logged(
+                state.as_ref(),
+                "ha_outbox_gc",
+                None,
+                TRIGGER_SOURCE_SCHEDULER,
+                "ha-outbox-gc",
+            )
+            .await
+            else {
+                state.proxy.backend_time().sleep(Duration::from_secs(3600)).await;
+                continue;
+            };
+
             state.proxy.backend_time().sleep(Duration::from_secs(3600)).await;
         }
     });
@@ -1147,6 +1171,23 @@ async fn run_manual_claimed_job(
             let _maintenance = acquire_db_maintenance_read_gate().await;
             match state.proxy.gc_auth_token_logs().await {
                 Ok(deleted) => finish(state, "success", format!("deleted_rows={deleted}")).await,
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        }
+        "ha_outbox_gc" => {
+            let _maintenance = acquire_db_maintenance_read_gate().await;
+            match run_ha_outbox_gc_once(
+                state.proxy.sqlite_database_path(),
+                HaOutboxGcOptions::default(),
+            )
+            .await
+            {
+                Ok(report) => finish(
+                    state,
+                    "success",
+                    format_ha_outbox_gc_report_message(&report, 1),
+                )
+                .await,
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -473,6 +473,7 @@ pub async fn serve(
     spawn_quota_sync_scheduler(state.clone());
     spawn_token_usage_rollup_scheduler(state.clone());
     spawn_auth_token_logs_gc_scheduler(state.clone());
+    spawn_ha_outbox_gc_scheduler(state.clone());
     spawn_mcp_sessions_gc_scheduler(state.clone());
     spawn_mcp_session_init_backoffs_gc_scheduler(state.clone());
     spawn_request_logs_gc_scheduler(state.clone());
@@ -582,140 +583,163 @@ async fn run_ha_standby_sync_once(
     internal_token: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let local_node_id = state.ha.status().await.node_id;
-    let applied_seq = state
-        .proxy
-        .get_ha_sync_watermark("standby_applied_seq")
-        .await?
-        .unwrap_or(0);
-    let baseline_applied = state
-        .proxy
-        .get_ha_sync_watermark("standby_baseline_applied")
-        .await?
-        .unwrap_or(0)
-        > 0;
-    let mut next_seq = applied_seq;
-    if !baseline_applied {
-        let target = format!("{}/api/admin/ha/baseline", source_url.trim_end_matches('/'));
+    for channel in [
+        tavily_hikari::HaSyncChannel::Control,
+        tavily_hikari::HaSyncChannel::Billing,
+        tavily_hikari::HaSyncChannel::Runtime,
+    ] {
+        let seq_key = format!("standby_{}_applied_seq", channel.as_str());
+        let baseline_key = format!("standby_{}_baseline_applied", channel.as_str());
+        let baseline_report_key = format!("standby_{}_baseline", channel.as_str());
+        let applied_seq = state
+            .proxy
+            .get_ha_sync_watermark(&seq_key)
+            .await?
+            .unwrap_or(0);
+        let baseline_applied = state
+            .proxy
+            .get_ha_sync_watermark(&baseline_key)
+            .await?
+            .unwrap_or(0)
+            > 0;
+        let mut next_seq = applied_seq;
+
+        if !baseline_applied {
+            let target = format!(
+                "{}/api/admin/ha/baseline?channel={}",
+                source_url.trim_end_matches('/'),
+                channel.as_str()
+            );
+            let response = client
+                .get(target)
+                .header("x-ha-internal-token", internal_token)
+                .send()
+                .await?;
+            if !response.status().is_success() {
+                return Err(format!(
+                    "baseline request failed for {} with {}",
+                    channel.as_str(),
+                    response.status()
+                )
+                .into());
+            }
+            let compressed = response.bytes().await?;
+            let decoded = zstd::stream::decode_all(compressed.as_ref())?;
+            let ndjson = String::from_utf8(decoded)?;
+            let result = state.proxy.apply_ha_baseline_ndjson(channel, &ndjson).await?;
+            next_seq = result.high_watermark;
+            state
+                .proxy
+                .persist_ha_sync_watermark(
+                    &baseline_report_key,
+                    Some(source_url),
+                    Some(&local_node_id),
+                    result.high_watermark,
+                    Some(&format!("rows={}", result.row_count)),
+                )
+                .await?;
+            state
+                .proxy
+                .persist_ha_sync_watermark(
+                    &seq_key,
+                    Some(source_url),
+                    Some(&local_node_id),
+                    result.high_watermark,
+                    Some("baseline"),
+                )
+                .await?;
+            state
+                .proxy
+                .persist_ha_sync_watermark(
+                    &baseline_key,
+                    Some(source_url),
+                    Some(&local_node_id),
+                    1,
+                    Some("baseline applied"),
+                )
+                .await?;
+        }
+
+        let target = format!(
+            "{}/api/admin/ha/events?channel={}&after={}&limit=1000",
+            source_url.trim_end_matches('/'),
+            channel.as_str(),
+            next_seq
+        );
         let response = client
             .get(target)
             .header("x-ha-internal-token", internal_token)
             .send()
             .await?;
+        if matches!(
+            response.status(),
+            reqwest::StatusCode::GONE | reqwest::StatusCode::PAYLOAD_TOO_LARGE
+        ) {
+            let reset_detail = if response.status() == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+                "events batch too large; baseline required"
+            } else {
+                "retention window missed; baseline required"
+            };
+            state
+                .proxy
+                .persist_ha_sync_watermark(
+                    &seq_key,
+                    Some(source_url),
+                    Some(&local_node_id),
+                    0,
+                    Some(reset_detail),
+                )
+                .await?;
+            state
+                .proxy
+                .persist_ha_sync_watermark(
+                    &baseline_key,
+                    Some(source_url),
+                    Some(&local_node_id),
+                    0,
+                    Some(reset_detail),
+                )
+                .await?;
+            continue;
+        }
         if !response.status().is_success() {
-            return Err(format!("baseline request failed with {}", response.status()).into());
+            return Err(format!(
+                "events request failed for {} with {}",
+                channel.as_str(),
+                response.status()
+            )
+            .into());
         }
         let compressed = response.bytes().await?;
         let decoded = zstd::stream::decode_all(compressed.as_ref())?;
         let ndjson = String::from_utf8(decoded)?;
-        let result = state.proxy.apply_ha_baseline_ndjson(&ndjson).await?;
-        next_seq = result.high_watermark;
-        state
-            .proxy
-            .persist_ha_sync_watermark(
-                "standby_baseline",
-                Some(source_url),
-                Some(&local_node_id),
-                result.high_watermark,
-                Some(&format!("rows={}", result.row_count)),
-            )
-            .await?;
-        state
-            .proxy
-            .persist_ha_sync_watermark(
-                "standby_applied_seq",
-                Some(source_url),
-                Some(&local_node_id),
-                result.high_watermark,
-                Some("baseline"),
-            )
-            .await?;
-        state
-            .proxy
-            .persist_ha_sync_watermark(
-                "standby_baseline_applied",
-                Some(source_url),
-                Some(&local_node_id),
-                1,
-                Some("baseline applied"),
-            )
+        let result = state.proxy.apply_ha_events_ndjson(channel, &ndjson).await?;
+        if result.high_watermark > next_seq {
+            next_seq = result.high_watermark;
+            state
+                .proxy
+                .persist_ha_sync_watermark(
+                    &seq_key,
+                    Some(source_url),
+                    Some(&local_node_id),
+                    next_seq,
+                    Some(&format!("events={}", result.row_count)),
+                )
+                .await?;
+        }
+        let ack_target = format!("{}/api/admin/ha/events/ack", source_url.trim_end_matches('/'));
+        let _ = client
+            .post(ack_target)
+            .header("x-ha-internal-token", internal_token)
+            .json(&serde_json::json!({
+                "channel": channel,
+                "peerNodeId": local_node_id,
+                "ackedSeq": next_seq
+            }))
+            .send()
             .await?;
     }
-
-    let target = format!(
-        "{}/api/admin/ha/events?after={}&limit=1000",
-        source_url.trim_end_matches('/'),
-        next_seq
-    );
-    let response = client
-        .get(target)
-        .header("x-ha-internal-token", internal_token)
-        .send()
-        .await?;
-    if matches!(
-        response.status(),
-        reqwest::StatusCode::GONE | reqwest::StatusCode::PAYLOAD_TOO_LARGE
-    ) {
-        let reset_detail = if response.status() == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
-            "events batch too large; baseline required"
-        } else {
-            "retention window missed; baseline required"
-        };
-        state
-            .proxy
-            .persist_ha_sync_watermark(
-                "standby_applied_seq",
-                Some(source_url),
-                Some(&local_node_id),
-                0,
-                Some(reset_detail),
-            )
-            .await?;
-        state
-            .proxy
-            .persist_ha_sync_watermark(
-                "standby_baseline_applied",
-                Some(source_url),
-                Some(&local_node_id),
-                0,
-                Some(reset_detail),
-            )
-            .await?;
-        state.proxy.flush_ha_state_writes().await?;
-        return Ok(());
-    }
-    if !response.status().is_success() {
-        return Err(format!("events request failed with {}", response.status()).into());
-    }
-    let compressed = response.bytes().await?;
-    let decoded = zstd::stream::decode_all(compressed.as_ref())?;
-    let ndjson = String::from_utf8(decoded)?;
-    let result = state.proxy.apply_ha_events_ndjson(&ndjson).await?;
-    if result.high_watermark > next_seq {
-        next_seq = result.high_watermark;
-        state
-            .proxy
-            .persist_ha_sync_watermark(
-                "standby_applied_seq",
-                Some(source_url),
-                Some(&local_node_id),
-                next_seq,
-                Some(&format!("events={}", result.row_count)),
-            )
-            .await?;
-    }
-    let ack_target = format!(
-        "{}/api/admin/ha/events/ack",
-        source_url.trim_end_matches('/')
-    );
-    let _ = client
-        .post(ack_target)
-        .header("x-ha-internal-token", internal_token)
-        .json(&serde_json::json!({
-            "peerNodeId": local_node_id,
-            "ackedSeq": next_seq
-        }))
-        .send()
-        .await?;
+    state.ha.mark_sync_success().await;
     state.proxy.flush_ha_state_writes().await?;
     Ok(())
 }

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -907,6 +907,112 @@ async fn ha_events_endpoint_returns_zstd_ndjson() {
     let _ = std::fs::remove_file(db_path);
 }
 
+#[tokio::test]
+async fn ha_events_endpoint_skips_legacy_non_control_rows_without_cursor_stall() {
+    let db_path = temp_db_path("ha-events-legacy-control-cursor");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-events-legacy-cursor-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'request_logs', 'legacy-1', 'upsert', '{"path":"/legacy-1"}', ?, 'legacy-1')
+        "#,
+    )
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert first legacy row");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'request_logs', 'legacy-2', 'upsert', '{"path":"/legacy-2"}', ?, 'legacy-2')
+        "#,
+    )
+    .bind(now + 1)
+    .execute(&pool)
+    .await
+    .expect("insert second legacy row");
+    let allowed_seq = sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'api_keys', 'key-2', 'upsert', '{"id":"key-2"}', ?, 'allowed')
+        "#,
+    )
+    .bind(now + 2)
+    .execute(&pool)
+    .await
+    .expect("insert allowed row")
+    .last_insert_rowid();
+    pool.close().await;
+
+    let events = proxy
+        .list_ha_events_after(tavily_hikari::HaSyncChannel::Control, 0, 2)
+        .await
+        .expect("list control events should skip legacy rows");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].seq, allowed_seq);
+    assert_eq!(events[0].resource, "api_keys");
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn ha_endpoints_require_explicit_channel_query() {
+    let db_path = temp_db_path("ha-channel-required");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-channel-required-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let ha = tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+        node_id: "node-channel-required".to_string(),
+        database_path: Some(db_str.clone()),
+        ..tavily_hikari::HaConfig::default()
+    });
+    let addr = spawn_ha_admin_server(proxy, ha, true).await;
+    let client = Client::new();
+
+    let baseline = client
+        .get(format!("http://{addr}/api/admin/ha/baseline"))
+        .send()
+        .await
+        .expect("baseline request");
+    assert_eq!(baseline.status(), reqwest::StatusCode::BAD_REQUEST);
+    let baseline_body = baseline.text().await.expect("baseline body");
+    assert!(
+        baseline_body.contains("missing required HA channel"),
+        "unexpected baseline error body: {baseline_body}"
+    );
+
+    let events = client
+        .get(format!("http://{addr}/api/admin/ha/events?after=0&limit=10"))
+        .send()
+        .await
+        .expect("events request");
+    assert_eq!(events.status(), reqwest::StatusCode::BAD_REQUEST);
+    let events_body = events.text().await.expect("events body");
+    assert!(
+        events_body.contains("missing required HA channel"),
+        "unexpected events error body: {events_body}"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
 #[test]
 fn ha_events_encoder_chunks_oversized_batches() {
     let events = (1..=4)

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -3,6 +3,8 @@ use super::core_support_and_parsing::*;
 use super::linuxdo_oauth_and_admin_keys::*;
 use super::upstream_support_and_manual_jobs::*;
 
+const TEST_SECS_PER_DAY: i64 = 24 * 60 * 60;
+
 #[tokio::test]
 async fn alerts_endpoints_and_dashboard_recent_alerts_share_default_window() {
     let db_path = temp_db_path("alerts-dashboard-default-window");
@@ -557,7 +559,214 @@ async fn ha_startup_clears_stale_outbox_suppression_marker() {
             .fetch_one(&pool)
             .await
             .expect("count emitted events");
-    assert_eq!(event_count, 1);
+    assert_eq!(event_count, 0);
+    pool.close().await;
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn ha_single_mode_does_not_emit_new_control_events() {
+    let db_path = temp_db_path("ha-single-no-control-events");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_in_ha_mode(
+        vec!["tvly-ha-single-mode-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+        tavily_hikari::TavilyProxyOptions::from_database_path(&db_str),
+        tavily_hikari::HaMode::Single,
+    )
+    .await
+    .expect("proxy created");
+    drop(proxy);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query("INSERT OR REPLACE INTO meta (key, value) VALUES ('request_rate_limit_v1', '77')")
+        .execute(&pool)
+        .await
+        .expect("write whitelisted meta");
+    let event_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count control outbox");
+    assert_eq!(event_count, 0);
+    pool.close().await;
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn ha_switching_back_to_single_disables_billing_and_runtime_triggers() {
+    let db_path = temp_db_path("ha-single-disables-non-control-triggers");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_in_ha_mode(
+        vec!["tvly-ha-single-disable-triggers-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+        tavily_hikari::TavilyProxyOptions::from_database_path(&db_str),
+        tavily_hikari::HaMode::ActiveStandby,
+    )
+    .await
+    .expect("proxy created");
+    drop(proxy);
+
+    let reopened = TavilyProxy::with_options_in_ha_mode(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        tavily_hikari::TavilyProxyOptions::from_database_path(&db_str),
+        tavily_hikari::HaMode::Single,
+    )
+    .await
+    .expect("proxy reopened in single mode");
+    drop(reopened);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let control_count_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count control outbox before single-mode writes");
+    let billing_count_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_billing_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count billing outbox before single-mode writes");
+    let runtime_count_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_runtime_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count runtime outbox before single-mode writes");
+    let trigger_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'trg_ha_%'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count remaining ha triggers");
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, display_name, username, active, created_at, updated_at)
+        VALUES ('user-ha-single-reopen', 'HA Single Reopen', 'ha_single_reopen', 1, 1, 1)
+        ON CONFLICT(id) DO NOTHING
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("seed user for runtime row");
+    sqlx::query(
+        r#"
+        INSERT INTO billing_ledger (
+            auth_token_log_id, token_id, billing_subject, billing_state, business_credits,
+            request_user_id, api_key_id, request_log_id, result_status, created_at, updated_at,
+            settled_at, error_message
+        ) VALUES (9101, 'tok-single-reopen', 'token:tok-single-reopen', 'charged', 2, NULL, NULL, NULL, 'success', 1, 1, 1, NULL)
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("insert billing row after single-mode reopen");
+    sqlx::query(
+        r#"
+        INSERT INTO account_quota_limits (
+            user_id, hourly_any_limit, hourly_limit, daily_limit, monthly_limit,
+            monthly_broken_limit, monthly_blocked_key_limit_delta, inherits_defaults,
+            created_at, updated_at
+        ) VALUES ('user-ha-single-reopen', 1, 2, 3, 4, 5, 0, 1, 1, 1)
+        ON CONFLICT(user_id) DO UPDATE SET updated_at = excluded.updated_at
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("insert runtime row after single-mode reopen");
+
+    let control_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count control outbox");
+    let billing_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_billing_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count billing outbox");
+    let runtime_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_runtime_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count runtime outbox");
+
+    assert_eq!(trigger_count, 0);
+    assert_eq!(control_count, control_count_before);
+    assert_eq!(billing_count, billing_count_before);
+    assert_eq!(runtime_count, runtime_count_before);
+    pool.close().await;
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn ha_billing_and_runtime_channels_do_not_route_into_control_outbox() {
+    let db_path = temp_db_path("ha-multichannel-outboxes");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_in_ha_mode(
+        vec!["tvly-ha-multichannel-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+        tavily_hikari::TavilyProxyOptions::from_database_path(&db_str),
+        tavily_hikari::HaMode::ActiveStandby,
+    )
+    .await
+    .expect("proxy created");
+    drop(proxy);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, display_name, username, active, created_at, updated_at)
+        VALUES ('user-runtime', 'Runtime User', 'runtime_user', 1, 1, 1)
+        ON CONFLICT(id) DO NOTHING
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("seed runtime user");
+    let control_count_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count initial control events");
+    sqlx::query(
+        r#"
+        INSERT INTO billing_ledger (
+            auth_token_log_id, token_id, billing_subject, billing_state, business_credits,
+            request_user_id, api_key_id, request_log_id, result_status, created_at, updated_at,
+            settled_at, error_message
+        ) VALUES (9001, 'tok-billing', 'token:tok-billing', 'charged', 3, NULL, NULL, NULL, 'success', 1, 1, 1, NULL)
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("insert billing row");
+    sqlx::query(
+        r#"
+        INSERT INTO account_quota_limits (
+            user_id, hourly_any_limit, hourly_limit, daily_limit, monthly_limit,
+            monthly_broken_limit, monthly_blocked_key_limit_delta, inherits_defaults,
+            created_at, updated_at
+        ) VALUES ('user-runtime', 1, 2, 3, 4, 5, 0, 1, 1, 1)
+        ON CONFLICT(user_id) DO UPDATE SET updated_at = excluded.updated_at
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("insert runtime row");
+
+    let control_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count control events");
+    let billing_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_billing_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count billing events");
+    let runtime_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_runtime_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count runtime events");
+
+    assert_eq!(control_count, control_count_before);
+    assert!(billing_count >= 1);
+    assert!(runtime_count >= 1);
     pool.close().await;
     let _ = std::fs::remove_file(db_path);
 }
@@ -596,7 +805,9 @@ async fn ha_baseline_uses_zstd_and_excludes_call_records() {
     });
     let active_addr = spawn_ha_admin_server(active_proxy, active_ha, true).await;
     let response = Client::new()
-        .get(format!("http://{active_addr}/api/admin/ha/baseline"))
+        .get(format!(
+            "http://{active_addr}/api/admin/ha/baseline?channel=control"
+        ))
         .send()
         .await
         .expect("baseline request");
@@ -672,7 +883,9 @@ async fn ha_events_endpoint_returns_zstd_ndjson() {
     });
     let addr = spawn_ha_admin_server(proxy, ha, true).await;
     let response = Client::new()
-        .get(format!("http://{addr}/api/admin/ha/events?after=0&limit=10"))
+        .get(format!(
+            "http://{addr}/api/admin/ha/events?channel=control&after=0&limit=10"
+        ))
         .send()
         .await
         .expect("events request");
@@ -700,10 +913,12 @@ fn ha_events_encoder_chunks_oversized_batches() {
         .map(|seq| HaEventResponseItem {
             seq,
             value: serde_json::json!({
-                "schemaVersion": 1,
+                "schemaVersion": 2,
                 "kind": "event",
+                "channel": "control",
                 "event": {
                     "seq": seq,
+                    "channel": "control",
                     "kind": "state",
                     "resource": "meta",
                     "resourceId": format!("request_rate_limit_v1-{seq}"),
@@ -718,13 +933,32 @@ fn ha_events_encoder_chunks_oversized_batches() {
             }),
         })
         .collect::<Vec<_>>();
-    let single = encode_ha_events_limited(0, 4, &events[..1], usize::MAX)
-        .expect("encode single event");
-    let full = encode_ha_events_limited(0, 4, &events, usize::MAX).expect("encode full batch");
+    let single = encode_ha_events_limited(
+        tavily_hikari::HaSyncChannel::Control,
+        0,
+        4,
+        &events[..1],
+        usize::MAX,
+    )
+    .expect("encode single event");
+    let full = encode_ha_events_limited(
+        tavily_hikari::HaSyncChannel::Control,
+        0,
+        4,
+        &events,
+        usize::MAX,
+    )
+    .expect("encode full batch");
     assert!(full.compressed.len() > single.compressed.len());
 
-    let chunked = encode_ha_events_limited(0, 4, &events, single.compressed.len())
-        .expect("chunk oversized batch");
+    let chunked = encode_ha_events_limited(
+        tavily_hikari::HaSyncChannel::Control,
+        0,
+        4,
+        &events,
+        single.compressed.len(),
+    )
+    .expect("chunk oversized batch");
     assert_eq!(chunked.event_count, 1);
     assert_eq!(chunked.last_seq, 1);
 }
@@ -755,19 +989,21 @@ async fn ha_events_storage_allows_nonzero_cursor_when_outbox_is_empty() {
     .unwrap_or(0);
     pool.close().await;
     let events = proxy
-        .list_ha_outbox_events_after(current_seq, 10)
+        .list_ha_events_after(tavily_hikari::HaSyncChannel::Control, current_seq, 10)
         .await
         .expect("empty retained outbox should not force baseline");
     assert!(events.is_empty());
 
     let pool = connect_sqlite_test_pool(&db_str).await;
+    let recent_ts = Utc::now().timestamp();
     let first_seq = sqlx::query(
         r#"
         INSERT INTO ha_outbox (kind, resource, resource_id, op, payload_json, created_at, checksum)
-        VALUES ('state', 'meta', 'request_rate_limit_v1', 'upsert', ?, 0, NULL)
+        VALUES ('state', 'meta', 'request_rate_limit_v1', 'upsert', ?, ?, NULL)
         "#,
     )
     .bind(serde_json::json!({"key":"request_rate_limit_v1","value":"55"}).to_string())
+    .bind(recent_ts)
     .execute(&pool)
     .await
     .expect("insert retained event")
@@ -775,25 +1011,86 @@ async fn ha_events_storage_allows_nonzero_cursor_when_outbox_is_empty() {
     let second_seq = sqlx::query(
         r#"
         INSERT INTO ha_outbox (kind, resource, resource_id, op, payload_json, created_at, checksum)
-        VALUES ('state', 'meta', 'api_rebalance_enabled_v1', 'upsert', ?, 0, NULL)
+        VALUES ('state', 'meta', 'api_rebalance_enabled_v1', 'upsert', ?, ?, NULL)
         "#,
     )
     .bind(serde_json::json!({"key":"api_rebalance_enabled_v1","value":"true"}).to_string())
+    .bind(recent_ts + 1)
         .execute(&pool)
         .await
         .expect("insert retained event")
         .last_insert_rowid();
     pool.close().await;
-    let err = proxy
-        .list_ha_outbox_events_after(first_seq, 10)
-        .await
-        .expect_err("pruned cursor should require baseline");
-    assert!(err.to_string().contains("retention window"));
     let events = proxy
-        .list_ha_outbox_events_after(second_seq, 10)
+        .list_ha_events_after(tavily_hikari::HaSyncChannel::Control, first_seq, 10)
         .await
-        .expect("current cursor can poll empty pruned outbox");
+        .expect("existing rows after cursor should still be returned");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].seq, second_seq);
+    assert_eq!(events[0].resource, "meta");
+    let events = proxy
+        .list_ha_events_after(tavily_hikari::HaSyncChannel::Control, second_seq, 10)
+        .await
+        .expect("current cursor can poll empty outbox after latest seq");
     assert!(events.is_empty());
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn ha_events_read_path_hides_expired_rows_without_deleting_them() {
+    let db_path = temp_db_path("ha-events-retention-read-filter");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-events-retention-filter-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let old_ts = Utc::now().timestamp() - (4 * TEST_SECS_PER_DAY);
+    let recent_ts = Utc::now().timestamp();
+    let old_seq = sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (kind, resource, resource_id, op, payload_json, created_at, checksum)
+        VALUES ('state', 'meta', 'request_rate_limit_v1', 'upsert', ?, ?, NULL)
+        "#,
+    )
+    .bind(serde_json::json!({"key":"request_rate_limit_v1","value":"55"}).to_string())
+    .bind(old_ts)
+    .execute(&pool)
+    .await
+    .expect("insert expired event")
+    .last_insert_rowid();
+    let recent_seq = sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (kind, resource, resource_id, op, payload_json, created_at, checksum)
+        VALUES ('state', 'meta', 'api_rebalance_enabled_v1', 'upsert', ?, ?, NULL)
+        "#,
+    )
+    .bind(serde_json::json!({"key":"api_rebalance_enabled_v1","value":"true"}).to_string())
+    .bind(recent_ts)
+    .execute(&pool)
+    .await
+    .expect("insert recent event")
+    .last_insert_rowid();
+    drop(pool);
+
+    let events = proxy
+        .list_ha_events_after(tavily_hikari::HaSyncChannel::Control, 0, 10)
+        .await
+        .expect("list retained events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].seq, recent_seq);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let stored_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE seq IN (?, ?)")
+        .bind(old_seq)
+        .bind(recent_seq)
+        .fetch_one(&pool)
+        .await
+        .expect("count persisted rows");
+    assert_eq!(stored_count, 2, "read path must not delete expired rows");
     let _ = std::fs::remove_file(db_path);
 }
 
@@ -834,7 +1131,7 @@ async fn ha_sync_transports_system_settings_meta_only() {
     active_pool.close().await;
 
     let baseline = active
-        .export_ha_baseline_ndjson("active-meta")
+        .export_ha_baseline_ndjson(tavily_hikari::HaSyncChannel::Control, "active-meta")
         .await
         .expect("export baseline");
     assert!(baseline.ndjson.contains("request_rate_limit_v1"));
@@ -842,7 +1139,7 @@ async fn ha_sync_transports_system_settings_meta_only() {
     assert!(!baseline.ndjson.contains("ha_unsynced_local_marker"));
 
     standby
-        .apply_ha_baseline_ndjson(&baseline.ndjson)
+        .apply_ha_baseline_ndjson(tavily_hikari::HaSyncChannel::Control, &baseline.ndjson)
         .await
         .expect("apply baseline");
     let standby_pool = connect_sqlite_test_pool(&standby_db_str).await;
@@ -861,6 +1158,10 @@ async fn ha_sync_transports_system_settings_meta_only() {
     standby_pool.close().await;
 
     let active_pool = connect_sqlite_test_pool(&active_db_str).await;
+    let before_seq: i64 = sqlx::query_scalar("SELECT COALESCE(MAX(seq), 0) FROM ha_outbox")
+        .fetch_one(&active_pool)
+        .await
+        .expect("read control watermark before update");
     sqlx::query("DELETE FROM ha_outbox")
         .execute(&active_pool)
         .await
@@ -879,24 +1180,10 @@ async fn ha_sync_transports_system_settings_meta_only() {
     active_pool.close().await;
 
     let events = active
-        .list_ha_outbox_events_after(0, 10)
+        .list_ha_events_after(tavily_hikari::HaSyncChannel::Control, before_seq, 10)
         .await
         .expect("list meta events");
-    assert_eq!(events.len(), 1, "only whitelisted meta should emit events");
-    assert_eq!(events[0].resource, "meta");
-    assert_eq!(events[0].payload["key"].as_str(), Some("request_rate_limit_v1"));
-    let events_ndjson = [
-        serde_json::json!({"schemaVersion":1,"kind":"events_start","after":0,"limit":10})
-            .to_string(),
-        serde_json::json!({"schemaVersion":1,"kind":"event","event":events[0]}).to_string(),
-        serde_json::json!({"schemaVersion":1,"kind":"events_end","lastSeq":events[0].seq,"eventCount":1})
-            .to_string(),
-    ]
-    .join("\n");
-    standby
-        .apply_ha_events_ndjson(&events_ndjson)
-        .await
-        .expect("apply meta event");
+    assert_eq!(events.len(), 0, "meta changes are baseline-only in channel v2");
     let standby_pool = connect_sqlite_test_pool(&standby_db_str).await;
     let request_rate_limit: Option<String> =
         sqlx::query_scalar("SELECT value FROM meta WHERE key = 'request_rate_limit_v1'")
@@ -908,7 +1195,7 @@ async fn ha_sync_transports_system_settings_meta_only() {
             .fetch_optional(&standby_pool)
             .await
             .expect("read unsynced updated meta");
-    assert_eq!(request_rate_limit.as_deref(), Some("55"));
+    assert_eq!(request_rate_limit.as_deref(), Some("42"));
     assert!(local_only.is_none());
     standby_pool.close().await;
 
@@ -922,8 +1209,9 @@ async fn ha_standby_sync_does_not_repeat_zero_watermark_baseline() {
     let events_count = Arc::new(AtomicUsize::new(0));
     let baseline_ndjson = [
         serde_json::json!({
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "kind": "baseline_start",
+            "channel": "control",
             "nodeId": "active-empty",
             "generatedAt": Utc::now().timestamp(),
             "highWatermark": 0,
@@ -931,8 +1219,9 @@ async fn ha_standby_sync_does_not_repeat_zero_watermark_baseline() {
         })
         .to_string(),
         serde_json::json!({
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "kind": "baseline_end",
+            "channel": "control",
             "nodeId": "active-empty",
             "highWatermark": 0,
             "rowCount": 0
@@ -942,15 +1231,17 @@ async fn ha_standby_sync_does_not_repeat_zero_watermark_baseline() {
     .join("\n");
     let events_ndjson = [
         serde_json::json!({
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "kind": "events_start",
+            "channel": "control",
             "after": 0,
             "limit": 1000
         })
         .to_string(),
         serde_json::json!({
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "kind": "events_end",
+            "channel": "control",
             "lastSeq": 0,
             "eventCount": 0
         })
@@ -1038,18 +1329,18 @@ async fn ha_standby_sync_does_not_repeat_zero_watermark_baseline() {
         .await
         .expect("second standby sync");
 
-    assert_eq!(baseline_count.load(Ordering::SeqCst), 1);
-    assert_eq!(events_count.load(Ordering::SeqCst), 2);
+    assert_eq!(baseline_count.load(Ordering::SeqCst), 3);
+    assert_eq!(events_count.load(Ordering::SeqCst), 6);
     assert_eq!(
         proxy
-            .get_ha_sync_watermark("standby_applied_seq")
+            .get_ha_sync_watermark("standby_control_applied_seq")
             .await
             .expect("read applied seq"),
         Some(0)
     );
     assert_eq!(
         proxy
-            .get_ha_sync_watermark("standby_baseline_applied")
+            .get_ha_sync_watermark("standby_control_baseline_applied")
             .await
             .expect("read baseline marker"),
         Some(1)
@@ -1076,7 +1367,7 @@ async fn ha_events_ack_records_peer_watermark() {
     let addr = spawn_ha_admin_server(proxy, ha, true).await;
     let response = Client::new()
         .post(format!("http://{addr}/api/admin/ha/events/ack"))
-        .json(&serde_json::json!({"peerNodeId":"standby-a","ackedSeq":42}))
+        .json(&serde_json::json!({"channel":"control","peerNodeId":"standby-a","ackedSeq":42}))
         .send()
         .await
         .expect("ack request");
@@ -1084,7 +1375,7 @@ async fn ha_events_ack_records_peer_watermark() {
 
     let pool = connect_sqlite_test_pool(&db_str).await;
     let acked: i64 =
-        sqlx::query_scalar("SELECT acked_seq FROM ha_peer_watermarks WHERE peer_node_id = 'standby-a'")
+        sqlx::query_scalar("SELECT acked_seq FROM ha_peer_watermarks WHERE peer_node_id = 'standby-a' AND channel = 'control'")
             .fetch_one(&pool)
             .await
             .expect("fetch peer watermark");
@@ -1107,7 +1398,7 @@ async fn ha_sync_watermark_reads_pending_overlay_before_flush() {
 
     proxy
         .persist_ha_sync_watermark(
-            "standby_applied_seq",
+            "standby_control_applied_seq",
             Some("source-a"),
             Some("target-a"),
             42,
@@ -1118,7 +1409,7 @@ async fn ha_sync_watermark_reads_pending_overlay_before_flush() {
 
     assert_eq!(
         proxy
-            .get_ha_sync_watermark("standby_applied_seq")
+            .get_ha_sync_watermark("standby_control_applied_seq")
             .await
             .expect("read pending watermark"),
         Some(42)
@@ -1131,7 +1422,7 @@ async fn ha_sync_watermark_reads_pending_overlay_before_flush() {
 
     assert_eq!(
         proxy
-            .get_ha_sync_watermark("standby_applied_seq")
+            .get_ha_sync_watermark("standby_control_applied_seq")
             .await
             .expect("read flushed watermark"),
         Some(42)
@@ -1204,12 +1495,14 @@ async fn ha_event_apply_preserves_foreign_keys_and_composite_deletes() {
     pool.close().await;
 
     let events = serde_json::json!([
-        {"schemaVersion":1,"kind":"events_start","after":0,"limit":10},
+        {"schemaVersion":2,"kind":"events_start","channel":"control","after":0,"limit":10},
         {
-            "schemaVersion":1,
+            "schemaVersion":2,
             "kind":"event",
+            "channel":"control",
             "event":{
                 "seq":1,
+                "channel":"control",
                 "kind":"state",
                 "resource":"api_keys",
                 "resourceId":"key-ha-apply",
@@ -1226,10 +1519,12 @@ async fn ha_event_apply_preserves_foreign_keys_and_composite_deletes() {
             }
         },
         {
-            "schemaVersion":1,
+            "schemaVersion":2,
             "kind":"event",
+            "channel":"control",
             "event":{
                 "seq":2,
+                "channel":"control",
                 "kind":"state",
                 "resource":"token_api_key_bindings",
                 "resourceId":"not-the-standby-rowid",
@@ -1243,10 +1538,12 @@ async fn ha_event_apply_preserves_foreign_keys_and_composite_deletes() {
             }
         },
         {
-            "schemaVersion":1,
+            "schemaVersion":2,
             "kind":"event",
+            "channel":"control",
             "event":{
                 "seq":3,
+                "channel":"control",
                 "kind":"state",
                 "resource":"api_key_maintenance_records",
                 "resourceId":"maint-ha-apply",
@@ -1266,7 +1563,7 @@ async fn ha_event_apply_preserves_foreign_keys_and_composite_deletes() {
                 "checksum":null
             }
         },
-        {"schemaVersion":1,"kind":"events_end","lastSeq":3,"eventCount":3}
+        {"schemaVersion":2,"kind":"events_end","channel":"control","lastSeq":3,"eventCount":3}
     ]);
     let ndjson = events
         .as_array()
@@ -1277,7 +1574,7 @@ async fn ha_event_apply_preserves_foreign_keys_and_composite_deletes() {
         .join("\n")
         + "\n";
     let result = proxy
-        .apply_ha_events_ndjson(&ndjson)
+        .apply_ha_events_ndjson(tavily_hikari::HaSyncChannel::Control, &ndjson)
         .await
         .expect("apply ha events");
     assert_eq!(result.high_watermark, 3);

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -234,9 +234,9 @@ impl KeyStore {
                     request_log_id INTEGER,
                     result_status TEXT NOT NULL,
                     created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
                     settled_at INTEGER,
-                    error_message TEXT,
-                    FOREIGN KEY (auth_token_log_id) REFERENCES auth_token_logs(id) ON DELETE CASCADE
+                    error_message TEXT
                 )
                 "#,
             )
@@ -255,6 +255,7 @@ impl KeyStore {
                     request_log_id,
                     result_status,
                     created_at,
+                    updated_at,
                     settled_at,
                     error_message
                 )
@@ -269,6 +270,7 @@ impl KeyStore {
                     request_log_id,
                     result_status,
                     created_at,
+                    COALESCE(updated_at, created_at),
                     settled_at,
                     error_message
                 FROM billing_ledger
@@ -296,6 +298,105 @@ impl KeyStore {
         rebuild_result?;
         reenable?;
         self.ensure_billing_ledger_indexes().await?;
+        Ok(())
+    }
+
+    async fn ensure_billing_ledger_ha_shape(&self) -> Result<(), ProxyError> {
+        let missing_updated_at = self.main_table_exists("billing_ledger").await?
+            && !self.table_column_exists("billing_ledger", "updated_at").await?;
+        let has_auth_token_fk = self
+            .table_has_foreign_key_to("billing_ledger", "auth_token_logs")
+            .await?;
+        if !missing_updated_at && !has_auth_token_fk {
+            return Ok(());
+        }
+        self.rebuild_billing_ledger_without_request_log_foreign_key()
+            .await
+    }
+
+    async fn rebuild_ha_peer_watermarks_for_channels(&self) -> Result<(), ProxyError> {
+        if !self.main_table_exists("ha_peer_watermarks").await? {
+            return Ok(());
+        }
+
+        let mut conn = self.pool.acquire().await?;
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&mut *conn)
+            .await?;
+        let rebuild_result = async {
+            sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+            sqlx::query("DROP TABLE IF EXISTS ha_peer_watermarks_new")
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query(
+                r#"
+                CREATE TABLE ha_peer_watermarks_new (
+                    peer_node_id TEXT NOT NULL,
+                    channel TEXT NOT NULL DEFAULT 'control',
+                    acked_seq INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    PRIMARY KEY (peer_node_id, channel)
+                )
+                "#,
+            )
+            .execute(&mut *conn)
+            .await?;
+            sqlx::query(
+                r#"
+                INSERT INTO ha_peer_watermarks_new (peer_node_id, channel, acked_seq, updated_at)
+                SELECT
+                    peer_node_id,
+                    COALESCE(channel, 'control'),
+                    acked_seq,
+                    updated_at
+                FROM ha_peer_watermarks
+                "#,
+            )
+            .execute(&mut *conn)
+            .await?;
+            sqlx::query("DROP TABLE ha_peer_watermarks")
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query("ALTER TABLE ha_peer_watermarks_new RENAME TO ha_peer_watermarks")
+                .execute(&mut *conn)
+                .await?;
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            Ok::<(), ProxyError>(())
+        }
+        .await;
+
+        if rebuild_result.is_err() {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        }
+        let reenable = sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&mut *conn)
+            .await;
+        rebuild_result?;
+        reenable?;
+        Ok(())
+    }
+
+    async fn ensure_ha_peer_watermarks_shape(&self) -> Result<(), ProxyError> {
+        if !self.main_table_exists("ha_peer_watermarks").await? {
+            return Ok(());
+        }
+        let missing_channel = !self.table_column_exists("ha_peer_watermarks", "channel").await?;
+        if missing_channel {
+            return self.rebuild_ha_peer_watermarks_for_channels().await;
+        }
+
+        let pk_rows = sqlx::query(
+            "SELECT name, pk FROM pragma_table_info('ha_peer_watermarks') WHERE pk > 0 ORDER BY pk ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        let pk_columns = pk_rows
+            .into_iter()
+            .map(|row| row.try_get::<String, _>("name"))
+            .collect::<Result<Vec<_>, _>>()?;
+        if pk_columns != vec!["peer_node_id".to_string(), "channel".to_string()] {
+            return self.rebuild_ha_peer_watermarks_for_channels().await;
+        }
         Ok(())
     }
 
@@ -523,6 +624,12 @@ impl KeyStore {
         sqlx::query(
             r#"CREATE INDEX IF NOT EXISTS idx_billing_ledger_charged_window
                ON billing_ledger(billing_state, created_at, auth_token_log_id)"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_billing_ledger_updated_at
+               ON billing_ledger(updated_at, auth_token_log_id)"#,
         )
         .execute(&self.pool)
         .await?;
@@ -1449,14 +1556,15 @@ impl KeyStore {
                 request_log_id INTEGER,
                 result_status TEXT NOT NULL,
                 created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
                 settled_at INTEGER,
-                error_message TEXT,
-                FOREIGN KEY (auth_token_log_id) REFERENCES auth_token_logs(id) ON DELETE CASCADE
+                error_message TEXT
             )
             "#,
         )
         .execute(&self.pool)
         .await?;
+        self.ensure_billing_ledger_ha_shape().await?;
         self.ensure_billing_ledger_indexes().await?;
 
         // Upgrade: add mcp_status column if missing
@@ -2286,6 +2394,7 @@ impl KeyStore {
                 request_log_id,
                 result_status,
                 created_at,
+                updated_at,
                 settled_at,
                 error_message
             )
@@ -2299,6 +2408,7 @@ impl KeyStore {
                 atl.api_key_id,
                 atl.request_log_id,
                 atl.result_status,
+                atl.created_at,
                 atl.created_at,
                 CASE
                     WHEN atl.billing_state = 'charged' THEN atl.created_at
@@ -2319,6 +2429,7 @@ impl KeyStore {
                 request_log_id = excluded.request_log_id,
                 result_status = excluded.result_status,
                 created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
                 settled_at = excluded.settled_at,
                 error_message = excluded.error_message
             "#,
@@ -2460,6 +2571,38 @@ impl KeyStore {
         .await?;
         sqlx::query(
             r#"
+            CREATE TABLE IF NOT EXISTS ha_billing_outbox (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                kind TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                resource_id TEXT NOT NULL,
+                op TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                checksum TEXT
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS ha_runtime_outbox (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                kind TEXT NOT NULL,
+                resource TEXT NOT NULL,
+                resource_id TEXT NOT NULL,
+                op TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                checksum TEXT
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
             CREATE TABLE IF NOT EXISTS ha_outbox_suppression (
                 id TEXT PRIMARY KEY CHECK (id = 'local')
             )
@@ -2482,20 +2625,33 @@ impl KeyStore {
         )
         .execute(&self.pool)
         .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_ha_billing_outbox_created
+               ON ha_billing_outbox(created_at, seq)"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_ha_runtime_outbox_created
+               ON ha_runtime_outbox(created_at, seq)"#,
+        )
+        .execute(&self.pool)
+        .await?;
 
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS ha_peer_watermarks (
-                peer_node_id TEXT PRIMARY KEY,
+                peer_node_id TEXT NOT NULL,
+                channel TEXT NOT NULL DEFAULT 'control',
                 acked_seq INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (peer_node_id, channel)
             )
             "#,
         )
         .execute(&self.pool)
         .await?;
-
-        self.ensure_ha_outbox_triggers().await?;
+        self.ensure_ha_peer_watermarks_shape().await?;
 
         Ok(())
     }

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -211,6 +211,12 @@ impl KeyStore {
         if !self.main_table_exists("billing_ledger").await? {
             return Ok(());
         }
+        let has_updated_at = self.table_column_exists("billing_ledger", "updated_at").await?;
+        let updated_at_select_expr = if has_updated_at {
+            "updated_at"
+        } else {
+            "created_at"
+        };
 
         let mut conn = self.pool.acquire().await?;
         sqlx::query("PRAGMA foreign_keys = OFF")
@@ -242,7 +248,7 @@ impl KeyStore {
             )
             .execute(&mut *conn)
             .await?;
-            sqlx::query(
+            let copy_sql = format!(
                 r#"
                 INSERT INTO billing_ledger_new (
                     auth_token_log_id,
@@ -270,14 +276,13 @@ impl KeyStore {
                     request_log_id,
                     result_status,
                     created_at,
-                    COALESCE(updated_at, created_at),
+                    {updated_at_select_expr},
                     settled_at,
                     error_message
                 FROM billing_ledger
-                "#,
-            )
-            .execute(&mut *conn)
-            .await?;
+                "#
+            );
+            sqlx::query(&copy_sql).execute(&mut *conn).await?;
             sqlx::query("DROP TABLE billing_ledger")
                 .execute(&mut *conn)
                 .await?;

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Debug)]
 pub struct HaBaselineExport {
+    pub channel: HaSyncChannel,
     pub ndjson: String,
     pub high_watermark: i64,
     pub row_count: usize,
@@ -7,7 +8,8 @@ pub struct HaBaselineExport {
 
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct HaOutboxEventRecord {
+pub struct HaEventRecord {
+    pub channel: HaSyncChannel,
     pub seq: i64,
     pub kind: String,
     pub resource: String,
@@ -20,53 +22,83 @@ pub struct HaOutboxEventRecord {
 
 #[derive(Clone, Debug)]
 pub struct HaApplyResult {
+    pub channel: HaSyncChannel,
     pub high_watermark: i64,
     pub row_count: usize,
 }
 
-const HA_BASELINE_SCHEMA_VERSION: i64 = 1;
-const HA_OUTBOX_RETENTION_SECS: i64 = 72 * 60 * 60;
+const HA_SCHEMA_VERSION: i64 = 2;
+const HA_CONTROL_OUTBOX_RETENTION_SECS: i64 = 72 * 60 * 60;
+const HA_CHANNEL_EXPORT_RETENTION_SECS: i64 = 92 * 24 * 60 * 60;
 
-const HA_BASELINE_TABLES: &[&str] = &[
-    "account_monthly_quota",
-    "account_quota_limit_snapshots",
-    "account_quota_limits",
-    "account_usage_buckets",
-    "account_usage_rollup_buckets",
+const HA_CONTROL_BASELINE_TABLES: &[&str] = &[
     "announcements",
     "api_key_low_quota_depletions",
     "api_key_maintenance_records",
     "api_key_quarantines",
-    "api_key_quota_sync_samples",
-    "api_key_transient_backoffs",
-    "api_key_user_usage_buckets",
     "api_keys",
-    "auth_token_quota",
     "auth_tokens",
-    "billing_ledger",
-    "forward_proxy_key_affinity",
-    "forward_proxy_node_overrides",
     "forward_proxy_settings",
-    "http_project_api_key_affinity",
     "linuxdo_credit_recharge_entitlements",
     "linuxdo_credit_recharge_orders",
     "meta",
-    "mcp_sessions",
     "oauth_accounts",
-    "quota_subject_locks",
-    "request_rate_limit_snapshots",
-    "scheduled_jobs",
-    "subject_key_breakages",
     "token_api_key_bindings",
-    "token_primary_api_key_affinity",
-    "token_usage_buckets",
-    "token_usage_stats",
     "user_api_key_bindings",
-    "user_primary_api_key_affinity",
     "user_tag_bindings",
     "user_tags",
     "user_token_bindings",
     "users",
+];
+
+const HA_CONTROL_EVENT_TABLES: &[&str] = &[
+    "announcements",
+    "api_key_low_quota_depletions",
+    "api_key_maintenance_records",
+    "api_key_quarantines",
+    "api_keys",
+    "auth_tokens",
+    "forward_proxy_settings",
+    "linuxdo_credit_recharge_entitlements",
+    "linuxdo_credit_recharge_orders",
+    "meta",
+    "oauth_accounts",
+    "token_api_key_bindings",
+    "user_api_key_bindings",
+    "user_tag_bindings",
+    "user_tags",
+    "user_token_bindings",
+    "users",
+];
+
+const HA_BILLING_BASELINE_TABLES: &[&str] = &["billing_ledger"];
+
+const HA_RUNTIME_BASELINE_TABLES: &[&str] = &[
+    "account_monthly_quota",
+    "account_quota_limits",
+    "account_usage_buckets",
+    "auth_token_quota",
+    "forward_proxy_key_affinity",
+    "forward_proxy_node_overrides",
+    "http_project_api_key_affinity",
+    "mcp_sessions",
+    "token_primary_api_key_affinity",
+    "token_usage_buckets",
+    "user_primary_api_key_affinity",
+];
+
+const HA_RUNTIME_EVENT_TABLES: &[&str] = &[
+    "account_monthly_quota",
+    "account_quota_limits",
+    "account_usage_buckets",
+    "auth_token_quota",
+    "forward_proxy_key_affinity",
+    "forward_proxy_node_overrides",
+    "http_project_api_key_affinity",
+    "mcp_sessions",
+    "token_primary_api_key_affinity",
+    "token_usage_buckets",
+    "user_primary_api_key_affinity",
 ];
 
 const HA_META_KEYS: &[&str] = &[
@@ -84,6 +116,51 @@ const HA_META_KEYS: &[&str] = &[
     "trusted_proxy_cidrs_v1",
     "user_blocked_key_base_limit_v1",
 ];
+
+fn ha_baseline_tables(channel: HaSyncChannel) -> &'static [&'static str] {
+    match channel {
+        HaSyncChannel::Control => HA_CONTROL_BASELINE_TABLES,
+        HaSyncChannel::Billing => HA_BILLING_BASELINE_TABLES,
+        HaSyncChannel::Runtime => HA_RUNTIME_BASELINE_TABLES,
+    }
+}
+
+fn ha_resource_allowed_for_channel(channel: HaSyncChannel, resource: &str) -> bool {
+    if ha_baseline_tables(channel).contains(&resource) {
+        return true;
+    }
+    if channel == HaSyncChannel::Control && resource == "meta" {
+        return true;
+    }
+    false
+}
+
+fn ha_channel_event_table(channel: HaSyncChannel) -> &'static str {
+    match channel {
+        HaSyncChannel::Control => "ha_outbox",
+        HaSyncChannel::Billing => "ha_billing_outbox",
+        HaSyncChannel::Runtime => "ha_runtime_outbox",
+    }
+}
+
+fn ha_channel_sequence_name(channel: HaSyncChannel) -> &'static str {
+    ha_channel_event_table(channel)
+}
+
+fn ha_channel_event_tables(channel: HaSyncChannel) -> &'static [&'static str] {
+    match channel {
+        HaSyncChannel::Control => HA_CONTROL_EVENT_TABLES,
+        HaSyncChannel::Billing => HA_BILLING_BASELINE_TABLES,
+        HaSyncChannel::Runtime => HA_RUNTIME_EVENT_TABLES,
+    }
+}
+
+fn ha_channel_retention_secs(channel: HaSyncChannel) -> i64 {
+    match channel {
+        HaSyncChannel::Control => HA_CONTROL_OUTBOX_RETENTION_SECS,
+        HaSyncChannel::Billing | HaSyncChannel::Runtime => HA_CHANNEL_EXPORT_RETENTION_SECS,
+    }
+}
 
 impl KeyStore {
     pub(crate) async fn persist_ha_node_state(
@@ -235,15 +312,17 @@ impl KeyStore {
 
     pub(crate) async fn export_ha_baseline_ndjson(
         &self,
+        channel: HaSyncChannel,
         node_id: &str,
     ) -> Result<HaBaselineExport, ProxyError> {
-        let high_watermark = self.ha_outbox_high_watermark().await?;
+        let high_watermark = self.ha_channel_high_watermark(channel).await?;
         let mut ndjson = String::new();
         let mut row_count = 0_usize;
         ndjson.push_str(
             &serde_json::to_string(&serde_json::json!({
-                "schemaVersion": HA_BASELINE_SCHEMA_VERSION,
+                "schemaVersion": HA_SCHEMA_VERSION,
                 "kind": "baseline_start",
+                "channel": channel,
                 "nodeId": node_id,
                 "generatedAt": self.backend_time.now_ts(),
                 "highWatermark": high_watermark,
@@ -253,7 +332,7 @@ impl KeyStore {
         );
         ndjson.push('\n');
 
-        for table in HA_BASELINE_TABLES {
+        for table in ha_baseline_tables(channel) {
             if !self.table_exists(table).await? {
                 continue;
             }
@@ -263,8 +342,9 @@ impl KeyStore {
                 let row = sanitize_ha_resource_payload(table, row);
                 ndjson.push_str(
                     &serde_json::to_string(&serde_json::json!({
-                        "schemaVersion": HA_BASELINE_SCHEMA_VERSION,
+                        "schemaVersion": HA_SCHEMA_VERSION,
                         "kind": "resource",
+                        "channel": channel,
                         "resource": table,
                         "op": "upsert",
                         "data": row
@@ -277,8 +357,9 @@ impl KeyStore {
 
         ndjson.push_str(
             &serde_json::to_string(&serde_json::json!({
-                "schemaVersion": HA_BASELINE_SCHEMA_VERSION,
+                "schemaVersion": HA_SCHEMA_VERSION,
                 "kind": "baseline_end",
+                "channel": channel,
                 "nodeId": node_id,
                 "highWatermark": high_watermark,
                 "rowCount": row_count
@@ -287,15 +368,22 @@ impl KeyStore {
         );
         ndjson.push('\n');
         Ok(HaBaselineExport {
+            channel,
             ndjson,
             high_watermark,
             row_count,
         })
     }
 
-    pub(crate) async fn ha_outbox_high_watermark(&self) -> Result<i64, ProxyError> {
+    pub(crate) async fn ha_channel_high_watermark(
+        &self,
+        channel: HaSyncChannel,
+    ) -> Result<i64, ProxyError> {
         Ok(
-            sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(seq) FROM ha_outbox")
+            sqlx::query_scalar::<_, Option<i64>>(&format!(
+                "SELECT MAX(seq) FROM {}",
+                quote_sqlite_identifier(ha_channel_event_table(channel))
+            ))
                 .fetch_one(&self.pool)
                 .await?
                 .unwrap_or(0),
@@ -316,6 +404,7 @@ impl KeyStore {
 
     pub(crate) async fn apply_ha_baseline_ndjson(
         &self,
+        channel: HaSyncChannel,
         ndjson: &str,
     ) -> Result<HaApplyResult, ProxyError> {
         let mut high_watermark = 0_i64;
@@ -344,7 +433,7 @@ impl KeyStore {
                         .ok_or_else(|| {
                             ProxyError::Other("HA baseline resource is missing".to_string())
                         })?;
-                    ensure_ha_resource_whitelisted(resource)?;
+                    ensure_ha_resource_whitelisted(channel, resource)?;
                     let data = value.get("data").cloned().ok_or_else(|| {
                         ProxyError::Other("HA baseline resource data is missing".to_string())
                     })?;
@@ -379,7 +468,7 @@ impl KeyStore {
         sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
         let result = async {
             insert_ha_outbox_suppression_on_conn(&mut conn).await?;
-            for table in HA_BASELINE_TABLES {
+            for table in ha_baseline_tables(channel) {
                 if self.table_exists(table).await? {
                     let sql = if *table == "meta" {
                         format!(
@@ -394,7 +483,7 @@ impl KeyStore {
                 }
             }
             for (resource, data) in &resources {
-                insert_json_row_on_conn(&mut conn, resource, data).await?;
+                insert_json_row_on_conn(&mut conn, channel, resource, data).await?;
                 row_count += 1;
             }
             clear_ha_outbox_suppression_on_conn(&mut conn).await?;
@@ -408,6 +497,7 @@ impl KeyStore {
                     .execute(&mut *conn)
                     .await?;
                 Ok(HaApplyResult {
+                    channel,
                     high_watermark,
                     row_count,
                 })
@@ -424,6 +514,7 @@ impl KeyStore {
 
     pub(crate) async fn apply_ha_events_ndjson(
         &self,
+        channel: HaSyncChannel,
         ndjson: &str,
     ) -> Result<HaApplyResult, ProxyError> {
         let mut last_seq = 0_i64;
@@ -442,7 +533,7 @@ impl KeyStore {
                         .get("resource")
                         .and_then(serde_json::Value::as_str)
                         .ok_or_else(|| ProxyError::Other("HA event resource is missing".to_string()))?;
-                    ensure_ha_resource_whitelisted(resource)?;
+                    ensure_ha_resource_whitelisted(channel, resource)?;
                     let op = event.get("op").and_then(serde_json::Value::as_str).unwrap_or("upsert");
                     let resource_id = event
                         .get("resourceId")
@@ -480,9 +571,12 @@ impl KeyStore {
             for (resource, resource_id, op, payload) in &events {
                 match op.as_str() {
                     "delete" => {
-                        delete_json_row_on_conn(&mut conn, resource, resource_id, payload).await?
+                        delete_json_row_on_conn(&mut conn, channel, resource, resource_id, payload)
+                            .await?
                     }
-                    "upsert" => insert_json_row_on_conn(&mut conn, resource, payload).await?,
+                    "upsert" => {
+                        insert_json_row_on_conn(&mut conn, channel, resource, payload).await?
+                    }
                     other => {
                         return Err(ProxyError::Other(format!(
                             "unsupported HA event operation: {other}"
@@ -499,6 +593,7 @@ impl KeyStore {
             Ok(()) => {
                 sqlx::query("COMMIT").execute(&mut *conn).await?;
                 Ok(HaApplyResult {
+                    channel,
                     high_watermark: last_seq,
                     row_count,
                 })
@@ -510,22 +605,29 @@ impl KeyStore {
         }
     }
 
-    pub(crate) async fn list_ha_outbox_events_after(
+    pub(crate) async fn list_ha_events_after(
         &self,
+        channel: HaSyncChannel,
         after_seq: i64,
         limit: i64,
-    ) -> Result<Vec<HaOutboxEventRecord>, ProxyError> {
-        self.prune_ha_outbox_retention().await?;
-        let min_seq: Option<i64> = sqlx::query_scalar("SELECT MIN(seq) FROM ha_outbox")
+    ) -> Result<Vec<HaEventRecord>, ProxyError> {
+        let table = quote_sqlite_identifier(ha_channel_event_table(channel));
+        let threshold = self.backend_time.now_ts() - ha_channel_retention_secs(channel);
+        let min_seq: Option<i64> = sqlx::query_scalar(&format!(
+            "SELECT MIN(seq) FROM {table} WHERE created_at >= ?"
+        ))
+            .bind(threshold)
             .fetch_one(&self.pool)
             .await?;
-        let last_seq: Option<i64> =
-            sqlx::query_scalar("SELECT seq FROM sqlite_sequence WHERE name = 'ha_outbox'")
+        let last_seq: Option<i64> = sqlx::query_scalar(&format!(
+            "SELECT seq FROM sqlite_sequence WHERE name = {}",
+            quote_sqlite_string(ha_channel_sequence_name(channel))
+        ))
                 .fetch_optional(&self.pool)
                 .await?;
         if min_seq.is_none() && after_seq > 0 && last_seq.unwrap_or(0) > after_seq {
             return Err(ProxyError::Other(
-                "HA outbox cursor is older than retention window".to_string(),
+                format!("HA {} cursor is older than retention window", channel.as_str()),
             ));
         }
         if let Some(min_seq) = min_seq
@@ -533,66 +635,68 @@ impl KeyStore {
             && after_seq < min_seq.saturating_sub(1)
         {
             return Err(ProxyError::Other(
-                "HA outbox cursor is older than retention window".to_string(),
+                format!("HA {} cursor is older than retention window", channel.as_str()),
             ));
         }
-        let whitelist_sql = HA_BASELINE_TABLES
-            .iter()
-            .map(|table| quote_sqlite_string(table))
-            .collect::<Vec<_>>()
-            .join(", ");
         let sql = format!(
             r#"
             SELECT seq, kind, resource, resource_id, op, payload_json, created_at, checksum
-              FROM ha_outbox
+              FROM {table}
              WHERE seq > ?
-               AND resource IN ({whitelist_sql})
+               AND created_at >= ?
              ORDER BY seq ASC
              LIMIT ?
             "#
         );
         let rows = sqlx::query(&sql)
-        .bind(after_seq.max(0))
-        .bind(limit.clamp(1, 1000))
-        .fetch_all(&self.pool)
-        .await?;
+            .bind(after_seq.max(0))
+            .bind(threshold)
+            .bind(limit.clamp(1, 1000))
+            .fetch_all(&self.pool)
+            .await?;
 
-        rows.into_iter()
-            .map(|row| {
-                let payload_raw: String = row.try_get("payload_json")?;
-                let payload = serde_json::from_str(&payload_raw)
-                    .map_err(|err| ProxyError::Other(format!("invalid HA outbox payload: {err}")))?;
-                let resource: String = row.try_get("resource")?;
-                let payload = sanitize_ha_resource_payload(&resource, payload);
-                Ok(HaOutboxEventRecord {
-                    seq: row.try_get("seq")?,
-                    kind: row.try_get("kind")?,
-                    resource,
-                    resource_id: row.try_get("resource_id")?,
-                    op: row.try_get("op")?,
-                    payload,
-                    created_at: row.try_get("created_at")?,
-                    checksum: row.try_get("checksum")?,
-                })
-            })
-            .collect()
+        let mut events = Vec::new();
+        for row in rows {
+            let resource: String = row.try_get("resource")?;
+            if !ha_resource_allowed_for_channel(channel, &resource) {
+                continue;
+            }
+            let payload_raw: String = row.try_get("payload_json")?;
+            let payload = serde_json::from_str(&payload_raw)
+                .map_err(|err| ProxyError::Other(format!("invalid HA outbox payload: {err}")))?;
+            let payload = sanitize_ha_resource_payload(&resource, payload);
+            events.push(HaEventRecord {
+                channel,
+                seq: row.try_get("seq")?,
+                kind: row.try_get("kind")?,
+                resource,
+                resource_id: row.try_get("resource_id")?,
+                op: row.try_get("op")?,
+                payload,
+                created_at: row.try_get("created_at")?,
+                checksum: row.try_get("checksum")?,
+            });
+        }
+        Ok(events)
     }
 
     pub(crate) async fn ack_ha_peer_watermark(
         &self,
+        channel: HaSyncChannel,
         peer_node_id: &str,
         acked_seq: i64,
     ) -> Result<(), ProxyError> {
         sqlx::query(
             r#"
-            INSERT INTO ha_peer_watermarks (peer_node_id, acked_seq, updated_at)
-            VALUES (?, ?, ?)
-            ON CONFLICT(peer_node_id) DO UPDATE SET
+            INSERT INTO ha_peer_watermarks (peer_node_id, channel, acked_seq, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(peer_node_id, channel) DO UPDATE SET
                 acked_seq = MAX(ha_peer_watermarks.acked_seq, excluded.acked_seq),
                 updated_at = excluded.updated_at
             "#,
         )
         .bind(peer_node_id)
+        .bind(channel.as_str())
         .bind(acked_seq.max(0))
         .bind(self.backend_time.now_ts())
         .execute(&self.pool)
@@ -603,13 +707,14 @@ impl KeyStore {
     #[allow(dead_code)]
     pub(crate) async fn insert_ha_outbox_event(
         &self,
+        channel: HaSyncChannel,
         kind: &str,
         resource: &str,
         resource_id: &str,
         op: &str,
         payload: &serde_json::Value,
     ) -> Result<i64, ProxyError> {
-        if !HA_BASELINE_TABLES.contains(&resource) {
+        if ensure_ha_resource_whitelisted(channel, resource).is_err() {
             return Err(ProxyError::Other(format!(
                 "HA outbox resource is not whitelisted: {resource}"
             )));
@@ -617,13 +722,16 @@ impl KeyStore {
         let payload_json =
             serde_json::to_string(payload).map_err(|err| ProxyError::Other(err.to_string()))?;
         let checksum = sha256_hex_bytes(payload_json.as_bytes());
+        let table = quote_sqlite_identifier(ha_channel_event_table(channel));
         let result = sqlx::query(
-            r#"
-            INSERT INTO ha_outbox (
+            &format!(
+                r#"
+            INSERT INTO {table} (
                 kind, resource, resource_id, op, payload_json, created_at, checksum
             )
             VALUES (?, ?, ?, ?, ?, ?, ?)
-            "#,
+            "#
+            ),
         )
         .bind(kind)
         .bind(resource)
@@ -821,9 +929,27 @@ impl KeyStore {
         Self::table_columns_on_conn(&mut conn, table).await
     }
 
-    pub(crate) async fn ensure_ha_outbox_triggers(&self) -> Result<(), ProxyError> {
+    pub(crate) async fn configure_ha_event_writes(&self, mode: HaMode) -> Result<(), ProxyError> {
+        self.drop_ha_channel_triggers(HaSyncChannel::Control).await?;
+        self.drop_ha_channel_triggers(HaSyncChannel::Billing).await?;
+        self.drop_ha_channel_triggers(HaSyncChannel::Runtime).await?;
+        if mode == HaMode::Single {
+            return Ok(());
+        }
+        self.ensure_ha_channel_outbox_triggers(HaSyncChannel::Control)
+            .await?;
+        self.ensure_ha_channel_outbox_triggers(HaSyncChannel::Billing)
+            .await?;
+        self.ensure_ha_channel_outbox_triggers(HaSyncChannel::Runtime)
+            .await
+    }
+
+    pub(crate) async fn ensure_ha_channel_outbox_triggers(
+        &self,
+        channel: HaSyncChannel,
+    ) -> Result<(), ProxyError> {
         let mut conn = self.pool.acquire().await?;
-        for table in HA_BASELINE_TABLES {
+        for table in ha_channel_event_tables(channel) {
             let table_exists = sqlx::query_scalar::<_, i64>(
                 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)",
             )
@@ -854,7 +980,11 @@ impl KeyStore {
                 ("update", "AFTER UPDATE", new_json.as_str(), new_resource_id.as_str(), "upsert"),
                 ("delete", "AFTER DELETE", old_json.as_str(), old_resource_id.as_str(), "delete"),
             ] {
-                let trigger = quote_sqlite_identifier(&format!("trg_ha_outbox_{table}_{suffix}"));
+                let trigger = quote_sqlite_identifier(&ha_trigger_name(
+                    channel,
+                    table,
+                    suffix,
+                ));
                 let row_alias = if timing == "AFTER DELETE" { "OLD" } else { "NEW" };
                 let row_filter = meta_filter
                     .as_ref()
@@ -866,7 +996,7 @@ impl KeyStore {
                     {timing} ON {table_ident}
                     WHEN NOT EXISTS (SELECT 1 FROM ha_outbox_suppression WHERE id = 'local'){row_filter}
                     BEGIN
-                        INSERT INTO ha_outbox (
+                        INSERT INTO {} (
                             kind, resource, resource_id, op, payload_json, created_at, checksum
                         )
                         VALUES (
@@ -879,7 +1009,8 @@ impl KeyStore {
                             NULL
                         );
                     END
-                    "#
+                    "#,
+                    quote_sqlite_identifier(ha_channel_event_table(channel))
                 );
                 sqlx::query(&sql).execute(&mut *conn).await?;
             }
@@ -887,12 +1018,24 @@ impl KeyStore {
         Ok(())
     }
 
-    async fn prune_ha_outbox_retention(&self) -> Result<(), ProxyError> {
-        let threshold = self.backend_time.now_ts() - HA_OUTBOX_RETENTION_SECS;
-        sqlx::query("DELETE FROM ha_outbox WHERE created_at < ?")
-            .bind(threshold)
-            .execute(&self.pool)
-            .await?;
+    async fn drop_ha_channel_triggers(&self, channel: HaSyncChannel) -> Result<(), ProxyError> {
+        let mut conn = self.pool.acquire().await?;
+        for table in ha_channel_event_tables(channel) {
+            for suffix in ["insert", "update", "delete"] {
+                sqlx::query(&format!(
+                    "DROP TRIGGER IF EXISTS {}",
+                    quote_sqlite_identifier(&format!("trg_ha_outbox_{}_{}", table, suffix))
+                ))
+                .execute(&mut *conn)
+                .await?;
+                sqlx::query(&format!(
+                    "DROP TRIGGER IF EXISTS {}",
+                    quote_sqlite_identifier(&ha_trigger_name(channel, table, suffix))
+                ))
+                .execute(&mut *conn)
+                .await?;
+            }
+        }
         Ok(())
     }
 
@@ -932,14 +1075,22 @@ fn ha_meta_key_list_sql() -> String {
         .join(", ")
 }
 
-fn ensure_ha_resource_whitelisted(resource: &str) -> Result<(), ProxyError> {
-    if HA_BASELINE_TABLES.contains(&resource) {
+fn ensure_ha_resource_whitelisted(
+    channel: HaSyncChannel,
+    resource: &str,
+) -> Result<(), ProxyError> {
+    if ha_resource_allowed_for_channel(channel, resource) {
         Ok(())
     } else {
         Err(ProxyError::Other(format!(
-            "HA resource is not whitelisted: {resource}"
+            "HA {} resource is not whitelisted: {resource}",
+            channel.as_str()
         )))
     }
+}
+
+fn ha_trigger_name(channel: HaSyncChannel, table: &str, suffix: &str) -> String {
+    format!("trg_ha_{}_{}_{}", channel.as_str(), table, suffix)
 }
 
 fn sanitize_ha_resource_payload(
@@ -997,10 +1148,11 @@ fn ha_trigger_resource_id(alias: &str, columns: &[String]) -> String {
 
 async fn insert_json_row_on_conn(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    channel: HaSyncChannel,
     table: &str,
     row: &serde_json::Value,
 ) -> Result<(), ProxyError> {
-    ensure_ha_resource_whitelisted(table)?;
+    ensure_ha_resource_whitelisted(channel, table)?;
     let Some(object) = row.as_object() else {
         return Err(ProxyError::Other(
             "HA row payload must be a JSON object".to_string(),
@@ -1083,11 +1235,12 @@ async fn insert_json_row_on_conn(
 
 async fn delete_json_row_on_conn(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    channel: HaSyncChannel,
     table: &str,
     resource_id: &str,
     row: &serde_json::Value,
 ) -> Result<(), ProxyError> {
-    ensure_ha_resource_whitelisted(table)?;
+    ensure_ha_resource_whitelisted(channel, table)?;
     let columns = table_column_info_on_conn(conn, table).await?;
     let mut primary_key_columns = columns
         .iter()
@@ -1188,5 +1341,119 @@ fn parse_ha_node_role(value: &str) -> Option<HaNodeRole> {
         "standby" => Some(HaNodeRole::Standby),
         "recovery" => Some(HaNodeRole::Recovery),
         _ => None,
+    }
+}
+
+impl KeyStore {
+    pub(crate) async fn delete_ha_channel_events_bounded(
+        &self,
+        channel: HaSyncChannel,
+        threshold: i64,
+        batch_size: i64,
+    ) -> Result<i64, ProxyError> {
+        let table = quote_sqlite_identifier(ha_channel_event_table(channel));
+        let deleted = sqlx::query(&format!(
+            r#"
+            DELETE FROM {table}
+            WHERE seq IN (
+                SELECT seq
+                FROM {table}
+                WHERE created_at < ?
+                ORDER BY seq ASC
+                LIMIT ?
+            )
+            "#
+        ))
+        .bind(threshold)
+        .bind(batch_size.max(1))
+        .execute(&self.pool)
+        .await?;
+        Ok(deleted.rows_affected() as i64)
+    }
+
+    pub(crate) async fn gc_ha_outbox_with_options(
+        &self,
+        options: HaOutboxGcOptions,
+    ) -> Result<HaOutboxGcReport, ProxyError> {
+        let started = Instant::now();
+        let batch_size = options.batch_size.max(1);
+        let max_batches = options.max_batches.max(1);
+        let deadline = started + Duration::from_secs(options.max_runtime_secs.max(1));
+        let mut deleted_rows = 0_i64;
+        let mut batches = 0_i64;
+        let mut completed = true;
+        let mut channels = Vec::new();
+
+        for channel in [
+            HaSyncChannel::Control,
+            HaSyncChannel::Billing,
+            HaSyncChannel::Runtime,
+        ] {
+            let retention_secs = ha_channel_retention_secs(channel);
+            let threshold = self.backend_time.now_ts() - retention_secs;
+            let mut channel_deleted_rows = 0_i64;
+            let mut channel_batches = 0_i64;
+
+            while channel_batches < max_batches && Instant::now() < deadline {
+                let deleted = self
+                    .delete_ha_channel_events_bounded(channel, threshold, batch_size)
+                    .await?;
+                channel_deleted_rows += deleted;
+                channel_batches += 1;
+                if deleted < batch_size {
+                    break;
+                }
+                completed = false;
+                if options.inter_batch_sleep_ms > 0 {
+                    self.backend_time
+                        .sleep(Duration::from_millis(options.inter_batch_sleep_ms))
+                        .await;
+                }
+            }
+
+            let has_more: bool = sqlx::query_scalar(&format!(
+                "SELECT EXISTS(SELECT 1 FROM {} WHERE created_at < ? LIMIT 1)",
+                quote_sqlite_identifier(ha_channel_event_table(channel))
+            ))
+            .bind(threshold)
+            .fetch_one(&self.pool)
+            .await?;
+            if has_more {
+                completed = false;
+            }
+
+            deleted_rows += channel_deleted_rows;
+            batches += channel_batches;
+            channels.push(HaOutboxGcChannelReport {
+                channel,
+                retention_secs,
+                threshold,
+                deleted_rows: channel_deleted_rows,
+                batches: channel_batches,
+                has_more,
+            });
+        }
+
+        let (busy, log_frames, checkpointed_frames) = if deleted_rows > 0 {
+            let (busy, log_frames, checkpointed_frames) =
+                self.checkpoint_sqlite_wal_passive().await?;
+            (busy != 0, log_frames, checkpointed_frames)
+        } else {
+            (false, 0, 0)
+        };
+
+        Ok(HaOutboxGcReport {
+            batch_size,
+            max_batches,
+            deleted_rows,
+            batches,
+            completed,
+            has_more: channels.iter().any(|channel| channel.has_more),
+            channels,
+            wal_checkpoint_busy: busy,
+            wal_checkpoint_log_frames: log_frames,
+            wal_checkpoint_checkpointed_frames: checkpointed_frames,
+            elapsed_ms: started.elapsed().as_millis(),
+        })
     }
 }

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -613,8 +613,13 @@ impl KeyStore {
     ) -> Result<Vec<HaEventRecord>, ProxyError> {
         let table = quote_sqlite_identifier(ha_channel_event_table(channel));
         let threshold = self.backend_time.now_ts() - ha_channel_retention_secs(channel);
+        let allowed_resources = ha_channel_event_tables(channel)
+            .iter()
+            .map(|resource| quote_sqlite_string(resource))
+            .collect::<Vec<_>>()
+            .join(", ");
         let min_seq: Option<i64> = sqlx::query_scalar(&format!(
-            "SELECT MIN(seq) FROM {table} WHERE created_at >= ?"
+            "SELECT MIN(seq) FROM {table} WHERE created_at >= ? AND resource IN ({allowed_resources})"
         ))
             .bind(threshold)
             .fetch_one(&self.pool)
@@ -644,6 +649,7 @@ impl KeyStore {
               FROM {table}
              WHERE seq > ?
                AND created_at >= ?
+               AND resource IN ({allowed_resources})
              ORDER BY seq ASC
              LIMIT ?
             "#
@@ -658,9 +664,6 @@ impl KeyStore {
         let mut events = Vec::new();
         for row in rows {
             let resource: String = row.try_get("resource")?;
-            if !ha_resource_allowed_for_channel(channel, &resource) {
-                continue;
-            }
             let payload_raw: String = row.try_get("payload_json")?;
             let payload = serde_json::from_str(&payload_raw)
                 .map_err(|err| ProxyError::Other(format!("invalid HA outbox payload: {err}")))?;

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -24,6 +24,7 @@ impl KeyStore {
             (
                 _,
                 "auth_token_logs_gc"
+                | "ha_outbox_gc"
                 | "mcp_sessions_gc"
                 | "mcp_session_init_backoffs_gc"
                 | "token_usage_rollup"
@@ -55,7 +56,7 @@ impl KeyStore {
                 WHEN {trigger_source_column} = 'manual' AND ({job_type_column} = 'request_logs_gc' OR {job_type_column} = 'db_compaction') THEN 0 \
                 WHEN {trigger_source_column} = 'manual' THEN 1 \
                 WHEN {job_type_column} = 'request_logs_gc' OR {job_type_column} = 'db_compaction' THEN 2 \
-                WHEN {job_type_column} = 'auth_token_logs_gc' OR {job_type_column} = 'mcp_sessions_gc' OR {job_type_column} = 'mcp_session_init_backoffs_gc' OR {job_type_column} = 'token_usage_rollup' OR {job_type_column} = 'usage_aggregation' THEN 3 \
+                WHEN {job_type_column} = 'auth_token_logs_gc' OR {job_type_column} = 'ha_outbox_gc' OR {job_type_column} = 'mcp_sessions_gc' OR {job_type_column} = 'mcp_session_init_backoffs_gc' OR {job_type_column} = 'token_usage_rollup' OR {job_type_column} = 'usage_aggregation' THEN 3 \
                 WHEN {job_type_column} = 'linuxdo_user_tag_binding_refresh' OR {job_type_column} = 'forward_proxy_geo_refresh' OR {job_type_column} = 'linuxdo_user_status_sync' THEN 4 \
                 WHEN {job_type_column} = 'quota_sync' OR {job_type_column} = 'quota_sync/manual' OR {job_type_column} = 'quota_sync/hot' THEN 5 \
                 ELSE 6 \

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -2552,7 +2552,7 @@ impl KeyStore {
             ),
             "usage" => format!("{column} = 'token_usage_rollup' OR {column} = 'usage_aggregation'"),
             "logs" => format!(
-                "{column} = 'auth_token_logs_gc' OR {column} = 'request_logs_gc' OR {column} = 'mcp_sessions_gc' OR {column} = 'mcp_session_init_backoffs_gc' OR {column} = 'log_cleanup'"
+                "{column} = 'auth_token_logs_gc' OR {column} = 'ha_outbox_gc' OR {column} = 'request_logs_gc' OR {column} = 'mcp_sessions_gc' OR {column} = 'mcp_session_init_backoffs_gc' OR {column} = 'log_cleanup'"
             ),
             "db" => format!("{column} = 'db_compaction'"),
             "geo" => format!("{column} = 'forward_proxy_geo_refresh'"),
@@ -2571,7 +2571,7 @@ impl KeyStore {
                 COUNT(*) AS all_count,
                 COALESCE(SUM(CASE WHEN job_type = 'quota_sync' OR job_type = 'quota_sync/manual' OR job_type = 'quota_sync/hot' THEN 1 ELSE 0 END), 0) AS quota_count,
                 COALESCE(SUM(CASE WHEN job_type = 'token_usage_rollup' OR job_type = 'usage_aggregation' THEN 1 ELSE 0 END), 0) AS usage_count,
-                COALESCE(SUM(CASE WHEN job_type = 'auth_token_logs_gc' OR job_type = 'request_logs_gc' OR job_type = 'mcp_sessions_gc' OR job_type = 'mcp_session_init_backoffs_gc' OR job_type = 'log_cleanup' THEN 1 ELSE 0 END), 0) AS logs_count,
+                COALESCE(SUM(CASE WHEN job_type = 'auth_token_logs_gc' OR job_type = 'ha_outbox_gc' OR job_type = 'request_logs_gc' OR job_type = 'mcp_sessions_gc' OR job_type = 'mcp_session_init_backoffs_gc' OR job_type = 'log_cleanup' THEN 1 ELSE 0 END), 0) AS logs_count,
                 COALESCE(SUM(CASE WHEN job_type = 'db_compaction' THEN 1 ELSE 0 END), 0) AS db_count,
                 COALESCE(SUM(CASE WHEN job_type = 'forward_proxy_geo_refresh' THEN 1 ELSE 0 END), 0) AS geo_count,
                 COALESCE(SUM(CASE WHEN job_type = 'linuxdo_user_status_sync' OR job_type = 'linuxdo_user_tag_binding_refresh' THEN 1 ELSE 0 END), 0) AS linuxdo_count

--- a/src/store/key_store_users_and_oauth.rs
+++ b/src/store/key_store_users_and_oauth.rs
@@ -1502,9 +1502,10 @@ impl KeyStore {
                 request_log_id,
                 result_status,
                 created_at,
+                updated_at,
                 settled_at,
                 error_message
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
             ON CONFLICT(auth_token_log_id) DO UPDATE SET
                 token_id = excluded.token_id,
                 billing_subject = excluded.billing_subject,
@@ -1515,6 +1516,7 @@ impl KeyStore {
                 request_log_id = excluded.request_log_id,
                 result_status = excluded.result_status,
                 created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
                 settled_at = NULL,
                 error_message = excluded.error_message
             "#,
@@ -1528,6 +1530,7 @@ impl KeyStore {
         .bind(api_key_id)
         .bind(request_log_id)
         .bind(result_status)
+        .bind(created_at)
         .bind(created_at)
         .bind(error_message)
         .execute(&self.pool)
@@ -1806,12 +1809,14 @@ impl KeyStore {
                         (SELECT created_at FROM auth_token_logs WHERE id = billing_ledger.auth_token_log_id),
                         billing_ledger.created_at
                     ),
+                    updated_at = ?,
                     settled_at = ?,
                     error_message = NULL
                 WHERE auth_token_log_id = ? AND billing_state = ?
                 "#,
             )
             .bind(BILLING_STATE_CHARGED)
+            .bind(Utc::now().timestamp())
             .bind(Utc::now().timestamp())
             .bind(log_id)
             .bind(BILLING_STATE_PENDING)
@@ -2080,12 +2085,14 @@ impl KeyStore {
                     (SELECT created_at FROM auth_token_logs WHERE id = billing_ledger.auth_token_log_id),
                     billing_ledger.created_at
                 ),
+                updated_at = ?,
                 settled_at = ?,
                 error_message = NULL
             WHERE auth_token_log_id = ? AND billing_state = ?
             "#,
         )
         .bind(BILLING_STATE_CHARGED)
+        .bind(Utc::now().timestamp())
         .bind(Utc::now().timestamp())
         .bind(log_id)
         .bind(BILLING_STATE_PENDING)
@@ -2125,13 +2132,15 @@ impl KeyStore {
                 WHEN error_message IS NULL OR error_message = '' THEN ?
                 WHEN error_message = ? THEN error_message
                 ELSE error_message || ' | ' || ?
-            END
+            END,
+                updated_at = ?
             WHERE auth_token_log_id = ?
             "#,
         )
         .bind(message)
         .bind(message)
         .bind(message)
+        .bind(self.backend_time.now_ts())
         .bind(log_id)
         .execute(&self.pool)
         .await?;

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -410,16 +410,68 @@ impl TavilyProxy {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        Self::with_options_and_time(keys, upstream, database_path, options, BackendTime::system())
+        Self::with_options_in_ha_mode(
+            keys,
+            upstream,
+            database_path,
+            options,
+            HaMode::Single,
+        )
+        .await
+    }
+
+    pub async fn with_options_in_ha_mode<I, S>(
+        keys: I,
+        upstream: &str,
+        database_path: &str,
+        options: TavilyProxyOptions,
+        ha_mode: HaMode,
+    ) -> Result<Self, ProxyError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::with_options_and_time_in_ha_mode(
+            keys,
+            upstream,
+            database_path,
+            options,
+            BackendTime::system(),
+            ha_mode,
+        )
             .await
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn with_options_and_time<I, S>(
         keys: I,
         upstream: &str,
         database_path: &str,
         options: TavilyProxyOptions,
         backend_time: BackendTime,
+    ) -> Result<Self, ProxyError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::with_options_and_time_in_ha_mode(
+            keys,
+            upstream,
+            database_path,
+            options,
+            backend_time,
+            HaMode::Single,
+        )
+        .await
+    }
+
+    pub(crate) async fn with_options_and_time_in_ha_mode<I, S>(
+        keys: I,
+        upstream: &str,
+        database_path: &str,
+        options: TavilyProxyOptions,
+        backend_time: BackendTime,
+        ha_mode: HaMode,
     ) -> Result<Self, ProxyError>
     where
         I: IntoIterator<Item = S>,
@@ -436,6 +488,7 @@ impl TavilyProxy {
 
         let key_store_started = Instant::now();
         let key_store = KeyStore::new_with_time(database_path, backend_time.clone()).await?;
+        key_store.configure_ha_event_writes(ha_mode).await?;
         eprintln!(
             "forward-proxy startup: sqlite initialized in {}ms",
             key_store_started.elapsed().as_millis()

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -216,42 +216,47 @@ impl TavilyProxy {
 
     pub async fn export_ha_baseline_ndjson(
         &self,
+        channel: HaSyncChannel,
         node_id: &str,
     ) -> Result<HaBaselineExport, ProxyError> {
-        self.key_store.export_ha_baseline_ndjson(node_id).await
+        self.key_store.export_ha_baseline_ndjson(channel, node_id).await
     }
 
     pub async fn apply_ha_baseline_ndjson(
         &self,
+        channel: HaSyncChannel,
         ndjson: &str,
     ) -> Result<HaApplyResult, ProxyError> {
-        self.key_store.apply_ha_baseline_ndjson(ndjson).await
+        self.key_store.apply_ha_baseline_ndjson(channel, ndjson).await
     }
 
     pub async fn apply_ha_events_ndjson(
         &self,
+        channel: HaSyncChannel,
         ndjson: &str,
     ) -> Result<HaApplyResult, ProxyError> {
-        self.key_store.apply_ha_events_ndjson(ndjson).await
+        self.key_store.apply_ha_events_ndjson(channel, ndjson).await
     }
 
-    pub async fn list_ha_outbox_events_after(
+    pub async fn list_ha_events_after(
         &self,
+        channel: HaSyncChannel,
         after_seq: i64,
         limit: i64,
-    ) -> Result<Vec<HaOutboxEventRecord>, ProxyError> {
+    ) -> Result<Vec<HaEventRecord>, ProxyError> {
         self.key_store
-            .list_ha_outbox_events_after(after_seq, limit)
+            .list_ha_events_after(channel, after_seq, limit)
             .await
     }
 
     pub async fn ack_ha_peer_watermark(
         &self,
+        channel: HaSyncChannel,
         peer_node_id: &str,
         acked_seq: i64,
     ) -> Result<(), ProxyError> {
         self.key_store
-            .ack_ha_peer_watermark(peer_node_id, acked_seq)
+            .ack_ha_peer_watermark(channel, peer_node_id, acked_seq)
             .await
     }
 

--- a/src/tests/account_quota_and_billing.rs
+++ b/src/tests/account_quota_and_billing.rs
@@ -1577,6 +1577,7 @@ async fn insert_charged_business_log(
             request_log_id,
             result_status,
             created_at,
+            updated_at,
             settled_at,
             error_message
         )
@@ -1590,6 +1591,7 @@ async fn insert_charged_business_log(
             NULL,
             NULL,
             result_status,
+            created_at,
             created_at,
             created_at,
             error_message
@@ -1607,6 +1609,7 @@ async fn insert_charged_business_log(
             request_log_id = excluded.request_log_id,
             result_status = excluded.result_status,
             created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
             settled_at = excluded.settled_at,
             error_message = excluded.error_message
         "#,

--- a/src/tests/jobs_and_request_log_retention.rs
+++ b/src/tests/jobs_and_request_log_retention.rs
@@ -58,6 +58,220 @@ async fn quota_subject_lock_retries_transient_sqlite_write_lock() {
 }
 
 #[tokio::test]
+async fn standalone_ha_outbox_gc_deletes_expired_rows_across_channels_in_bounded_batches() {
+    let db_path = temp_db_path("ha-outbox-gc-bounded-control-only");
+    let db_str = db_path.to_string_lossy().to_string();
+    let old_control_ts = Utc::now().timestamp() - (4 * SECS_PER_DAY);
+    let old_long_retention_ts = Utc::now().timestamp() - (93 * SECS_PER_DAY);
+    let recent_ts = Utc::now().timestamp();
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(true),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        CREATE TABLE ha_outbox (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind TEXT NOT NULL,
+            resource TEXT NOT NULL,
+            resource_id TEXT NOT NULL,
+            op TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            checksum TEXT
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create ha_outbox");
+    sqlx::query(
+        r#"
+        CREATE TABLE ha_billing_outbox (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind TEXT NOT NULL,
+            resource TEXT NOT NULL,
+            resource_id TEXT NOT NULL,
+            op TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            checksum TEXT
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create ha_billing_outbox");
+    sqlx::query(
+        r#"
+        CREATE TABLE ha_runtime_outbox (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind TEXT NOT NULL,
+            resource TEXT NOT NULL,
+            resource_id TEXT NOT NULL,
+            op TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            checksum TEXT
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create ha_runtime_outbox");
+    sqlx::query(r#"CREATE INDEX idx_ha_outbox_created ON ha_outbox(created_at, seq)"#)
+        .execute(&pool)
+        .await
+        .expect("create control outbox index");
+    sqlx::query(
+        r#"CREATE INDEX idx_ha_billing_outbox_created ON ha_billing_outbox(created_at, seq)"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create billing outbox index");
+    sqlx::query(
+        r#"CREATE INDEX idx_ha_runtime_outbox_created ON ha_runtime_outbox(created_at, seq)"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create runtime outbox index");
+
+    for seq in 0..3 {
+        sqlx::query(
+            r#"
+            INSERT INTO ha_outbox (
+                kind, resource, resource_id, op, payload_json, created_at, checksum
+            ) VALUES ('state', 'users', ?, 'upsert', '{}', ?, NULL)
+            "#,
+        )
+        .bind(format!("old-{seq}"))
+        .bind(old_control_ts + seq)
+        .execute(&pool)
+        .await
+        .expect("seed old control event");
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'users', 'recent-1', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(recent_ts)
+    .execute(&pool)
+    .await
+    .expect("seed recent control event");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_billing_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'billing_ledger', 'billing-1', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(old_long_retention_ts)
+    .execute(&pool)
+    .await
+    .expect("seed billing outbox event");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_billing_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'billing_ledger', 'billing-recent', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(recent_ts)
+    .execute(&pool)
+    .await
+    .expect("seed recent billing outbox event");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_runtime_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'mcp_sessions', 'runtime-1', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(old_long_retention_ts)
+    .execute(&pool)
+    .await
+    .expect("seed runtime outbox event");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_runtime_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES ('state', 'mcp_sessions', 'runtime-recent', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(recent_ts)
+    .execute(&pool)
+    .await
+    .expect("seed recent runtime outbox event");
+    drop(pool);
+
+    let report = run_ha_outbox_gc_once(
+        &db_str,
+        HaOutboxGcOptions {
+            batch_size: 2,
+            max_batches: 1,
+            max_runtime_secs: 30,
+            inter_batch_sleep_ms: 0,
+        },
+    )
+    .await
+    .expect("run standalone ha outbox gc");
+    assert_eq!(report.deleted_rows, 4);
+    assert_eq!(report.batches, 3);
+    assert!(!report.completed);
+    assert!(report.has_more);
+    assert_eq!(report.channels.len(), 3);
+    assert_eq!(report.channels[0].channel, HaSyncChannel::Control);
+    assert_eq!(report.channels[0].deleted_rows, 2);
+    assert!(report.channels[0].has_more);
+    assert_eq!(report.channels[1].channel, HaSyncChannel::Billing);
+    assert_eq!(report.channels[1].deleted_rows, 1);
+    assert!(!report.channels[1].has_more);
+    assert_eq!(report.channels[2].channel, HaSyncChannel::Runtime);
+    assert_eq!(report.channels[2].deleted_rows, 1);
+    assert!(!report.channels[2].has_more);
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("reopen sqlite pool");
+    let control_remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count remaining control events");
+    let old_control_remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE created_at < ?")
+            .bind(recent_ts - SECS_PER_DAY)
+            .fetch_one(&pool)
+            .await
+            .expect("count remaining old control events");
+    let billing_remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_billing_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count remaining billing events");
+    let runtime_remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ha_runtime_outbox")
+        .fetch_one(&pool)
+        .await
+        .expect("count remaining runtime events");
+
+    assert_eq!(control_remaining, 2);
+    assert_eq!(old_control_remaining, 1);
+    assert_eq!(billing_remaining, 1);
+    assert_eq!(runtime_remaining, 1);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn scheduled_job_start_retries_transient_sqlite_write_lock() {
     let db_path = temp_db_path("scheduled-job-start-retries-sqlite-lock");
     let db_str = db_path.to_string_lossy().to_string();

--- a/tests/rust_source_line_budgets.rs
+++ b/tests/rust_source_line_budgets.rs
@@ -11,7 +11,7 @@ const EXCEPTIONS: &[(&str, usize, &str)] = &[
     ),
     (
         "src/tests/jobs_and_request_log_retention.rs",
-        3120,
+        3360,
         "Retention, GC, and compaction-path coverage still lives in the consolidated jobs/request-log regression suite while the new auth-token retention cases land before a broader test extraction pass.",
     ),
     (


### PR DESCRIPTION
Summary
- split HA sync into control, billing, and runtime channels
- keep HA_MODE=single silent and move HA cleanup into explicit bounded/offline maintenance paths
- add full production-shaped snapshot export plus offline cleanup validation tooling

Test Plan
- cargo fmt --check
- cargo check
- cargo test alerts_and_ha -- --nocapture
- cargo test standalone_ha_outbox_gc_deletes_expired_rows_across_channels_in_bounded_batches -- --nocapture
- bash -n scripts/ha-outbox-maintenance.sh scripts/export-live-db-snapshot-to-testbox.sh
- full offline validation on codex-testbox using a complete snapshot copied from 101

Spec: docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
Spec Disposition: update
Spec Sync: done
Spec Drift: none
Solutions: docs/solutions/operations/sqlite-write-lock-contention.md
Solutions Sync: done
Project Docs: -
Project Docs Sync: n/a(no project-doc change)

Notes
- full production-shaped validation input copied from 101 to codex-testbox run `20260620_072848_f9d661f1_ha_outbox`
- snapshot set included `tavily_proxy.db` and `tavily_proxy-observability.db`
- SHA-256 matched after transfer and `PRAGMA integrity_check` returned `ok` for both files
- offline cleanup deleted 7425069 retained HA rows in 48 passes / 373 batches
- compaction was skipped because reclaimable ratio stayed below threshold (`0.165383`)
