### PR TITLE
fix: repair HA outbox growth on upgraded databases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN cargo build --release --locked \
     --bin observability_sidecar_migrate \
     --bin observability_lock_holder \
     --bin db_compaction_once \
-    --bin request_logs_gc_once
+    --bin request_logs_gc_once \
+    --bin ha_outbox_cleanup_once \
+    --bin ha_trigger_repair_once
 
 ########## Stage 2: import the official Xray runtime ##########
 FROM ghcr.io/xtls/xray-core:${XRAY_CORE_VERSION} AS xray-downloader
@@ -50,6 +52,8 @@ COPY --from=builder /app/target/release/observability_sidecar_migrate /usr/local
 COPY --from=builder /app/target/release/observability_lock_holder /usr/local/bin/observability_lock_holder
 COPY --from=builder /app/target/release/db_compaction_once /usr/local/bin/db_compaction_once
 COPY --from=builder /app/target/release/request_logs_gc_once /usr/local/bin/request_logs_gc_once
+COPY --from=builder /app/target/release/ha_outbox_cleanup_once /usr/local/bin/ha_outbox_cleanup_once
+COPY --from=builder /app/target/release/ha_trigger_repair_once /usr/local/bin/ha_trigger_repair_once
 COPY --from=xray-downloader /usr/local/bin/xray /usr/local/bin/xray
 COPY --from=xray-downloader /usr/local/share/xray /usr/local/share/xray
 # Copy prebuilt web assets (produced by CI before Docker build)

--- a/docs-site/docs/en/deployment-anonymity.md
+++ b/docs-site/docs/en/deployment-anonymity.md
@@ -136,7 +136,7 @@ unexpected SQLite file growth, keep the recovery flow consistent:
 3. confirm `scheduled_jobs` has no fresh long-running `quota_sync*` `running` rows
 4. confirm `database is locked` is no longer continuously spiking in logs
 5. use `request_logs_gc_once` first for request-log backlog
-6. use `ha_outbox_cleanup_once` or `scripts/ha-outbox-maintenance.sh` first for HA outbox backlog
+6. repair HA triggers first, then use `ha_outbox_cleanup_once` or `scripts/ha-outbox-maintenance.sh` for HA outbox backlog
 7. run `db_compaction_once` only when `reclaimable_bytes >= 512MB` or you are explicitly in a
    maintenance window
 8. clean temporary snapshots, offline backup intermediates, and dangling images after the
@@ -147,6 +147,7 @@ The operator CLIs inside the image are:
 ```bash
 request_logs_gc_once --json
 ha_outbox_cleanup_once --json
+ha_trigger_repair_once --json
 db_compaction_once --json
 db_compaction_once --json --force
 ```
@@ -161,10 +162,14 @@ scripts/export-live-db-snapshot-to-testbox.sh
 Notes:
 
 - `request_logs_gc_once` performs bounded request-log/body cleanup
-- `ha_outbox_cleanup_once` performs bounded historical HA outbox cleanup; the online `ha_outbox_gc`
-  scheduler is intentionally lighter and handles freshness cleanup only
-- `scripts/ha-outbox-maintenance.sh` is the operator wrapper that keeps the order as “cleanup
-  first, compaction only if needed”
+- `ha_trigger_repair_once` explicitly removes upgraded-database leftovers such as stale
+  `trg_ha_outbox_*` triggers before backlog cleanup starts
+- `ha_outbox_cleanup_once` performs bounded historical HA outbox cleanup; it can also
+  `--repair-triggers`, and its report separates invalid-legacy deletions from ordinary retention
+  deletions. The online `ha_outbox_gc` scheduler is intentionally lighter and handles freshness
+  cleanup only
+- `scripts/ha-outbox-maintenance.sh` is the operator wrapper that keeps the order as “repair +
+  cleanup first, compaction only if needed”
 - `db_compaction_once` shrinks SQLite files and honors the reclaimable-space threshold by default
 - `db_compaction_once --force` is only for an explicit maintenance window
 - offline validation input must be the full DB set: `tavily_proxy.db` plus

--- a/docs-site/docs/en/deployment-anonymity.md
+++ b/docs-site/docs/en/deployment-anonymity.md
@@ -109,12 +109,66 @@ Key points:
 
 ## Persistence, backup, and upgrades
 
-The key long-lived data is the SQLite file:
+The long-lived data is not just one main DB file:
 
-- default container path: `/srv/app/data/tavily_proxy.db`
-- back it up before upgrades
-- the container image itself is stateless, so most upgrades are just a new tag plus restart
+- core DB: `/srv/app/data/tavily_proxy.db`
+- observability sidecar: `/srv/app/data/tavily_proxy-observability.db`
 - if you maintain Caddy or reverse-proxy config alongside it, back that up too
+
+Upgrade notes:
+
+- the container image itself is stateless, so most upgrades are just a new tag plus restart
+- do not back up only `tavily_proxy.db` when preparing offline validation or rollback input; treat
+  the core DB plus the observability sidecar as one complete database set
+- prefer `scripts/export-live-db-snapshot-to-testbox.sh` when you need a read-only validation copy.
+  It runs SQLite `.backup` per file, records SHA-256 sums, and verifies `PRAGMA integrity_check`
+- after the service is already running the new image, remove maintenance leftovers such as orphaned
+  temporary snapshot directories, large one-off backup artifacts, and dangling images so disk usage
+  does not keep drifting upward
+
+## SQLite and HA maintenance windows
+
+If you see `database is locked`, long-running `quota_sync` rows, oversized `ha_outbox` backlog, or
+unexpected SQLite file growth, keep the recovery flow consistent:
+
+1. roll forward to the target image and do a controlled restart
+2. verify `/health` returns `200`
+3. confirm `scheduled_jobs` has no fresh long-running `quota_sync*` `running` rows
+4. confirm `database is locked` is no longer continuously spiking in logs
+5. use `request_logs_gc_once` first for request-log backlog
+6. use `ha_outbox_cleanup_once` or `scripts/ha-outbox-maintenance.sh` first for HA outbox backlog
+7. run `db_compaction_once` only when `reclaimable_bytes >= 512MB` or you are explicitly in a
+   maintenance window
+8. clean temporary snapshots, offline backup intermediates, and dangling images after the
+   maintenance pass
+
+The operator CLIs inside the image are:
+
+```bash
+request_logs_gc_once --json
+ha_outbox_cleanup_once --json
+db_compaction_once --json
+db_compaction_once --json --force
+```
+
+For large offline validation or cleanup rehearsal, export a full read-only snapshot set from 101
+before copying it to the shared testbox:
+
+```bash
+scripts/export-live-db-snapshot-to-testbox.sh
+```
+
+Notes:
+
+- `request_logs_gc_once` performs bounded request-log/body cleanup
+- `ha_outbox_cleanup_once` performs bounded historical HA outbox cleanup; the online `ha_outbox_gc`
+  scheduler is intentionally lighter and handles freshness cleanup only
+- `scripts/ha-outbox-maintenance.sh` is the operator wrapper that keeps the order as “cleanup
+  first, compaction only if needed”
+- `db_compaction_once` shrinks SQLite files and honors the reclaimable-space threshold by default
+- `db_compaction_once --force` is only for an explicit maintenance window
+- offline validation input must be the full DB set: `tavily_proxy.db` plus
+  `tavily_proxy-observability.db`, not the main DB alone
 
 ## High-anonymity forwarding
 

--- a/docs-site/docs/zh/deployment-anonymity.md
+++ b/docs-site/docs/zh/deployment-anonymity.md
@@ -110,39 +110,56 @@ export ADMIN_AUTH_FORWARD_ENABLED=false
 
 ## 持久化、备份与升级
 
-需要长期保留的数据核心就是 SQLite 文件：
+需要长期保留的数据不只是一份主库：
 
-- 默认容器路径：`/srv/app/data/tavily_proxy.db`
-- 升级前建议先备份这个文件
-- 容器镜像本身是无状态的，升级通常就是换 tag 后重启
+- core DB：默认容器路径 `/srv/app/data/tavily_proxy.db`
+- observability sidecar：默认容器路径 `/srv/app/data/tavily_proxy-observability.db`
 - 如果你还维护了 Caddy / 反代配置，也应该把这部分一起纳入备份
 
-## SQLite 维护窗口建议
+升级要点：
 
-如果你遇到 `database is locked`、`quota_sync` 长时间停在 `running`、或者 request logs backlog
-很大，建议把恢复步骤固定成同一套剧本：
+- 容器镜像本身是无状态的，升级通常就是换 tag 后重启
+- 升级前不要只拷 `tavily_proxy.db`；离线验证或回滚准备应把 core DB 与 observability sidecar 一起作为完整数据库集处理
+- 如需生成只读快照，优先用仓库里的 `scripts/export-live-db-snapshot-to-testbox.sh`。它会对两份 SQLite 都执行 `.backup`、记录 SHA-256，并验证 `PRAGMA integrity_check`
+- 若线上容器已更新到新镜像，记得同步清理本次维护产生的临时快照目录、孤儿大文件与 dangling image，避免磁盘残留继续放大运维风险
 
-1. 发布新镜像后做一次受控重启
+## SQLite 与 HA 维护窗口建议
+
+如果你遇到 `database is locked`、`quota_sync` 长时间停在 `running`、`ha_outbox` backlog
+过大、或者 SQLite 文件体积明显失控，建议把恢复步骤固定成同一套剧本：
+
+1. 先更新到目标镜像，并做一次受控重启
 2. 验证 `/health` 返回 `200`
 3. 检查 `scheduled_jobs` 里没有新的长时间 `quota_sync*` `running`
 4. 检查日志里 `database is locked` 不再持续爆发
