### PR TITLE
fix(store): harden sqlite write contention paths

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -41,6 +41,12 @@ Short-lived SQLite writer collisions can happen when request-path billing/sessio
 background writes all touch the same DB. Treating every transient busy/locked response as fatal makes
 brief contention visible as HTTP 500s or failed background bookkeeping.
 
+On `2026-06-22`, one production sample provided a clean example of this shape: `/health` and
+`/api/version` stayed fast, but the latest sampled hour still contained `34`
+`database is locked` errors and `296` slow statements, concentrated around
+`record_pending_billing_attempt failed for /mcp`, `request stats persist`, and a retained-log
+month-tail public metrics scan.
+
 ## Resolution
 
 - Add a runtime DB logging contract before changing lock semantics again. For this service, default
@@ -216,6 +222,17 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - If an owner-facing read depends on coalesced rollups, prefer a freshness-gated flush over an
   unconditional flush. This keeps near-real-time semantics without turning every public/admin read
   into a write barrier under SQLite's single-writer budget.
+- When request-path billing needs both a history row and a ledger row, keep them in one SQLite
+  transaction before adding retries. Retrying two independent writes can duplicate the history row
+  and only masks the actual contention bug.
+- For request-path and flush contention, expose one stable structured retry/exhaustion contract:
+  `operation`, `request_path`, `request_kind`, `attempt|attempts`, `backoff_ms`, `elapsed_ms`,
+  `retry_budget_ms`, `pending_batch_counts`, `oldest_pending_created_at`,
+  `newest_pending_created_at`, and `billing_subject_kind`. Use `token|account|unknown` only; never
+  log raw billing subjects, token secrets, or request bodies.
+- If public metrics only need success counts, do not reuse a generic retained-log summary scan for a
+  month-tail fallback. Subtract the retained tail from the last daily rollup bucket with a bounded
+  success-count query instead of reintroducing a wide `WITH scoped_logs AS (...)` scan.
 - Do not let lock-contention tests depend on real wall-clock sleep just to cross a retry window or a
   one-second timestamp boundary. Prefer deterministic state shaping or a controlled time seam so the
   test still exercises the production retry logic without paying real-time cost.
@@ -272,10 +289,22 @@ brief contention visible as HTTP 500s or failed background bookkeeping.
 - `src/tavily_proxy/proxy_ha.rs`
 - `src/server/schedulers.rs`
 
-## 101 Symptom Mapping
+## 2026-06-22 validation set
 
-For the `2026-06-19 01:00 +08:00` onward 101 sample, the runtime DB log contract should map the
-observed symptoms like this:
+- `cargo test mcp_tools_call_tavily_search_retries_pending_billing_when_sqlite_writer_lock_releases -- --nocapture`
+- `cargo test ensure_user_token_binding_with_preferred_retries_when_begin_is_locked -- --nocapture`
+- `cargo test public_success_breakdown_waits_for_inflight_flush_before_serving_metrics -- --nocapture`
+
+## Rollout grep
+
+- `journalctl -u tavily-hikari -n 2000 | rg 'sqlite_transient_write_retry|sqlite_transient_write_exhausted'`
+- `journalctl -u tavily-hikari -n 2000 | rg 'operation=request stats persist|operation=insert_token_log_pending_billing|operation=apply_pending_billing_log'`
+- `journalctl -u tavily-hikari -n 2000 | rg 'record_pending_billing_attempt failed for /mcp|WITH scoped_logs AS'`
+
+## Symptom Mapping
+
+For the `2026-06-19 01:00 +08:00` onward production sample, the runtime DB log contract should map
+the observed symptoms like this:
 
 - `forward-proxy startup: sqlite initialized in 38906ms`
   -> keep the startup lifecycle event and expect

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -95,7 +95,7 @@
 - Added resumable `request_logs` batch copy semantics keyed by preserved `id`, so partial sidecar
   copies can resume safely without duplicating rows or breaking preserved `request_log_id`
   references.
-- Standardized the validation path around a shared-testbox single-node Compose harness plus a 101
+- Standardized the validation path around a shared-testbox single-node Compose harness plus a
   short-maintenance cutover/rollback runbook, with the pre-cutover core DB exported to testbox as
   the rollback anchor.
 - Replaced the earlier WAL-mode offline-lock heuristic with an explicit sibling
@@ -107,8 +107,8 @@
 
 ## 2026-06-18
 
-- A 101 short-maintenance cutover attempt exposed a contract bug in the first explicit migration:
-  the tool copied `request_logs` and reset derived-table rebuild markers, then service startup
+- A short-maintenance cutover attempt exposed a contract bug in the first explicit migration: the
+  tool copied `request_logs` and reset derived-table rebuild markers, then service startup
   synchronously awaited the large derived rollup rebuild before opening the HTTP listener.
 - The explicit migration contract now treats a successful reopen of the normal startup path as part
   of completion, so `completed=true` only means “offline rebuild succeeded and the service can
@@ -131,8 +131,8 @@
 
 ## 2026-06-20
 
-- Validated the first lossless startup/read-path hardening pass against a live 101 SQLite snapshot
-  copied online with SQLite `.backup`, then replayed on `codex-testbox`.
+- Validated the first lossless startup/read-path hardening pass against a live production SQLite
+  snapshot copied online with SQLite `.backup`, then replayed on the shared testbox.
 - The first upgraded boot still paid one-time repair/migration work on the historical snapshot:
   `billing_ledger` repair ran once, and the new alert-supporting indexes were created on
   `auth_token_logs`.
@@ -146,3 +146,15 @@
 - Offline `billing_ledger_audit` on that snapshot still reported `118` day-only mismatches between
   quota samples and ledger-derived daily windows. That audit drift remains a separate quota
   correctness follow-up and is not repaired by the startup ledger bootstrap path itself.
+
+## 2026-06-22
+
+- Production evidence re-opened the topic at the request hot path: `/health` and `/api/version`
+  stayed responsive, but the latest sampled hour still showed `34` transient `database is locked`
+  failures and `296` slow statements.
+- The highest-value live signatures were `record_pending_billing_attempt failed for /mcp`,
+  `db operation error: operation=request stats persist`, and a public metrics month-tail query
+  shaped like `WITH scoped_logs AS (...) FROM observability.request_logs`.
+- The fix line stayed narrow: request-path pending billing now retries inside one bounded
+  transaction, request-stats flush now retries with batch-aware requeue proof and structured
+  contention logs, and public success metrics stop using the retained-log wide-scan fallback.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -22,6 +22,16 @@
   `2026-06-19 01:00 +08:00`: `oauth account upsert`, `apply_pending_billing_log`, and the
   downstream request-path billing failures that bubble up as `/api/tavily/search` or MCP proxy
   errors.
+- `insert_token_log_pending_billing` now writes `auth_token_logs` + `billing_ledger` in one
+  transaction and retries transient SQLite writer contention inside a `10s` application budget.
+  The retry/exhaustion logs emit stable structured fields for `operation`, `request_path`,
+  `request_kind`, `attempt|attempts`, `backoff_ms`, `elapsed_ms`, `retry_budget_ms`,
+  `pending_batch_counts`, `oldest_pending_created_at`, `newest_pending_created_at`, and
+  `billing_subject_kind`.
+- `apply_pending_billing_log` now emits the same structured contention contract, keyed by the
+  request path/kind already stored on the pending billing row, so “short contention recovered” and
+  “budget exhausted, fail closed” are distinguishable in production logs without exposing the raw
+  billing subject.
 - Background scheduler/worker DB work now has unified phase logs around `scheduled job enqueue`
   and `request stats persist`, so `quota-sync-hot enqueue`, `scheduled job finish`, and request
   stats flush contention all have a stable DB operation prefix in addition to the existing
@@ -137,10 +147,18 @@
 - Request-derived rollups now flush in one background batcher (`1s / 100 pending keys`) instead of
   issuing synchronous rollup writes per request. Owner-facing summary, key-metrics, and request-log
   catalog reads flush that coalescer before reading.
+- `flush_request_stats_writes` now retries transient SQLite writer contention inside a bounded `10s`
+  application budget before requeueing the drained batch. The retry/exhaustion logs include
+  pending-batch counts plus the oldest/newest drained `created_at`, so operators can tell
+  whether they are looking at recoverable flush pressure or final fail-closed exhaustion.
 - Public `/api/public/metrics` and the first `metrics` event on `/api/public/events` now reuse the
   same freshness-gated read path on top of `dashboard_request_rollup_buckets`. The read path checks
   the last flushed timestamp plus the oldest pending request-stat write and only triggers one
   synchronous flush when the requested window is actually stale.
+- Public success breakdown month-tail fallback is now rollup-first and success-count-only. The
+  live path no longer depends on `fetch_visible_request_log_window_metrics` /
+  `WITH scoped_logs AS (...) FROM observability.request_logs`; it subtracts only the retained tail
+  success count from the last daily bucket and keeps day/month public counters unchanged.
 - Request observability tables now attach through a per-core sibling sidecar SQLite file
   (`<core-stem>-observability.db`) in the new layout. `request_logs`, `api_key_usage_buckets`,
   `dashboard_request_rollup_buckets`, and `request_log_catalog_rollups` are created in that
@@ -234,6 +252,11 @@
   the SQLite writer slot, both at the store layer and through the owner-facing HTTP trigger route.
 - Added request-rollup tests that prove public metrics skip synchronous flush when freshness is
   already current and perform one bounded flush when the live window is stale.
+- Added `/mcp` end-to-end contention coverage:
+  `cargo test mcp_tools_call_tavily_search_retries_pending_billing_when_sqlite_writer_lock_releases -- --nocapture`
+  now holds `BEGIN IMMEDIATE` beyond SQLite's builtin `busy_timeout`, releases inside the
+  application retry budget, and proves one billable `/mcp` request still returns `200` and charges
+  quota after the writer lock clears.
 - Extended alert endpoint coverage so request-kind filtered event/group reads continue returning the
   canonical keys exposed by the HTTP contract after the SQL-side pagination/aggregation rewrite.
 - Added worker orchestration coverage that proves only one remote-I/O maintenance job enters
@@ -258,6 +281,36 @@
   succeeded and a normal startup reopen succeeded,” not just “the offline sidecar tables were
   rebuilt.”
 - Added request-stats coverage proving summary/key-metric reads flush pending coalesced deltas
