### PR TITLE
fix(perf): harden startup and alert read paths

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -63,6 +63,18 @@ reads:
 - Replace repeated window scans with a single bounded scan that derives all needed windows, then add
   a short manager-scoped TTL cache when settings and live stats can request the same window set in
   one admin refresh cycle.
+- For public metrics or SSE surfaces backed by request-stat rollups, gate synchronous flushes on
+  persisted freshness plus the oldest pending coalesced write. Do not force a flush on every public
+  read once the rollup window is already current enough.
+- Move alert events/groups/recent summary/catalog to SQL-side pagination and aggregation. Pulling
+  all matching alert events into Rust and then sorting, grouping, or paginating in memory does not
+  survive a retained `auth_token_logs` window.
+- Canonicalize alert `request_kind` inside the SQL projection before filtering or grouping rows.
+  Mixed legacy keys such as `tavily_search` / `mcp_search` otherwise drift from the canonical
+  request-kind keys returned by the HTTP contract and can make filtered pages appear empty.
+- Prefer `auth_token_logs`-native fields and narrow joins on alert reads. If a path only needs
+  request kind, failure class, token, or mirrored API-key metadata, do not widen it with a
+  `LEFT JOIN request_logs` just to re-derive fields already stored on the alert-side truth table.
 - For per-user IP statistics over `request_logs`, force the user/IP/time index on count, sample, and
   timeline reads. On large databases SQLite can prefer the visibility/time index for
   `visibility + created_at` predicates and then build temporary B-trees for `GROUP BY`,
@@ -88,6 +100,9 @@ reads:
 - Add query-plan regression tests for admin read hot paths when the fix depends on SQLite choosing a
   specific index. Local small databases may return quickly even when the planner would be disastrous
   on production data volume.
+- When admin and public read paths share one rollup family, keep one freshness contract. Letting
+  HTTP and SSE each invent separate “maybe flush” logic is an easy way to reintroduce duplicate
+  scans and inconsistent first-paint latency.
 - `COUNT(DISTINCT ...)` over request logs is especially prone to temp B-trees; keep its input
   cardinality small with user-first filtering and avoid running it over all visible rows in a recent
   time window for every admin refresh.
@@ -99,4 +114,5 @@ reads:
 - `src/store/key_store_request_logs_and_dashboard.rs`
 - `src/store/key_store_token_logs.rs`
 - `src/store/key_store_keys.rs`
+- `src/store/key_store_alerts.rs`
 - `src/forward_proxy/storage.rs`

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -174,6 +174,12 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - Keep startup backfills cheap and no-op aware. Large production SQLite files make repeated per-user
   repair loops expensive even when every row is already correct; use an indexed precheck in the
   readiness path and move periodic refresh work to a background scheduler.
+- For `billing_ledger` startup truth repair specifically, persist a high-watermark marker and let
+  the readiness path prove “no gap / no drift” before invoking a whole-ledger reconcile. The first
+  upgraded boot may still need one repair, but steady-state restarts should only pay the precheck.
+- If an owner-facing read depends on coalesced rollups, prefer a freshness-gated flush over an
+  unconditional flush. This keeps near-real-time semantics without turning every public/admin read
+  into a write barrier under SQLite's single-writer budget.
 - Do not let lock-contention tests depend on real wall-clock sleep just to cross a retry window or a
   one-second timestamp boundary. Prefer deterministic state shaping or a controlled time seam so the
   test still exercises the production retry logic without paying real-time cost.
@@ -214,6 +220,7 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - `src/bin/request_logs_gc_once.rs`
 - `src/bin/ha_outbox_cleanup_once.rs`
 - `scripts/export-live-db-snapshot-to-testbox.sh`
+- `src/store/key_store_bootstrap.rs`
 - `src/store/key_store_users_and_oauth.rs`
 - `src/store/key_store_request_logs_and_dashboard.rs`
 - `src/tavily_proxy/proxy_auth_and_oauth.rs`

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -128,3 +128,21 @@
   remain rebuild-needed and are recovered by rerunning the offline tool.
 - Restored `valuable_failure_429_count` in the offline `api_key_usage_buckets` rebuild path so
   per-key upstream-429 failures survive explicit sidecar migration.
+
+## 2026-06-20
+
+- Validated the first lossless startup/read-path hardening pass against a live 101 SQLite snapshot
+  copied online with SQLite `.backup`, then replayed on `codex-testbox`.
+- The first upgraded boot still paid one-time repair/migration work on the historical snapshot:
+  `billing_ledger` repair ran once, and the new alert-supporting indexes were created on
+  `auth_token_logs`.
+- The second boot on that same repaired snapshot logged
+  `billing ledger startup precheck skipped: ... reason=no_gap` and reduced
+  `sqlite startup total` from about `24s` to about `2.2s`, confirming the routine restart tax is
+  gone after the first successful repair.
+- The same production-derived replay returned `/api/public/metrics` in about `1.44s`,
+  `/api/alerts/events` in about `0.14s`, and emitted the first public SSE `metrics` event
+  immediately after connect.
+- Offline `billing_ledger_audit` on that snapshot still reported `118` day-only mismatches between
+  quota samples and ledger-derived daily windows. That audit drift remains a separate quota
+  correctness follow-up and is not repaired by the startup ledger bootstrap path itself.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -115,6 +115,10 @@
   `billing_subject`, `business_credits`, request linkage, and settlement metadata are backfilled
   from `auth_token_logs` at startup and then maintained in `billing_ledger` on every new pending
   billing record and settlement.
+- Billing-ledger startup repair is now no-op aware. Startup records a high-watermark metadata key,
+  runs a cheap indexed precheck first, and only enters the historical full reconcile path when a
+  gap or drift is detected. Steady-state restarts now log `billing ledger startup precheck skipped`
+  instead of paying the full `billing_ledger` UPSERT cost every time.
 - Pending-billing readers and rollups that previously scanned `auth_token_logs.billing_state` now
   read from `billing_ledger`, while `auth_token_logs.billing_state` is still mirrored for backward
   compatibility with existing admin/history surfaces.
@@ -133,6 +137,10 @@
 - Request-derived rollups now flush in one background batcher (`1s / 100 pending keys`) instead of
   issuing synchronous rollup writes per request. Owner-facing summary, key-metrics, and request-log
   catalog reads flush that coalescer before reading.
+- Public `/api/public/metrics` and the first `metrics` event on `/api/public/events` now reuse the
+  same freshness-gated read path on top of `dashboard_request_rollup_buckets`. The read path checks
+  the last flushed timestamp plus the oldest pending request-stat write and only triggers one
+  synchronous flush when the requested window is actually stale.
 - Request observability tables now attach through a per-core sibling sidecar SQLite file
   (`<core-stem>-observability.db`) in the new layout. `request_logs`, `api_key_usage_buckets`,
   `dashboard_request_rollup_buckets`, and `request_log_catalog_rollups` are created in that
@@ -206,6 +214,10 @@
   columns explicitly and avoid unnecessary billing joins in count/facet queries. That removes the
   `ambiguous column name` regressions that appeared once synchronous billing truth moved out of
   `auth_token_logs` and the admin token-log surfaces began reading mixed ledger/history data.
+- Alert events/groups/recent-summary/catalog reads now stop full-fetching alert events into Rust for
+  in-memory paging/grouping. Those paths page and aggregate in SQL, canonicalize `request_kind`
+  before filtering/grouping, and rely on dedicated `auth_token_logs` indexes for
+  `failure_kind/result_status/token_id + created_at` windows.
 - Service startup now abandons leftover `queued` and `running` maintenance rows from the previous
   process lifetime before starting the new worker.
 - Added `request_logs_gc_once` as a one-shot operational binary. It supports JSON output and
@@ -220,6 +232,10 @@
   the HTTP response hints returned by `/api/jobs/trigger`.
 - Added regression coverage for duplicate manual trigger coalescing while another connection holds
   the SQLite writer slot, both at the store layer and through the owner-facing HTTP trigger route.
+- Added request-rollup tests that prove public metrics skip synchronous flush when freshness is
+  already current and perform one bounded flush when the live window is stale.
+- Extended alert endpoint coverage so request-kind filtered event/group reads continue returning the
+  canonical keys exposed by the HTTP contract after the SQL-side pagination/aggregation rewrite.
 - Added worker orchestration coverage that proves only one remote-I/O maintenance job enters
   `running` at a time and that `request_logs_gc` can still complete while a quota-sync remote phase
   is waiting on `/usage`.

--- a/docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md
+++ b/docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md
@@ -140,6 +140,10 @@
 - `2026-04-06`：使用当前 worktree 的 Storybook 静态预览端口 `127.0.0.1:30020` 打开 `Admin/Components/DashboardOverview/ZhDarkEvidence` iframe，确认 dashboard 总览结构、风险观察与快捷入口在轻量 overview 收敛后保持稳定。
 - `2026-04-30`：`cargo test admin_forward_proxy_settings_and_stats_endpoints_work -- --nocapture` 通过，覆盖 forward proxy stats 单次窗口集合查询后的响应结构。
 - `2026-05-01`：`cargo test admin_forward_proxy_settings_and_stats_endpoints_work -- --nocapture` 通过，覆盖 forward proxy stats 短 TTL 缓存后的响应结构不变。
+- `2026-06-20`：在 101 生产快照的共享测试机回放上，`/api/public/metrics` 与 `/api/public/events`
+  首条 `metrics` 事件复用了同一套 rollup freshness 判定，`/api/public/metrics` 首包约
+  `1.44s`，SSE 首条 `metrics` 事件立即可见；同时 `/api/alerts/events` 在 SQL 侧分页/聚合改造后
+  约 `0.14s` 返回。
 
 ## 实现里程碑
 
@@ -169,3 +173,6 @@
 - 2026-04-17: 将 `summary_windows` 与 dashboard 小时图切到 `dashboard_request_rollup_buckets`，移除 2 秒 freshness 缓存依赖，确保当前小时与本地估算额度可近实时出现在 overview / snapshot。
 - 2026-04-30: 将 forward proxy 窗口统计收敛为单次 bounded scan，并补充 admin heavy-read 并发保护，避免线上 SQLite worker 饱和时 dashboard overview 被重读拖慢。
 - 2026-05-01: 为 forward proxy 窗口集合查询增加 manager-scoped 短 TTL 缓存，减少同一管理端刷新周期内的重复 7d scan。
+- 2026-06-20: 将 dashboard rollup freshness 合同扩展到公共 metrics / public SSE 首条
+  `metrics` 读取，并将 alerts 事件/分组/summary 改为 SQL 侧有界读取，避免管理端和公共首页分别
+  重新引入宽时间窗扫描。

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -160,6 +160,7 @@
         "tests::request_rollup::observability_",
         "tests::maintenance_and_mcp_affinity::mcp_",
         "tests::request_rollup::public_",
+        "tests::request_rollup_public_metrics::public_",
         "tests::jobs_and_request_log_retention::quota_",
         "tests::request_rollup::quota_",
         "tests::observability_and_lifecycle::large_",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,6 +975,9 @@ const META_KEY_API_KEY_USAGE_BUCKETS_REQUEST_VALUE_V2_DONE: &str =
     "api_key_usage_buckets_request_value_v2_done";
 const META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE: &str =
     "dashboard_request_rollup_buckets_v1_done";
+const META_KEY_BILLING_LEDGER_STARTUP_HIGH_WATERMARK_V1: &str =
+    "billing_ledger_startup_high_watermark_v1";
+const META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1: &str = "request_stats_last_flushed_at_v1";
 const META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE: &str = "request_log_catalog_rollup_v1_done";
 const META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS: &str =
     "request_log_catalog_rollup_v1_retention_days";

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -399,6 +399,39 @@ async fn alerts_endpoints_and_dashboard_recent_alerts_share_default_window() {
             .and_then(|value| value.as_i64()),
         Some(1)
     );
+    assert_eq!(
+        filtered_events_body
+            .pointer("/items/0/requestKind/key")
+            .and_then(|value| value.as_str()),
+        Some("api:search")
+    );
+
+    let filtered_groups_resp = client
+        .get(format!(
+            "http://{}/api/alerts/groups?request_kind={}&type=upstream_rate_limited_429",
+            admin_addr, upstream_429_request_kind
+        ))
+        .header(reqwest::header::COOKIE, &admin_cookie)
+        .send()
+        .await
+        .expect("filtered alert groups request");
+    assert_eq!(filtered_groups_resp.status(), reqwest::StatusCode::OK);
+    let filtered_groups_body: serde_json::Value = filtered_groups_resp
+        .json()
+        .await
+        .expect("filtered alert groups json");
+    assert_eq!(
+        filtered_groups_body
+            .get("total")
+            .and_then(|value| value.as_i64()),
+        Some(1)
+    );
+    assert_eq!(
+        filtered_groups_body
+            .pointer("/items/0/requestKind/key")
+            .and_then(|value| value.as_str()),
+        Some("api:search")
+    );
 
     let groups_resp = client
         .get(format!("http://{}/api/alerts/groups", admin_addr))

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -10,33 +10,14 @@ struct AlertEventFilters<'a> {
 }
 
 #[derive(Debug, Clone)]