-5. 需要继续清理日志 backlog 时，优先运行 `request_logs_gc_once`
-6. 只有在 `reclaimable_bytes >= 512MB` 或你明确要开维护窗口时，再运行 `db_compaction_once`
+5. request logs backlog 优先运行 `request_logs_gc_once`
+6. `ha_outbox` backlog 优先运行 `ha_outbox_cleanup_once` 或 `scripts/ha-outbox-maintenance.sh`
+7. 只有在 `reclaimable_bytes >= 512MB`，或者你明确进入维护窗口时，再运行 `db_compaction_once`
+8. 维护完成后清理临时快照目录、离线备份中间文件和 dangling image，避免把磁盘再次打满
 
-容器镜像内置了两个 operator CLI：
+容器镜像内置了这些 operator CLI：
 
 ```bash
 request_logs_gc_once --json
+ha_outbox_cleanup_once --json
 db_compaction_once --json
 db_compaction_once --json --force
+```
+
+如需对大 backlog 做离线演练，先在 101 导出完整只读快照，再上传到 shared testbox：
+
+```bash
+scripts/export-live-db-snapshot-to-testbox.sh
 ```
 
 说明：
 
 - `request_logs_gc_once` 用于 bounded 地清理 request logs / body backlog
-- `db_compaction_once` 用于 SQLite 文件压缩；默认会尊重 reclaimable space 阈值，不满足条件时返回
-  `skipped=true`
+- `ha_outbox_cleanup_once` 用于 bounded 地清理历史 HA outbox backlog；线上 scheduler 里的 `ha_outbox_gc` 只负责轻量 freshness cleanup，不负责重型历史收缩
+- `scripts/ha-outbox-maintenance.sh` 是一层运维封装，顺序固定为“先 cleanup，后按需 compaction”
+- `db_compaction_once` 用于 SQLite 文件压缩；默认会尊重 reclaimable space 阈值，不满足条件时返回 `skipped=true`
 - `db_compaction_once --force` 只建议在明确的维护窗口里使用
+- 离线验证输入必须是完整数据库集：`tavily_proxy.db` + `tavily_proxy-observability.db`，不能只拷主库
 
 ## 高匿名透传
 

--- a/docs-site/docs/zh/deployment-anonymity.md
+++ b/docs-site/docs/zh/deployment-anonymity.md
@@ -133,7 +133,7 @@ export ADMIN_AUTH_FORWARD_ENABLED=false
 3. 检查 `scheduled_jobs` 里没有新的长时间 `quota_sync*` `running`
 4. 检查日志里 `database is locked` 不再持续爆发
 5. request logs backlog 优先运行 `request_logs_gc_once`
-6. `ha_outbox` backlog 优先运行 `ha_outbox_cleanup_once` 或 `scripts/ha-outbox-maintenance.sh`
+6. `ha_outbox` backlog 先修 trigger，再运行 `ha_outbox_cleanup_once` 或 `scripts/ha-outbox-maintenance.sh`
 7. 只有在 `reclaimable_bytes >= 512MB`，或者你明确进入维护窗口时，再运行 `db_compaction_once`
 8. 维护完成后清理临时快照目录、离线备份中间文件和 dangling image，避免把磁盘再次打满
 
@@ -142,6 +142,7 @@ export ADMIN_AUTH_FORWARD_ENABLED=false
 ```bash
 request_logs_gc_once --json
 ha_outbox_cleanup_once --json
+ha_trigger_repair_once --json
 db_compaction_once --json
 db_compaction_once --json --force
 ```
@@ -155,8 +156,9 @@ scripts/export-live-db-snapshot-to-testbox.sh
 说明：
 
 - `request_logs_gc_once` 用于 bounded 地清理 request logs / body backlog
-- `ha_outbox_cleanup_once` 用于 bounded 地清理历史 HA outbox backlog；线上 scheduler 里的 `ha_outbox_gc` 只负责轻量 freshness cleanup，不负责重型历史收缩
-- `scripts/ha-outbox-maintenance.sh` 是一层运维封装，顺序固定为“先 cleanup，后按需 compaction”
+- `ha_trigger_repair_once` 用于显式修复升级库中残留的旧 `trg_ha_outbox_*` trigger；如果真实问题是旧 trigger 还在持续写 `ha_outbox`，必须先跑它
+- `ha_outbox_cleanup_once` 用于 bounded 地清理历史 HA outbox backlog；它支持 `--repair-triggers`，并会在报告中区分 `invalid legacy` 删除量与正常 retention 删除量。线上 scheduler 里的 `ha_outbox_gc` 只负责轻量 freshness cleanup，不负责重型历史收缩
+- `scripts/ha-outbox-maintenance.sh` 是一层运维封装，顺序固定为“先 repair + cleanup，后按需 compaction”
 - `db_compaction_once` 用于 SQLite 文件压缩；默认会尊重 reclaimable space 阈值，不满足条件时返回 `skipped=true`
 - `db_compaction_once --force` 只建议在明确的维护窗口里使用
 - 离线验证输入必须是完整数据库集：`tavily_proxy.db` + `tavily_proxy-observability.db`，不能只拷主库

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -168,6 +168,13 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - If the live system stores the main DB and observability data in sibling SQLite files, export the
   offline validation input with SQLite `.backup` per file and carry forward SHA-256 plus
   `PRAGMA integrity_check` evidence for each member of the set.
+- If the snapshot export path stages large temporary backup files on the source host, treat cleanup
+  of those staging directories as part of the same maintenance runbook. A successful upload to the
+  shared testbox is not the end of the flow if tens of GiB remain under a temporary source path.
+- Treat disk hygiene as an explicit post-maintenance step. Remove orphaned one-off snapshot
+  directories, stale gzip/sqlite artifacts, and dangling images once the new release is verified, or
+  the next “database is too large” incident can be self-inflicted by leftover maintenance inputs
+  rather than live product data.
 - Avoid high-resource retention catch-up tactics such as rebuilding large log tables or producing a
   large WAL. If the backlog is very large, run repeated bounded cleanup windows and verify progress
   with row counts and resource telemetry.
@@ -203,6 +210,10 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
   a separate maintenance-window decision after retention cleanup has completed.
 - Automatic compaction should be threshold-gated and cooldown-limited. Triggering it on every GC
   pass can turn a cleanup backlog into a new writer-pressure loop.
+- Do not treat a large main SQLite file as proof that the main DB alone is the whole persistence
+  surface. In this project the observability sibling sidecar is part of the production-shaped input,
+  while `ha_outbox` and other retained rows can make the core file look “unreasonably large” until
+  retention cleanup and optional compaction are completed in the right order.
 - Stale `scheduled_jobs.running` rows from a previous process lifetime are still an operational
   restart concern. Claim-time stale abandonment should cover fresh quota-sync wedges, but the
   broader maintenance queue should abandon every leftover `queued`/`running` row on startup instead

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -120,6 +120,10 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - Treat large retained HA event cleanup like request-log cleanup: bounded online GC for freshness,
   explicit offline one-shot cleanup for backlog removal, and optional later compaction only when
   reclaimable bytes justify it.
+- For upgraded HA databases, treat trigger repair as a separate first-class maintenance step.
+  If legacy `trg_ha_outbox_*` triggers from the old single-channel era remain in `sqlite_master`,
+  online GC will never catch up because the live node keeps appending fresh non-control noise into
+  `ha_outbox`. Repair the trigger set first, then start backlog cleanup.
 - When offline maintenance proof depends on a production-derived SQLite copy, define the input as a
   full DB set instead of a single file. In this service that means the core DB plus the
   observability sibling sidecar; copying only `tavily_proxy.db` would miss the attached
@@ -162,12 +166,19 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - Provide the same offline path for compaction. Manual HTTP trigger endpoints are still useful, but
   operators need a `db_compaction_once`-style bypass for maintenance windows when the online job
   gate is busy.
-- For HA maintenance windows, the safe order is `ha_outbox_cleanup_once` first, `db_compaction_once`
-  second. Reversing that order vacuums retained dead rows too early and can waste I/O without
-  reclaiming the real backlog yet.
+- For HA maintenance windows, the safe order is `ha_trigger_repair_once` (or
+  `ha_outbox_cleanup_once --repair-triggers`) first, `ha_outbox_cleanup_once` second, and
+  `db_compaction_once` optional third. Reversing that order can leave the live node still writing
+  invalid backlog, or vacuum retained dead rows too early and waste I/O without reclaiming the real
+  problem.
 - If the live system stores the main DB and observability data in sibling SQLite files, export the
   offline validation input with SQLite `.backup` per file and carry forward SHA-256 plus
   `PRAGMA integrity_check` evidence for each member of the set.
+- For hot WAL-mode production databases, prefer a single-step backup for offline export instead of
+  small incremental page loops. SQLite's incremental backup API can restart when the live source is
+  modified underneath it; on a busy writer this can turn a snapshot export into an apparent
+  livelock. Use page-level progress reporting for observability, but default the real export path
+  to one single-step copy.
 - If the snapshot export path stages large temporary backup files on the source host, treat cleanup
   of those staging directories as part of the same maintenance runbook. A successful upload to the
   shared testbox is not the end of the flow if tens of GiB remain under a temporary source path.
@@ -214,6 +225,11 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
   surface. In this project the observability sibling sidecar is part of the production-shaped input,
   while `ha_outbox` and other retained rows can make the core file look “unreasonably large” until
   retention cleanup and optional compaction are completed in the right order.
+- A successful cleanup proof does not guarantee that offline compaction can run on every shared
+  validation host. `VACUUM` still needs enough free filesystem headroom for the rewritten database.
+  When cleanup shows multi-GiB reclaimable space but the shared validation host has only a few GiB
+  left, record that as an environment-capacity blocker and reserve the actual compaction for a real
+  maintenance window with adequate free space.
 - Stale `scheduled_jobs.running` rows from a previous process lifetime are still an operational
   restart concern. Claim-time stale abandonment should cover fresh quota-sync wedges, but the
   broader maintenance queue should abandon every leftover `queued`/`running` row on startup instead