+
+## 2026-06-22 evidence
+
+- One production sample showed `database is locked` `34` times and `slow statement` `296` times in
+  the latest sampled hour while `/health` and `/api/version` stayed fast, confirming writer
+  contention rather than process deadlock.
+- The live hot-path evidence clustered around:
+  `request stats persist`,
+  `record_pending_billing_attempt failed for /mcp`,
+  and retained-log month-tail scans shaped like
+  `WITH scoped_logs AS (...) FROM observability.request_logs`.
+- Host pressure (root volume near `99%`, swap heavily used) is now recorded as an amplifying
+  factor, not the primary root cause.
+
+## Validation commands
+
+- `cargo test mcp_tools_call_tavily_search_retries_pending_billing_when_sqlite_writer_lock_releases -- --nocapture`
+- `cargo test ensure_user_token_binding_with_preferred_retries_when_begin_is_locked -- --nocapture`
+- `cargo test public_success_breakdown_waits_for_inflight_flush_before_serving_metrics -- --nocapture`
+
+## Rollout notes
+
+- `project_doc_disposition=defer`: the deployment inventory/runbook remains a rollout-stage sync
+  target because this round does not deploy from the repo.
+- Post-deploy grep targets:
+  `sqlite_transient_write_retry`,
+  `sqlite_transient_write_exhausted`,
+  `operation=request stats persist`,
+  `operation=insert_token_log_pending_billing`,
+  `operation=apply_pending_billing_log`.
   before returning.
 - Added request-stats coverage proving auth-token activity reads and admin rate-5m usage-series
   reads flush pending coalesced deltas before returning.
@@ -310,8 +363,8 @@
 
 ## Operations Notes
 
-- The `2026-06-19 01:00 +08:00` to `2026-06-19 10:18 +08:00` 101 sample that motivated this pass
-  showed all three runtime responsibility surfaces at once:
+- The `2026-06-19 01:00 +08:00` to `2026-06-19 10:18 +08:00` production sample that motivated
+  this pass showed all three runtime responsibility surfaces at once:
   - startup: `forward-proxy startup: sqlite initialized in 38906ms`
   - background queueing/worker writes: `quota-sync-hot: enqueue job error`, `scheduled job finish`,
     `request stats persist warning`
@@ -345,33 +398,17 @@
   space crosses the threshold or operators explicitly force a maintenance window.
 - The large-legacy sidecar cutover is now a separate operator runbook instead of an automatic
   startup side effect. The validated flow is:
-  - on codex-testbox, seed a production-shaped legacy core DB snapshot, run the migration
+  - on a shared testbox, seed a production-shaped legacy core DB snapshot, run the migration
     container first, then start the current-branch service image against the migrated files and
     verify `/health`, `/api/version`, `/api/tavily/search`, `/mcp`, and request-log reads;
-  - on 101, stop `tavily-hikari`, export the pre-cutover core DB as the rollback anchor to
-    codex-testbox, run `observability_sidecar_migrate` locally against
-    `/srv/app/data/tavily_proxy.db`, restart, and validate the same request-log and MCP surfaces;
+  - on the production host, stop the service, export the pre-cutover core DB as the rollback
+    anchor to the shared testbox, run `observability_sidecar_migrate` locally against the
+    configured DB
+    path, restart, and validate the same request-log and MCP surfaces;
   - if validation fails, stop the service, restore the pre-cutover core DB, delete the sibling
     `tavily_proxy-observability.db`, and then restart.
-- The current 101 deployment facts that this runbook assumes were rechecked on 2026-06-17:
-  - compose working directory `/home/ivan/srv/ai`
-  - running service name `tavily-hikari` in compose project `ai`
-  - container mount `/srv/app/data -> /var/lib/docker/volumes/ai-tavily-hikari-data/_data`
-  - host free space about `56G`
-  - `sqlite3` available at `/usr/bin/sqlite3`
-- Recommended 101 cutover sequence:
-  - stop the service:
-    `ssh 192.168.31.11 'cd /home/ivan/srv/ai && docker compose stop tavily-hikari'`
-  - create a consistent cold backup on 101:
-    `ssh 192.168.31.11 'sqlite3 /var/lib/docker/volumes/ai-tavily-hikari-data/_data/tavily_proxy.db \".backup /tmp/tavily_proxy.pre_sidecar.db\" && gzip -f /tmp/tavily_proxy.pre_sidecar.db'`
-  - upload the rollback anchor to codex-testbox:
-    `ssh 192.168.31.11 'cat /tmp/tavily_proxy.pre_sidecar.db.gz' | ssh codex-testbox 'cat > /srv/codex/workspaces/ivan/tavily-hikari__7aa37deb/backups/tavily_proxy.pre_sidecar.db.gz'`
-  - run the explicit migration on 101:
-    `ssh 192.168.31.11 'cd /home/ivan/srv/ai && docker compose run --rm -T --entrypoint observability_sidecar_migrate tavily-hikari --db-path /srv/app/data/tavily_proxy.db --batch-size 5000 --json'`
-  - restart and validate:
-    `ssh 192.168.31.11 'cd /home/ivan/srv/ai && docker compose up -d tavily-hikari && docker compose ps tavily-hikari'`
-  - rollback if validation fails:
-    `ssh 192.168.31.11 'cd /home/ivan/srv/ai && docker compose stop tavily-hikari && gzip -dc /tmp/tavily_proxy.pre_sidecar.db.gz > /var/lib/docker/volumes/ai-tavily-hikari-data/_data/tavily_proxy.db && rm -f /var/lib/docker/volumes/ai-tavily-hikari-data/_data/tavily_proxy-observability.db && docker compose up -d tavily-hikari'`
+- The deployment-specific hostnames, paths, and cutover commands are intentionally omitted here.
+  Keep those details in the private deployment inventory/runbook rather than the repository spec.
 - The stop-service proof for this runbook is the sibling `tavily_proxy-observability-migrate.lock`:
   live server and GC paths hold it shared, while the explicit migration command must acquire it
   exclusively before mutating the legacy core DB. The remaining SQLite write probe stays in the

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -4,7 +4,7 @@
 
 - Lifecycle: active
 - Created: 2026-05-07
-- Last: 2026-06-18
+- Last: 2026-06-22
 
 ## Background
 
@@ -38,10 +38,16 @@ source when a usable persisted runtime already exists.
 
 - Keep request-path billing and MCP session locks from failing on transient SQLite busy/locked
   errors when the existing bounded wait budget can absorb the contention.
+- Keep billable `/mcp` request completion and pending-billing settlement on the same bounded
+  transient-write retry contract, so a short production writer lock no longer produces
+  `record_pending_billing_attempt failed for /mcp: database is locked` while the upstream response
+  itself was otherwise successful.
 - Preserve quota ledger correctness, pending billing replay, session affinity, research key pinning,
   and API rebalance behavior.
 - Remove avoidable request hot-path SQLite writes that do not need to be synchronous truth, while
   preserving fail-closed billing semantics and owner-facing observability.
+- Keep public success metrics on rollup-first bounded reads so month-tail fallback no longer depends
+  on a retained-log wide scan against `observability.request_logs`.
 - Make background job bookkeeping tolerate transient lock pressure without amplifying request-path
   failures.
 - Keep forward-proxy startup from turning short SQLite writer contention into a long readiness
@@ -61,6 +67,10 @@ source when a usable persisted runtime already exists.
   bounded backoff and must remain inside the existing lock timeout/lease budget.
 - Token billing and MCP session lock callers must retain the current fail-closed semantics if the
   bounded retry window is exhausted.
+- `record_pending_billing_attempt*`, `insert_token_log_pending_billing`, and
+  `apply_pending_billing_log` must share one bounded transient SQLite write retry contract.
+  Successful recovery within budget must keep the request/settlement green; budget exhaustion must
+  still fail closed.
 - `scheduled_jobs` must remain the persisted fact source for maintenance work, but it now needs a
   first-class queued lifecycle: `queued` rows persist before execution, `queued_at` records queue
   admission time, and `started_at` only records the actual execution start time.
@@ -118,6 +128,11 @@ source when a usable persisted runtime already exists.
   `request_logs` table or generating a large WAL. Large backlogs are expected to catch up over
   repeated bounded windows.
 - Retry logs may include operation, attempt, backoff, and final error context.
+- Retry/exhaustion logs for this topic must expose a stable structured contract with
+  `operation`, `request_path`, `request_kind`, `attempt|attempts`, `backoff_ms`, `elapsed_ms`,
+  `retry_budget_ms`, `pending_batch_counts`, `oldest_pending_created_at`,
+  `newest_pending_created_at`, and `billing_subject_kind`. The subject kind must remain one of
+  `token|account|unknown`; raw billing subjects, request bodies, and token secrets must not appear.
 - Request-path billing-subject serialization may rely on an in-process guard for the current
   single-process active node, instead of persisting a SQLite lock row for every request.
 - Pending/charged billing truth may move to a dedicated `billing_ledger` table as long as pending
@@ -172,16 +187,18 @@ source when a usable persisted runtime already exists.
   Compose project and run directory, avoid global Docker cleanup, and only remove this owner’s
   inactive workspaces or runs after confirming they are not referenced by any live
   `com.docker.compose.project`.
-- The production cutover procedure for the 101 deployment is a short maintenance-window, local-host
-  migration. Operators must stop the service, export a pre-cutover cold backup of the core DB to
-  codex-testbox as the rollback anchor, run the offline migration on 101 itself, restart and
-  validate, and if anything fails restore the pre-cutover core DB and delete the sibling sidecar
-  before bringing the service back.
+- The production cutover procedure is a short maintenance-window, local-host migration. Operators
+  must stop the service, export a pre-cutover cold backup of the core DB to a rollback anchor, run
+  the offline migration on the target host itself, restart and validate, and if anything fails
+  restore the pre-cutover core DB and delete the sibling sidecar before bringing the service back.
 
 ## Acceptance
 
 - Under a competing SQLite writer, acquiring a quota subject lock eventually succeeds after the
   writer releases within the existing wait budget.
+- Under a competing SQLite writer that outlives SQLite's builtin busy timeout but releases before
+  the bounded application retry budget, one billable `/mcp` tools/call request still returns `200`,
+  records the billing row, and charges quota after the writer lock clears.
 - Under a competing SQLite writer, scheduled job start retries rather than immediately returning
   `database is locked`.
 - Under a competing SQLite writer, forward-proxy startup runtime snapshot persistence retries