-struct RawAuthTokenAlertRow {
-    id: i64,
-    token_id: String,
-    key_id: Option<String>,
-    request_log_id: Option<i64>,
-    tavily_status_code: Option<i64>,
-    method: String,
-    path: String,
-    query: Option<String>,
-    request_kind_key: Option<String>,
-    request_kind_label: Option<String>,
-    request_kind_detail: Option<String>,
-    result_status: String,
-    failure_kind: Option<String>,
-    error_message: Option<String>,
-    counts_business_quota: bool,
-    created_at: i64,
-    user_id: Option<String>,
-    user_display_name: Option<String>,
-    user_username: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-struct RawMaintenanceAlertRow {
-    id: String,
-    key_id: String,
+struct AlertEventProjectionRow {
+    source_kind: String,
+    source_id: String,
+    row_sort_id: String,
+    alert_type: String,
+    occurred_at: i64,
     token_id: Option<String>,
+    key_id: Option<String>,
     request_log_id: Option<i64>,
     method: Option<String>,
     path: Option<String>,
@@ -47,7 +28,7 @@ struct RawMaintenanceAlertRow {
     result_status: Option<String>,
     failure_kind: Option<String>,
     error_message: Option<String>,
-    created_at: i64,
+    counts_business_quota: Option<bool>,
     user_id: Option<String>,
     user_display_name: Option<String>,
     user_username: Option<String>,
@@ -57,19 +38,14 @@ struct RawMaintenanceAlertRow {
 }
 
 #[derive(Debug, Clone)]
-struct AlertGroupAccumulator {
+struct AlertGroupProjectionRow {
+    row_sort_id: String,
     alert_type: String,
     subject_kind: String,
     subject_id: String,
-    subject_label: String,
-    user: Option<AlertUserRef>,
-    token: Option<AlertEntityRef>,
-    key: Option<AlertEntityRef>,
-    request_kind: Option<TokenRequestKind>,
-    count: i64,
+    total_count: i64,
     first_seen: i64,
     last_seen: i64,
-    latest_event: AlertEventRecord,
 }
 
 fn normalize_alert_request_kind_filters(request_kinds: &[String]) -> Vec<String> {
@@ -249,47 +225,60 @@ fn alert_group_id(event: &AlertEventRecord) -> String {
 }
 
 impl KeyStore {
-    async fn fetch_alert_auth_token_events(
-        &self,
-        filters: AlertEventFilters<'_>,
-    ) -> Result<Vec<AlertEventRecord>, ProxyError> {
-        if filters.alert_type == Some(ALERT_TYPE_UPSTREAM_KEY_BLOCKED) {
-            return Ok(Vec::new());
+    fn push_alert_request_kind_filter(
+        query: &mut QueryBuilder<'_, Sqlite>,
+        request_kind_expr: &str,
+        request_kinds: &[String],
+    ) {
+        let normalized = normalize_alert_request_kind_filters(request_kinds);
+        if normalized.is_empty() {
+            return;
         }
+        query.push(" AND ");
+        query.push(request_kind_expr);
+        query.push(" IN (");
+        {
+            let mut separated = query.separated(", ");
+            for request_kind in normalized {
+                separated.push_bind(request_kind);
+            }
+        }
+        query.push(")");
+    }
 
-        let mut query = QueryBuilder::new(
-            r#"
-            SELECT
-                atl.id,
-                atl.token_id,
-                COALESCE(atl.api_key_id, rl.api_key_id) AS api_key_id,
-                atl.request_log_id,
-                rl.tavily_status_code,
-                atl.method,
-                atl.path,
-                atl.query,
-                atl.request_kind_key,
-                atl.request_kind_label,
-                atl.request_kind_detail,
-                atl.result_status,
-                atl.failure_kind,
-                atl.error_message,
-                atl.counts_business_quota,
-                atl.created_at,
-                u.id AS user_id,
-                u.display_name AS user_display_name,
-                u.username AS user_username
-            FROM auth_token_logs atl
-            LEFT JOIN request_logs rl ON rl.id = atl.request_log_id
-            LEFT JOIN user_token_bindings b ON b.token_id = atl.token_id
-            LEFT JOIN users u ON u.id = b.user_id
-            WHERE (
-                atl.failure_kind = 'upstream_rate_limited_429'
-                OR atl.result_status = 'quota_exhausted'
-            )
-            "#,
-        );
-
+    fn push_auth_alert_filters<'a>(
+        query: &mut QueryBuilder<'a, Sqlite>,
+        filters: AlertEventFilters<'a>,
+        key_expr: &str,
+    ) {
+        if let Some(alert_type) = filters.alert_type {
+            match alert_type {
+                ALERT_TYPE_UPSTREAM_RATE_LIMITED_429 => {
+                    query.push(" AND atl.failure_kind = ").push_bind(alert_type);
+                }
+                ALERT_TYPE_UPSTREAM_USAGE_LIMIT_432 => {
+                    query.push(
+                        " AND atl.result_status = 'quota_exhausted' AND rl.tavily_status_code = 432",
+                    );
+                }
+                ALERT_TYPE_USER_REQUEST_RATE_LIMITED => {
+                    query.push(
+                        " AND atl.result_status = 'quota_exhausted' AND atl.counts_business_quota = 0",
+                    );
+                }
+                ALERT_TYPE_USER_QUOTA_EXHAUSTED => {
+                    query.push(
+                        " AND atl.result_status = 'quota_exhausted' AND COALESCE(rl.tavily_status_code, 0) <> 432 AND atl.counts_business_quota <> 0",
+                    );
+                }
+                ALERT_TYPE_UPSTREAM_KEY_BLOCKED => {
+                    query.push(" AND 1 = 0");
+                }
+                _ => {
+                    query.push(" AND 1 = 0");
+                }
+            };
+        }
         if let Some(since) = filters.since {
             query.push(" AND atl.created_at >= ").push_bind(since);
         }
@@ -303,181 +292,19 @@ impl KeyStore {
             query.push(" AND atl.token_id = ").push_bind(token_id);
         }
         if let Some(key_id) = filters.key_id {
-            query.push(" AND COALESCE(atl.api_key_id, rl.api_key_id) = ")
-                .push_bind(key_id);
+            query.push(" AND ").push(key_expr).push(" = ").push_bind(key_id);
         }
-        query.push(" ORDER BY atl.created_at DESC, atl.id DESC");
-
-        let rows = query.build().fetch_all(&self.pool).await?;
-        let normalized_request_kinds = normalize_alert_request_kind_filters(filters.request_kinds);
-
-        let events = rows
-            .into_iter()
-            .map(|row| {
-                Ok(RawAuthTokenAlertRow {
-                    id: row.try_get("id")?,
-                    token_id: row.try_get("token_id")?,
-                    key_id: row.try_get("api_key_id")?,
-                    request_log_id: row.try_get("request_log_id")?,
-                    tavily_status_code: row.try_get("tavily_status_code")?,
-                    method: row.try_get("method")?,
-                    path: row.try_get("path")?,
-                    query: row.try_get("query")?,
-                    request_kind_key: row.try_get("request_kind_key")?,
-                    request_kind_label: row.try_get("request_kind_label")?,
-                    request_kind_detail: row.try_get("request_kind_detail")?,
-                    result_status: row.try_get("result_status")?,
-                    failure_kind: row.try_get("failure_kind")?,
-                    error_message: row.try_get("error_message")?,
-                    counts_business_quota: row.try_get::<i64, _>("counts_business_quota")? != 0,
-                    created_at: row.try_get("created_at")?,
-                    user_id: row.try_get("user_id")?,
-                    user_display_name: row.try_get("user_display_name")?,
-                    user_username: row.try_get("user_username")?,
-                })
-            })
-            .collect::<Result<Vec<_>, sqlx::Error>>()?
-            .into_iter()
-            .filter_map(|row| {
-                let alert_type =
-                    if row.failure_kind.as_deref() == Some(ALERT_TYPE_UPSTREAM_RATE_LIMITED_429) {
-                        ALERT_TYPE_UPSTREAM_RATE_LIMITED_429.to_string()
-                    } else if row.result_status == "quota_exhausted"
-                        && row.tavily_status_code == Some(432)
-                    {
-                        ALERT_TYPE_UPSTREAM_USAGE_LIMIT_432.to_string()
-                    } else if row.result_status == "quota_exhausted" && !row.counts_business_quota {
-                        ALERT_TYPE_USER_REQUEST_RATE_LIMITED.to_string()
-                    } else if row.result_status == "quota_exhausted" {
-                        ALERT_TYPE_USER_QUOTA_EXHAUSTED.to_string()
-                    } else {
-                        return None;
-                    };
-
-                if let Some(expected_type) = filters.alert_type
-                    && expected_type != alert_type
-                {
-                    return None;
-                }
-
-                let user =
-                    build_alert_user_ref(row.user_id, row.user_display_name, row.user_username);
-                let token = Some(AlertEntityRef {
-                    id: row.token_id.clone(),
-                    label: row.token_id.clone(),
-                });
-                let key = build_alert_entity_ref(row.key_id);
-                let request_kind = build_alert_request_kind(
-                    Some(row.method.as_str()),
-                    Some(row.path.as_str()),
-                    row.query.as_deref(),
-                    row.request_kind_key,
-                    row.request_kind_label,
-                    row.request_kind_detail,
-                );
-
-                if !normalized_request_kinds.is_empty()
-                    && request_kind
-                        .as_ref()
-                        .map(|value| !normalized_request_kinds.contains(&value.key))
-                        .unwrap_or(true)
-                {
-                    return None;
-                }
-
-                let request = row.request_log_id.map(|request_log_id| AlertRequestRef {
-                    id: request_log_id,
-                    method: row.method.clone(),
-                    path: row.path.clone(),
-                    query: row.query.clone(),
-                });
-                let (subject_kind, subject_id, subject_label) = alert_subject_tuple(
-                    alert_type.as_str(),
-                    user.as_ref(),
-                    token.as_ref(),
-                    key.as_ref(),
-                );
-                let (title, summary) = build_alert_title_and_summary(
-                    alert_type.as_str(),
-                    subject_label.as_str(),
-                    token.as_ref(),
-                    key.as_ref(),
-                    request_kind.as_ref(),
-                    None,
-                );
-
-                Some(AlertEventRecord {
-                    id: format!("atl:{}", row.id),
-                    alert_type,
-                    title,
-                    summary,
-                    occurred_at: row.created_at,
-                    subject_kind,
-                    subject_id,
-                    subject_label,
-                    user,
-                    token,
-                    key,
-                    request,
-                    request_kind,
-                    failure_kind: row.failure_kind,
-                    result_status: Some(row.result_status),
-                    error_message: row.error_message,
-                    reason_code: None,
-                    reason_summary: None,
-                    reason_detail: None,
-                    source: AlertSourceRef {
-                        kind: ALERT_SOURCE_AUTH_TOKEN_LOG.to_string(),
-                        id: row.id.to_string(),
-                    },
-                })
-            })
-            .collect::<Vec<_>>();
-        Ok(events)
     }
 
-    async fn fetch_alert_maintenance_events(
-        &self,
-        filters: AlertEventFilters<'_>,
-    ) -> Result<Vec<AlertEventRecord>, ProxyError> {
+    fn push_maintenance_alert_filters<'a>(
+        query: &mut QueryBuilder<'a, Sqlite>,
+        filters: AlertEventFilters<'a>,
+    ) {
         if let Some(alert_type) = filters.alert_type
             && alert_type != ALERT_TYPE_UPSTREAM_KEY_BLOCKED
         {
-            return Ok(Vec::new());
+            query.push(" AND 1 = 0");
         }
-
-        let mut query = QueryBuilder::new(
-            r#"
-            SELECT
-                m.id,
-                m.key_id,
-                COALESCE(m.auth_token_id, atl.token_id) AS token_id,
-                COALESCE(m.request_log_id, atl.request_log_id) AS request_log_id,
-                COALESCE(atl.method, rl.method) AS method,
-                COALESCE(atl.path, rl.path) AS path,
-                COALESCE(atl.query, rl.query) AS query,
-                atl.request_kind_key,
-                atl.request_kind_label,
-                atl.request_kind_detail,
-                atl.result_status,
-                atl.failure_kind,
-                atl.error_message,
-                m.created_at,
-                u.id AS user_id,
-                u.display_name AS user_display_name,
-                u.username AS user_username,
-                m.reason_code,
-                m.reason_summary,
-                m.reason_detail
-            FROM api_key_maintenance_records m
-            LEFT JOIN auth_token_logs atl ON atl.id = m.auth_token_log_id
-            LEFT JOIN request_logs rl ON rl.id = COALESCE(m.request_log_id, atl.request_log_id)
-            LEFT JOIN user_token_bindings b ON b.token_id = COALESCE(m.auth_token_id, atl.token_id)
-            LEFT JOIN users u ON u.id = b.user_id
-            WHERE COALESCE(m.reason_code, '') IN ('account_deactivated', 'key_revoked', 'invalid_api_key')
-            "#,
-        );
-
         if let Some(since) = filters.since {
             query.push(" AND m.created_at >= ").push_bind(since);
         }
@@ -495,258 +322,511 @@ impl KeyStore {
         if let Some(key_id) = filters.key_id {
             query.push(" AND m.key_id = ").push_bind(key_id);
         }
-        query.push(" ORDER BY m.created_at DESC, m.id DESC");
-
-        let rows = query.build().fetch_all(&self.pool).await?;
-        let normalized_request_kinds = normalize_alert_request_kind_filters(filters.request_kinds);
-
-        let events = rows
-            .into_iter()
-            .map(|row| {
-                Ok(RawMaintenanceAlertRow {
-                    id: row.try_get("id")?,
-                    key_id: row.try_get("key_id")?,
-                    token_id: row.try_get("token_id")?,
-                    request_log_id: row.try_get("request_log_id")?,
-                    method: row.try_get("method")?,
-                    path: row.try_get("path")?,
-                    query: row.try_get("query")?,
-                    request_kind_key: row.try_get("request_kind_key")?,
-                    request_kind_label: row.try_get("request_kind_label")?,
-                    request_kind_detail: row.try_get("request_kind_detail")?,
-                    result_status: row.try_get("result_status")?,
-                    failure_kind: row.try_get("failure_kind")?,
-                    error_message: row.try_get("error_message")?,
-                    created_at: row.try_get("created_at")?,
-                    user_id: row.try_get("user_id")?,
-                    user_display_name: row.try_get("user_display_name")?,
-                    user_username: row.try_get("user_username")?,
-                    reason_code: row.try_get("reason_code")?,
-                    reason_summary: row.try_get("reason_summary")?,
-                    reason_detail: row.try_get("reason_detail")?,
-                })
-            })
-            .collect::<Result<Vec<_>, sqlx::Error>>()?
-            .into_iter()
-            .filter_map(|row| {
-                let request_kind = build_alert_request_kind(
-                    row.method.as_deref(),
-                    row.path.as_deref(),
-                    row.query.as_deref(),
-                    row.request_kind_key,
-                    row.request_kind_label,
-                    row.request_kind_detail,
-                );
-
-                if !normalized_request_kinds.is_empty()
-                    && request_kind
-                        .as_ref()
-                        .map(|value| !normalized_request_kinds.contains(&value.key))
-                        .unwrap_or(true)
-                {
-                    return None;
-                }
-
-                let user =
-                    build_alert_user_ref(row.user_id, row.user_display_name, row.user_username);
-                let token = build_alert_entity_ref(row.token_id);
-                let key = Some(AlertEntityRef {
-                    id: row.key_id.clone(),
-                    label: row.key_id.clone(),
-                });
-                let request = row.request_log_id.map(|request_log_id| AlertRequestRef {
-                    id: request_log_id,
-                    method: row.method.clone().unwrap_or_else(|| "POST".to_string()),
-                    path: row.path.clone().unwrap_or_else(|| "/unknown".to_string()),
-                    query: row.query.clone(),
-                });
-                let (subject_kind, subject_id, subject_label) = alert_subject_tuple(
-                    ALERT_TYPE_UPSTREAM_KEY_BLOCKED,
-                    user.as_ref(),
-                    token.as_ref(),
-                    key.as_ref(),
-                );
-                let (title, summary) = build_alert_title_and_summary(
-                    ALERT_TYPE_UPSTREAM_KEY_BLOCKED,
-                    subject_label.as_str(),
-                    token.as_ref(),
-                    key.as_ref(),
-                    request_kind.as_ref(),
-                    row.reason_summary.as_deref(),
-                );
-
-                Some(AlertEventRecord {
-                    id: format!("maint:{}", row.id),
-                    alert_type: ALERT_TYPE_UPSTREAM_KEY_BLOCKED.to_string(),
-                    title,
-                    summary,
-                    occurred_at: row.created_at,
-                    subject_kind,
-                    subject_id,
-                    subject_label,
-                    user,
-                    token,
-                    key,
-                    request,
-                    request_kind,
-                    failure_kind: row.failure_kind,
-                    result_status: row.result_status,
-                    error_message: row.error_message,
-                    reason_code: row.reason_code,
-                    reason_summary: row.reason_summary,
-                    reason_detail: row.reason_detail,
-                    source: AlertSourceRef {
-                        kind: ALERT_SOURCE_API_KEY_MAINTENANCE_RECORD.to_string(),
-                        id: row.id,
-                    },
-                })
-            })
-            .collect::<Vec<_>>();
-        Ok(events)
     }
 
-    async fn fetch_alert_events_filtered(
-        &self,
-        filters: AlertEventFilters<'_>,
-    ) -> Result<Vec<AlertEventRecord>, ProxyError> {
-        let (auth_token_events, maintenance_events) = tokio::join!(
-            self.fetch_alert_auth_token_events(filters),
-            self.fetch_alert_maintenance_events(filters)
+    fn push_alert_events_cte<'a>(
+        query: &mut QueryBuilder<'a, Sqlite>,
+        filters: AlertEventFilters<'a>,
+    ) {
+        let stored_request_kind_sql = "atl.request_kind_key";
+        let effective_request_kind_sql = request_log_request_kind_key_sql(
+            "COALESCE(rl.path, atl.path)",
+            "rl.request_body",
+            stored_request_kind_sql,
         );
-        let mut events = Vec::new();
-        events.extend(auth_token_events?);
-        events.extend(maintenance_events?);
-        events.sort_by(|left, right| {
-            right
-                .occurred_at
-                .cmp(&left.occurred_at)
-                .then_with(|| right.id.cmp(&left.id))
-        });
-        Ok(events)
+        let effective_request_kind_label_sql =
+            canonical_request_kind_label_sql(&effective_request_kind_sql);
+        let maintenance_request_kind_sql = request_log_request_kind_key_sql(
+            "COALESCE(atl.path, rl.path)",
+            "rl.request_body",
+            "COALESCE(atl.request_kind_key, rl.request_kind_key)",
+        );
+        let maintenance_request_kind_label_sql =
+            canonical_request_kind_label_sql(&maintenance_request_kind_sql);
+
+        query.push("WITH alerts AS (");
+        query.push(" SELECT ");
+        query.push_bind(ALERT_SOURCE_AUTH_TOKEN_LOG);
+        query.push(format!(
+            r#" AS source_kind,
+                CAST(atl.id AS TEXT) AS source_id,
+                printf('atl:%020lld', atl.id) AS row_sort_id,
+                CASE
+                    WHEN atl.failure_kind = 'upstream_rate_limited_429' THEN 'upstream_rate_limited_429'
+                    WHEN atl.result_status = 'quota_exhausted' AND rl.tavily_status_code = 432 THEN 'upstream_usage_limit_432'
+                    WHEN atl.result_status = 'quota_exhausted' AND atl.counts_business_quota = 0 THEN 'user_request_rate_limited'
+                    WHEN atl.result_status = 'quota_exhausted' THEN 'user_quota_exhausted'
+                    ELSE ''
+                END AS alert_type,
+                atl.created_at AS occurred_at,
+                atl.token_id AS token_id,
+                COALESCE(atl.api_key_id, rl.api_key_id) AS key_id,
+                atl.request_log_id AS request_log_id,
+                atl.method AS method,
+                atl.path AS path,
+                atl.query AS query,
+                {effective_request_kind_sql} AS request_kind_key,
+                {effective_request_kind_label_sql} AS request_kind_label,
+                atl.request_kind_detail AS request_kind_detail,
+                atl.result_status AS result_status,
+                atl.failure_kind AS failure_kind,
+                atl.error_message AS error_message,
+                atl.counts_business_quota AS counts_business_quota,
+                u.id AS user_id,
+                u.display_name AS user_display_name,
+                u.username AS user_username,
+                NULL AS reason_code,
+                NULL AS reason_summary,
+                NULL AS reason_detail
+            FROM auth_token_logs atl
+            LEFT JOIN observability.request_logs rl ON rl.id = atl.request_log_id
+            LEFT JOIN user_token_bindings b ON b.token_id = atl.token_id
+            LEFT JOIN users u ON u.id = b.user_id
+            WHERE (
+                atl.failure_kind = 'upstream_rate_limited_429'
+                OR atl.result_status = 'quota_exhausted'
+            )
+            "#
+        ));
+        Self::push_auth_alert_filters(
+            query,
+            filters,
+            "COALESCE(atl.api_key_id, rl.api_key_id)",
+        );
+
+        query.push(
+            r#"
+            UNION ALL
+            SELECT
+            "#,
+        );
+        query.push_bind(ALERT_SOURCE_API_KEY_MAINTENANCE_RECORD);
+        query.push(format!(
+            r#" AS source_kind,
+                m.id AS source_id,
+                printf('maint:%s', m.id) AS row_sort_id,
+                'upstream_key_blocked' AS alert_type,
+                m.created_at AS occurred_at,
+                COALESCE(m.auth_token_id, atl.token_id) AS token_id,
+                m.key_id AS key_id,
+                COALESCE(m.request_log_id, atl.request_log_id) AS request_log_id,
+                COALESCE(atl.method, rl.method) AS method,
+                COALESCE(atl.path, rl.path) AS path,
+                COALESCE(atl.query, rl.query) AS query,
+                {maintenance_request_kind_sql} AS request_kind_key,
+                {maintenance_request_kind_label_sql} AS request_kind_label,
+                atl.request_kind_detail AS request_kind_detail,
+                atl.result_status AS result_status,
+                atl.failure_kind AS failure_kind,
+                atl.error_message AS error_message,
+                NULL AS counts_business_quota,
+                u.id AS user_id,
+                u.display_name AS user_display_name,
+                u.username AS user_username,
+                m.reason_code AS reason_code,
+                m.reason_summary AS reason_summary,
+                m.reason_detail AS reason_detail
+            FROM api_key_maintenance_records m
+            LEFT JOIN auth_token_logs atl ON atl.id = m.auth_token_log_id
+            LEFT JOIN observability.request_logs rl ON rl.id = COALESCE(m.request_log_id, atl.request_log_id)
+            LEFT JOIN user_token_bindings b ON b.token_id = COALESCE(m.auth_token_id, atl.token_id)
+            LEFT JOIN users u ON u.id = b.user_id
+            WHERE COALESCE(m.reason_code, '') IN ('account_deactivated', 'key_revoked', 'invalid_api_key')
+            "#
+        ));
+        Self::push_maintenance_alert_filters(query, filters);
+        query.push(")");
     }
 
-    fn paginate_alert_events(
-        events: Vec<AlertEventRecord>,
-        page: i64,
-        per_page: i64,
-    ) -> PaginatedAlertEvents {
-        let total = events.len() as i64;
-        let page = page.max(1);
-        let per_page = per_page.clamp(1, 100);
-        let start = ((page - 1) * per_page) as usize;
-        let end = (start + per_page as usize).min(events.len());
-        let items = if start >= events.len() {
-            Vec::new()
-        } else {
-            events[start..end].to_vec()
-        };
-        PaginatedAlertEvents {
-            items,
-            total,
-            page,
-            per_page,
-        }
+    fn alert_subject_kind_sql(alias: &str) -> String {
+        format!(
+            "CASE \
+                WHEN {alias}.alert_type = 'upstream_key_blocked' AND {alias}.key_id IS NOT NULL THEN 'key' \
+                WHEN {alias}.user_id IS NOT NULL THEN 'user' \
+                WHEN {alias}.token_id IS NOT NULL THEN 'token' \
+                WHEN {alias}.key_id IS NOT NULL THEN 'key' \
+                ELSE 'token' \
+            END"
+        )
     }
 
-    fn group_alert_events(events: &[AlertEventRecord]) -> Vec<AlertGroupRecord> {
-        let mut groups: HashMap<String, AlertGroupAccumulator> = HashMap::new();
-        for event in events {
-            let group_id = alert_group_id(event);
-            let entry = groups
-                .entry(group_id.clone())
-                .or_insert_with(|| AlertGroupAccumulator {
-                    alert_type: event.alert_type.clone(),
-                    subject_kind: event.subject_kind.clone(),
-                    subject_id: event.subject_id.clone(),
-                    subject_label: event.subject_label.clone(),
-                    user: event.user.clone(),
-                    token: event.token.clone(),
-                    key: event.key.clone(),
-                    request_kind: event.request_kind.clone(),
-                    count: 0,
-                    first_seen: event.occurred_at,
-                    last_seen: event.occurred_at,
-                    latest_event: event.clone(),
-                });
-            entry.count += 1;
-            entry.first_seen = entry.first_seen.min(event.occurred_at);
-            if event.occurred_at >= entry.last_seen {
-                entry.last_seen = event.occurred_at;
-                if event.occurred_at > entry.latest_event.occurred_at
-                    || (event.occurred_at == entry.latest_event.occurred_at
-                        && event.id > entry.latest_event.id)
-                {
-                    entry.latest_event = event.clone();
-                    entry.token = event.token.clone();
-                    entry.key = event.key.clone();
-                    entry.user = event.user.clone();
-                }
-            }
-        }
-
-        let mut grouped = groups
-            .into_iter()
-            .map(|(id, value)| AlertGroupRecord {
-                id,
-                alert_type: value.alert_type,
-                subject_kind: value.subject_kind,
-                subject_id: value.subject_id,
-                subject_label: value.subject_label,
-                user: value.user,
-                token: value.token,
-                key: value.key,
-                request_kind: value.request_kind,
-                count: value.count,
-                first_seen: value.first_seen,
-                last_seen: value.last_seen,
-                latest_event: value.latest_event,
-            })
-            .collect::<Vec<_>>();
-        grouped.sort_by(|left, right| {
-            right
-                .last_seen
-                .cmp(&left.last_seen)
-                .then_with(|| right.count.cmp(&left.count))
-                .then_with(|| right.id.cmp(&left.id))
-        });
-        grouped
+    fn alert_subject_id_sql(alias: &str) -> String {
+        format!(
+            "CASE \
+                WHEN {alias}.alert_type = 'upstream_key_blocked' AND {alias}.key_id IS NOT NULL THEN {alias}.key_id \
+                WHEN {alias}.user_id IS NOT NULL THEN {alias}.user_id \
+                WHEN {alias}.token_id IS NOT NULL THEN {alias}.token_id \
+                WHEN {alias}.key_id IS NOT NULL THEN {alias}.key_id \
+                ELSE 'unknown' \
+            END"
+        )
     }
 
-    fn paginate_alert_groups(
-        groups: Vec<AlertGroupRecord>,
-        page: i64,
-        per_page: i64,
-    ) -> PaginatedAlertGroups {
-        let total = groups.len() as i64;
-        let page = page.max(1);
-        let per_page = per_page.clamp(1, 100);
-        let start = ((page - 1) * per_page) as usize;
-        let end = (start + per_page as usize).min(groups.len());
-        let items = if start >= groups.len() {
-            Vec::new()
-        } else {
-            groups[start..end].to_vec()
-        };
-        PaginatedAlertGroups {
-            items,
-            total,
-            page,
-            per_page,
-        }
+    fn alert_group_request_kind_sql(alias: &str) -> String {
+        format!("COALESCE(NULLIF(TRIM({alias}.request_kind_key), ''), 'unknown')")
     }
 
-    fn summarize_alert_type_counts(events: &[AlertEventRecord]) -> Vec<AlertTypeCount> {
+    fn push_alert_groups_cte<'a>(
+        query: &mut QueryBuilder<'a, Sqlite>,
+        filters: AlertEventFilters<'a>,
+    ) {
+        let subject_kind_sql = Self::alert_subject_kind_sql("alerts");
+        let subject_id_sql = Self::alert_subject_id_sql("alerts");
+        let request_kind_sql = Self::alert_group_request_kind_sql("alerts");
+        Self::push_alert_events_cte(query, filters);
+        query.push(format!(
+            r#",
+            grouped_alerts AS (
+                SELECT
+                    alerts.row_sort_id AS row_sort_id,
+                    alerts.alert_type AS alert_type,
+                    {subject_kind_sql} AS subject_kind,
+                    {subject_id_sql} AS subject_id,
+                    {request_kind_sql} AS request_kind_key,
+                    COUNT(*) OVER (
+                        PARTITION BY alerts.alert_type, {subject_kind_sql}, {subject_id_sql}, {request_kind_sql}
+                    ) AS total_count,
+                    MIN(alerts.occurred_at) OVER (
+                        PARTITION BY alerts.alert_type, {subject_kind_sql}, {subject_id_sql}, {request_kind_sql}
+                    ) AS first_seen,
+                    MAX(alerts.occurred_at) OVER (
+                        PARTITION BY alerts.alert_type, {subject_kind_sql}, {subject_id_sql}, {request_kind_sql}
+                    ) AS last_seen,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY alerts.alert_type, {subject_kind_sql}, {subject_id_sql}, {request_kind_sql}
+                        ORDER BY alerts.occurred_at DESC, alerts.row_sort_id DESC
+                    ) AS group_rank
+                FROM alerts
+            )"#
+        ));
+    }
+
+    fn decode_alert_group_projection_row(
+        row: &sqlx::sqlite::SqliteRow,
+    ) -> Result<AlertGroupProjectionRow, sqlx::Error> {
+        Ok(AlertGroupProjectionRow {
+            row_sort_id: row.try_get("row_sort_id")?,
+            alert_type: row.try_get("alert_type")?,
+            subject_kind: row.try_get("subject_kind")?,
+            subject_id: row.try_get("subject_id")?,
+            total_count: row.try_get("total_count")?,
+            first_seen: row.try_get("first_seen")?,
+            last_seen: row.try_get("last_seen")?,
+        })
+    }
+
+    fn summarize_alert_type_count_rows(rows: Vec<sqlx::sqlite::SqliteRow>) -> Vec<AlertTypeCount> {
         let mut counts = default_alert_type_counts();
         let mut index_by_type = HashMap::new();
         for (index, item) in counts.iter().enumerate() {
             index_by_type.insert(item.alert_type.clone(), index);
         }
-        for event in events {
-            if let Some(index) = index_by_type.get(&event.alert_type).copied() {
-                counts[index].count += 1;
+        for row in rows {
+            let Ok(alert_type) = row.try_get::<String, _>("alert_type") else {
+                continue;
+            };
+            let Ok(count) = row.try_get::<i64, _>("count") else {
+                continue;
+            };
+            if let Some(index) = index_by_type.get(&alert_type).copied() {
+                counts[index].count = count;
             }
         }
         counts
+    }
+
+    async fn fetch_alert_event_projection_page(
+        &self,
+        filters: AlertEventFilters<'_>,
+        page: i64,
+        per_page: i64,
+    ) -> Result<PaginatedAlertEvents, ProxyError> {
+        let page = page.max(1);
+        let per_page = per_page.clamp(1, 100);
+        let offset = (page - 1) * per_page;
+        let mut count_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut count_query, filters);
+        count_query.push(" SELECT COUNT(*) FROM alerts WHERE 1 = 1");
+        Self::push_alert_request_kind_filter(
+            &mut count_query,
+            "COALESCE(NULLIF(TRIM(request_kind_key), ''), 'unknown')",
+            filters.request_kinds,
+        );
+        let total: i64 = count_query.build_query_scalar().fetch_one(&self.pool).await?;
+
+        let mut query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut query, filters);
+        query.push(" SELECT * FROM alerts WHERE 1 = 1");
+        Self::push_alert_request_kind_filter(
+            &mut query,
+            "COALESCE(NULLIF(TRIM(request_kind_key), ''), 'unknown')",
+            filters.request_kinds,
+        );
+        query.push(" ORDER BY occurred_at DESC, row_sort_id DESC LIMIT ");
+        query.push_bind(per_page);
+        query.push(" OFFSET ");
+        query.push_bind(offset);
+
+        let rows = query.build().fetch_all(&self.pool).await?;
+        let items = rows
+            .into_iter()
+            .map(Self::decode_alert_event_projection_row)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter_map(Self::build_alert_event_from_projection)
+            .collect::<Vec<_>>();
+
+        Ok(PaginatedAlertEvents {
+            items,
+            total,
+            page,
+            per_page,
+        })
+    }
+
+    async fn fetch_group_latest_events_by_projection(
+        &self,
+        filters: AlertEventFilters<'_>,
+        groups: &[AlertGroupProjectionRow],
+    ) -> Result<HashMap<String, AlertEventRecord>, ProxyError> {
+        if groups.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut query, filters);
+        query.push(" SELECT * FROM alerts WHERE row_sort_id IN (");
+        {
+            let mut separated = query.separated(", ");
+            for group in groups {
+                separated.push_bind(group.row_sort_id.as_str());
+            }
+        }
+        query.push(")");
+
+        let rows = query.build().fetch_all(&self.pool).await?;
+        let mut events_by_row_sort_id = HashMap::new();
+        for row in rows {
+            let decoded = Self::decode_alert_event_projection_row(row)?;
+            let row_sort_id = decoded.row_sort_id.clone();
+            if let Some(event) = Self::build_alert_event_from_projection(decoded) {
+                events_by_row_sort_id.insert(row_sort_id, event);
+            }
+        }
+        Ok(events_by_row_sort_id)
+    }
+
+    fn build_alert_group_records(
+        groups: Vec<AlertGroupProjectionRow>,
+        latest_events_by_row_sort_id: HashMap<String, AlertEventRecord>,
+    ) -> Vec<AlertGroupRecord> {
+        groups
+            .into_iter()
+            .filter_map(|group| {
+                let latest_event = latest_events_by_row_sort_id.get(&group.row_sort_id)?.clone();
+                Some(AlertGroupRecord {
+                    id: alert_group_id(&latest_event),
+                    alert_type: group.alert_type,
+                    subject_kind: group.subject_kind,
+                    subject_id: group.subject_id,
+                    subject_label: latest_event.subject_label.clone(),
+                    user: latest_event.user.clone(),
+                    token: latest_event.token.clone(),
+                    key: latest_event.key.clone(),
+                    request_kind: latest_event.request_kind.clone(),
+                    count: group.total_count,
+                    first_seen: group.first_seen,
+                    last_seen: group.last_seen,
+                    latest_event,
+                })
+            })
+            .collect()
+    }
+
+    async fn fetch_alert_group_projection_page(
+        &self,
+        filters: AlertEventFilters<'_>,
+        page: i64,
+        per_page: i64,
+    ) -> Result<PaginatedAlertGroups, ProxyError> {
+        let page = page.max(1);
+        let per_page = per_page.clamp(1, 100);
+        let offset = (page - 1) * per_page;
+
+        let mut count_query = QueryBuilder::new("");
+        Self::push_alert_groups_cte(&mut count_query, filters);
+        count_query.push(" SELECT COUNT(*) FROM grouped_alerts WHERE group_rank = 1");
+        Self::push_alert_request_kind_filter(
+            &mut count_query,
+            "COALESCE(NULLIF(TRIM(request_kind_key), ''), 'unknown')",
+            filters.request_kinds,
+        );
+        let total: i64 = count_query.build_query_scalar().fetch_one(&self.pool).await?;
+
+        let mut query = QueryBuilder::new("");
+        Self::push_alert_groups_cte(&mut query, filters);
+        query.push(" SELECT * FROM grouped_alerts WHERE group_rank = 1");
+        Self::push_alert_request_kind_filter(
+            &mut query,
+            "COALESCE(NULLIF(TRIM(request_kind_key), ''), 'unknown')",
+            filters.request_kinds,
+        );
+        query.push(
+            " ORDER BY last_seen DESC, total_count DESC, alert_type DESC, row_sort_id DESC LIMIT ",
+        );
+        query.push_bind(per_page);
+        query.push(" OFFSET ");
+        query.push_bind(offset);
+
+        let rows = query.build().fetch_all(&self.pool).await?;
+        let groups = rows
+            .iter()
+            .map(Self::decode_alert_group_projection_row)
+            .collect::<Result<Vec<_>, _>>()?;
+        let latest_events_by_row_sort_id =
+            self.fetch_group_latest_events_by_projection(filters, &groups).await?;
+        let items = Self::build_alert_group_records(groups, latest_events_by_row_sort_id);
+
+        Ok(PaginatedAlertGroups {
+            items,
+            total,
+            page,
+            per_page,
+        })
+    }
+
+    fn decode_alert_event_projection_row(
+        row: sqlx::sqlite::SqliteRow,
+    ) -> Result<AlertEventProjectionRow, sqlx::Error> {
+        Ok(AlertEventProjectionRow {
+            source_kind: row.try_get("source_kind")?,
+            source_id: row.try_get("source_id")?,
+            row_sort_id: row.try_get("row_sort_id")?,
+            alert_type: row.try_get("alert_type")?,
+            occurred_at: row.try_get("occurred_at")?,
+            token_id: row.try_get("token_id")?,
+            key_id: row.try_get("key_id")?,
+            request_log_id: row.try_get("request_log_id")?,
+            method: row.try_get("method")?,
+            path: row.try_get("path")?,
+            query: row.try_get("query")?,
+            request_kind_key: row.try_get("request_kind_key")?,
+            request_kind_label: row.try_get("request_kind_label")?,
+            request_kind_detail: row.try_get("request_kind_detail")?,
+            result_status: row.try_get("result_status")?,
+            failure_kind: row.try_get("failure_kind")?,
+            error_message: row.try_get("error_message")?,
+            counts_business_quota: row
+                .try_get::<Option<i64>, _>("counts_business_quota")?
+                .map(|value| value != 0),
+            user_id: row.try_get("user_id")?,
+            user_display_name: row.try_get("user_display_name")?,
+            user_username: row.try_get("user_username")?,
+            reason_code: row.try_get("reason_code")?,
+            reason_summary: row.try_get("reason_summary")?,
+            reason_detail: row.try_get("reason_detail")?,
+        })
+    }
+
+    fn build_alert_event_from_projection(row: AlertEventProjectionRow) -> Option<AlertEventRecord> {
+        let AlertEventProjectionRow {
+            source_kind,
+            source_id,
+            row_sort_id: _,
+            alert_type,
+            occurred_at,
+            token_id,
+            key_id,
+            request_log_id,
+            method,
+            path,
+            query,
+            request_kind_key,
+            request_kind_label,
+            request_kind_detail,
+            result_status,
+            failure_kind,
+            error_message,
+            counts_business_quota,
+            user_id,
+            user_display_name,
+            user_username,
+            reason_code,
+            reason_summary,
+            reason_detail,
+        } = row;
+
+        let resolved_alert_type = if !alert_type.trim().is_empty() {
+            alert_type
+        } else if failure_kind.as_deref() == Some(ALERT_TYPE_UPSTREAM_RATE_LIMITED_429) {
+            ALERT_TYPE_UPSTREAM_RATE_LIMITED_429.to_string()
+        } else if result_status.as_deref() == Some("quota_exhausted")
+            && counts_business_quota == Some(false)
+        {
+            ALERT_TYPE_USER_REQUEST_RATE_LIMITED.to_string()
+        } else if result_status.as_deref() == Some("quota_exhausted") {
+            ALERT_TYPE_USER_QUOTA_EXHAUSTED.to_string()
+        } else {
+            return None;
+        };
+
+        let user = build_alert_user_ref(user_id, user_display_name, user_username);
+        let token = build_alert_entity_ref(token_id);
+        let key = build_alert_entity_ref(key_id);
+        let request_kind = build_alert_request_kind(
+            method.as_deref(),
+            path.as_deref(),
+            query.as_deref(),
+            request_kind_key,
+            request_kind_label,
+            request_kind_detail,
+        );
+        let request = request_log_id.map(|request_log_id| AlertRequestRef {
+            id: request_log_id,
+            method: method.clone().unwrap_or_else(|| "POST".to_string()),
+            path: path.clone().unwrap_or_else(|| "/unknown".to_string()),
+            query: query.clone(),
+        });
+        let (subject_kind, subject_id, subject_label) = alert_subject_tuple(
+            resolved_alert_type.as_str(),
+            user.as_ref(),
+            token.as_ref(),
+            key.as_ref(),
+        );
+        let (title, summary) = build_alert_title_and_summary(
+            resolved_alert_type.as_str(),
+            subject_label.as_str(),
+            token.as_ref(),
+            key.as_ref(),
+            request_kind.as_ref(),
+            reason_summary.as_deref(),
+        );
+
+        Some(AlertEventRecord {
+            id: format!("{source_kind}:{source_id}"),
+            alert_type: resolved_alert_type,
+            title,
+            summary,
+            occurred_at,
+            subject_kind,
+            subject_id,
+            subject_label,
+            user,
+            token,
+            key,
+            request,
+            request_kind,
+            failure_kind,
+            result_status,
+            error_message,
+            reason_code,
+            reason_summary,
+            reason_detail,
+            source: AlertSourceRef {
+                kind: source_kind,
+                id: source_id,
+            },
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -762,8 +842,8 @@ impl KeyStore {
         page: i64,
         per_page: i64,
     ) -> Result<PaginatedAlertEvents, ProxyError> {
-        let events = self
-            .fetch_alert_events_filtered(AlertEventFilters {
+        self.fetch_alert_event_projection_page(
+            AlertEventFilters {
                 alert_type,
                 since,
                 until,
@@ -771,9 +851,11 @@ impl KeyStore {
                 token_id,
                 key_id,
                 request_kinds,
-            })
-            .await?;
-        Ok(Self::paginate_alert_events(events, page, per_page))
+            },
+            page,
+            per_page,
+        )
+        .await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -789,8 +871,8 @@ impl KeyStore {
         page: i64,
         per_page: i64,
     ) -> Result<PaginatedAlertGroups, ProxyError> {
-        let events = self
-            .fetch_alert_events_filtered(AlertEventFilters {
+        self.fetch_alert_group_projection_page(
+            AlertEventFilters {
                 alert_type,
                 since,
                 until,
@@ -798,124 +880,150 @@ impl KeyStore {
                 token_id,
                 key_id,
                 request_kinds,
-            })
-            .await?;
-        Ok(Self::paginate_alert_groups(
-            Self::group_alert_events(&events),
+            },
             page,
             per_page,
-        ))
+        )
+        .await
     }
 
     pub(crate) async fn fetch_alert_catalog(&self) -> Result<AlertCatalog, ProxyError> {
-        let events = self
-            .fetch_alert_events_filtered(AlertEventFilters {
-                alert_type: None,
-                since: None,
-                until: None,
-                user_id: None,
-                token_id: None,
-                key_id: None,
-                request_kinds: &[],
-            })
-            .await?;
-
-        let types = Self::summarize_alert_type_counts(&events)
+        let filters = AlertEventFilters {
+            alert_type: None,
+            since: None,
+            until: None,
+            user_id: None,
+            token_id: None,
+            key_id: None,
+            request_kinds: &[],
+        };
+        let mut request_kind_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut request_kind_query, filters);
+        request_kind_query.push(
+            " SELECT \
+                request_kind_key, \
+                MIN(request_kind_label) AS request_kind_label, \
+                COUNT(*) AS count \
+              FROM alerts \
+              WHERE COALESCE(NULLIF(TRIM(request_kind_key), ''), '') <> '' \
+                AND COALESCE(NULLIF(TRIM(request_kind_key), ''), 'unknown') <> 'unknown' \
+              GROUP BY request_kind_key \
+              ORDER BY count DESC, request_kind_label ASC, request_kind_key ASC",
+        );
+        let request_kind_rows = request_kind_query.build().fetch_all(&self.pool).await?;
+        let request_kind_options = request_kind_rows
             .into_iter()
-            .map(|value| LogFacetOption {
-                value: value.alert_type,
-                count: value.count,
+            .map(|row| -> Result<TokenRequestKindOption, sqlx::Error> {
+                let key: String = row.try_get("request_kind_key")?;
+                let label = row
+                    .try_get::<Option<String>, _>("request_kind_label")?
+                    .unwrap_or_else(|| key.clone());
+                let count: i64 = row.try_get("count")?;
+                Ok(TokenRequestKindOption {
+                    key: key.clone(),
+                    label,
+                    protocol_group: token_request_kind_protocol_group(&key).to_string(),
+                    billing_group: token_request_kind_billing_group(&key).to_string(),
+                    count,
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
 
-        let mut request_kind_map: HashMap<String, TokenRequestKindOption> = HashMap::new();
-        let mut users_map: HashMap<String, AlertFacetOption> = HashMap::new();
-        let mut tokens_map: HashMap<String, AlertFacetOption> = HashMap::new();
-        let mut keys_map: HashMap<String, AlertFacetOption> = HashMap::new();
+        let mut users_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut users_query, filters);
+        users_query.push(
+            " SELECT \
+                user_id AS value, \
+                COALESCE(NULLIF(TRIM(user_display_name), ''), NULLIF(TRIM(user_username), ''), user_id) AS label, \
+                COUNT(*) AS count \
+              FROM alerts \
+              WHERE user_id IS NOT NULL \
+              GROUP BY user_id, label \
+              ORDER BY count DESC, label ASC, value ASC",
+        );
+        let users = users_query
+            .build()
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(|row| -> Result<AlertFacetOption, sqlx::Error> {
+                Ok(AlertFacetOption {
+                    value: row.try_get("value")?,
+                    label: row.try_get("label")?,
+                    count: row.try_get("count")?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
-        for event in &events {
-            if let Some(request_kind) = event.request_kind.as_ref() {
-                request_kind_map
-                    .entry(request_kind.key.clone())
-                    .and_modify(|entry| entry.count += 1)
-                    .or_insert_with(|| TokenRequestKindOption {
-                        key: request_kind.key.clone(),
-                        label: request_kind.label.clone(),
-                        protocol_group: token_request_kind_protocol_group(&request_kind.key)
-                            .to_string(),
-                        billing_group: token_request_kind_billing_group(&request_kind.key)
-                            .to_string(),
-                        count: 1,
-                    });
-            }
+        let mut tokens_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut tokens_query, filters);
+        tokens_query.push(
+            " SELECT \
+                token_id AS value, \
+                token_id AS label, \
+                COUNT(*) AS count \
+              FROM alerts \
+              WHERE token_id IS NOT NULL \
+              GROUP BY token_id \
+              ORDER BY count DESC, label ASC, value ASC",
+        );
+        let tokens = tokens_query
+            .build()
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(|row| -> Result<AlertFacetOption, sqlx::Error> {
+                Ok(AlertFacetOption {
+                    value: row.try_get("value")?,
+                    label: row.try_get("label")?,
+                    count: row.try_get("count")?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
-            if let Some(user) = event.user.as_ref() {
-                users_map
-                    .entry(user.user_id.clone())
-                    .and_modify(|entry| entry.count += 1)
-                    .or_insert_with(|| AlertFacetOption {
-                        value: user.user_id.clone(),
-                        label: alert_user_label(user),
-                        count: 1,
-                    });
-            }
-            if let Some(token) = event.token.as_ref() {
-                tokens_map
-                    .entry(token.id.clone())
-                    .and_modify(|entry| entry.count += 1)
-                    .or_insert_with(|| AlertFacetOption {
-                        value: token.id.clone(),
-                        label: token.label.clone(),
-                        count: 1,
-                    });
-            }
-            if let Some(key) = event.key.as_ref() {
-                keys_map
-                    .entry(key.id.clone())
-                    .and_modify(|entry| entry.count += 1)
-                    .or_insert_with(|| AlertFacetOption {
-                        value: key.id.clone(),
-                        label: key.label.clone(),
-                        count: 1,
-                    });
-            }
-        }
+        let mut keys_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut keys_query, filters);
+        keys_query.push(
+            " SELECT \
+                key_id AS value, \
+                key_id AS label, \
+                COUNT(*) AS count \
+              FROM alerts \
+              WHERE key_id IS NOT NULL \
+              GROUP BY key_id \
+              ORDER BY count DESC, label ASC, value ASC",
+        );
+        let keys = keys_query
+            .build()
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(|row| -> Result<AlertFacetOption, sqlx::Error> {
+                Ok(AlertFacetOption {
+                    value: row.try_get("value")?,
+                    label: row.try_get("label")?,
+                    count: row.try_get("count")?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
-        let mut request_kind_options = request_kind_map.into_values().collect::<Vec<_>>();
-        request_kind_options.sort_by(|left, right| {
-            right
-                .count
-                .cmp(&left.count)
-                .then_with(|| left.label.cmp(&right.label))
-                .then_with(|| left.key.cmp(&right.key))
-        });
-
-        let mut users = users_map.into_values().collect::<Vec<_>>();
-        users.sort_by(|left, right| {
-            right
-                .count
-                .cmp(&left.count)
-                .then_with(|| left.label.cmp(&right.label))
-                .then_with(|| left.value.cmp(&right.value))
-        });
-
-        let mut tokens = tokens_map.into_values().collect::<Vec<_>>();
-        tokens.sort_by(|left, right| {
-            right
-                .count
-                .cmp(&left.count)
-                .then_with(|| left.label.cmp(&right.label))
-                .then_with(|| left.value.cmp(&right.value))
-        });
-
-        let mut keys = keys_map.into_values().collect::<Vec<_>>();
-        keys.sort_by(|left, right| {
-            right
-                .count
-                .cmp(&left.count)
-                .then_with(|| left.label.cmp(&right.label))
-                .then_with(|| left.value.cmp(&right.value))
-        });
+        let mut types_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut types_query, filters);
+        types_query.push(
+            " SELECT alert_type, COUNT(*) AS count \
+              FROM alerts \
+              WHERE COALESCE(NULLIF(TRIM(alert_type), ''), '') <> '' \
+              GROUP BY alert_type",
+        );
+        let types = Self::summarize_alert_type_count_rows(
+            types_query.build().fetch_all(&self.pool).await?,
+        )
+        .into_iter()
+        .map(|value| LogFacetOption {
+            value: value.alert_type,
+            count: value.count,
+        })
+        .collect::<Vec<_>>();
 
         Ok(AlertCatalog {
             retention_days: self.effective_auth_token_log_retention_days().await?,
@@ -936,24 +1044,45 @@ impl KeyStore {
             .backend_time
             .now_ts()
             .saturating_sub(clamped_window_hours.saturating_mul(3600));
-        let events = self
-            .fetch_alert_events_filtered(AlertEventFilters {
-                alert_type: None,
-                since: Some(since),
-                until: None,
-                user_id: None,
-                token_id: None,
-                key_id: None,
-                request_kinds: &[],
-            })
-            .await?;
-        let grouped = Self::group_alert_events(&events);
+        let filters = AlertEventFilters {
+            alert_type: None,
+            since: Some(since),
+            until: None,
+            user_id: None,
+            token_id: None,
+            key_id: None,
+            request_kinds: &[],
+        };
+        let mut summary_query = QueryBuilder::new("");
+        Self::push_alert_groups_cte(&mut summary_query, filters);
+        summary_query.push(
+            " SELECT \
+                (SELECT COUNT(*) FROM alerts) AS total_events, \
+                (SELECT COUNT(*) FROM grouped_alerts WHERE group_rank = 1) AS grouped_count",
+        );
+        let summary_row = summary_query.build().fetch_one(&self.pool).await?;
+        let total_events: i64 = summary_row.try_get("total_events")?;
+        let grouped_count: i64 = summary_row.try_get("grouped_count")?;
+
+        let mut counts_query = QueryBuilder::new("");
+        Self::push_alert_events_cte(&mut counts_query, filters);
+        counts_query.push(
+            " SELECT alert_type, COUNT(*) AS count \
+              FROM alerts \
+              WHERE COALESCE(NULLIF(TRIM(alert_type), ''), '') <> '' \
+              GROUP BY alert_type",
+        );
+        let counts_by_type = Self::summarize_alert_type_count_rows(
+            counts_query.build().fetch_all(&self.pool).await?,
+        );
+
+        let top_groups = self.fetch_alert_group_projection_page(filters, 1, 5).await?.items;
         Ok(RecentAlertsSummary {
             window_hours: clamped_window_hours,
-            total_events: events.len() as i64,
-            grouped_count: grouped.len() as i64,
-            counts_by_type: Self::summarize_alert_type_counts(&events),
-            top_groups: grouped.into_iter().take(5).collect(),
+            total_events,
+            grouped_count,
+            counts_by_type,
+            top_groups,
         })
     }
 }

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -638,6 +638,139 @@ impl KeyStore {
         )
         .execute(&self.pool)
         .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_billing_ledger_request_log
+               ON billing_ledger(request_log_id, auth_token_log_id)"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn billing_ledger_startup_repair_upper_bound(&self) -> Result<Option<i64>, ProxyError> {
+        sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT MAX(id)
+            FROM auth_token_logs
+            WHERE billing_state <> 'none'
+               OR billing_subject IS NOT NULL
+               OR business_credits IS NOT NULL
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(ProxyError::Database)
+    }
+
+    async fn billing_ledger_startup_repair_needs_reconcile(
+        &self,
+        upper_bound: i64,
+    ) -> Result<bool, ProxyError> {
+        let persisted_high_watermark = self
+            .get_meta_i64(META_KEY_BILLING_LEDGER_STARTUP_HIGH_WATERMARK_V1)
+            .await?
+            .unwrap_or_default();
+        if persisted_high_watermark >= upper_bound {
+            let has_gap = sqlx::query_scalar::<_, i64>(
+                r#"
+                SELECT 1
+                FROM auth_token_logs atl
+                WHERE atl.id <= ?
+                  AND (
+                    atl.billing_state <> 'none'
+                    OR atl.billing_subject IS NOT NULL
+                    OR atl.business_credits IS NOT NULL
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM billing_ledger bl
+                    WHERE bl.auth_token_log_id = atl.id
+                  )
+                LIMIT 1
+                "#,
+            )
+            .bind(upper_bound)
+            .fetch_optional(&self.pool)
+            .await?;
+            if has_gap.is_none() {
+                return Ok(false);
+            }
+        }
+
+        let mismatch = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT 1
+            FROM auth_token_logs atl
+            LEFT JOIN billing_ledger bl ON bl.auth_token_log_id = atl.id
+            WHERE atl.id <= ?
+              AND (
+                atl.billing_state <> 'none'
+                OR atl.billing_subject IS NOT NULL
+                OR atl.business_credits IS NOT NULL
+              )
+              AND (
+                bl.auth_token_log_id IS NULL
+                OR bl.token_id <> atl.token_id
+                OR COALESCE(bl.billing_subject, '') <> COALESCE(atl.billing_subject, '')
+                OR bl.billing_state <> atl.billing_state
+                OR COALESCE(bl.business_credits, -1) <> COALESCE(atl.business_credits, -1)
+                OR COALESCE(bl.request_user_id, '') <> COALESCE(atl.request_user_id, '')
+                OR COALESCE(bl.api_key_id, '') <> COALESCE(atl.api_key_id, '')
+                OR bl.result_status <> atl.result_status
+                OR bl.created_at <> atl.created_at
+                OR COALESCE(bl.error_message, '') <> COALESCE(atl.error_message, '')
+              )
+            LIMIT 1
+            "#,
+        )
+        .bind(upper_bound)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(mismatch.is_some())
+    }
+
+    async fn maybe_repair_billing_ledger_from_auth_token_logs(&self) -> Result<(), ProxyError> {
+        let Some(upper_bound) = self.billing_ledger_startup_repair_upper_bound().await? else {
+            self.set_meta_i64(META_KEY_BILLING_LEDGER_STARTUP_HIGH_WATERMARK_V1, 0)
+                .await?;
+            eprintln!("billing ledger startup precheck skipped: upper_bound=0, reason=no_billable_logs");
+            return Ok(());
+        };
+
+        let precheck_started = Instant::now();
+        let needs_reconcile = self
+            .billing_ledger_startup_repair_needs_reconcile(upper_bound)
+            .await?;
+        log_slow_db_operation(
+            "billing ledger startup precheck",
+            precheck_started.elapsed(),
+            Some("component=startup"),
+        );
+
+        if !needs_reconcile {
+            self.set_meta_i64(META_KEY_BILLING_LEDGER_STARTUP_HIGH_WATERMARK_V1, upper_bound)
+                .await?;
+            eprintln!(
+                "billing ledger startup precheck skipped: upper_bound={upper_bound}, reason=no_gap"
+            );
+            return Ok(());
+        }
+
+        eprintln!("billing ledger startup repair started: upper_bound={upper_bound}");
+        let repair_started = Instant::now();
+        self.backfill_billing_ledger_from_auth_token_logs().await?;
+        self.set_meta_i64(META_KEY_BILLING_LEDGER_STARTUP_HIGH_WATERMARK_V1, upper_bound)
+            .await?;
+        let elapsed = repair_started.elapsed();
+        log_slow_db_operation(
+            "billing ledger startup repair",
+            elapsed,
+            Some("component=startup"),
+        );
+        eprintln!(
+            "billing ledger startup repair completed: upper_bound={upper_bound}, elapsed_ms={}",
+            elapsed.as_millis()
+        );
         Ok(())
     }
 
@@ -1764,7 +1897,9 @@ impl KeyStore {
             request_kind_schema_changed = true;
         }
 
-        self.backfill_billing_ledger_from_auth_token_logs().await?;
+        self.ensure_meta_schema().await?;
+        self.maybe_repair_billing_ledger_from_auth_token_logs()
+            .await?;
 
         self.ensure_auth_token_logs_indexes().await?;
 

--- a/src/store/key_store_migrations_b.rs
+++ b/src/store/key_store_migrations_b.rs
@@ -575,6 +575,24 @@ impl KeyStore {
         )
         .execute(&self.pool)
         .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_token_logs_failure_created
+               ON auth_token_logs(failure_kind, created_at DESC, id DESC)"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_token_logs_result_created
+               ON auth_token_logs(result_status, created_at DESC, id DESC)"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_token_logs_result_token_created
+               ON auth_token_logs(result_status, token_id, created_at DESC, id DESC)"#,
+        )
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 

--- a/src/store/key_store_public_metrics_freshness.rs
+++ b/src/store/key_store_public_metrics_freshness.rs
@@ -1,10 +1,7 @@
 impl KeyStore {
-    async fn request_stats_last_flushed_at(&self) -> Result<Option<i64>, ProxyError> {
-        self.get_meta_i64(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1).await
-    }
-
     async fn flush_request_stats_writes_if_public_metrics_stale(
         &self,
+        month_start: i64,
         day_start: i64,
         day_end: i64,
     ) -> Result<(), ProxyError> {
@@ -19,20 +16,15 @@ impl KeyStore {
             .await
             .unwrap_or(oldest_pending_created_at);
 
-        if newest_pending_created_at >= day_end {
+        let pending_overlaps_day =
+            oldest_pending_created_at < day_end && newest_pending_created_at >= day_start;
+        let pending_overlaps_month = newest_pending_created_at >= month_start;
+
+        if !(pending_overlaps_day || pending_overlaps_month) {
             return Ok(());
         }
 
-        let last_flushed_at = self.request_stats_last_flushed_at().await?.unwrap_or_default();
-        let has_window_pending = newest_pending_created_at >= day_start;
-        let needs_flush = if has_window_pending {
-            last_flushed_at < newest_pending_created_at
-        } else {
-            !(last_flushed_at >= oldest_pending_created_at && last_flushed_at >= day_start)
-        };
-        if needs_flush {
-            self.flush_request_stats_writes().await?;
-        }
+        self.flush_request_stats_writes().await?;
         Ok(())
     }
 }

--- a/src/store/key_store_public_metrics_freshness.rs
+++ b/src/store/key_store_public_metrics_freshness.rs
@@ -1,0 +1,29 @@
+impl KeyStore {
+    async fn request_stats_last_flushed_at(&self) -> Result<Option<i64>, ProxyError> {
+        self.get_meta_i64(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1).await
+    }
+
+    async fn flush_request_stats_writes_if_public_metrics_stale(
+        &self,
+        day_start: i64,
+        day_end: i64,
+    ) -> Result<(), ProxyError> {
+        let Some(oldest_pending_created_at) =
+            self.request_stats_coalescer.pending_oldest_created_at().await
+        else {
+            return Ok(());
+        };
+
+        if oldest_pending_created_at >= day_end {
+            return Ok(());
+        }
+
+        let last_flushed_at = self.request_stats_last_flushed_at().await?.unwrap_or_default();
+        let needs_flush =
+            !(last_flushed_at >= oldest_pending_created_at && last_flushed_at >= day_start);
+        if needs_flush {
+            self.flush_request_stats_writes().await?;
+        }
+        Ok(())
+    }
+}

--- a/src/store/key_store_public_metrics_freshness.rs
+++ b/src/store/key_store_public_metrics_freshness.rs
@@ -5,16 +5,13 @@ impl KeyStore {
         day_start: i64,
         day_end: i64,
     ) -> Result<(), ProxyError> {
-        let Some(oldest_pending_created_at) =
-            self.request_stats_coalescer.pending_oldest_created_at().await
+        let Some((oldest_pending_created_at, newest_pending_created_at)) = self
+            .request_stats_coalescer
+            .freshness_created_at_bounds()
+            .await
         else {
             return Ok(());
         };
-        let newest_pending_created_at = self
-            .request_stats_coalescer
-            .pending_newest_created_at()
-            .await
-            .unwrap_or(oldest_pending_created_at);
 
         let pending_overlaps_day =
             oldest_pending_created_at < day_end && newest_pending_created_at >= day_start;

--- a/src/store/key_store_public_metrics_freshness.rs
+++ b/src/store/key_store_public_metrics_freshness.rs
@@ -13,14 +13,23 @@ impl KeyStore {
         else {
             return Ok(());
         };
+        let newest_pending_created_at = self
+            .request_stats_coalescer
+            .pending_newest_created_at()
+            .await
+            .unwrap_or(oldest_pending_created_at);
 
-        if oldest_pending_created_at >= day_end {
+        if newest_pending_created_at >= day_end {
             return Ok(());
         }
 
         let last_flushed_at = self.request_stats_last_flushed_at().await?.unwrap_or_default();
-        let needs_flush =
-            !(last_flushed_at >= oldest_pending_created_at && last_flushed_at >= day_start);
+        let has_window_pending = newest_pending_created_at >= day_start;
+        let needs_flush = if has_window_pending {
+            last_flushed_at < newest_pending_created_at
+        } else {
+            !(last_flushed_at >= oldest_pending_created_at && last_flushed_at >= day_start)
+        };
         if needs_flush {
             self.flush_request_stats_writes().await?;
         }

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -3016,7 +3016,7 @@ impl KeyStore {
         day_start: i64,
         day_end: i64,
     ) -> Result<SuccessBreakdown, ProxyError> {
-        self.flush_request_stats_writes_if_public_metrics_stale(day_start, day_end)
+        self.flush_request_stats_writes_if_public_metrics_stale(month_start, day_start, day_end)
             .await?;
         let now = self.backend_time.now_ts();
         let month_request_log_floor = self

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -496,6 +496,7 @@ impl KeyStore {
                 return Err(err);
             }
             state.oldest_pending_created_at = None;
+            state.newest_pending_created_at = None;
             self.request_stats_coalescer.flushed.notify_waiters();
         }
     }

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -447,6 +447,18 @@ impl KeyStore {
                     .await?;
                 }
 
+                sqlx::query(
+                    r#"
+                    INSERT INTO meta (key, value)
+                    VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    "#,
+                )
+                .bind(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1)
+                .bind(updated_at.to_string())
+                .execute(&mut *tx)
+                .await?;
+
                 tx.commit().await?;
                 Ok::<_, ProxyError>(())
             }
@@ -483,6 +495,7 @@ impl KeyStore {
                 self.request_stats_coalescer.flushed.notify_waiters();
                 return Err(err);
             }
+            state.oldest_pending_created_at = None;
             self.request_stats_coalescer.flushed.notify_waiters();
         }
     }
@@ -3002,7 +3015,8 @@ impl KeyStore {
         day_start: i64,
         day_end: i64,
     ) -> Result<SuccessBreakdown, ProxyError> {
-        self.flush_request_stats_writes().await?;
+        self.flush_request_stats_writes_if_public_metrics_stale(day_start, day_end)
+            .await?;
         let now = self.backend_time.now_ts();
         let month_request_log_floor = self
             .fetch_visible_request_log_floor_since(month_start)

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -262,18 +262,19 @@ impl KeyStore {
                     return Ok(());
                 } else {
                     state.flushing = true;
+                    state.flushing_oldest_created_at = state.oldest_pending_created_at.take();
+                    state.flushing_newest_created_at = state.newest_pending_created_at.take();
                     Some((
                         std::mem::take(&mut state.pending_dashboard_rollups),
                         std::mem::take(&mut state.pending_api_key_usage),
                         std::mem::take(&mut state.pending_auth_token_activity),
                         std::mem::take(&mut state.pending_account_request_rollups),
                         std::mem::take(&mut state.pending_request_log_catalog),
-                        state.oldest_pending_created_at.take(),
-                        state.newest_pending_created_at.take(),
+                        state.flushing_oldest_created_at,
+                        state.flushing_newest_created_at,
                     ))
                 }
             };
-
             let Some((
                 pending_dashboard_rollups,
                 pending_api_key_usage,
@@ -296,7 +297,6 @@ impl KeyStore {
             let updated_at = Utc::now().timestamp();
             let result = async {
                 let mut tx = self.pool.begin().await?;
-
                 let mut dashboard_entries = pending_dashboard_rollups
                     .drain()
                     .collect::<Vec<_>>();
@@ -473,6 +473,8 @@ impl KeyStore {
                 state.flushing = false;
                 state.flush_deadline = None;
                 if let Err(err) = result {
+                    state.flushing_oldest_created_at = None;
+                    state.flushing_newest_created_at = None;
                     for (key, counts) in pending_dashboard_rollups {
                         state.pending_dashboard_rollups.entry(key).or_default().add(counts);
                     }
@@ -516,6 +518,8 @@ impl KeyStore {
                     self.request_stats_coalescer.flushed.notify_waiters();
                     return Err(err);
                 }
+                state.flushing_oldest_created_at = None;
+                state.flushing_newest_created_at = None;
                 if RequestStatsCoalescer::pending_key_count(&state) == 0 {
                     state.oldest_pending_created_at = None;
                     state.newest_pending_created_at = None;

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -268,6 +268,8 @@ impl KeyStore {
                         std::mem::take(&mut state.pending_auth_token_activity),
                         std::mem::take(&mut state.pending_account_request_rollups),
                         std::mem::take(&mut state.pending_request_log_catalog),
+                        state.oldest_pending_created_at.take(),
+                        state.newest_pending_created_at.take(),
                     ))
                 }
             };
@@ -278,6 +280,8 @@ impl KeyStore {
                 pending_auth_token_activity,
                 pending_account_request_rollups,
                 pending_request_log_catalog,
+                drained_oldest_pending_created_at,
+                drained_newest_pending_created_at,
             )) = pending
             else {
                 self.request_stats_coalescer.wait_until_flushed().await;
@@ -464,75 +468,67 @@ impl KeyStore {
             }
             .await;
 
-            let mut state = self.request_stats_coalescer.state.lock().await;
-            state.flushing = false;
-            state.flush_deadline = None;
-            if let Err(err) = result {
-                for (key, counts) in pending_dashboard_rollups {
-                    state.pending_dashboard_rollups.entry(key).or_default().add(counts);
+            {
+                let mut state = self.request_stats_coalescer.state.lock().await;
+                state.flushing = false;
+                state.flush_deadline = None;
+                if let Err(err) = result {
+                    for (key, counts) in pending_dashboard_rollups {
+                        state.pending_dashboard_rollups.entry(key).or_default().add(counts);
+                    }
+                    for (key, delta) in pending_api_key_usage {
+                        state.pending_api_key_usage.entry(key).or_default().add(delta);
+                    }
+                    for (token_id, delta) in pending_auth_token_activity {
+                        state
+                            .pending_auth_token_activity
+                            .entry(token_id)
+                            .or_default()
+                            .add(delta);
+                    }
+                    for (key, delta) in pending_account_request_rollups {
+                        state
+                            .pending_account_request_rollups
+                            .entry(key)
+                            .or_default()
+                            .add(delta);
+                    }
+                    for (key, delta) in pending_request_log_catalog {
+                        *state.pending_request_log_catalog.entry(key).or_default() += delta;
+                    }
+                    if let Some(created_at) = drained_oldest_pending_created_at {
+                        state.oldest_pending_created_at = Some(
+                            state
+                                .oldest_pending_created_at
+                                .map(|current| current.min(created_at))
+                                .unwrap_or(created_at),
+                        );
+                    }
+                    if let Some(created_at) = drained_newest_pending_created_at {
+                        state.newest_pending_created_at = Some(
+                            state
+                                .newest_pending_created_at
+                                .map(|current| current.max(created_at))
+                                .unwrap_or(created_at),
+                        );
+                    }
+                    RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
+                    self.request_stats_coalescer.flushed.notify_waiters();
+                    return Err(err);
                 }
-                for (key, delta) in pending_api_key_usage {
-                    state.pending_api_key_usage.entry(key).or_default().add(delta);
+                if RequestStatsCoalescer::pending_key_count(&state) == 0 {
+                    state.oldest_pending_created_at = None;
+                    state.newest_pending_created_at = None;
+                } else {
+                    RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
                 }
-                for (token_id, delta) in pending_auth_token_activity {
-                    state
-                        .pending_auth_token_activity
-                        .entry(token_id)
-                        .or_default()
-                        .add(delta);
-                }
-                for (key, delta) in pending_account_request_rollups {
-                    state
-                        .pending_account_request_rollups
-                        .entry(key)
-                        .or_default()
-                        .add(delta);
-                }
-                for (key, delta) in pending_request_log_catalog {
-                    *state.pending_request_log_catalog.entry(key).or_default() += delta;
-                }
-                RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
                 self.request_stats_coalescer.flushed.notify_waiters();
-                return Err(err);
             }
-            state.oldest_pending_created_at = None;
-            state.newest_pending_created_at = None;
-            self.request_stats_coalescer.flushed.notify_waiters();
+            #[cfg(test)]
+            self.request_stats_coalescer
+                .wait_for_post_flush_pause_if_installed()
+                .await;
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn enqueue_request_stats_rollup_for_test(
-        &self,
-        api_key_id: Option<&str>,
-        created_at: i64,
-        outcome: &str,
-    ) {
-        let mut counts = DashboardRequestRollupCounts {
-            total_requests: 1,
-            api_billable: 1,
-            ..DashboardRequestRollupCounts::default()
-        };
-        match outcome {
-            OUTCOME_SUCCESS => {
-                counts.success_count = 1;
-                counts.valuable_success_count = 1;
-            }
-            OUTCOME_ERROR => {
-                counts.error_count = 1;
-                counts.valuable_failure_count = 1;
-            }
-            OUTCOME_QUOTA_EXHAUSTED => {
-                counts.quota_exhausted_count = 1;
-                counts.valuable_failure_count = 1;
-            }
-            _ => {
-                counts.unknown_count = 1;
-            }
-        }
-        self.request_stats_coalescer
-            .enqueue_request_log_rollups(api_key_id, "test-auth-token", None, created_at, counts, None)
-            .await;
     }
 
     async fn migrate_log_effect_buckets(&self) -> Result<(), ProxyError> {

--- a/src/store/key_store_request_logs_and_dashboard_test_support.rs
+++ b/src/store/key_store_request_logs_and_dashboard_test_support.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+impl KeyStore {
+    pub(crate) async fn enqueue_request_stats_rollup_for_test(
+        &self,
+        api_key_id: Option<&str>,
+        created_at: i64,
+        outcome: &str,
+    ) {
+        let mut counts = DashboardRequestRollupCounts {
+            total_requests: 1,
+            api_billable: 1,
+            ..DashboardRequestRollupCounts::default()
+        };
+        match outcome {
+            OUTCOME_SUCCESS => {
+                counts.success_count = 1;
+                counts.valuable_success_count = 1;
+            }
+            OUTCOME_ERROR => {
+                counts.error_count = 1;
+                counts.valuable_failure_count = 1;
+            }
+            OUTCOME_QUOTA_EXHAUSTED => {
+                counts.quota_exhausted_count = 1;
+                counts.valuable_failure_count = 1;
+            }
+            _ => {
+                counts.unknown_count = 1;
+            }
+        }
+        self.request_stats_coalescer
+            .enqueue_request_log_rollups(api_key_id, "test-auth-token", None, created_at, counts, None)
+            .await;
+    }
+}

--- a/src/store/key_store_request_logs_and_dashboard_test_support.rs
+++ b/src/store/key_store_request_logs_and_dashboard_test_support.rs
@@ -29,7 +29,14 @@ impl KeyStore {
             }
         }
         self.request_stats_coalescer
-            .enqueue_request_log_rollups(api_key_id, "test-auth-token", None, created_at, counts, None)
+            .enqueue_request_log_rollups(
+                api_key_id,
+                "test-auth-token",
+                None,
+                created_at,
+                counts,
+                None,
+            )
             .await;
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2244,6 +2244,16 @@ pub(crate) struct RequestStatsCoalescer {
     pub(crate) state: Arc<Mutex<RequestStatsCoalescerState>>,
     pub(crate) wake: Arc<Notify>,
     pub(crate) flushed: Arc<Notify>,
+    #[cfg(test)]
+    pub(crate) post_flush_pause: Arc<Mutex<Option<RequestStatsPostFlushPause>>>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub(crate) struct RequestStatsPostFlushPause {
+    pub(crate) arrived: Arc<Notify>,
+    pub(crate) release: Arc<Notify>,
+    pub(crate) released: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Default for RequestStatsCoalescer {
@@ -2252,6 +2262,8 @@ impl Default for RequestStatsCoalescer {
             state: Arc::new(Mutex::new(RequestStatsCoalescerState::default())),
             wake: Arc::new(Notify::new()),
             flushed: Arc::new(Notify::new()),
+            #[cfg(test)]
+            post_flush_pause: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -2455,6 +2467,33 @@ impl RequestStatsCoalescer {
             notified.await;
         }
     }
+
+    #[cfg(test)]
+    pub(crate) async fn install_post_flush_pause(&self) -> RequestStatsPostFlushPause {
+        let pause = RequestStatsPostFlushPause {
+            arrived: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+            released: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+        let mut slot = self.post_flush_pause.lock().await;
+        *slot = Some(pause.clone());
+        pause
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn take_post_flush_pause(&self) -> Option<RequestStatsPostFlushPause> {
+        self.post_flush_pause.lock().await.take()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_post_flush_pause_if_installed(&self) {
+        if let Some(pause) = self.take_post_flush_pause().await {
+            pause.arrived.notify_waiters();
+            while !pause.released.load(std::sync::atomic::Ordering::SeqCst) {
+                pause.release.notified().await;
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -2507,6 +2546,8 @@ include!("key_store_jobs.rs");
 include!("key_store_account_limit_snapshots.rs");
 include!("key_store_account_usage_rollups.rs");
 include!("key_store_ha.rs");
+#[cfg(test)]
+include!("key_store_request_logs_and_dashboard_test_support.rs");
 
 #[cfg(test)]
 mod tests {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2234,6 +2234,8 @@ pub(crate) struct RequestStatsCoalescerState {
     pub(crate) pending_request_log_catalog: HashMap<RequestLogCatalogRollupKey, i64>,
     pub(crate) oldest_pending_created_at: Option<i64>,
     pub(crate) newest_pending_created_at: Option<i64>,
+    pub(crate) flushing_oldest_created_at: Option<i64>,
+    pub(crate) flushing_newest_created_at: Option<i64>,
     pub(crate) flush_deadline: Option<Instant>,
     pub(crate) flushing: bool,
     pub(crate) shutdown: bool,
@@ -2438,14 +2440,38 @@ impl RequestStatsCoalescer {
         self.wake.notify_one();
     }
 
+    #[cfg(test)]
     pub(crate) async fn pending_oldest_created_at(&self) -> Option<i64> {
         let state = self.state.lock().await;
         state.oldest_pending_created_at
     }
 
+    #[cfg(test)]
     pub(crate) async fn pending_newest_created_at(&self) -> Option<i64> {
         let state = self.state.lock().await;
         state.newest_pending_created_at
+    }
+
+    pub(crate) async fn freshness_created_at_bounds(&self) -> Option<(i64, i64)> {
+        let state = self.state.lock().await;
+        let oldest_created_at = match (
+            state.oldest_pending_created_at,
+            state.flushing_oldest_created_at,
+        ) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (Some(value), None) | (None, Some(value)) => Some(value),
+            (None, None) => None,
+        }?;
+        let newest_created_at = match (
+            state.newest_pending_created_at,
+            state.flushing_newest_created_at,
+        ) {
+            (Some(left), Some(right)) => Some(left.max(right)),
+            (Some(value), None) | (None, Some(value)) => Some(value),
+            (None, None) => None,
+        }
+        .unwrap_or(oldest_created_at);
+        Some((oldest_created_at, newest_created_at))
     }
 
     pub(crate) async fn wait_until_flushed(&self) {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2232,6 +2232,7 @@ pub(crate) struct RequestStatsCoalescerState {
     pub(crate) pending_account_request_rollups:
         HashMap<AccountRequestRollupKey, AccountUsageRollupDelta>,
     pub(crate) pending_request_log_catalog: HashMap<RequestLogCatalogRollupKey, i64>,
+    pub(crate) oldest_pending_created_at: Option<i64>,
     pub(crate) flush_deadline: Option<Instant>,
     pub(crate) flushing: bool,
     pub(crate) shutdown: bool,
@@ -2270,6 +2271,15 @@ impl RequestStatsCoalescer {
         if Self::pending_key_count(state) > 0 && state.flush_deadline.is_none() {
             state.flush_deadline = Some(Instant::now() + Self::FLUSH_INTERVAL);
         }
+    }
+
+    fn note_pending_created_at(state: &mut RequestStatsCoalescerState, created_at: i64) {
+        state.oldest_pending_created_at = Some(
+            state
+                .oldest_pending_created_at
+                .map(|current| current.min(created_at))
+                .unwrap_or(created_at),
+        );
     }
 
     pub(crate) async fn enqueue_request_log_rollups(
@@ -2326,6 +2336,7 @@ impl RequestStatsCoalescer {
                     .entry(request_log_catalog_key)
                     .or_default() += 1;
             }
+            Self::note_pending_created_at(&mut state, created_at);
             Self::mark_flush_deadline_if_pending(&mut state);
         }
         self.wake.notify_one();
@@ -2347,6 +2358,7 @@ impl RequestStatsCoalescer {
                 0,
                 0,
             );
+            Self::note_pending_created_at(&mut state, created_at);
             Self::mark_flush_deadline_if_pending(&mut state);
         }
         self.wake.notify_one();
@@ -2401,9 +2413,15 @@ impl RequestStatsCoalescer {
                     .or_default()
                     .local_estimated_credits += credits;
             }
+            Self::note_pending_created_at(&mut state, created_at);
             Self::mark_flush_deadline_if_pending(&mut state);
         }
         self.wake.notify_one();
+    }
+
+    pub(crate) async fn pending_oldest_created_at(&self) -> Option<i64> {
+        let state = self.state.lock().await;
+        state.oldest_pending_created_at
     }
 
     pub(crate) async fn wait_until_flushed(&self) {
@@ -2451,6 +2469,7 @@ pub(crate) struct KeyStore {
 
 include!("key_store_bootstrap.rs");
 include!("key_store_observability_sidecar.rs");
+include!("key_store_public_metrics_freshness.rs");
 include!("key_store_request_logs_gc.rs");
 include!("key_store_migrations_a.rs");
 include!("key_store_migrations_b.rs");

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2233,6 +2233,7 @@ pub(crate) struct RequestStatsCoalescerState {
         HashMap<AccountRequestRollupKey, AccountUsageRollupDelta>,
     pub(crate) pending_request_log_catalog: HashMap<RequestLogCatalogRollupKey, i64>,
     pub(crate) oldest_pending_created_at: Option<i64>,
+    pub(crate) newest_pending_created_at: Option<i64>,
     pub(crate) flush_deadline: Option<Instant>,
     pub(crate) flushing: bool,
     pub(crate) shutdown: bool,
@@ -2278,6 +2279,12 @@ impl RequestStatsCoalescer {
             state
                 .oldest_pending_created_at
                 .map(|current| current.min(created_at))
+                .unwrap_or(created_at),
+        );
+        state.newest_pending_created_at = Some(
+            state
+                .newest_pending_created_at
+                .map(|current| current.max(created_at))
                 .unwrap_or(created_at),
         );
     }
@@ -2422,6 +2429,11 @@ impl RequestStatsCoalescer {
     pub(crate) async fn pending_oldest_created_at(&self) -> Option<i64> {
         let state = self.state.lock().await;
         state.oldest_pending_created_at
+    }
+
+    pub(crate) async fn pending_newest_created_at(&self) -> Option<i64> {
+        let state = self.state.lock().await;
+        state.newest_pending_created_at
     }
 
     pub(crate) async fn wait_until_flushed(&self) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,6 +32,7 @@ mod proxy_affinity_and_summary;
 mod proxy_affinity_runtime_geo;
 mod request_kind_and_core;
 mod request_rollup;
+mod request_rollup_public_metrics;
 mod support;
 mod usage_series_and_backfills;
 mod user_business_calls_1h;

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -163,3 +163,46 @@ async fn public_success_breakdown_flushes_when_newer_pending_rollup_is_inside_wi
 
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn public_success_breakdown_flushes_when_pending_rollup_is_outside_day_but_inside_month() {
+    let db_path = temp_db_path("public-success-breakdown-month-only-pending");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-public-success-month-only-pending".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let key_id = proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list key metrics")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let now = Utc::now();
+    let month_start = start_of_month(now).timestamp();
+    let day_window = server_local_day_window_utc(now.with_timezone(&Local));
+    let pending_created_at = day_window.start.saturating_sub(120);
+    assert!(pending_created_at >= month_start);
+
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(Some(&key_id), pending_created_at, OUTCOME_SUCCESS)
+        .await;
+
+    let public = proxy
+        .success_breakdown(Some(day_window))
+        .await
+        .expect("public success breakdown");
+
+    assert_eq!(public.monthly_success, 1);
+    assert_eq!(public.daily_success, 0);
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -311,3 +311,105 @@ async fn public_success_breakdown_flushes_pending_rollup_enqueued_during_flush()
 
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn public_success_breakdown_waits_for_inflight_flush_before_serving_metrics() {
+    let db_path = temp_db_path("public-success-breakdown-inflight-flush-wait");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-public-success-inflight-wait".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let key_id = proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list key metrics")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let now = Utc::now().timestamp();
+    let created_at = now.saturating_sub(10);
+    let window = TimeRangeUtc {
+        start: now.saturating_sub(300),
+        end: now.saturating_add(60),
+    };
+
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(Some(&key_id), created_at, OUTCOME_SUCCESS)
+        .await;
+
+    let lock_options = SqliteConnectOptions::new()
+        .filename(&db_str)
+        .create_if_missing(false)
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(5));
+    let mut lock_conn = sqlx::SqliteConnection::connect_with(&lock_options)
+        .await
+        .expect("open lock connection");
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut lock_conn)
+        .await
+        .expect("lock writer");
+
+    let store = proxy.key_store.clone();
+    let flush_handle = tokio::spawn(async move { store.flush_request_stats_writes().await });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let is_inflight = {
+                let state = proxy.key_store.request_stats_coalescer.state.lock().await;
+                state.flushing
+                    && state.oldest_pending_created_at.is_none()
+                    && state.flushing_oldest_created_at == Some(created_at)
+                    && state.flushing_newest_created_at == Some(created_at)
+            };
+            if is_inflight {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("flush entered inflight state");
+
+    let proxy_for_read = proxy.clone();
+    let (done_tx, mut done_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let result = proxy_for_read.success_breakdown(Some(window)).await;
+        let _ = done_tx.send(result);
+    });
+
+    tokio::select! {
+        early = &mut done_rx => {
+            panic!("public metrics returned before inflight flush completed: {early:?}");
+        }
+        _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+    }
+
+    sqlx::query("ROLLBACK")
+        .execute(&mut lock_conn)
+        .await
+        .expect("release writer lock");
+    lock_conn.close().await.expect("close lock connection");
+
+    flush_handle
+        .await
+        .expect("flush join")
+        .expect("flush request stats");
+
+    let public = done_rx
+        .await
+        .expect("public metrics result channel")
+        .expect("public success breakdown");
+    assert_eq!(public.monthly_success, 1);
+    assert_eq!(public.daily_success, 1);
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -206,3 +206,108 @@ async fn public_success_breakdown_flushes_when_pending_rollup_is_outside_day_but
 
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn public_success_breakdown_flushes_pending_rollup_enqueued_during_flush() {
+    let db_path = temp_db_path("public-success-breakdown-concurrent-pending-flush");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-public-success-concurrent-pending".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let key_id = proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list key metrics")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let now = Utc::now().timestamp();
+    let first_created_at = now.saturating_sub(60);
+    let second_created_at = now.saturating_sub(10);
+    let window = TimeRangeUtc {
+        start: now.saturating_sub(300),
+        end: now.saturating_add(60),
+    };
+
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(Some(&key_id), first_created_at, OUTCOME_SUCCESS)
+        .await;
+
+    let store = proxy.key_store.clone();
+    let pause = store
+        .request_stats_coalescer
+        .install_post_flush_pause()
+        .await;
+    let flush_handle = tokio::spawn(async move { store.flush_request_stats_writes().await });
+
+    tokio::time::timeout(Duration::from_secs(1), pause.arrived.notified())
+        .await
+        .expect("flush reached post-flush pause");
+
+    assert_eq!(
+        proxy
+            .key_store
+            .request_stats_coalescer
+            .pending_oldest_created_at()
+            .await,
+        None
+    );
+
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(Some(&key_id), second_created_at, OUTCOME_SUCCESS)
+        .await;
+
+    assert_eq!(
+        proxy
+            .key_store
+            .request_stats_coalescer
+            .pending_oldest_created_at()
+            .await,
+        Some(second_created_at)
+    );
+    assert_eq!(
+        proxy
+            .key_store
+            .request_stats_coalescer
+            .pending_newest_created_at()
+            .await,
+        Some(second_created_at)
+    );
+
+    pause
+        .released
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    pause.release.notify_waiters();
+
+    flush_handle
+        .await
+        .expect("flush join")
+        .expect("flush request stats");
+
+    let public = proxy
+        .success_breakdown(Some(window))
+        .await
+        .expect("public success breakdown");
+
+    assert_eq!(public.monthly_success, 2);
+    assert_eq!(public.daily_success, 2);
+    assert_eq!(
+        proxy
+            .key_store
+            .request_stats_coalescer
+            .pending_oldest_created_at()
+            .await,
+        None
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[tokio::test]
+async fn public_success_breakdown_skips_flush_when_no_pending_request_stats() {
+    let db_path = temp_db_path("public-success-breakdown-no-pending-flush");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-public-success-no-pending".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    proxy
+        .key_store
+        .set_meta_i64(
+            META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1,
+            Utc::now().timestamp(),
+        )
+        .await
+        .expect("set request stats flush watermark");
+
+    let now = Utc::now().timestamp();
+    let window = TimeRangeUtc {
+        start: now.saturating_sub(300),
+        end: now.saturating_add(60),
+    };
+    let public = proxy
+        .success_breakdown(Some(window))
+        .await
+        .expect("public success breakdown");
+
+    assert_eq!(public.monthly_success, 0);
+    assert_eq!(public.daily_success, 0);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn public_success_breakdown_flushes_pending_request_stats_for_current_window() {
+    let db_path = temp_db_path("public-success-breakdown-pending-flush");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-public-success-pending".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let key_id = proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list key metrics")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let now = Utc::now().timestamp();
+    let window = TimeRangeUtc {
+        start: now.saturating_sub(300),
+        end: now.saturating_add(60),
+    };
+
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(
+            Some(&key_id),
+            now.saturating_sub(10),
+            OUTCOME_SUCCESS,
+        )
+        .await;
+
+    let public = proxy
+        .success_breakdown(Some(window))
+        .await
+        .expect("public success breakdown");
+
+    assert_eq!(public.monthly_success, 1);
+    assert_eq!(public.daily_success, 1);
+
+    let persisted_flush = proxy
+        .key_store
+        .get_meta_i64(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1)
+        .await
+        .expect("read request stats flush watermark");
+    assert!(persisted_flush.unwrap_or_default() > 0);
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -91,3 +91,75 @@ async fn public_success_breakdown_flushes_pending_request_stats_for_current_wind
 
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn public_success_breakdown_flushes_when_newer_pending_rollup_is_inside_window() {
+    let db_path = temp_db_path("public-success-breakdown-mixed-pending-window");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-public-success-mixed-pending".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let key_id = proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list key metrics")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let now = Utc::now().timestamp();
+    let day_start = now.saturating_sub(300);
+    let window = TimeRangeUtc {
+        start: day_start,
+        end: now.saturating_add(60),
+    };
+
+    proxy
+        .key_store
+        .set_meta_i64(
+            META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1,
+            day_start.saturating_sub(5),
+        )
+        .await
+        .expect("set request stats flush watermark");
+
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(
+            Some(&key_id),
+            day_start.saturating_sub(120),
+            OUTCOME_SUCCESS,
+        )
+        .await;
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(
+            Some(&key_id),
+            now.saturating_sub(10),
+            OUTCOME_SUCCESS,
+        )
+        .await;
+
+    let public = proxy
+        .success_breakdown(Some(window))
+        .await
+        .expect("public success breakdown");
+
+    assert_eq!(public.monthly_success, 2);
+    assert_eq!(public.daily_success, 1);
+
+    let persisted_flush = proxy
+        .key_store
+        .get_meta_i64(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1)
+        .await
+        .expect("read request stats flush watermark");
+    assert!(persisted_flush.unwrap_or_default() >= now.saturating_sub(10));
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
## Summary
- add a no-op startup precheck for `billing_ledger` so routine boots skip full reconcile when there is no gap
- gate public metrics and public SSE reads on shared rollup freshness instead of forcing synchronous flushes on every request
- move alerts events/groups/summary/catalog onto SQL-side bounded reads and canonical `request_kind` filtering
- sync the related specs and solutions with the new implementation and validation evidence

## Validation
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --test rust_source_line_budgets`
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run build`
- real production-shaped validation on `codex-testbox` using a zero-downtime SQLite snapshot copied from machine 101

## Production-shaped proof
- first boot on the copied snapshot performed the one-time repair and index build successfully
- second boot logged `billing ledger startup precheck skipped` and reduced `sqlite startup total` to about `2.2s`
- `GET /api/public/metrics` on the repaired snapshot returned successfully in about `1.44s`
- `GET /api/alerts/events` on the repaired snapshot returned successfully in about `0.14s`
- `/api/public/events` emitted the initial `metrics` event immediately on connect
- `billing_ledger_audit` still reports 118 historical day-only mismatches; that is tracked as a follow-up quota audit issue, not a regression from this change

## References
- Specs:
  - `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`
  - `docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions:
  - `docs/solutions/operations/sqlite-admin-read-containment.md`
  - `docs/solutions/operations/sqlite-write-lock-contention.md`
- Solutions Sync: done
- Project Docs: -
- Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