--- a/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
@@ -47,6 +47,23 @@ The scheduler still performs bounded online `ha_outbox_gc`, but that path is int
 to per-channel expired-row cleanup plus a passive WAL checkpoint so it cannot recreate the previous
 SWAP spike failure mode.
 
+## Upgrade Trigger Repair Revision
+
+Production-shaped validation confirmed that the post-upgrade `ha_outbox` growth was not just stale
+retained history. The upgraded 101 database still carried old single-channel `trg_ha_outbox_*`
+triggers, so hot tables such as `billing_ledger`, `account_usage_rollup_buckets`, and
+`scheduled_jobs` kept appending fresh invalid rows into `ha_outbox` even after the code had moved
+to three explicit channels.
+
+- The accepted fix is an explicit repair-first maintenance step that enumerates HA replication
+  triggers from `sqlite_master`, drops the whole legacy/current HA trigger set, and recreates only
+  the current `control/billing/runtime` contract.
+- Invalid legacy `ha_outbox` rows are now treated as garbage and removed immediately during
+  cleanup instead of waiting for retention.
+- Shared-testbox validation against a full 101 snapshot deleted `27,770,036` invalid legacy rows
+  plus `1,373,458` ordinary retention rows, proving that the continuous growth was rooted in stale
+  upgraded triggers rather than only slow historical decay.
+
 ## Full Live Snapshot Validation Revision
 
 Merge-ready validation for the HA outbox fix now requires a complete production-shaped SQLite input
@@ -58,6 +75,15 @@ sidecar sibling, not the main `.db` file alone.
   not a hand-picked subset of rows.
 - Offline HA cleanup and optional compaction proof now runs against that copied snapshot set inside
   one isolated testbox run directory.
+- Hot WAL-mode production snapshots should default to a single-step SQLite backup instead of small
+  incremental page loops. Incremental `backup_step()` on a busy live source can restart repeatedly
+  when the source changes under it and may never finish in practice; the accepted export default is
+  therefore `pages=-1` with progress logging for observability.
+- Shared-testbox compaction proof remains subject to the testbox's own disk headroom. In the
+  validated run the cleanup created about `12 GiB` of reclaimable space, but `VACUUM` still failed
+  on the testbox because the root filesystem only had about `3.5 GiB` free. That does not weaken
+  the repair-first conclusion; it means the real production maintenance window must ensure enough
+  temporary free space before compaction starts.
 
 ## Admin IA Revision
 

--- a/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
@@ -25,6 +25,11 @@
 - Added offline `ha_outbox_cleanup_once` and `scripts/ha-outbox-maintenance.sh` so large retained
   historical `ha_outbox` rows can be cleaned explicitly during a maintenance window before an
   optional `db_compaction_once`.
+- Added a dedicated `ha_trigger_repair_once` one-shot CLI and upgraded HA trigger reconcile so an
+  upgraded database no longer relies on the current whitelist alone when dropping triggers.
+  Startup/manual repair now enumerates `sqlite_master`, removes legacy `trg_ha_outbox_*` leftovers
+  that no longer belong to `control/billing/runtime`, then rebuilds only the current three-channel
+  contract.
 - Added `scripts/export-live-db-snapshot-to-testbox.sh` so operators can export the full live
   SQLite validation input from 101 into an isolated `codex-testbox` run directory. The script is
   intentionally sidecar-aware and treats the validation input as a set:
@@ -34,8 +39,27 @@
 - The accepted offline validation sequence is now explicit:
   1. create a full read-only snapshot set on 101
   2. upload that full set into one `codex-testbox` run directory
-  3. run `ha_outbox_cleanup_once` / `scripts/ha-outbox-maintenance.sh` there
-  4. run `db_compaction_once` only if the threshold gate says reclaimable space is large enough
+  3. run `ha_trigger_repair_once` or `ha_outbox_cleanup_once --repair-triggers` there
+  4. run `ha_outbox_cleanup_once` / `scripts/ha-outbox-maintenance.sh` there
+  5. run `db_compaction_once` only if the threshold gate says reclaimable space is large enough
+- `ha_outbox_cleanup_once` now distinguishes immediate invalid-legacy cleanup from normal retention
+  cleanup in its JSON/plain reports, so operators can prove whether the pass is shrinking a stale
+  upgraded backlog or only trimming aged rows.
+- Shared-testbox validation against a full 101 snapshot confirmed the upgraded-database failure
+  mode and the repair-first fix:
+  - `ha_trigger_repair_once --ha-mode active_standby` dropped `30` legacy single-channel triggers
+    before recreating the current `control/billing/runtime` trigger set.
+  - `ha_outbox_cleanup_once --repair-triggers --run-until-complete --json` deleted `29,143,494`
+    rows in total, including `27,770,036` invalid legacy `ha_outbox` rows and `1,373,458` normal
+    retention rows.
+  - After cleanup, `ha_outbox` contained only current control resources and shrank to `163,357`
+    rows, while `ha_billing_outbox` / `ha_runtime_outbox` stayed at `265,496` / `19,822` rows.
+  - The same validation run left `freelist_count=2,951,432`, proving roughly `12 GiB` of
+    reclaimable space and confirming that a follow-up compaction is worth running in the real
+    maintenance window.
+  - `db_compaction_once` on the shared testbox failed with `database or disk is full` because the
+    host root filesystem had only about `3.5 GiB` free. That is an environment-capacity blocker,
+    not a repair-path failure; production compaction still needs adequate temporary free space.
 - “Full live DB validation input” does not mean “copy the main `.db` file only.” For this service
   it means the core DB plus the observability sibling sidecar; otherwise offline verification can
   silently miss the production request-log/read-model layout.

--- a/scripts/export-live-db-snapshot-to-testbox.sh
+++ b/scripts/export-live-db-snapshot-to-testbox.sh
@@ -12,10 +12,16 @@ Environment variables:
   SOURCE_HOST                 Defaults to 192.168.31.11
   SOURCE_SSH_TARGET           Defaults to SOURCE_HOST
   TESTBOX_HOST                Defaults to codex-testbox
-  SOURCE_DB_DIR               Defaults to /var/lib/docker/volumes/ai-tavily-hikari-data/_data
+  SOURCE_CONTAINER_NAME       Defaults to tavily-hikari
+  SOURCE_CONTAINER_DB_DIR     Defaults to /srv/app/data
+  SOURCE_HELPER_IMAGE         Defaults to python:3.12-alpine
+  SOURCE_BACKUP_PAGES         Defaults to -1 (single-step backup to avoid hot-DB restart loops)
+  SOURCE_BACKUP_SLEEP_SECS    Defaults to 0.005
+  SOURCE_BACKUP_PROGRESS_SECS Defaults to 15
+  SOURCE_DB_DIR               Fallback host path, defaults to /var/lib/docker/volumes/ai-tavily-hikari-data/_data
   SOURCE_CORE_DB_NAME         Defaults to tavily_proxy.db
   SOURCE_OBSERVABILITY_DB_NAME Defaults to tavily_proxy-observability.db
-  SOURCE_SNAPSHOT_DIR         Defaults to /tmp/<repo>-<run-id>
+  SOURCE_SNAPSHOT_DIR         Defaults to /home/ivan/srv/media/shared_data/<repo>-<run-id>
   RUN_ID                      Optional explicit run id
   KEEP_SOURCE_SNAPSHOTS       true/false, defaults to false
 
@@ -35,6 +41,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SOURCE_HOST="${SOURCE_HOST:-192.168.31.11}"
 SOURCE_SSH_TARGET="${SOURCE_SSH_TARGET:-$SOURCE_HOST}"
 TESTBOX_HOST="${TESTBOX_HOST:-codex-testbox}"
+SOURCE_CONTAINER_NAME="${SOURCE_CONTAINER_NAME:-tavily-hikari}"
+SOURCE_CONTAINER_DB_DIR="${SOURCE_CONTAINER_DB_DIR:-/srv/app/data}"
+SOURCE_HELPER_IMAGE="${SOURCE_HELPER_IMAGE:-python:3.12-alpine}"
+SOURCE_BACKUP_PAGES="${SOURCE_BACKUP_PAGES:--1}"
+SOURCE_BACKUP_SLEEP_SECS="${SOURCE_BACKUP_SLEEP_SECS:-0.005}"
+SOURCE_BACKUP_PROGRESS_SECS="${SOURCE_BACKUP_PROGRESS_SECS:-15}"
 SOURCE_DB_DIR="${SOURCE_DB_DIR:-/var/lib/docker/volumes/ai-tavily-hikari-data/_data}"
 SOURCE_CORE_DB_NAME="${SOURCE_CORE_DB_NAME:-tavily_proxy.db}"
 SOURCE_OBSERVABILITY_DB_NAME="${SOURCE_OBSERVABILITY_DB_NAME:-tavily_proxy-observability.db}"
@@ -70,7 +82,7 @@ REMOTE_RUN="$REMOTE_WORKSPACE/runs/$RUN_ID"
 REMOTE_REPO_DIR="$REMOTE_RUN/repo"
 REMOTE_DB_DIR="$REMOTE_RUN/live-db"
 