@@ -193,6 +210,9 @@ source when a usable persisted runtime already exists.
 - With a large backlog of old request logs, one scheduler pass records bounded progress instead of
   running indefinitely; later catch-up passes eventually remove all rows older than the retention
   threshold.
+- Public success metrics continue to wait for inflight request-stat flushes, but the month-tail
+  fallback no longer emits the retained-log wide scan shape
+  `WITH scoped_logs AS (...) FROM observability.request_logs` on the public metrics path.
 - Overlapping DB-backed maintenance jobs in one process run through one persisted queue and one
   maintenance worker, so a second job is accepted/coalesced as `queued` instead of competing for the
   SQLite writer slot.
@@ -249,9 +269,9 @@ source when a usable persisted runtime already exists.
 - The current branch must be able to reproduce that explicit migration path on shared testbox from a
   production-shaped cold snapshot, then start normally and pass `/health`, `/api/version`,
   `/api/tavily/search`, `/mcp`, and request-log read-path smoke checks against the migrated data.
-- The 101 cutover runbook must be executable as written against the current deployment topology:
-  `docker compose` project `ai`, service `tavily-hikari`, volume mount `/srv/app/data -> /var/lib/docker/volumes/ai-tavily-hikari-data/_data`, `sqlite3` available on host, and rollback
-  anchor uploaded to codex-testbox before the local migration mutates the core DB.
+- The cutover runbook must be executable as written against the current deployment topology, with a
+  local `docker compose` service, host-level `sqlite3`, a writable data mount, and the rollback
+  anchor uploaded before the local migration mutates the core DB.
 - Existing billing tests continue to prove locked billing subject stability, pending billing
   replay, and account/token quota attribution.
 - Existing MCP/API routing behavior remains unchanged, including research result GET key pinning.

--- a/src/server/tests/mcp_billing_and_sessions.rs
+++ b/src/server/tests/mcp_billing_and_sessions.rs
@@ -1339,6 +1339,135 @@ use super::upstream_support_and_manual_jobs::*;
     }
 
     #[tokio::test]
