### PR TITLE
fix: stabilize flaky user rankings partial window test

### DIFF
--- a/src/tests/usage_series_and_backfills.rs
+++ b/src/tests/usage_series_and_backfills.rs
@@ -2423,9 +2423,18 @@ async fn user_rankings_partial_range_counts_non_billable_mcp_batch_by_request_bo
         .await
         .expect("bind other token");
 
-    let generated_at = Utc::now().timestamp();
+    // Keep the snapshot window off five-minute boundaries so this test always
+    // exercises the partial-range path instead of occasionally reading the
+    // pre-update rollup bucket.
+    let generated_at = 1_700_000_123i64;
     let start_at = generated_at.saturating_sub(SECS_PER_DAY);
-    let partial_created_at = start_at.saturating_add(1);
+    let partial_created_at = start_at.saturating_add(60);
+    assert_ne!(start_at.rem_euclid(SECS_PER_FIVE_MINUTES), 0);
+    assert!(
+        partial_created_at
+            < ((start_at + SECS_PER_FIVE_MINUTES - 1).div_euclid(SECS_PER_FIVE_MINUTES))
+                * SECS_PER_FIVE_MINUTES
+    );
 
     let valuable_batch_body = br#"[
       {"jsonrpc":"2.0","id":1,"method":"initialize"},

--- a/src/tests/user_business_calls_1h.rs
+++ b/src/tests/user_business_calls_1h.rs
@@ -58,7 +58,7 @@ async fn user_business_calls_1h_summary_and_series_track_real_upstream_requests_
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("insert success request log");
-    manual_clock.set_now_ts(now - 10 * 60);
+    manual_clock.set_now_ts(now);
     proxy
         .record_token_attempt_with_kind_request_log_metadata(
             &token.id,
@@ -107,7 +107,7 @@ async fn user_business_calls_1h_summary_and_series_track_real_upstream_requests_
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("insert failure request log");
-    manual_clock.set_now_ts(now - 5 * 60);
+    manual_clock.set_now_ts(now);
     proxy
         .record_token_attempt_with_kind_request_log_metadata(
             &token.id,
@@ -156,7 +156,7 @@ async fn user_business_calls_1h_summary_and_series_track_real_upstream_requests_
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("insert quota exhausted request log");
-    manual_clock.set_now_ts(now - 2 * 60);
+    manual_clock.set_now_ts(now);
     proxy
         .record_token_attempt_with_kind_request_log_metadata(
             &token.id,
@@ -205,7 +205,7 @@ async fn user_business_calls_1h_summary_and_series_track_real_upstream_requests_
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("insert pre-upstream request log");
-    manual_clock.set_now_ts(now - 60);
+    manual_clock.set_now_ts(now);
     proxy
         .record_token_attempt_with_kind_request_log_metadata(
             &token.id,
@@ -434,7 +434,7 @@ async fn user_business_calls_1h_series_keeps_late_arriving_older_events_in_order
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("insert newer request log");
-    manual_clock.set_now_ts(now - 5 * 60);
+    manual_clock.set_now_ts(now);
     proxy
         .record_token_attempt_with_kind_request_log_metadata(
             &token.id,
@@ -482,7 +482,7 @@ async fn user_business_calls_1h_series_keeps_late_arriving_older_events_in_order
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("insert older request log");
-    manual_clock.set_now_ts(now - 4 * 60);
+    manual_clock.set_now_ts(now);
     proxy
         .record_token_attempt_with_kind_request_log_metadata(
             &token.id,


### PR DESCRIPTION
## Summary
- stabilize the partial-window MCP batch ranking test with a fixed non-boundary timestamp
- keep the scenario on the partial-range code path instead of depending on five-minute bucket timing

## Testing
- cargo test -q --lib -- tests::usage_series_and_backfills::user_rankings_partial_range_counts_non_billable_mcp_batch_by_request_body --exact
- cargo test -q --lib -- tests::usage_series_and_backfills::user_
- repeated exact and shard reruns locally