-SOURCE_TMP_DIR="${SOURCE_SNAPSHOT_DIR:-/tmp/${REPO_NAME}-${RUN_ID}}"
+SOURCE_TMP_DIR="${SOURCE_SNAPSHOT_DIR:-/home/ivan/srv/media/shared_data/${REPO_NAME}-${RUN_ID}}"
 SOURCE_CORE_LIVE="$SOURCE_DB_DIR/$SOURCE_CORE_DB_NAME"
 SOURCE_SIDECAR_LIVE="$SOURCE_DB_DIR/$SOURCE_OBSERVABILITY_DB_NAME"
 SOURCE_CORE_SNAPSHOT="$SOURCE_TMP_DIR/$SOURCE_CORE_DB_NAME"
@@ -89,6 +101,12 @@ ssh -o BatchMode=yes "$TESTBOX_HOST" "cat > '$REMOTE_WORKSPACE/workspace.txt'" <
 local_repo_root=$REPO_ROOT
 created_utc=$CREATED_UTC
 source_host=$SOURCE_HOST
+source_container_name=$SOURCE_CONTAINER_NAME
+source_container_db_dir=$SOURCE_CONTAINER_DB_DIR
+source_helper_image=$SOURCE_HELPER_IMAGE
+source_backup_pages=$SOURCE_BACKUP_PAGES
+source_backup_sleep_secs=$SOURCE_BACKUP_SLEEP_SECS
+source_backup_progress_secs=$SOURCE_BACKUP_PROGRESS_SECS
 source_db_dir=$SOURCE_DB_DIR
 TXT
 
@@ -108,6 +126,12 @@ rsync -az --delete \
 printf 'Creating read-only SQLite backups on %s ...\n' "$SOURCE_SSH_TARGET"
 SOURCE_MANIFEST="$(ssh -o BatchMode=yes "$SOURCE_SSH_TARGET" "bash -s" -- \
   "$SOURCE_TMP_DIR" \
+  "$SOURCE_CONTAINER_NAME" \
+  "$SOURCE_CONTAINER_DB_DIR" \
+  "$SOURCE_HELPER_IMAGE" \
+  "$SOURCE_BACKUP_PAGES" \
+  "$SOURCE_BACKUP_SLEEP_SECS" \
+  "$SOURCE_BACKUP_PROGRESS_SECS" \
   "$SOURCE_CORE_LIVE" \
   "$SOURCE_SIDECAR_LIVE" \
   "$SOURCE_CORE_SNAPSHOT" \
@@ -115,19 +139,50 @@ SOURCE_MANIFEST="$(ssh -o BatchMode=yes "$SOURCE_SSH_TARGET" "bash -s" -- \
 set -euo pipefail
 
 tmp_dir="$1"
-core_live="$2"
-sidecar_live="$3"
-core_snapshot="$4"
-sidecar_snapshot="$5"
+container_name="$2"
+container_db_dir="$3"
+helper_image="$4"
+backup_pages="$5"
+backup_sleep_secs="$6"
+backup_progress_secs="$7"
+core_live="$8"
+sidecar_live="$9"
+core_snapshot="${10}"
+sidecar_snapshot="${11}"
 
 mkdir -p "$tmp_dir"
-test -f "$core_live"
-test -f "$sidecar_live"
-
-core_live_bytes="$(stat -c %s "$core_live")"
-core_live_wal_bytes="$(stat -c %s "${core_live}-wal" 2>/dev/null || echo 0)"
-sidecar_live_bytes="$(stat -c %s "$sidecar_live")"
 available_tmp_bytes="$(df -B1 --output=avail "$tmp_dir" | tail -n1 | tr -d ' ')"
+
+snapshot_source_kind="host-path"
+effective_core_live="$core_live"
+effective_sidecar_live="$sidecar_live"
+
+if docker inspect "$container_name" >/dev/null 2>&1; then
+  if docker exec "$container_name" sh -lc "command -v sqlite3 >/dev/null && test -f '$container_db_dir/$(basename "$core_live")' && test -f '$container_db_dir/$(basename "$sidecar_live")'"; then
+    snapshot_source_kind="container-sqlite-backup"
+    effective_core_live="$container_db_dir/$(basename "$core_live")"
+    effective_sidecar_live="$container_db_dir/$(basename "$sidecar_live")"
+    core_live_bytes="$(docker exec "$container_name" sh -lc "stat -c %s '$effective_core_live'")"
+    core_live_wal_bytes="$(docker exec "$container_name" sh -lc "stat -c %s '${effective_core_live}-wal' 2>/dev/null || echo 0")"
+    sidecar_live_bytes="$(docker exec "$container_name" sh -lc "stat -c %s '$effective_sidecar_live'")"
+  elif docker exec "$container_name" sh -lc "test -f '$container_db_dir/$(basename "$core_live")' && test -f '$container_db_dir/$(basename "$sidecar_live")'"; then
+    snapshot_source_kind="container-helper-python-backup"
+    effective_core_live="$container_db_dir/$(basename "$core_live")"
+    effective_sidecar_live="$container_db_dir/$(basename "$sidecar_live")"
+    core_live_bytes="$(docker run --rm --volumes-from "$container_name":ro "$helper_image" sh -lc "stat -c %s '$effective_core_live'")"
+    core_live_wal_bytes="$(docker run --rm --volumes-from "$container_name":ro "$helper_image" sh -lc "stat -c %s '${effective_core_live}-wal' 2>/dev/null || echo 0")"
+    sidecar_live_bytes="$(docker run --rm --volumes-from "$container_name":ro "$helper_image" sh -lc "stat -c %s '$effective_sidecar_live'")"
+  fi
+fi
+
+if [[ "$snapshot_source_kind" == "host-path" ]]; then
+  test -f "$effective_core_live"
+  test -f "$effective_sidecar_live"
+  core_live_bytes="$(stat -c %s "$effective_core_live")"
+  core_live_wal_bytes="$(stat -c %s "${effective_core_live}-wal" 2>/dev/null || echo 0)"
+  sidecar_live_bytes="$(stat -c %s "$effective_sidecar_live")"
+fi
+
 required_tmp_bytes="$((core_live_bytes + core_live_wal_bytes + sidecar_live_bytes + 1073741824))"
 
 if (( available_tmp_bytes < required_tmp_bytes )); then
@@ -136,24 +191,128 @@ if (( available_tmp_bytes < required_tmp_bytes )); then
 fi
 
 rm -f "$core_snapshot" "$sidecar_snapshot"
-sqlite3 "$core_live" ".timeout 10000" ".backup '$core_snapshot'"
-sqlite3 "$sidecar_live" ".timeout 10000" ".backup '$sidecar_snapshot'"
+
+if [[ "$snapshot_source_kind" == "container-sqlite-backup" ]]; then
+  docker exec "$container_name" sh -lc "sqlite3 '$effective_core_live' \".timeout 10000\" \".backup '/tmp/$(basename "$core_snapshot")'\""
+  docker exec "$container_name" sh -lc "sqlite3 '$effective_sidecar_live' \".timeout 10000\" \".backup '/tmp/$(basename "$sidecar_snapshot")'\""
+  docker cp "$container_name:/tmp/$(basename "$core_snapshot")" "$core_snapshot"
+  docker cp "$container_name:/tmp/$(basename "$sidecar_snapshot")" "$sidecar_snapshot"
+  docker exec "$container_name" sh -lc "rm -f '/tmp/$(basename "$core_snapshot")' '/tmp/$(basename "$sidecar_snapshot")'"
+elif [[ "$snapshot_source_kind" == "container-helper-python-backup" ]]; then
+  docker run --rm \
+    --volumes-from "$container_name":ro \
+    -v "$tmp_dir:/backup" \
+    "$helper_image" \
+    python3 -c '
+import os
+import sqlite3
+import sys
+import time
+
+
+BACKUP_PAGES = int(sys.argv[1])
+BACKUP_SLEEP_SECS = float(sys.argv[2])
+BACKUP_PROGRESS_SECS = float(sys.argv[3])
+CORE_SRC_PATH = sys.argv[4]
+CORE_DST_PATH = sys.argv[5]
+SIDECAR_SRC_PATH = sys.argv[6]
+SIDECAR_DST_PATH = sys.argv[7]
+
+
+def backup_database(label: str, src_path: str, dst_path: str) -> None:
+    if os.path.exists(dst_path):
+        os.remove(dst_path)
+    src = sqlite3.connect(f"file:{src_path}?mode=ro", uri=True, timeout=30.0)
+    dst = sqlite3.connect(dst_path, timeout=30.0)
+    start = time.time()
+    last_report = 0.0
+
+    def progress(status: int, remaining: int, total: int) -> None:
+        nonlocal last_report
+        now = time.time()
+        if total <= 0:
+            return
+        if remaining == 0 or last_report == 0.0 or (now - last_report) >= BACKUP_PROGRESS_SECS:
+            copied = total - remaining
+            pct = (copied / total) * 100.0
+            elapsed = now - start
+            print(
+                f"[sqlite-backup] label={label} copied_pages={copied} total_pages={total} remaining_pages={remaining} pct={pct:.2f} elapsed_secs={elapsed:.1f}",
+                file=sys.stderr,
+                flush=True,
+            )
+            last_report = now
+
+    try:
+        dst.execute("PRAGMA journal_mode=OFF;")
+        dst.execute("PRAGMA synchronous=OFF;")
+        dst.execute("PRAGMA temp_store=MEMORY;")
+        dst.execute("PRAGMA locking_mode=EXCLUSIVE;")
+        if BACKUP_PAGES == -1:
+            total_pages = src.execute("PRAGMA page_count;").fetchone()[0]
+            print(
+                f"[sqlite-backup] label={label} mode=single-step total_pages={total_pages}",
+                file=sys.stderr,
+                flush=True,
+            )
+        src.backup(
+            dst,
+            pages=BACKUP_PAGES,
+            sleep=BACKUP_SLEEP_SECS,
+            progress=progress,
+        )
+        dst.commit()
+    finally:
+        src.close()
+        dst.close()
+
+
+backup_database("core", CORE_SRC_PATH, CORE_DST_PATH)
+backup_database("observability", SIDECAR_SRC_PATH, SIDECAR_DST_PATH)
+' "$backup_pages" "$backup_sleep_secs" "$backup_progress_secs" "$effective_core_live" "/backup/$(basename "$core_snapshot")" "$effective_sidecar_live" "/backup/$(basename "$sidecar_snapshot")"
+else
+  sqlite3 "$effective_core_live" ".timeout 10000" ".backup '$core_snapshot'"
+  sqlite3 "$effective_sidecar_live" ".timeout 10000" ".backup '$sidecar_snapshot'"
+fi
 
 core_integrity="$(sqlite3 "$core_snapshot" 'PRAGMA integrity_check;' | tr -d '\r')"
 sidecar_integrity="$(sqlite3 "$sidecar_snapshot" 'PRAGMA integrity_check;' | tr -d '\r')"
+core_snapshot_bytes="$(stat -c %s "$core_snapshot")"
+sidecar_snapshot_bytes="$(stat -c %s "$sidecar_snapshot")"
+core_snapshot_page_count="$(sqlite3 "$core_snapshot" 'PRAGMA page_count;' | tr -d '\r')"
+sidecar_snapshot_page_count="$(sqlite3 "$sidecar_snapshot" 'PRAGMA page_count;' | tr -d '\r')"
+
+if (( core_snapshot_bytes <= 0 )); then
+  echo "core snapshot is empty" >&2
+  exit 3
+fi
+if (( sidecar_snapshot_bytes <= 0 )); then
+  echo "sidecar snapshot is empty" >&2
+  exit 4
+fi
+if [[ "${core_snapshot_page_count:-0}" == "0" ]]; then
+  echo "core snapshot page_count is zero" >&2
+  exit 5
+fi
+if [[ "${sidecar_snapshot_page_count:-0}" == "0" ]]; then
+  echo "sidecar snapshot page_count is zero" >&2
+  exit 6
+fi
 
 if [[ "$core_integrity" != "ok" ]]; then
   echo "core snapshot integrity_check failed: $core_integrity" >&2
-  exit 3
+  exit 7
 fi
 if [[ "$sidecar_integrity" != "ok" ]]; then
   echo "sidecar snapshot integrity_check failed: $sidecar_integrity" >&2
-  exit 4
+  exit 8
 fi
 
 printf 'source_tmp_dir=%s\n' "$tmp_dir"
-printf 'core_live_path=%s\n' "$core_live"
-printf 'sidecar_live_path=%s\n' "$sidecar_live"
+printf 'snapshot_source_kind=%s\n' "$snapshot_source_kind"
+printf 'helper_image=%s\n' "$helper_image"
+printf 'core_live_path=%s\n' "$effective_core_live"
+printf 'sidecar_live_path=%s\n' "$effective_sidecar_live"
 printf 'core_live_bytes=%s\n' "$core_live_bytes"
 printf 'core_live_wal_bytes=%s\n' "$core_live_wal_bytes"
 printf 'sidecar_live_bytes=%s\n' "$sidecar_live_bytes"
@@ -161,8 +320,10 @@ printf 'available_tmp_bytes=%s\n' "$available_tmp_bytes"
 printf 'required_tmp_bytes=%s\n' "$required_tmp_bytes"
 printf 'core_snapshot_path=%s\n' "$core_snapshot"
 printf 'sidecar_snapshot_path=%s\n' "$sidecar_snapshot"
-printf 'core_snapshot_bytes=%s\n' "$(stat -c %s "$core_snapshot")"
-printf 'sidecar_snapshot_bytes=%s\n' "$(stat -c %s "$sidecar_snapshot")"
+printf 'core_snapshot_bytes=%s\n' "$core_snapshot_bytes"
+printf 'sidecar_snapshot_bytes=%s\n' "$sidecar_snapshot_bytes"
+printf 'core_snapshot_page_count=%s\n' "$core_snapshot_page_count"
+printf 'sidecar_snapshot_page_count=%s\n' "$sidecar_snapshot_page_count"
 printf 'core_snapshot_sha256=%s\n' "$(sha256sum "$core_snapshot" | awk '{print $1}')"
 printf 'sidecar_snapshot_sha256=%s\n' "$(sha256sum "$sidecar_snapshot" | awk '{print $1}')"
 printf 'core_snapshot_integrity=%s\n' "$core_integrity"
@@ -171,6 +332,8 @@ EOS
 )"
 
 SOURCE_TMP_DIR_REMOTE="$(manifest_get source_tmp_dir)"