+    async fn mcp_tools_call_tavily_search_retries_pending_billing_when_sqlite_writer_lock_releases()
+     {
+        let db_path = temp_db_path("mcp-tools-call-search-billing-writer-lock-retry");
+        let db_str = db_path.to_string_lossy().to_string();
+
+        let _hourly_business_guard = EnvVarGuard::set("TOKEN_HOURLY_LIMIT", "1000");
+
+        let expected_api_key = "tvly-mcp-tools-call-search-billing-writer-lock-retry-key";
+        let arrived = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let (upstream_addr, hits) = spawn_mock_mcp_upstream_for_tavily_search_delayed(
+            expected_api_key.to_string(),
+            arrived.clone(),
+            release.clone(),
+        )
+        .await;
+        let upstream = format!("http://{}", upstream_addr);
+
+        let proxy =
+            TavilyProxy::with_endpoint(vec![expected_api_key.to_string()], &upstream, &db_str)
+                .await
+                .expect("proxy created");
+        let access_token = proxy
+            .create_access_token(Some("mcp-tools-call-search-billing-writer-lock-retry"))
+            .await
+            .expect("create access token");
+
+        let proxy_addr = spawn_proxy_server(proxy.clone(), upstream.clone()).await;
+        let client = Client::new();
+        let url = format!(
+            "http://{}/mcp?tavilyApiKey={}",
+            proxy_addr, access_token.token
+        );
+
+        let handle = tokio::spawn({
+            let client = client.clone();
+            let url = url.clone();
+            async move {
+                client
+                    .post(&url)
+                    .json(&serde_json::json!({
+                        "method": "tools/call",
+                        "params": {
+                            "name": "tavily-search",
+                            "arguments": {
+                                "query": "mcp transient writer lock",
+                                "search_depth": "basic"
+                            }
+                        }
+                    }))
+                    .send()
+                    .await
+                    .expect("request")
+            }
+        });
+
+        arrived.notified().await;
+
+        let lock_options = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_str)
+            .create_if_missing(false)
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+            .busy_timeout(Duration::from_millis(1));
+        let mut lock_conn = sqlx::SqliteConnection::connect_with(&lock_options)
+            .await
+            .expect("open lock connection");
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut lock_conn)
+            .await
+            .expect("hold writer lock");
+
+        release.notify_one();
+
+        tokio::time::sleep(Duration::from_millis(5200)).await;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match sqlx::query("COMMIT").execute(&mut lock_conn).await {
+                Ok(_) => break,
+                Err(sqlx::Error::Database(err))
+                    if err.message().contains("database is locked")
+                        && tokio::time::Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(err) => panic!("release write lock: {err}"),
+            }
+        }
+
+        let resp = handle.await.expect("task join");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        let pool = connect_sqlite_test_pool(&db_str).await;
+        let row = sqlx::query(
+            r#"
+            SELECT result_status, error_message, business_credits, billing_state
+            FROM auth_token_logs
+            WHERE token_id = ?
+            ORDER BY id DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(&access_token.id)
+        .fetch_one(&pool)
+        .await
+        .expect("token log row exists");
+        let status: String = row.try_get("result_status").unwrap();
+        let message: Option<String> = row.try_get("error_message").unwrap();
+        let business_credits: Option<i64> = row.try_get("business_credits").unwrap();
+        let billing_state: String = row.try_get("billing_state").unwrap();
+        assert_eq!(status, "success");
+        assert_eq!(business_credits, Some(1));
+        assert_eq!(billing_state, "charged");
+        assert!(
+            !message.unwrap_or_default().contains("record_pending_billing_attempt failed"),
+            "pending billing should recover before returning"
+        );
+
+        let verdict = proxy
+            .peek_token_quota(&access_token.id)
+            .await
+            .expect("peek quota");
+        assert_eq!(verdict.hourly_used, 1);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn mcp_tools_call_tavily_non_search_tools_charge_credits_from_usage() {
         let db_path = temp_db_path("mcp-tools-call-non-search-credits");
         let db_str = db_path.to_string_lossy().to_string();

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -247,293 +247,6 @@ impl KeyStore {
         Ok(())
     }
 
-    pub(crate) async fn flush_request_stats_writes(&self) -> Result<(), ProxyError> {
-        loop {
-            let pending = {
-                let mut state = self.request_stats_coalescer.state.lock().await;
-                if state.flushing {
-                    None
-                } else if state.pending_dashboard_rollups.is_empty()
-                    && state.pending_api_key_usage.is_empty()
-                    && state.pending_auth_token_activity.is_empty()
-                    && state.pending_account_request_rollups.is_empty()
-                    && state.pending_request_log_catalog.is_empty()
-                {
-                    return Ok(());
-                } else {
-                    state.flushing = true;
-                    state.flushing_oldest_created_at = state.oldest_pending_created_at.take();
-                    state.flushing_newest_created_at = state.newest_pending_created_at.take();
-                    Some((
-                        std::mem::take(&mut state.pending_dashboard_rollups),
-                        std::mem::take(&mut state.pending_api_key_usage),
-                        std::mem::take(&mut state.pending_auth_token_activity),
-                        std::mem::take(&mut state.pending_account_request_rollups),
-                        std::mem::take(&mut state.pending_request_log_catalog),
-                        state.flushing_oldest_created_at,
-                        state.flushing_newest_created_at,
-                    ))
-                }
-            };
-            let Some((
-                pending_dashboard_rollups,
-                pending_api_key_usage,
-                pending_auth_token_activity,
-                pending_account_request_rollups,
-                pending_request_log_catalog,
-                drained_oldest_pending_created_at,
-                drained_newest_pending_created_at,
-            )) = pending
-            else {
-                self.request_stats_coalescer.wait_until_flushed().await;
-                continue;
-            };
-
-            let mut pending_dashboard_rollups = pending_dashboard_rollups;
-            let mut pending_api_key_usage = pending_api_key_usage;
-            let mut pending_auth_token_activity = pending_auth_token_activity;
-            let mut pending_account_request_rollups = pending_account_request_rollups;
-            let mut pending_request_log_catalog = pending_request_log_catalog;
-            let updated_at = Utc::now().timestamp();
-            let result = async {
-                let mut tx = self.pool.begin().await?;
-                let mut dashboard_entries = pending_dashboard_rollups
-                    .drain()
-                    .collect::<Vec<_>>();
-                dashboard_entries.sort_by(|left, right| left.0.cmp(&right.0));
-                for ((bucket_start, bucket_secs), counts) in dashboard_entries {
-                    Self::upsert_dashboard_request_rollup_bucket(
-                        &mut tx,
-                        bucket_start,
-                        bucket_secs,
-                        counts,
-                        updated_at,
-                    )
-                    .await?;
-                }
-
-                let mut api_key_usage_entries =
-                    pending_api_key_usage.drain().collect::<Vec<_>>();
-                api_key_usage_entries.sort_by(|left, right| left.0.cmp(&right.0));
-                for ((key_id, bucket_start), delta) in api_key_usage_entries {
-                    Self::upsert_api_key_usage_bucket_delta(
-                        &mut tx,
-                        &key_id,
-                        bucket_start,
-                        delta,
-                        updated_at,
-                    )
-                    .await?;
-                }
-
-                let mut auth_token_activity_entries =
-                    pending_auth_token_activity.drain().collect::<Vec<_>>();
-                auth_token_activity_entries.sort_by(|left, right| left.0.cmp(&right.0));
-                for (token_id, delta) in auth_token_activity_entries {
-                    Self::upsert_auth_token_activity_delta(&mut tx, &token_id, delta).await?;
-                }
-
-                let mut account_request_rollup_entries =
-                    pending_account_request_rollups.drain().collect::<Vec<_>>();
-                account_request_rollup_entries.sort_by(|left, right| left.0.cmp(&right.0));
-                for (key, delta) in account_request_rollup_entries {
-                    let user_id = key.user_id;
-                    let bucket_start = key.five_minute_bucket_start;
-                    let day_bucket_start = key.day_bucket_start;
-                    if delta.request_count > 0 {
-                        for (bucket_kind, rollup_bucket_start) in [
-                            (AccountUsageRollupBucketKind::FiveMinute, bucket_start),
-                            (AccountUsageRollupBucketKind::Day, day_bucket_start),
-                        ] {
-                            sqlx::query(
-                                r#"
-                                INSERT INTO account_usage_rollup_buckets (
-                                    user_id,
-                                    metric_kind,
-                                    bucket_kind,
-                                    bucket_start,
-                                    value,
-                                    updated_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?)
-                                ON CONFLICT(user_id, metric_kind, bucket_kind, bucket_start)
-                                DO UPDATE SET
-                                    value = account_usage_rollup_buckets.value + excluded.value,
-                                    updated_at = excluded.updated_at
-                                "#,
-                            )
-                            .bind(&user_id)
-                            .bind(AccountUsageRollupMetricKind::RequestCount.as_str())
-                            .bind(bucket_kind.as_str())
-                            .bind(rollup_bucket_start)
-                            .bind(delta.request_count)
-                            .bind(updated_at)
-                            .execute(&mut *tx)
-                            .await?;
-                        }
-                    }
-                    if delta.primary_success > 0 {
-                        for (bucket_kind, rollup_bucket_start) in [
-                            (AccountUsageRollupBucketKind::FiveMinute, bucket_start),
-                            (AccountUsageRollupBucketKind::Day, day_bucket_start),
-                        ] {
-                            sqlx::query(
-                                r#"
-                                INSERT INTO account_usage_rollup_buckets (
-                                    user_id,
-                                    metric_kind,
-                                    bucket_kind,
-                                    bucket_start,
-                                    value,
-                                    updated_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?)
-                                ON CONFLICT(user_id, metric_kind, bucket_kind, bucket_start)
-                                DO UPDATE SET
-                                    value = account_usage_rollup_buckets.value + excluded.value,
-                                    updated_at = excluded.updated_at
-                                "#,
-                            )
-                            .bind(&user_id)
-                            .bind(AccountUsageRollupMetricKind::PrimarySuccess.as_str())
-                            .bind(bucket_kind.as_str())
-                            .bind(rollup_bucket_start)
-                            .bind(delta.primary_success)
-                            .bind(updated_at)
-                            .execute(&mut *tx)
-                            .await?;
-                        }
-                    }
-                    if delta.secondary_success > 0 {
-                        for (bucket_kind, rollup_bucket_start) in [
-                            (AccountUsageRollupBucketKind::FiveMinute, bucket_start),
-                            (AccountUsageRollupBucketKind::Day, day_bucket_start),
-                        ] {
-                            sqlx::query(
-                                r#"
-                                INSERT INTO account_usage_rollup_buckets (
-                                    user_id,
-                                    metric_kind,
-                                    bucket_kind,
-                                    bucket_start,
-                                    value,
-                                    updated_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?)
-                                ON CONFLICT(user_id, metric_kind, bucket_kind, bucket_start)
-                                DO UPDATE SET
-                                    value = account_usage_rollup_buckets.value + excluded.value,
-                                    updated_at = excluded.updated_at
-                                "#,
-                            )
-                            .bind(&user_id)
-                            .bind(AccountUsageRollupMetricKind::SecondarySuccess.as_str())
-                            .bind(bucket_kind.as_str())
-                            .bind(rollup_bucket_start)
-                            .bind(delta.secondary_success)
-                            .bind(updated_at)
-                            .execute(&mut *tx)
-                            .await?;
-                        }
-                    }
-                }
-
-                let mut request_log_catalog_entries =
-                    pending_request_log_catalog.drain().collect::<Vec<_>>();
-                request_log_catalog_entries.sort_by(|left, right| left.0.cmp(&right.0));
-                for (key, request_count_delta) in request_log_catalog_entries {
-                    Self::upsert_request_log_catalog_rollup_delta(
-                        &mut tx,
-                        &key,
-                        request_count_delta,
-                        updated_at,
-                    )
-                    .await?;
-                }
-
-                sqlx::query(
-                    r#"
-                    INSERT INTO meta (key, value)
-                    VALUES (?, ?)
-                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
-                    "#,
-                )
-                .bind(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1)
-                .bind(updated_at.to_string())
-                .execute(&mut *tx)
-                .await?;
-
-                tx.commit().await?;
-                Ok::<_, ProxyError>(())
-            }
-            .await;
-
-            {
-                let mut state = self.request_stats_coalescer.state.lock().await;
-                state.flushing = false;
-                state.flush_deadline = None;
-                if let Err(err) = result {
-                    state.flushing_oldest_created_at = None;
-                    state.flushing_newest_created_at = None;
-                    for (key, counts) in pending_dashboard_rollups {
-                        state.pending_dashboard_rollups.entry(key).or_default().add(counts);
-                    }
-                    for (key, delta) in pending_api_key_usage {
-                        state.pending_api_key_usage.entry(key).or_default().add(delta);
-                    }
-                    for (token_id, delta) in pending_auth_token_activity {
-                        state
-                            .pending_auth_token_activity
-                            .entry(token_id)
-                            .or_default()
-                            .add(delta);
-                    }
-                    for (key, delta) in pending_account_request_rollups {
-                        state
-                            .pending_account_request_rollups
-                            .entry(key)
-                            .or_default()
-                            .add(delta);
-                    }
-                    for (key, delta) in pending_request_log_catalog {
-                        *state.pending_request_log_catalog.entry(key).or_default() += delta;
-                    }
-                    if let Some(created_at) = drained_oldest_pending_created_at {
-                        state.oldest_pending_created_at = Some(
-                            state
-                                .oldest_pending_created_at
-                                .map(|current| current.min(created_at))
-                                .unwrap_or(created_at),
-                        );
-                    }
-                    if let Some(created_at) = drained_newest_pending_created_at {
-                        state.newest_pending_created_at = Some(
-                            state
-                                .newest_pending_created_at
-                                .map(|current| current.max(created_at))
-                                .unwrap_or(created_at),
-                        );
-                    }
-                    RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
-                    self.request_stats_coalescer.flushed.notify_waiters();
-                    return Err(err);
-                }
-                state.flushing_oldest_created_at = None;
-                state.flushing_newest_created_at = None;
-                if RequestStatsCoalescer::pending_key_count(&state) == 0 {
-                    state.oldest_pending_created_at = None;
-                    state.newest_pending_created_at = None;
-                } else {
-                    RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
-                }
-                self.request_stats_coalescer.flushed.notify_waiters();
-            }
-            #[cfg(test)]
-            self.request_stats_coalescer
-                .wait_for_post_flush_pause_if_installed()
-                .await;
-        }
-    }
 
     async fn migrate_log_effect_buckets(&self) -> Result<(), ProxyError> {
         let binding_codes = [
@@ -2731,6 +2444,8 @@ impl KeyStore {
         .map_err(ProxyError::Database)
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
     async fn fetch_visible_request_log_window_metrics(
         &self,
         start: i64,
@@ -2801,6 +2516,8 @@ impl KeyStore {
         })
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
     async fn fetch_api_key_usage_bucket_window_metrics(
         &self,
         bucket_start_at_least: i64,
@@ -2869,61 +2586,6 @@ impl KeyStore {
         })
     }
 
-    async fn fetch_utc_month_gap_bucket_metrics(
-        &self,
-        month_start: i64,
-        month_request_log_floor: Option<i64>,
-        gap_fallback_end: i64,
-    ) -> Result<SummaryWindowMetrics, ProxyError> {
-        let gap_end = match month_request_log_floor {
-            Some(floor) if floor > month_start => floor,
-            Some(_) => return Ok(SummaryWindowMetrics::default()),
-            None => gap_fallback_end,
-        };
-        if gap_end <= month_start {
-            return Ok(SummaryWindowMetrics::default());
-        }
-
-        let first_bucket_start = local_day_bucket_start_utc_ts(month_start);
-        let first_exact_bucket_start = if first_bucket_start == month_start {
-            month_start
-        } else {
-            next_local_day_start_utc_ts(first_bucket_start)
-        };
-        let last_gap_bucket_start = local_day_bucket_start_utc_ts(gap_end);
-
-        let mut backfill = SummaryWindowMetrics::default();
-        if first_exact_bucket_start < last_gap_bucket_start {
-            add_summary_window_metrics(
-                &mut backfill,
-                &self
-                    .fetch_api_key_usage_bucket_window_metrics(
-                        first_exact_bucket_start,
-                        Some(last_gap_bucket_start),
-                    )
-                    .await?,
-            );
-        }
-
-        if gap_end > last_gap_bucket_start && last_gap_bucket_start >= month_start {
-            let last_gap_bucket_end = next_local_day_start_utc_ts(last_gap_bucket_start);
-            let full_day_bucket = self
-                .fetch_api_key_usage_bucket_window_metrics(
-                    last_gap_bucket_start,
-                    Some(last_gap_bucket_end),
-                )
-                .await?;
-            let retained_tail = self
-                .fetch_visible_request_log_window_metrics(gap_end, last_gap_bucket_end)
-                .await?;
-            add_summary_window_metrics(
-                &mut backfill,
-                &subtract_summary_window_metrics(&full_day_bucket, &retained_tail),
-            );
-        }
-
-        Ok(backfill)
-    }
 
     async fn fetch_dashboard_rollup_success_count_tx(
         tx: &mut Transaction<'_, Sqlite>,
@@ -3049,9 +2711,8 @@ impl KeyStore {
             .fetch_visible_request_log_floor_since(month_start)
             .await?;
         let historical_month_success = self
-            .fetch_utc_month_gap_bucket_metrics(month_start, month_request_log_floor, now)
-            .await?
-            .success_count;
+            .fetch_utc_month_gap_success_count(month_start, month_request_log_floor, now)
+            .await?;
         let mut tx = self.pool.begin().await?;
         let (retained_partial_minute_success, dashboard_month_start) =
             match month_request_log_floor {

--- a/src/store/key_store_request_stats_flush_and_public_metrics.rs
+++ b/src/store/key_store_request_stats_flush_and_public_metrics.rs
@@ -1,0 +1,505 @@
+impl KeyStore {
+    pub(crate) async fn flush_request_stats_writes(&self) -> Result<(), ProxyError> {
+        const RETRY_BUDGET: Duration = Duration::from_secs(10);
+        loop {
+            let pending = {
+                let mut state = self.request_stats_coalescer.state.lock().await;
+                if state.flushing {
+                    None
+                } else if state.pending_dashboard_rollups.is_empty()
+                    && state.pending_api_key_usage.is_empty()
+                    && state.pending_auth_token_activity.is_empty()
+                    && state.pending_account_request_rollups.is_empty()
+                    && state.pending_request_log_catalog.is_empty()
+                {
+                    return Ok(());
+                } else {
+                    state.flushing = true;
+                    state.flushing_oldest_created_at = state.oldest_pending_created_at.take();
+                    state.flushing_newest_created_at = state.newest_pending_created_at.take();
+                    Some((
+                        std::mem::take(&mut state.pending_dashboard_rollups),
+                        std::mem::take(&mut state.pending_api_key_usage),
+                        std::mem::take(&mut state.pending_auth_token_activity),
+                        std::mem::take(&mut state.pending_account_request_rollups),
+                        std::mem::take(&mut state.pending_request_log_catalog),
+                        state.flushing_oldest_created_at,
+                        state.flushing_newest_created_at,
+                    ))
+                }
+            };
+            let Some((
+                pending_dashboard_rollups,
+                pending_api_key_usage,
+                pending_auth_token_activity,
+                pending_account_request_rollups,
+                pending_request_log_catalog,
+                drained_oldest_pending_created_at,
+                drained_newest_pending_created_at,
+            )) = pending
+            else {
+                self.request_stats_coalescer.wait_until_flushed().await;
+                continue;
+            };
+
+            let pending_batch_counts = format!(
+                "dashboard={},api_key={},auth_token={},account_rollup={},request_catalog={}",
+                pending_dashboard_rollups.len(),
+                pending_api_key_usage.len(),
+                pending_auth_token_activity.len(),
+                pending_account_request_rollups.len(),
+                pending_request_log_catalog.len(),
+            );
+            let log_fields = SqliteContentionLogFields {
+                operation: "flush_request_stats_writes",
+                request_path: "/internal/request-stats-flush",
+                request_kind: "internal:request-stats-flush",
+                billing_subject_kind: "unknown",
+                retry_budget_ms: RETRY_BUDGET.as_millis() as u64,
+                pending_batch_counts: pending_batch_counts.as_str(),
+                oldest_pending_created_at: drained_oldest_pending_created_at,
+                newest_pending_created_at: drained_newest_pending_created_at,
+            };
+            let deadline = self.backend_time.instant_now() + RETRY_BUDGET;
+            let operation_started = Instant::now();
+            let mut retry_attempt = 0usize;
+            let result = loop {
+                match self
+                    .flush_request_stats_writes_once(
+                        &pending_dashboard_rollups,
+                        &pending_api_key_usage,
+                        &pending_auth_token_activity,
+                        &pending_account_request_rollups,
+                        &pending_request_log_catalog,
+                    )
+                    .await
+                {
+                    Ok(()) => break Ok(()),
+                    Err(err) => {
+                        if !is_transient_sqlite_write_error(&err) {
+                            break Err(err);
+                        }
+                        let now = self.backend_time.instant_now();
+                        if now >= deadline {
+                            log_sqlite_transient_write_exhaustion_with_fields(
+                                log_fields,
+                                retry_attempt + 1,
+                                operation_started.elapsed(),
+                                &err,
+                            );
+                            break Err(err);
+                        }
+                        let remaining = deadline.saturating_duration_since(now);
+                        let backoff = sqlite_transient_write_retry_delay(retry_attempt).min(remaining);
+                        log_sqlite_transient_write_retry_with_fields(
+                            log_fields,
+                            retry_attempt + 1,
+                            backoff,
+                            operation_started.elapsed(),
+                            &err,
+                        );
+                        self.backend_time.sleep(backoff).await;
+                        retry_attempt += 1;
+                    }
+                }
+            };
+
+            {
+                let mut state = self.request_stats_coalescer.state.lock().await;
+                state.flushing = false;
+                state.flush_deadline = None;
+                if let Err(err) = result {
+                    state.flushing_oldest_created_at = None;
+                    state.flushing_newest_created_at = None;
+                    for (key, counts) in pending_dashboard_rollups {
+                        state.pending_dashboard_rollups.entry(key).or_default().add(counts);
+                    }
+                    for (key, delta) in pending_api_key_usage {
+                        state.pending_api_key_usage.entry(key).or_default().add(delta);
+                    }
+                    for (token_id, delta) in pending_auth_token_activity {
+                        state
+                            .pending_auth_token_activity
+                            .entry(token_id)
+                            .or_default()
+                            .add(delta);
+                    }
+                    for (key, delta) in pending_account_request_rollups {
+                        state
+                            .pending_account_request_rollups
+                            .entry(key)
+                            .or_default()
+                            .add(delta);
+                    }
+                    for (key, delta) in pending_request_log_catalog {
+                        *state.pending_request_log_catalog.entry(key).or_default() += delta;
+                    }
+                    if let Some(created_at) = drained_oldest_pending_created_at {
+                        state.oldest_pending_created_at = Some(
+                            state
+                                .oldest_pending_created_at
+                                .map(|current| current.min(created_at))
+                                .unwrap_or(created_at),
+                        );
+                    }
+                    if let Some(created_at) = drained_newest_pending_created_at {
+                        state.newest_pending_created_at = Some(
+                            state
+                                .newest_pending_created_at
+                                .map(|current| current.max(created_at))
+                                .unwrap_or(created_at),
+                        );
+                    }
+                    RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
+                    self.request_stats_coalescer.flushed.notify_waiters();
+                    return Err(err);
+                }
+                state.flushing_oldest_created_at = None;
+                state.flushing_newest_created_at = None;
+                if RequestStatsCoalescer::pending_key_count(&state) == 0 {
+                    state.oldest_pending_created_at = None;
+                    state.newest_pending_created_at = None;
+                } else {
+                    RequestStatsCoalescer::mark_flush_deadline_if_pending(&mut state);
+                }
+                self.request_stats_coalescer.flushed.notify_waiters();
+            }
+            #[cfg(test)]
+            self.request_stats_coalescer
+                .wait_for_post_flush_pause_if_installed()
+                .await;
+        }
+    }
+
+    async fn flush_request_stats_writes_once(
+        &self,
+        pending_dashboard_rollups: &HashMap<(i64, i64), DashboardRequestRollupCounts>,
+        pending_api_key_usage: &HashMap<(String, i64), ApiKeyUsageBucketDelta>,
+        pending_auth_token_activity: &HashMap<String, AuthTokenActivityDelta>,
+        pending_account_request_rollups: &HashMap<AccountRequestRollupKey, AccountUsageRollupDelta>,
+        pending_request_log_catalog: &HashMap<RequestLogCatalogRollupKey, i64>,
+    ) -> Result<(), ProxyError> {
+        let updated_at = Utc::now().timestamp();
+        let mut tx = self.pool.begin().await?;
+        let mut dashboard_entries = pending_dashboard_rollups
+            .iter()
+            .map(|(key, counts)| (*key, *counts))
+            .collect::<Vec<_>>();
+        dashboard_entries.sort_by(|left, right| left.0.cmp(&right.0));
+        for ((bucket_start, bucket_secs), counts) in dashboard_entries {
+            Self::upsert_dashboard_request_rollup_bucket(
+                &mut tx,
+                bucket_start,
+                bucket_secs,
+                counts,
+                updated_at,
+            )
+            .await?;
+        }
+
+        let mut api_key_usage_entries = pending_api_key_usage
+            .iter()
+            .map(|(key, delta)| (key.clone(), *delta))
+            .collect::<Vec<_>>();
+        api_key_usage_entries.sort_by(|left, right| left.0.cmp(&right.0));
+        for ((key_id, bucket_start), delta) in api_key_usage_entries {
+            Self::upsert_api_key_usage_bucket_delta(
+                &mut tx,
+                &key_id,
+                bucket_start,
+                delta,
+                updated_at,
+            )
+            .await?;
+        }
+
+        let mut auth_token_activity_entries = pending_auth_token_activity
+            .iter()
+            .map(|(token_id, delta)| (token_id.clone(), delta.clone()))
+            .collect::<Vec<_>>();
+        auth_token_activity_entries.sort_by(|left, right| left.0.cmp(&right.0));
+        for (token_id, delta) in auth_token_activity_entries {
+            Self::upsert_auth_token_activity_delta(&mut tx, &token_id, delta).await?;
+        }
+
+        let mut account_request_rollup_entries = pending_account_request_rollups
+            .iter()
+            .map(|(key, delta)| (key.clone(), *delta))
+            .collect::<Vec<_>>();
+        account_request_rollup_entries.sort_by(|left, right| left.0.cmp(&right.0));
+        for (key, delta) in account_request_rollup_entries {
+            let user_id = key.user_id;
+            let bucket_start = key.five_minute_bucket_start;
+            let day_bucket_start = key.day_bucket_start;
+            if delta.request_count > 0 {
+                for (bucket_kind, rollup_bucket_start) in [
+                    (AccountUsageRollupBucketKind::FiveMinute, bucket_start),
+                    (AccountUsageRollupBucketKind::Day, day_bucket_start),
+                ] {
+                    sqlx::query(
+                        r#"
+                        INSERT INTO account_usage_rollup_buckets (
+                            user_id,
+                            metric_kind,
+                            bucket_kind,
+                            bucket_start,
+                            value,
+                            updated_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(user_id, metric_kind, bucket_kind, bucket_start)
+                        DO UPDATE SET
+                            value = account_usage_rollup_buckets.value + excluded.value,
+                            updated_at = excluded.updated_at
+                        "#,
+                    )
+                    .bind(&user_id)
+                    .bind(AccountUsageRollupMetricKind::RequestCount.as_str())
+                    .bind(bucket_kind.as_str())
+                    .bind(rollup_bucket_start)
+                    .bind(delta.request_count)
+                    .bind(updated_at)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+            }
+            if delta.primary_success > 0 {
+                for (bucket_kind, rollup_bucket_start) in [
+                    (AccountUsageRollupBucketKind::FiveMinute, bucket_start),
+                    (AccountUsageRollupBucketKind::Day, day_bucket_start),
+                ] {
+                    sqlx::query(
+                        r#"
+                        INSERT INTO account_usage_rollup_buckets (
+                            user_id,
+                            metric_kind,
+                            bucket_kind,
+                            bucket_start,
+                            value,
+                            updated_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(user_id, metric_kind, bucket_kind, bucket_start)
+                        DO UPDATE SET
+                            value = account_usage_rollup_buckets.value + excluded.value,
+                            updated_at = excluded.updated_at
+                        "#,
+                    )
+                    .bind(&user_id)
+                    .bind(AccountUsageRollupMetricKind::PrimarySuccess.as_str())
+                    .bind(bucket_kind.as_str())
+                    .bind(rollup_bucket_start)
+                    .bind(delta.primary_success)
+                    .bind(updated_at)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+            }
+            if delta.secondary_success > 0 {
+                for (bucket_kind, rollup_bucket_start) in [
+                    (AccountUsageRollupBucketKind::FiveMinute, bucket_start),
+                    (AccountUsageRollupBucketKind::Day, day_bucket_start),
+                ] {
+                    sqlx::query(
+                        r#"
+                        INSERT INTO account_usage_rollup_buckets (
+                            user_id,
+                            metric_kind,
+                            bucket_kind,
+                            bucket_start,
+                            value,
+                            updated_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(user_id, metric_kind, bucket_kind, bucket_start)
+                        DO UPDATE SET
+                            value = account_usage_rollup_buckets.value + excluded.value,
+                            updated_at = excluded.updated_at
+                        "#,
+                    )
+                    .bind(&user_id)
+                    .bind(AccountUsageRollupMetricKind::SecondarySuccess.as_str())
+                    .bind(bucket_kind.as_str())
+                    .bind(rollup_bucket_start)
+                    .bind(delta.secondary_success)
+                    .bind(updated_at)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+            }
+        }
+
+        let mut request_log_catalog_entries = pending_request_log_catalog
+            .iter()
+            .map(|(key, delta)| (key.clone(), *delta))
+            .collect::<Vec<_>>();
+        request_log_catalog_entries.sort_by(|left, right| left.0.cmp(&right.0));
+        for (key, delta) in request_log_catalog_entries {
+            Self::upsert_request_log_catalog_rollup_delta(&mut tx, &key, delta, updated_at).await?;
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO meta (key, value)
+            VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            "#,
+        )
+        .bind(META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1)
+        .bind(updated_at.to_string())
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn fetch_api_key_usage_bucket_success_count(
+        &self,
+        bucket_start_at_least: i64,
+        bucket_start_before: Option<i64>,
+    ) -> Result<i64, ProxyError> {
+        if let Some(bucket_start_before) = bucket_start_before {
+            sqlx::query_scalar::<_, i64>(
+                r#"
+                SELECT COALESCE(SUM(success_count), 0)
+                FROM api_key_usage_buckets
+                WHERE bucket_secs = 86400
+                  AND bucket_start >= ?
+                  AND bucket_start < ?
+                "#,
+            )
+            .bind(bucket_start_at_least)
+            .bind(bucket_start_before)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(ProxyError::Database)
+        } else {
+            sqlx::query_scalar::<_, i64>(
+                r#"
+                SELECT COALESCE(SUM(success_count), 0)
+                FROM api_key_usage_buckets
+                WHERE bucket_secs = 86400
+                  AND bucket_start >= ?
+                "#,
+            )
+            .bind(bucket_start_at_least)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(ProxyError::Database)
+        }
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    async fn fetch_utc_month_gap_bucket_metrics(
+        &self,
+        month_start: i64,
+        month_request_log_floor: Option<i64>,
+        gap_fallback_end: i64,
+    ) -> Result<SummaryWindowMetrics, ProxyError> {
+        let gap_end = match month_request_log_floor {
+            Some(floor) if floor > month_start => floor,
+            Some(_) => return Ok(SummaryWindowMetrics::default()),
+            None => gap_fallback_end,
+        };
+        if gap_end <= month_start {
+            return Ok(SummaryWindowMetrics::default());
+        }
+
+        let first_bucket_start = local_day_bucket_start_utc_ts(month_start);
+        let first_exact_bucket_start = if first_bucket_start == month_start {
+            month_start
+        } else {
+            next_local_day_start_utc_ts(first_bucket_start)
+        };
+        let last_gap_bucket_start = local_day_bucket_start_utc_ts(gap_end);
+
+        let mut backfill = SummaryWindowMetrics::default();
+        if first_exact_bucket_start < last_gap_bucket_start {
+            add_summary_window_metrics(
+                &mut backfill,
+                &self
+                    .fetch_api_key_usage_bucket_window_metrics(
+                        first_exact_bucket_start,
+                        Some(last_gap_bucket_start),
+                    )
+                    .await?,
+            );
+        }
+
+        if gap_end > last_gap_bucket_start && last_gap_bucket_start >= month_start {
+            let last_gap_bucket_end = next_local_day_start_utc_ts(last_gap_bucket_start);
+            let full_day_bucket = self
+                .fetch_api_key_usage_bucket_window_metrics(
+                    last_gap_bucket_start,
+                    Some(last_gap_bucket_end),
+                )
+                .await?;
+            let retained_tail = self
+                .fetch_visible_request_log_window_metrics(gap_end, last_gap_bucket_end)
+                .await?;
+            add_summary_window_metrics(
+                &mut backfill,
+                &subtract_summary_window_metrics(&full_day_bucket, &retained_tail),
+            );
+        }
+
+        Ok(backfill)
+    }
+
+    async fn fetch_utc_month_gap_success_count(
+        &self,
+        month_start: i64,
+        month_request_log_floor: Option<i64>,
+        gap_fallback_end: i64,
+    ) -> Result<i64, ProxyError> {
+        let gap_end = match month_request_log_floor {
+            Some(floor) if floor > month_start => floor,
+            Some(_) => return Ok(0),
+            None => gap_fallback_end,
+        };
+        if gap_end <= month_start {
+            return Ok(0);
+        }
+
+        let first_bucket_start = local_day_bucket_start_utc_ts(month_start);
+        let first_exact_bucket_start = if first_bucket_start == month_start {
+            month_start
+        } else {
+            next_local_day_start_utc_ts(first_bucket_start)
+        };
+        let last_gap_bucket_start = local_day_bucket_start_utc_ts(gap_end);
+        let mut success_count = 0;
+
+        if first_exact_bucket_start < last_gap_bucket_start {
+            success_count += self
+                .fetch_api_key_usage_bucket_success_count(
+                    first_exact_bucket_start,
+                    Some(last_gap_bucket_start),
+                )
+                .await?;
+        }
+
+        if gap_end > last_gap_bucket_start && last_gap_bucket_start >= month_start {
+            let last_gap_bucket_end = next_local_day_start_utc_ts(last_gap_bucket_start);
+            let full_day_success = self
+                .fetch_api_key_usage_bucket_success_count(
+                    last_gap_bucket_start,
+                    Some(last_gap_bucket_end),
+                )
+                .await?;
+            let mut tx = self.pool.begin().await?;
+            let retained_tail_success = Self::fetch_visible_request_log_success_count_tx(
+                &mut tx,
+                gap_end,
+                last_gap_bucket_end,
+            )
+            .await?;
+            tx.commit().await?;
+            success_count += subtract_nonnegative(full_day_success, retained_tail_success);
+        }
+
+        Ok(success_count)
+    }
+}

--- a/src/store/key_store_users_and_oauth.rs
+++ b/src/store/key_store_users_and_oauth.rs
@@ -1395,11 +1395,6 @@ impl KeyStore {
         } else {
             Some(business_credits)
         };
-        let billing_state = if request_kind.key == "mcp:session-delete-unsupported" {
-            BILLING_STATE_NONE
-        } else {
-            BILLING_STATE_PENDING
-        };
         let failure_kind = failure_kind
             .map(str::to_string)
             .or_else(|| classify_failure_kind(path, http_status, mcp_status, error_message, &[]));
@@ -1415,6 +1410,164 @@ impl KeyStore {
         );
         let request_log_created_at = diagnostic_metadata.created_at;
         let upstream_operation_for_business = diagnostic_metadata.upstream_operation.clone();
+        let retry_budget = Duration::from_secs(10);
+        let retry_budget_ms = retry_budget.as_millis() as u64;
+        let deadline = self.backend_time.instant_now() + retry_budget;
+        let operation_started = Instant::now();
+        let billing_subject_kind = classify_billing_subject_kind(billing_subject);
+        let log_fields = SqliteContentionLogFields {
+            operation: "insert_token_log_pending_billing",
+            request_path: path,
+            request_kind: request_kind.key.as_str(),
+            billing_subject_kind,
+            retry_budget_ms,
+            pending_batch_counts: "dashboard=0,api_key=0,auth_token=0,account_rollup=0,request_catalog=0",
+            oldest_pending_created_at: None,
+            newest_pending_created_at: None,
+        };
+        let mut retry_attempt = 0usize;
+        let log_id = loop {
+            match self
+                .insert_token_log_pending_billing_once(
+                    token_id,
+                    method,
+                    path,
+                    query,
+                    http_status,
+                    mcp_status,
+                    counts_business_quota,
+                    result_status,
+                    error_message,
+                    business_credits,
+                    billing_subject,
+                    &request_kind,
+                    api_key_id,
+                    failure_kind.as_deref(),
+                    key_effect_code,
+                    key_effect_summary.as_deref(),
+                    binding_effect_code,
+                    binding_effect_summary.as_deref(),
+                    selection_effect_code,
+                    selection_effect_summary.as_deref(),
+                    request_log_id,
+                    created_at,
+                    request_user_id.as_deref(),
+                    &diagnostic_metadata,
+                )
+                .await
+            {
+                Ok(log_id) => {
+                    log_slow_db_operation(
+                        "insert_token_log_pending_billing",
+                        operation_started.elapsed(),
+                        Some(
+                            format!(
+                                "request_path={path}, request_kind={}, billing_subject_kind={billing_subject_kind}",
+                                request_kind.key
+                            )
+                            .as_str(),
+                        ),
+                    );
+                    break log_id;
+                }
+                Err(err) => {
+                    if !is_transient_sqlite_write_error(&err) {
+                        log_db_operation_error(
+                            "insert_token_log_pending_billing",
+                            operation_started.elapsed(),
+                            Some(
+                                format!(
+                                    "request_path={path}, request_kind={}, billing_subject_kind={billing_subject_kind}",
+                                    request_kind.key
+                                )
+                                .as_str(),
+                            ),
+                            &err,
+                        );
+                        return Err(err);
+                    }
+
+                    let now = self.backend_time.instant_now();
+                    if now >= deadline {
+                        log_sqlite_transient_write_exhaustion_with_fields(
+                            log_fields,
+                            retry_attempt + 1,
+                            operation_started.elapsed(),
+                            &err,
+                        );
+                        log_db_operation_error(
+                            "insert_token_log_pending_billing",
+                            operation_started.elapsed(),
+                            Some(
+                                format!(
+                                    "request_path={path}, request_kind={}, billing_subject_kind={billing_subject_kind}",
+                                    request_kind.key
+                                )
+                                .as_str(),
+                            ),
+                            &err,
+                        );
+                        return Err(err);
+                    }
+
+                    let remaining = deadline.saturating_duration_since(now);
+                    let backoff = sqlite_transient_write_retry_delay(retry_attempt).min(remaining);
+                    log_sqlite_transient_write_retry_with_fields(
+                        log_fields,
+                        retry_attempt + 1,
+                        backoff,
+                        operation_started.elapsed(),
+                        &err,
+                    );
+                    self.backend_time.sleep(backoff).await;
+                    retry_attempt += 1;
+                }
+            }
+        };
+        self.request_stats_coalescer
+            .enqueue_auth_token_activity(token_id, request_user_id.as_deref(), created_at)
+            .await;
+        Ok((
+            log_id,
+            build_user_business_call_event_write(
+                request_user_id,
+                counts_business_quota,
+                upstream_operation_for_business,
+                result_status,
+                request_log_created_at.unwrap_or(created_at),
+            ),
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_token_log_pending_billing_once(
+        &self,
+        token_id: &str,
+        method: &Method,
+        path: &str,
+        query: Option<&str>,
+        http_status: Option<i64>,
+        mcp_status: Option<i64>,
+        counts_business_quota: i64,
+        result_status: &str,
+        error_message: Option<&str>,
+        business_credits: Option<i64>,
+        billing_subject: &str,
+        request_kind: &TokenRequestKind,
+        api_key_id: Option<&str>,
+        failure_kind: Option<&str>,
+        key_effect_code: &str,
+        key_effect_summary: Option<&str>,
+        binding_effect_code: &str,
+        binding_effect_summary: Option<&str>,
+        selection_effect_code: &str,
+        selection_effect_summary: Option<&str>,
+        request_log_id: Option<i64>,
+        created_at: i64,
+        request_user_id: Option<&str>,
+        diagnostic_metadata: &RequestLogDiagnosticMetadata,
+    ) -> Result<i64, ProxyError> {
+        let mut tx = self.pool.begin().await?;
         let log_id: i64 = sqlx::query_scalar(
             r#"
             INSERT INTO auth_token_logs (
@@ -1472,21 +1625,25 @@ impl KeyStore {
         .bind(binding_effect_summary)
         .bind(selection_effect_code)
         .bind(selection_effect_summary)
-        .bind(diagnostic_metadata.gateway_mode)
-        .bind(diagnostic_metadata.experiment_variant)
-        .bind(diagnostic_metadata.proxy_session_id)
-        .bind(diagnostic_metadata.routing_subject_hash)
-        .bind(diagnostic_metadata.upstream_operation)
-        .bind(diagnostic_metadata.fallback_reason)
+        .bind(diagnostic_metadata.gateway_mode.as_deref())
+        .bind(diagnostic_metadata.experiment_variant.as_deref())
+        .bind(diagnostic_metadata.proxy_session_id.as_deref())
+        .bind(diagnostic_metadata.routing_subject_hash.as_deref())
+        .bind(diagnostic_metadata.upstream_operation.as_deref())
+        .bind(diagnostic_metadata.fallback_reason.as_deref())
         .bind(counts_business_quota)
         .bind(business_credits)
         .bind(billing_subject)
-        .bind(billing_state)
+        .bind(if request_kind.key == "mcp:session-delete-unsupported" {
+            BILLING_STATE_NONE
+        } else {
+            BILLING_STATE_PENDING
+        })
         .bind(api_key_id)
         .bind(request_log_id)
         .bind(created_at)
-        .bind(request_user_id.as_deref())
-        .fetch_one(&self.pool)
+        .bind(request_user_id)
+        .fetch_one(&mut *tx)
         .await?;
 
         sqlx::query(
@@ -1524,30 +1681,23 @@ impl KeyStore {
         .bind(log_id)
         .bind(token_id)
         .bind(billing_subject)
-        .bind(billing_state)
+        .bind(if request_kind.key == "mcp:session-delete-unsupported" {
+            BILLING_STATE_NONE
+        } else {
+            BILLING_STATE_PENDING
+        })
         .bind(business_credits)
-        .bind(request_user_id.as_deref())
+        .bind(request_user_id)
         .bind(api_key_id)
         .bind(request_log_id)
         .bind(result_status)
         .bind(created_at)
         .bind(created_at)
         .bind(error_message)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
-        self.request_stats_coalescer
-            .enqueue_auth_token_activity(token_id, request_user_id.as_deref(), created_at)
-            .await;
-        Ok((
-            log_id,
-            build_user_business_call_event_write(
-                request_user_id,
-                counts_business_quota,
-                upstream_operation_for_business,
-                result_status,
-                request_log_created_at.unwrap_or(created_at),
-            ),
-        ))
+        tx.commit().await?;
+        Ok(log_id)
     }
 
     async fn resolve_request_log_diagnostic_metadata(
@@ -1687,10 +1837,33 @@ impl KeyStore {
         &self,
         log_id: i64,
     ) -> Result<PendingBillingSettleOutcome, ProxyError> {
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let retry_budget = Duration::from_secs(10);
+        let deadline = Instant::now() + retry_budget;
         let mut retry_attempt = 0usize;
         let operation_started = Instant::now();
         let context = format!("log_id={log_id}");
+        let (request_path, request_kind, billing_subject_kind) = self
+            .pending_billing_log_retry_metadata(log_id)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| {
+                (
+                    "/internal/pending-billing-settle".to_string(),
+                    "internal:pending-billing-settle".to_string(),
+                    "unknown".to_string(),
+                )
+            });
+        let log_fields = SqliteContentionLogFields {
+            operation: "apply_pending_billing_log",
+            request_path: request_path.as_str(),
+            request_kind: request_kind.as_str(),
+            billing_subject_kind: billing_subject_kind.as_str(),
+            retry_budget_ms: retry_budget.as_millis() as u64,
+            pending_batch_counts: "dashboard=0,api_key=0,auth_token=0,account_rollup=0,request_catalog=0",
+            oldest_pending_created_at: None,
+            newest_pending_created_at: None,
+        };
         loop {
             match self.apply_pending_billing_log_once(log_id).await {
                 Ok(outcome) => {
@@ -1702,17 +1875,29 @@ impl KeyStore {
                     return Ok(outcome);
                 }
                 Err(err) => {
-                    if sleep_before_sqlite_transient_write_retry(
-                        &self.backend_time,
-                        "apply_pending_billing_log",
-                        retry_attempt,
-                        deadline,
-                        &err,
-                    )
-                    .await
-                    {
-                        retry_attempt += 1;
-                        continue;
+                    if is_transient_sqlite_write_error(&err) {
+                        let now = self.backend_time.instant_now();
+                        if now < deadline {
+                            let remaining = deadline.saturating_duration_since(now);
+                            let backoff =
+                                sqlite_transient_write_retry_delay(retry_attempt).min(remaining);
+                            log_sqlite_transient_write_retry_with_fields(
+                                log_fields,
+                                retry_attempt + 1,
+                                backoff,
+                                operation_started.elapsed(),
+                                &err,
+                            );
+                            self.backend_time.sleep(backoff).await;
+                            retry_attempt += 1;
+                            continue;
+                        }
+                        log_sqlite_transient_write_exhaustion_with_fields(
+                            log_fields,
+                            retry_attempt + 1,
+                            operation_started.elapsed(),
+                            &err,
+                        );
                     }
                     log_db_operation_error(
                         "apply_pending_billing_log",
@@ -1724,6 +1909,36 @@ impl KeyStore {
                 }
             }
         }
+    }
+
+    async fn pending_billing_log_retry_metadata(
+        &self,
+        log_id: i64,
+    ) -> Result<Option<(String, String, String)>, ProxyError> {
+        let row = sqlx::query_as::<_, (Option<String>, Option<String>, Option<String>)>(
+            r#"
+            SELECT atl.path, atl.request_kind_key, bl.billing_subject
+            FROM billing_ledger bl
+            LEFT JOIN auth_token_logs atl ON atl.id = bl.auth_token_log_id
+            WHERE bl.auth_token_log_id = ?
+            LIMIT 1
+            "#,
+        )
+        .bind(log_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(path, request_kind, billing_subject)| {
+            let billing_subject_kind = billing_subject
+                .as_deref()
+                .map(classify_billing_subject_kind)
+                .unwrap_or("unknown")
+                .to_string();
+            (
+                path.unwrap_or_else(|| "/internal/pending-billing-settle".to_string()),
+                request_kind.unwrap_or_else(|| "internal:pending-billing-settle".to_string()),
+                billing_subject_kind,
+            )
+        }))
     }
 
     async fn apply_pending_billing_log_once(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -265,6 +265,101 @@ pub(crate) async fn sleep_before_sqlite_transient_write_retry(
     true
 }
 
+pub(crate) fn classify_billing_subject_kind(billing_subject: &str) -> &'static str {
+    if billing_subject.starts_with("token:") {
+        "token"
+    } else if billing_subject.starts_with("account:") {
+        "account"
+    } else {
+        "unknown"
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SqliteContentionLogFields<'a> {
+    pub(crate) operation: &'a str,
+    pub(crate) request_path: &'a str,
+    pub(crate) request_kind: &'a str,
+    pub(crate) billing_subject_kind: &'a str,
+    pub(crate) retry_budget_ms: u64,
+    pub(crate) pending_batch_counts: &'a str,
+    pub(crate) oldest_pending_created_at: Option<i64>,
+    pub(crate) newest_pending_created_at: Option<i64>,
+}
+
+pub(crate) fn log_sqlite_transient_write_retry_with_fields(
+    fields: SqliteContentionLogFields<'_>,
+    attempt: usize,
+    backoff: Duration,
+    elapsed: Duration,
+    err: &ProxyError,
+) {
+    warn!(
+        component = "db",
+        event = "sqlite_transient_write_retry",
+        operation = fields.operation,
+        request_path = fields.request_path,
+        request_kind = fields.request_kind,
+        attempt,
+        backoff_ms = backoff.as_millis() as u64,
+        elapsed_ms = elapsed.as_millis() as u64,
+        retry_budget_ms = fields.retry_budget_ms,
+        pending_batch_counts = fields.pending_batch_counts,
+        oldest_pending_created_at = fields.oldest_pending_created_at.unwrap_or_default(),
+        newest_pending_created_at = fields.newest_pending_created_at.unwrap_or_default(),
+        billing_subject_kind = fields.billing_subject_kind,
+        err = %err,
+        "{}: transient sqlite write error (request_path={}, request_kind={}, attempt={}, backoff={}ms, elapsed={}ms, retry_budget={}ms, pending_batch_counts={}, oldest_pending_created_at={}, newest_pending_created_at={}, billing_subject_kind={}): {}",
+        fields.operation,
+        fields.request_path,
+        fields.request_kind,
+        attempt,
+        backoff.as_millis(),
+        elapsed.as_millis(),
+        fields.retry_budget_ms,
+        fields.pending_batch_counts,
+        fields.oldest_pending_created_at.unwrap_or_default(),
+        fields.newest_pending_created_at.unwrap_or_default(),
+        fields.billing_subject_kind,
+        err,
+    );
+}
+
+pub(crate) fn log_sqlite_transient_write_exhaustion_with_fields(
+    fields: SqliteContentionLogFields<'_>,
+    attempts: usize,
+    elapsed: Duration,
+    err: &ProxyError,
+) {
+    warn!(
+        component = "db",
+        event = "sqlite_transient_write_exhausted",
+        operation = fields.operation,
+        request_path = fields.request_path,
+        request_kind = fields.request_kind,
+        attempts,
+        elapsed_ms = elapsed.as_millis() as u64,
+        retry_budget_ms = fields.retry_budget_ms,
+        pending_batch_counts = fields.pending_batch_counts,
+        oldest_pending_created_at = fields.oldest_pending_created_at.unwrap_or_default(),
+        newest_pending_created_at = fields.newest_pending_created_at.unwrap_or_default(),
+        billing_subject_kind = fields.billing_subject_kind,
+        err = %err,
+        "{}: transient sqlite write retry budget exhausted (request_path={}, request_kind={}, attempts={}, elapsed={}ms, retry_budget={}ms, pending_batch_counts={}, oldest_pending_created_at={}, newest_pending_created_at={}, billing_subject_kind={}): {}",
+        fields.operation,
+        fields.request_path,
+        fields.request_kind,
+        attempts,
+        elapsed.as_millis(),
+        fields.retry_budget_ms,
+        fields.pending_batch_counts,
+        fields.oldest_pending_created_at.unwrap_or_default(),
+        fields.newest_pending_created_at.unwrap_or_default(),
+        fields.billing_subject_kind,
+        err,
+    );
+}
+
 pub(crate) fn is_invalid_current_month_billing_subject_error(err: &ProxyError) -> bool {
     match err {
         ProxyError::QuotaDataMissing { reason } => {
@@ -317,6 +412,7 @@ fn subtract_nonnegative(total: i64, subtract: i64) -> i64 {
     total.saturating_sub(subtract).max(0)
 }
 
+#[allow(dead_code)]
 fn subtract_summary_window_metrics(
     total: &SummaryWindowMetrics,
     subtract: &SummaryWindowMetrics,
@@ -2566,6 +2662,7 @@ include!("key_store_alerts.rs");
 include!("key_store_announcements.rs");
 include!("key_store_dashboard_window_metrics.rs");
 include!("key_store_dashboard_month_series.rs");
+include!("key_store_request_stats_flush_and_public_metrics.rs");
 include!("key_store_request_logs_and_dashboard.rs");
 include!("key_store_request_logs_summary_windows.rs");
 include!("key_store_user_rankings.rs");

--- a/src/tests/usage_series_and_backfills.rs
+++ b/src/tests/usage_series_and_backfills.rs
@@ -180,6 +180,201 @@ async fn request_stats_coalescer_uses_event_day_bucket_for_account_rollups() {
 }
 
 #[tokio::test]
+async fn request_stats_coalescer_flush_preserves_secondary_success_rate5m_rollups() {
+    let db_path = temp_db_path("request-stats-coalescer-secondary-success-rate5m");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "secondary-success-rate5m".to_string(),
+            username: Some("secondary_success_rate5m".to_string()),
+            name: Some("Secondary Success Rate5m".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("secondary-success-rate5m"))
+        .await
+        .expect("bind token");
+
+    let secondary_batch_body = br#"[
+      {"jsonrpc":"2.0","id":1,"method":"initialize"},
+      {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+    ]"#;
+    let primary_batch_body = br#"[
+      {"jsonrpc":"2.0","id":1,"method":"initialize"},
+      {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"tavily-search"}}
+    ]"#;
+    let created_at = Utc::now().timestamp();
+    let secondary_request_log_id = proxy
+        .record_local_request_log_without_key(
+            Some(&token.id),
+            &Method::POST,
+            "/mcp",
+            None,
+            StatusCode::OK,
+            Some(200),
+            secondary_batch_body,
+            b"{}",
+            OUTCOME_SUCCESS,
+            None,
+            &[],
+            &[],
+            None,
+        )
+        .await
+        .expect("record secondary batch request log");
+    proxy
+        .record_token_attempt_with_kind_request_log_metadata(
+            &token.id,
+            &Method::POST,
+            "/mcp",
+            None,
+            Some(StatusCode::OK.as_u16() as i64),
+            Some(200),
+            false,
+            OUTCOME_SUCCESS,
+            None,
+            &TokenRequestKind::new("mcp:batch", "MCP | batch", None),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(secondary_request_log_id),
+        )
+        .await
+        .expect("record linked secondary batch token log");
+
+    let primary_request_log_id = proxy
+        .record_local_request_log_without_key(
+            Some(&token.id),
+            &Method::POST,
+            "/mcp",
+            None,
+            StatusCode::OK,
+            Some(200),
+            primary_batch_body,
+            b"{}",
+            OUTCOME_SUCCESS,
+            None,
+            &[],
+            &[],
+            None,
+        )
+        .await
+        .expect("record primary batch request log");
+    proxy
+        .record_token_attempt_with_kind_request_log_metadata(
+            &token.id,
+            &Method::POST,
+            "/mcp",
+            None,
+            Some(StatusCode::OK.as_u16() as i64),
+            Some(200),
+            true,
+            OUTCOME_SUCCESS,
+            None,
+            &TokenRequestKind::new("mcp:batch", "MCP | batch", None),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(primary_request_log_id),
+        )
+        .await
+        .expect("record linked primary batch token log");
+
+    sqlx::query("UPDATE auth_token_logs SET created_at = ?, request_user_id = ? WHERE request_log_id IN (?, ?)")
+        .bind(created_at)
+        .bind(&user.user_id)
+        .bind(secondary_request_log_id)
+        .bind(primary_request_log_id)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("align batch token log ownership and time");
+
+    proxy
+        .key_store
+        .flush_request_stats_writes()
+        .await
+        .expect("flush request stats");
+
+    let five_minute_bucket_start = created_at - created_at.rem_euclid(SECS_PER_FIVE_MINUTES);
+    let day_bucket_start = local_day_bucket_start_utc_ts(created_at);
+    let five_minute_secondary_values = proxy
+        .key_store
+        .fetch_account_usage_rollup_values(
+            &user.user_id,
+            AccountUsageRollupMetricKind::SecondarySuccess,
+            AccountUsageRollupBucketKind::FiveMinute,
+            five_minute_bucket_start,
+            five_minute_bucket_start + SECS_PER_FIVE_MINUTES,
+        )
+        .await
+        .expect("load flushed secondary five minute bucket");
+    let five_minute_primary_values = proxy
+        .key_store
+        .fetch_account_usage_rollup_values(
+            &user.user_id,
+            AccountUsageRollupMetricKind::PrimarySuccess,
+            AccountUsageRollupBucketKind::FiveMinute,
+            five_minute_bucket_start,
+            five_minute_bucket_start + SECS_PER_FIVE_MINUTES,
+        )
+        .await
+        .expect("load flushed primary five minute bucket");
+    let day_secondary_values = proxy
+        .key_store
+        .fetch_account_usage_rollup_values(
+            &user.user_id,
+            AccountUsageRollupMetricKind::SecondarySuccess,
+            AccountUsageRollupBucketKind::Day,
+            day_bucket_start,
+            day_bucket_start + SECS_PER_DAY,
+        )
+        .await
+        .expect("load flushed secondary day bucket");
+    let day_primary_values = proxy
+        .key_store
+        .fetch_account_usage_rollup_values(
+            &user.user_id,
+            AccountUsageRollupMetricKind::PrimarySuccess,
+            AccountUsageRollupBucketKind::Day,
+            day_bucket_start,
+            day_bucket_start + SECS_PER_DAY,
+        )
+        .await
+        .expect("load flushed primary day bucket");
+
+    assert_eq!(
+        five_minute_secondary_values.get(&five_minute_bucket_start),
+        Some(&1)
+    );
+    assert_eq!(
+        five_minute_primary_values.get(&five_minute_bucket_start),
+        Some(&1)
+    );
+    assert_eq!(day_secondary_values.get(&day_bucket_start), Some(&1));
+    assert_eq!(day_primary_values.get(&day_bucket_start), Some(&1));
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn account_usage_rollup_rebuild_backfills_full_month_chart_horizon() {
     let db_path = temp_db_path("account-usage-rollup-month-chart-horizon");
     let db_str = db_path.to_string_lossy().to_string();


### PR DESCRIPTION
Summary
- Harden SQLite write contention on billable /mcp pending billing, request-stats flush, and public metrics month-tail fallback.

Validation
- cargo test
- cargo clippy --all-targets -- -D warnings

References
- Spec: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solution: docs/solutions/operations/sqlite-write-lock-contention.md
- Solution Disposition: refresh
- Solution Sync: done
- Project Docs: defer -> private deployment inventory/runbook
- Project Docs Sync: deferred