+SNAPSHOT_SOURCE_KIND="$(manifest_get snapshot_source_kind)"
+HELPER_IMAGE_REMOTE="$(manifest_get helper_image)"
 CORE_LIVE_PATH_REMOTE="$(manifest_get core_live_path)"
 SIDECAR_LIVE_PATH_REMOTE="$(manifest_get sidecar_live_path)"
 CORE_LIVE_BYTES="$(manifest_get core_live_bytes)"
@@ -198,7 +361,15 @@ run_id=$RUN_ID
 created_utc=$CREATED_UTC
 source_host=$SOURCE_HOST
 source_ssh_target=$SOURCE_SSH_TARGET
+source_container_name=$SOURCE_CONTAINER_NAME
+source_container_db_dir=$SOURCE_CONTAINER_DB_DIR
+source_helper_image=$SOURCE_HELPER_IMAGE
+source_backup_pages=$SOURCE_BACKUP_PAGES
+source_backup_sleep_secs=$SOURCE_BACKUP_SLEEP_SECS
+source_backup_progress_secs=$SOURCE_BACKUP_PROGRESS_SECS
 source_db_dir=$SOURCE_DB_DIR
+snapshot_source_kind=$SNAPSHOT_SOURCE_KIND
+helper_image=$HELPER_IMAGE_REMOTE
 core_live_path=$CORE_LIVE_PATH_REMOTE
 sidecar_live_path=$SIDECAR_LIVE_PATH_REMOTE
 core_live_bytes=$CORE_LIVE_BYTES

--- a/scripts/ha-outbox-maintenance.sh
+++ b/scripts/ha-outbox-maintenance.sh
@@ -8,21 +8,53 @@ RUN_UNTIL_COMPLETE="${RUN_UNTIL_COMPLETE:-true}"
 JSON="${JSON:-true}"
 COMPACT_AFTER="${COMPACT_AFTER:-false}"
 FORCE_COMPACTION="${FORCE_COMPACTION:-false}"
+REPAIR_TRIGGERS="${REPAIR_TRIGGERS:-true}"
+HA_MODE="${HA_MODE:-active_standby}"
 BATCH_SIZE="${BATCH_SIZE:-20000}"
 MAX_BATCHES="${MAX_BATCHES:-8}"
 MAX_RUNTIME_SECS="${MAX_RUNTIME_SECS:-20}"
 INTER_BATCH_SLEEP_MS="${INTER_BATCH_SLEEP_MS:-0}"
 
+resolve_runner() {
+  local bin_name="$1"
+  if [[ -n "${TAVILY_HIKARI_BIN_DIR:-}" && -x "${TAVILY_HIKARI_BIN_DIR}/${bin_name}" ]]; then
+    printf '%s\n' "${TAVILY_HIKARI_BIN_DIR}/${bin_name}"
+    return 0
+  fi
+  if command -v "$bin_name" >/dev/null 2>&1; then
+    command -v "$bin_name"
+    return 0
+  fi
+  printf 'cargo-run:%s\n' "$bin_name"
+}
+
+build_command() {
+  local bin_name="$1"
+  local resolved
+  resolved="$(resolve_runner "$bin_name")"
+  if [[ "$resolved" == cargo-run:* ]]; then
+    printf 'cargo run --bin %s --' "$bin_name"
+  else
+    printf '%s' "$resolved"
+  fi
+}
+
 pushd "$ROOT_DIR" >/dev/null
 
-cleanup_cmd=(
-  cargo run --bin ha_outbox_cleanup_once --
+cleanup_runner="$(build_command ha_outbox_cleanup_once)"
+IFS=' ' read -r -a cleanup_cmd <<<"$cleanup_runner"
+cleanup_cmd+=(
   --db-path "$DB_PATH"
   --batch-size "$BATCH_SIZE"
   --max-batches "$MAX_BATCHES"
   --max-runtime-secs "$MAX_RUNTIME_SECS"
   --inter-batch-sleep-ms "$INTER_BATCH_SLEEP_MS"
+  --ha-mode "$HA_MODE"
 )
+
+if [[ "$REPAIR_TRIGGERS" == "true" || "$REPAIR_TRIGGERS" == "1" ]]; then
+  cleanup_cmd+=(--repair-triggers)
+fi
 
 if [[ "$RUN_UNTIL_COMPLETE" == "true" || "$RUN_UNTIL_COMPLETE" == "1" ]]; then
   cleanup_cmd+=(--run-until-complete)
@@ -36,7 +68,9 @@ echo "Running HA outbox cleanup against $DB_PATH ..."
 "${cleanup_cmd[@]}"
 
 if [[ "$COMPACT_AFTER" == "true" || "$COMPACT_AFTER" == "1" ]]; then
-  compaction_cmd=(cargo run --bin db_compaction_once -- --db-path "$DB_PATH")
+  compaction_runner="$(build_command db_compaction_once)"
+  IFS=' ' read -r -a compaction_cmd <<<"$compaction_runner"
+  compaction_cmd+=(--db-path "$DB_PATH")
   if [[ "$FORCE_COMPACTION" == "true" || "$FORCE_COMPACTION" == "1" ]]; then
     compaction_cmd+=(--force)
   fi

--- a/src/bin/ha_outbox_cleanup_once.rs
+++ b/src/bin/ha_outbox_cleanup_once.rs
@@ -35,6 +35,14 @@ struct Cli {
     #[arg(long, default_value_t = HaOutboxGcOptions::default().inter_batch_sleep_ms)]
     inter_batch_sleep_ms: u64,
 
+    /// Repair HA triggers against the current three-channel contract before cleanup.
+    #[arg(long, default_value_t = false)]
+    repair_triggers: bool,
+
+    /// HA mode used when repairing triggers.
+    #[arg(long, env = "HA_MODE", default_value = "active_standby")]
+    ha_mode: String,
+
     /// Continue running bounded passes until no retained control outbox rows remain.
     #[arg(long, default_value_t = false)]
     run_until_complete: bool,
@@ -69,11 +77,15 @@ fn positive_u64(value: &str) -> Result<u64, String> {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CliReport {
+    repaired_triggers: bool,
+    trigger_repair_report: Option<tavily_hikari::HaTriggerRepairReport>,
     run_until_complete: bool,
     passes: usize,
     batch_size: i64,
     max_batches: i64,
     deleted_rows: i64,
+    invalid_legacy_deleted_rows: i64,
+    retention_deleted_rows: i64,
     batches: i64,
     completed: bool,
     has_more: bool,
@@ -86,16 +98,33 @@ struct CliReport {
 }
 
 impl CliReport {
-    fn from_passes(run_until_complete: bool, reports: Vec<HaOutboxGcReport>) -> Self {
+    fn from_passes(
+        run_until_complete: bool,
+        repaired_triggers: bool,
+        trigger_repair_report: Option<tavily_hikari::HaTriggerRepairReport>,
+        reports: Vec<HaOutboxGcReport>,
+    ) -> Self {
         let last = reports
             .last()
             .expect("ha outbox cleanup cli always records at least one pass");
         Self {
+            repaired_triggers,
+            trigger_repair_report,
             run_until_complete,
             passes: reports.len(),
             batch_size: last.batch_size,
             max_batches: last.max_batches,
             deleted_rows: reports.iter().map(|report| report.deleted_rows).sum(),
+            invalid_legacy_deleted_rows: reports
+                .iter()
+                .flat_map(|report| report.channels.iter())
+                .map(|channel| channel.invalid_legacy_deleted_rows)
+                .sum(),
+            retention_deleted_rows: reports
+                .iter()
+                .flat_map(|report| report.channels.iter())
+                .map(|channel| channel.retention_deleted_rows)
+                .sum(),
             batches: reports.iter().map(|report| report.batches).sum(),
             completed: last.completed,
             has_more: last.has_more,
@@ -131,7 +160,10 @@ fn write_plain_report(mut writer: impl Write, report: &CliReport) -> io::Result<
     };
     writeln!(
         writer,
-        "ha_outbox_gc: {}",
+        "ha_outbox_gc: repaired_triggers={} invalid_legacy_deleted_rows={} retention_deleted_rows={} {}",
+        report.repaired_triggers,
+        report.invalid_legacy_deleted_rows,
+        report.retention_deleted_rows,
         format_ha_outbox_gc_report_message(&aggregate, report.passes)
     )?;
     writer.flush()
@@ -141,6 +173,7 @@ fn write_plain_report(mut writer: impl Write, report: &CliReport) -> io::Result<
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
     let cli = Cli::parse();
+    let mode = tavily_hikari::HaMode::parse(&cli.ha_mode);
     let options = HaOutboxGcOptions {
         batch_size: cli.batch_size,
         max_batches: cli.max_batches,
@@ -148,6 +181,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         inter_batch_sleep_ms: cli.inter_batch_sleep_ms,
     };
     let mut reports = Vec::new();
+    let trigger_repair_report = if cli.repair_triggers {
+        Some(tavily_hikari::repair_ha_triggers_once(&cli.db_path, mode).await?)
+    } else {
+        None
+    };
 
     loop {
         let report = run_ha_outbox_gc_once(&cli.db_path, options).await?;
@@ -158,7 +196,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let cli_report = CliReport::from_passes(cli.run_until_complete, reports);
+    let cli_report = CliReport::from_passes(
+        cli.run_until_complete,
+        cli.repair_triggers,
+        trigger_repair_report,
+        reports,
+    );
     if cli.json {
         write_json_report(io::stdout().lock(), &cli_report)?;
     } else {
@@ -166,4 +209,72 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_report_sums_invalid_and_retention_passes() {
+        let report = CliReport::from_passes(
+            true,
+            true,
+            None,
+            vec![
+                HaOutboxGcReport {
+                    batch_size: 10,
+                    max_batches: 2,
+                    deleted_rows: 5,
+                    batches: 1,
+                    completed: false,
+                    has_more: true,
+                    channels: vec![HaOutboxGcChannelReport {
+                        channel: tavily_hikari::HaSyncChannel::Control,
+                        retention_secs: 72,
+                        threshold: 100,
+                        invalid_legacy_deleted_rows: 2,
+                        retention_deleted_rows: 3,
+                        deleted_rows: 5,
+                        batches: 1,
+                        has_more: true,
+                    }],
+                    wal_checkpoint_busy: false,
+                    wal_checkpoint_log_frames: 0,
+                    wal_checkpoint_checkpointed_frames: 0,
+                    elapsed_ms: 12,
+                },
+                HaOutboxGcReport {
+                    batch_size: 10,
+                    max_batches: 2,
+                    deleted_rows: 2,
+                    batches: 1,
+                    completed: true,
+                    has_more: false,
+                    channels: vec![HaOutboxGcChannelReport {
+                        channel: tavily_hikari::HaSyncChannel::Control,
+                        retention_secs: 72,
+                        threshold: 100,
+                        invalid_legacy_deleted_rows: 1,
+                        retention_deleted_rows: 1,
+                        deleted_rows: 2,
+                        batches: 1,
+                        has_more: false,
+                    }],
+                    wal_checkpoint_busy: false,
+                    wal_checkpoint_log_frames: 0,
+                    wal_checkpoint_checkpointed_frames: 0,
+                    elapsed_ms: 8,
+                },
+            ],
+        );
+
+        assert!(report.repaired_triggers);
+        assert_eq!(report.deleted_rows, 7);
+        assert_eq!(report.invalid_legacy_deleted_rows, 3);
+        assert_eq!(report.retention_deleted_rows, 4);
+        assert_eq!(report.batches, 2);
+        assert!(report.completed);
+        assert_eq!(report.elapsed_ms, 20);
+    }
 }

--- a/src/bin/ha_trigger_repair_once.rs
+++ b/src/bin/ha_trigger_repair_once.rs
@@ -1,0 +1,63 @@
+use clap::Parser;
+use dotenvy::dotenv;
+use tavily_hikari::{HaMode, repair_ha_triggers_once};
+
+#[derive(Debug, Parser)]
+#[command(
+    author,
+    version,
+    about = "Repair HA replication triggers for the current three-channel contract"
+)]
+struct Cli {
+    /// SQLite database path to mutate.
+    #[arg(long, env = "PROXY_DB_PATH", default_value = "data/tavily_proxy.db")]
+    db_path: String,
+
+    /// HA mode to reconcile against.
+    #[arg(long, env = "HA_MODE", default_value = "active_standby")]
+    ha_mode: String,
+
+    /// Emit JSON output. Plain output is retained for interactive use.
+    #[arg(long, default_value_t = false)]
+    json: bool,
+}
+
+fn format_plain(report: &tavily_hikari::HaTriggerRepairReport) -> String {
+    let channels = report
+        .channels
+        .iter()
+        .map(|channel| {
+            format!(
+                "{}:{}:{}:{}",
+                channel.channel.as_str(),
+                channel.legacy_triggers_dropped,
+                channel.current_triggers_dropped,
+                channel.triggers_created
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "ha_trigger_repair: mode={} legacy_triggers_dropped={} current_triggers_dropped={} triggers_created={} channels={} elapsed_ms={}",
+        report.mode.as_str(),
+        report.legacy_triggers_dropped,
+        report.current_triggers_dropped,
+        report.triggers_created,
+        channels,
+        report.elapsed_ms
+    )
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv().ok();
+    let cli = Cli::parse();
+    let mode = HaMode::parse(&cli.ha_mode);
+    let report = repair_ha_triggers_once(&cli.db_path, mode).await?;
+    if cli.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{}", format_plain(&report));
+    }
+    Ok(())
+}

--- a/src/ha.rs
+++ b/src/ha.rs
@@ -18,6 +18,13 @@ pub enum HaMode {
 }
 
 impl HaMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::ActiveStandby => "active_standby",
+        }
+    }
+
     pub fn parse(raw: &str) -> Self {
         match raw.trim().to_ascii_lowercase().as_str() {
             "active_standby" | "active-standby" | "ha" => Self::ActiveStandby,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,6 +440,8 @@ pub struct HaOutboxGcChannelReport {
     pub channel: HaSyncChannel,
     pub retention_secs: i64,
     pub threshold: i64,
+    pub invalid_legacy_deleted_rows: i64,
+    pub retention_deleted_rows: i64,
     pub deleted_rows: i64,
     pub batches: i64,
     pub has_more: bool,
@@ -471,9 +473,11 @@ pub fn format_ha_outbox_gc_report_message(report: &HaOutboxGcReport, passes: usi
             .channels
             .iter()
             .map(|channel| format!(
-                "{}:{}:{}:{}:{}",
+                "{}:{}:{}:{}:{}:{}:{}",
                 channel.channel.as_str(),
                 channel.deleted_rows,
+                channel.invalid_legacy_deleted_rows,
+                channel.retention_deleted_rows,
                 channel.retention_secs,
                 channel.batches,
                 channel.has_more
@@ -520,6 +524,34 @@ pub async fn verify_observability_sidecar_reopen(database_path: &str) -> Result<
 pub async fn configure_ha_write_mode(database_path: &str, mode: HaMode) -> Result<(), ProxyError> {
     let store = crate::store::KeyStore::new_with_time(database_path, BackendTime::system()).await?;
     store.configure_ha_event_writes(mode).await
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HaTriggerRepairChannelReport {
+    pub channel: HaSyncChannel,
+    pub legacy_triggers_dropped: i64,
+    pub current_triggers_dropped: i64,
+    pub triggers_created: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HaTriggerRepairReport {
+    pub mode: HaMode,
+    pub legacy_triggers_dropped: i64,
+    pub current_triggers_dropped: i64,
+    pub triggers_created: i64,
+    pub channels: Vec<HaTriggerRepairChannelReport>,
+    pub elapsed_ms: u128,
+}
+
+pub async fn repair_ha_triggers_once(
+    database_path: &str,
+    mode: HaMode,
+) -> Result<HaTriggerRepairReport, ProxyError> {
+    let store = crate::store::KeyStore::new_with_time(database_path, BackendTime::system()).await?;
+    store.repair_ha_triggers(mode).await
 }
 
 impl ForwardProxyProgressEvent {

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -729,6 +729,97 @@ async fn ha_switching_back_to_single_disables_billing_and_runtime_triggers() {
 }
 
 #[tokio::test]
+async fn ha_repair_clears_legacy_single_channel_triggers_from_upgraded_db() {
+    let db_path = temp_db_path("ha-repair-legacy-single-channel-triggers");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_in_ha_mode(
+        vec!["tvly-ha-repair-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+        tavily_hikari::TavilyProxyOptions::from_database_path(&db_str),
+        tavily_hikari::HaMode::ActiveStandby,
+    )
+    .await
+    .expect("proxy created");
+    drop(proxy);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query(
+        r#"
+        CREATE TRIGGER trg_ha_outbox_scheduled_jobs_insert
+        AFTER INSERT ON scheduled_jobs
+        BEGIN
+            INSERT INTO ha_outbox (
+                kind, resource, resource_id, op, payload_json, created_at, checksum
+            )
+            VALUES (
+                'state',
+                'scheduled_jobs',
+                CAST(NEW.id AS TEXT),
+                'upsert',
+                json_object('id', NEW.id, 'job_type', NEW.job_type),
+                CAST(strftime('%s','now') AS INTEGER),
+                NULL
+            );
+        END
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create legacy scheduled_jobs trigger");
+    sqlx::query(
+        r#"
+        INSERT INTO scheduled_jobs (
+            job_type, trigger_source, status, attempt, queued_at, started_at, finished_at, message
+        ) VALUES ('legacy_ha_trigger_test', 'manual', 'queued', 1, 1, NULL, NULL, NULL)
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("insert scheduled job with legacy trigger");
+    let legacy_count_before: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'scheduled_jobs'")
+            .fetch_one(&pool)
+            .await
+            .expect("count legacy scheduled_jobs rows before repair");
+    assert_eq!(legacy_count_before, 1);
+    pool.close().await;
+
+    let report =
+        tavily_hikari::repair_ha_triggers_once(&db_str, tavily_hikari::HaMode::ActiveStandby)
+            .await
+            .expect("repair ha triggers");
+    assert!(report.legacy_triggers_dropped >= 1);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let legacy_trigger_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = 'trg_ha_outbox_scheduled_jobs_insert'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count legacy trigger after repair");
+    assert_eq!(legacy_trigger_count, 0);
+    sqlx::query(
+        r#"
+        INSERT INTO scheduled_jobs (
+            job_type, trigger_source, status, attempt, queued_at, started_at, finished_at, message
+        ) VALUES ('legacy_ha_trigger_test_after', 'manual', 'queued', 1, 2, NULL, NULL, NULL)
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("insert scheduled job after repair");
+    let legacy_count_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'scheduled_jobs'")
+            .fetch_one(&pool)
+            .await
+            .expect("count legacy scheduled_jobs rows after repair");
+    assert_eq!(legacy_count_after, 1);
+    pool.close().await;
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn ha_billing_and_runtime_channels_do_not_route_into_control_outbox() {
     let db_path = temp_db_path("ha-multichannel-outboxes");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -162,6 +162,18 @@ fn ha_channel_retention_secs(channel: HaSyncChannel) -> i64 {
     }
 }
 
+fn ha_channel_outbox_trigger_prefixes(channel: HaSyncChannel) -> Vec<String> {
+    let mut prefixes = vec![format!("trg_ha_{}_", channel.as_str())];
+    if channel == HaSyncChannel::Control {
+        prefixes.push("trg_ha_outbox_".to_string());
+    }
+    prefixes
+}
+
+fn ha_channel_allowed_resources(channel: HaSyncChannel) -> &'static [&'static str] {
+    ha_baseline_tables(channel)
+}
+
 impl KeyStore {
     pub(crate) async fn persist_ha_node_state(
         &self,
@@ -933,25 +945,58 @@ impl KeyStore {
     }
 
     pub(crate) async fn configure_ha_event_writes(&self, mode: HaMode) -> Result<(), ProxyError> {
-        self.drop_ha_channel_triggers(HaSyncChannel::Control).await?;
-        self.drop_ha_channel_triggers(HaSyncChannel::Billing).await?;
-        self.drop_ha_channel_triggers(HaSyncChannel::Runtime).await?;
-        if mode == HaMode::Single {
-            return Ok(());
+        self.repair_ha_triggers(mode).await.map(|_| ())
+    }
+
+    pub(crate) async fn repair_ha_triggers(
+        &self,
+        mode: HaMode,
+    ) -> Result<HaTriggerRepairReport, ProxyError> {
+        let started = Instant::now();
+        let mut channels = Vec::new();
+
+        for channel in [
+            HaSyncChannel::Control,
+            HaSyncChannel::Billing,
+            HaSyncChannel::Runtime,
+        ] {
+            let (legacy_triggers_dropped, current_triggers_dropped) =
+                self.drop_ha_channel_triggers(channel).await?;
+            let triggers_created = if mode == HaMode::Single {
+                0
+            } else {
+                self.ensure_ha_channel_outbox_triggers(channel).await?
+            };
+            channels.push(HaTriggerRepairChannelReport {
+                channel,
+                legacy_triggers_dropped,
+                current_triggers_dropped,
+                triggers_created,
+            });
         }
-        self.ensure_ha_channel_outbox_triggers(HaSyncChannel::Control)
-            .await?;
-        self.ensure_ha_channel_outbox_triggers(HaSyncChannel::Billing)
-            .await?;
-        self.ensure_ha_channel_outbox_triggers(HaSyncChannel::Runtime)
-            .await
+
+        Ok(HaTriggerRepairReport {
+            mode,
+            legacy_triggers_dropped: channels
+                .iter()
+                .map(|channel| channel.legacy_triggers_dropped)
+                .sum(),
+            current_triggers_dropped: channels
+                .iter()
+                .map(|channel| channel.current_triggers_dropped)
+                .sum(),
+            triggers_created: channels.iter().map(|channel| channel.triggers_created).sum(),
+            channels,
+            elapsed_ms: started.elapsed().as_millis(),
+        })
     }
 
     pub(crate) async fn ensure_ha_channel_outbox_triggers(
         &self,
         channel: HaSyncChannel,
-    ) -> Result<(), ProxyError> {
+    ) -> Result<i64, ProxyError> {
         let mut conn = self.pool.acquire().await?;
+        let mut created = 0_i64;
         for table in ha_channel_event_tables(channel) {
             let table_exists = sqlx::query_scalar::<_, i64>(
                 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?)",
@@ -1016,30 +1061,49 @@ impl KeyStore {
                     quote_sqlite_identifier(ha_channel_event_table(channel))
                 );
                 sqlx::query(&sql).execute(&mut *conn).await?;
+                created += 1;
             }
         }
-        Ok(())
+        Ok(created)
     }
 
-    async fn drop_ha_channel_triggers(&self, channel: HaSyncChannel) -> Result<(), ProxyError> {
+    async fn drop_ha_channel_triggers(&self, channel: HaSyncChannel) -> Result<(i64, i64), ProxyError> {
         let mut conn = self.pool.acquire().await?;
+        let mut current_trigger_names = std::collections::HashSet::new();
         for table in ha_channel_event_tables(channel) {
             for suffix in ["insert", "update", "delete"] {
-                sqlx::query(&format!(
-                    "DROP TRIGGER IF EXISTS {}",
-                    quote_sqlite_identifier(&format!("trg_ha_outbox_{}_{}", table, suffix))
-                ))
-                .execute(&mut *conn)
-                .await?;
-                sqlx::query(&format!(
-                    "DROP TRIGGER IF EXISTS {}",
-                    quote_sqlite_identifier(&ha_trigger_name(channel, table, suffix))
-                ))
-                .execute(&mut *conn)
-                .await?;
+                if channel == HaSyncChannel::Control {
+                    current_trigger_names.insert(format!("trg_ha_outbox_{}_{}", table, suffix));
+                }
+                current_trigger_names.insert(ha_trigger_name(channel, table, suffix));
             }
         }
-        Ok(())
+        let mut current_triggers_dropped = 0_i64;
+        let mut legacy_triggers_dropped = 0_i64;
+        let prefixes = ha_channel_outbox_trigger_prefixes(channel);
+        let rows = sqlx::query(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger' ORDER BY name ASC",
+        )
+        .fetch_all(&mut *conn)
+        .await?;
+        for row in rows {
+            let name: String = row.try_get("name")?;
+            if !prefixes.iter().any(|prefix| name.starts_with(prefix)) {
+                continue;
+            }
+            sqlx::query(&format!(
+                "DROP TRIGGER IF EXISTS {}",
+                quote_sqlite_identifier(&name)
+            ))
+            .execute(&mut *conn)
+            .await?;
+            if current_trigger_names.contains(&name) {
+                current_triggers_dropped += 1;
+            } else {
+                legacy_triggers_dropped += 1;
+            }
+        }
+        Ok((legacy_triggers_dropped, current_triggers_dropped))
     }
 
 }
@@ -1374,6 +1438,62 @@ impl KeyStore {
         Ok(deleted.rows_affected() as i64)
     }
 
+    pub(crate) async fn delete_ha_invalid_legacy_events_bounded(
+        &self,
+        channel: HaSyncChannel,
+        batch_size: i64,
+    ) -> Result<i64, ProxyError> {
+        let table = quote_sqlite_identifier(ha_channel_event_table(channel));
+        let allowed_resources = ha_channel_allowed_resources(channel)
+            .iter()
+            .map(|resource| quote_sqlite_string(resource))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let where_sql = if allowed_resources.is_empty() {
+            "1=1".to_string()
+        } else {
+            format!("resource NOT IN ({allowed_resources})")
+        };
+        let deleted = sqlx::query(&format!(
+            r#"
+            DELETE FROM {table}
+            WHERE seq IN (
+                SELECT seq
+                FROM {table}
+                WHERE {where_sql}
+                ORDER BY seq ASC
+                LIMIT ?
+            )
+            "#
+        ))
+        .bind(batch_size.max(1))
+        .execute(&self.pool)
+        .await?;
+        Ok(deleted.rows_affected() as i64)
+    }
+
+    pub(crate) async fn ha_invalid_legacy_events_exist(
+        &self,
+        channel: HaSyncChannel,
+    ) -> Result<bool, ProxyError> {
+        let table = quote_sqlite_identifier(ha_channel_event_table(channel));
+        let allowed_resources = ha_channel_allowed_resources(channel)
+            .iter()
+            .map(|resource| quote_sqlite_string(resource))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = if allowed_resources.is_empty() {
+            format!("SELECT EXISTS(SELECT 1 FROM {table} LIMIT 1)")
+        } else {
+            format!(
+                "SELECT EXISTS(SELECT 1 FROM {table} WHERE resource NOT IN ({allowed_resources}) LIMIT 1)"
+            )
+        };
+        Ok(sqlx::query_scalar::<_, bool>(&sql)
+            .fetch_one(&self.pool)
+            .await?)
+    }
+
     pub(crate) async fn gc_ha_outbox_with_options(
         &self,
         options: HaOutboxGcOptions,
@@ -1395,15 +1515,32 @@ impl KeyStore {
             let retention_secs = ha_channel_retention_secs(channel);
             let threshold = self.backend_time.now_ts() - retention_secs;
             let mut channel_deleted_rows = 0_i64;
+            let mut invalid_legacy_deleted_rows = 0_i64;
+            let mut retention_deleted_rows = 0_i64;
             let mut channel_batches = 0_i64;
 
             while channel_batches < max_batches && Instant::now() < deadline {
-                let deleted = self
-                    .delete_ha_channel_events_bounded(channel, threshold, batch_size)
+                let deleted_invalid = self
+                    .delete_ha_invalid_legacy_events_bounded(channel, batch_size)
                     .await?;
-                channel_deleted_rows += deleted;
+                invalid_legacy_deleted_rows += deleted_invalid;
+                channel_deleted_rows += deleted_invalid;
                 channel_batches += 1;
-                if deleted < batch_size {
+                if deleted_invalid > 0 {
+                    if deleted_invalid < batch_size {
+                        continue;
+                    }
+                } else {
+                    let deleted_retention = self
+                        .delete_ha_channel_events_bounded(channel, threshold, batch_size)
+                        .await?;
+                    retention_deleted_rows += deleted_retention;
+                    channel_deleted_rows += deleted_retention;
+                    if deleted_retention < batch_size {
+                        break;
+                    }
+                }
+                if deleted_invalid > 0 && deleted_invalid < batch_size {
                     break;
                 }
                 completed = false;
@@ -1414,13 +1551,15 @@ impl KeyStore {
                 }
             }
 
-            let has_more: bool = sqlx::query_scalar(&format!(
+            let has_more_retention: bool = sqlx::query_scalar(&format!(
                 "SELECT EXISTS(SELECT 1 FROM {} WHERE created_at < ? LIMIT 1)",
                 quote_sqlite_identifier(ha_channel_event_table(channel))
             ))
             .bind(threshold)
             .fetch_one(&self.pool)
             .await?;
+            let has_more_invalid = self.ha_invalid_legacy_events_exist(channel).await?;
+            let has_more = has_more_invalid || has_more_retention;
             if has_more {
                 completed = false;
             }
@@ -1431,6 +1570,8 @@ impl KeyStore {
                 channel,
                 retention_secs,
                 threshold,
+                invalid_legacy_deleted_rows,
+                retention_deleted_rows,
                 deleted_rows: channel_deleted_rows,
                 batches: channel_batches,
                 has_more,

--- a/src/tests/jobs_and_request_log_retention.rs
+++ b/src/tests/jobs_and_request_log_retention.rs
@@ -272,6 +272,103 @@ async fn standalone_ha_outbox_gc_deletes_expired_rows_across_channels_in_bounded
 }
 
 #[tokio::test]
+async fn standalone_ha_outbox_gc_deletes_invalid_legacy_rows_before_retention_rows() {
+    let db_path = temp_db_path("ha-outbox-gc-invalid-legacy-first");
+    let db_str = db_path.to_string_lossy().to_string();
+    let old_control_ts = Utc::now().timestamp() - (4 * SECS_PER_DAY);
+    let recent_ts = Utc::now().timestamp();
+
+    let proxy = TavilyProxy::with_options_in_ha_mode(
+        vec!["tvly-ha-invalid-gc-key".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        HaMode::ActiveStandby,
+    )
+    .await
+    .expect("proxy created");
+    drop(proxy);
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open sqlite pool");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_outbox (
+            kind, resource, resource_id, op, payload_json, created_at, checksum
+        ) VALUES
+            ('state', 'scheduled_jobs', 'legacy-1', 'upsert', '{}', ?, NULL),
+            ('state', 'scheduled_jobs', 'legacy-2', 'upsert', '{}', ?, NULL),
+            ('state', 'users', 'old-user', 'upsert', '{}', ?, NULL),
+            ('state', 'users', 'recent-user', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(recent_ts)
+    .bind(recent_ts + 1)
+    .bind(old_control_ts)
+    .bind(recent_ts + 2)
+    .execute(&pool)
+    .await
+    .expect("seed control outbox rows");
+    drop(pool);
+
+    let report = run_ha_outbox_gc_once(
+        &db_str,
+        HaOutboxGcOptions {
+            batch_size: 10,
+            max_batches: 2,
+            max_runtime_secs: 30,
+            inter_batch_sleep_ms: 0,
+        },
+    )
+    .await
+    .expect("run standalone ha outbox gc");
+
+    let control = report
+        .channels
+        .iter()
+        .find(|channel| channel.channel == HaSyncChannel::Control)
+        .expect("control report");
+    assert_eq!(control.invalid_legacy_deleted_rows, 2);
+    assert_eq!(control.retention_deleted_rows, 1);
+    assert_eq!(control.deleted_rows, 3);
+
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .create_if_missing(false),
+    )
+    .await
+    .expect("reopen sqlite pool");
+    let legacy_remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'scheduled_jobs'")
+            .fetch_one(&pool)
+            .await
+            .expect("count legacy rows");
+    let old_allowed_remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ha_outbox WHERE resource = 'users' AND created_at < ?",
+    )
+    .bind(recent_ts - SECS_PER_DAY)
+    .fetch_one(&pool)
+    .await
+    .expect("count old allowed rows");
+    let recent_allowed_remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'users'")
+            .fetch_one(&pool)
+            .await
+            .expect("count remaining allowed rows");
+    assert_eq!(legacy_remaining, 0);
+    assert_eq!(old_allowed_remaining, 0);
+    assert_eq!(recent_allowed_remaining, 1);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn scheduled_job_start_retries_transient_sqlite_write_lock() {
     let db_path = temp_db_path("scheduled-job-start-retries-sqlite-lock");
     let db_str = db_path.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary
- add `ha_trigger_repair_once` and make HA trigger reconcile enumerate/drop stale upgraded triggers from `sqlite_master`
- delete invalid legacy `ha_outbox` rows before ordinary retention cleanup and expose separate counters in cleanup reports
- harden the full live-db export/maintenance runbook and bake the new operator binaries into the image

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test alerts_and_ha -- --nocapture`
- `cargo test standalone_ha_outbox_gc_deletes_invalid_legacy_rows_before_retention_rows -- --nocapture`
- shared-testbox full 101 snapshot validation using `tavily_proxy.db` + `tavily_proxy-observability.db`
  - `ha_trigger_repair_once --ha-mode active_standby` dropped 30 legacy single-channel triggers
  - `ha_outbox_cleanup_once --repair-triggers --run-until-complete --json` deleted 29,143,494 rows
  - invalid legacy deletions: 27,770,036
  - retention deletions: 1,373,458
  - post-cleanup `ha_outbox` rows: 163,357
  - post-cleanup freelist count: 2,951,432 (~12 GiB reclaimable)
  - `db_compaction_once` was correctly worth running but the shared testbox blocked it with `database or disk is full` because `/srv/codex` had only ~3.5 GiB free

## References
- Specs: `docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md`, `docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md`
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`
- Project Docs: `docs-site/docs/en/deployment-anonymity.md`, `docs-site/docs/zh/deployment-anonymity.md`
