### PR TITLE
fix(ha): rebaseline standby channel after fk gaps

### DIFF
--- a/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
@@ -124,6 +124,13 @@ the 101 primary look like it had a leak whenever billing baseline export repeate
 - HA sync state persistence also needs an explicit per-channel flush boundary. Coalescing watermark
   and node-state writes until the end of the whole sync loop is not safe once each channel owns its
   own long-running apply transaction.
+- Standby validation on `hinet-lam` exposed another HA-sync semantic gap after the memory fix:
+  runtime events can still arrive in a channel-local order that is valid on the active node but
+  temporarily invalid on the standby because the required parent row has not been re-established in
+  that channel window yet. The accepted behavior is not to keep retrying the same event batch
+  forever. Instead, a standby channel that fails events apply with SQLite foreign-key errors must
+  reset its own `baseline_applied` / `applied_seq` watermarks and recover on the next interval via
+  a fresh baseline pull.
 - Readiness semantics split accordingly: active/full-business roles still treat xray readiness as a
   health requirement, while standby/recovery roles do not.
 - Shared-testbox proof is now part of the accepted contract rather than an ad hoc smoke check. For

--- a/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
@@ -33,6 +33,11 @@
   events apply steps, so the next channel's `BEGIN IMMEDIATE` transaction does not race with a
   coalesced state write and reintroduce `database is locked` / nested-transaction failures during
   large baseline catch-up.
+- HA standby sync now treats SQLite foreign-key failures during per-channel events apply as a
+  broken incremental window for that channel instead of a fatal whole-loop error. When a channel
+  hits `FOREIGN KEY constraint failed`, the standby resets that channel's `baseline_applied` and
+  `applied_seq` watermarks to `0`, flushes the reset immediately, and lets the next sync interval
+  recover through a fresh baseline pull rather than retrying the same invalid event batch forever.
 - HA node-state persistence now deduplicates identical coalesced snapshots before writing SQLite.
   This keeps the standby-side EdgeOne authority refresh loop from rewriting the same `ha_node_state`
   row every five seconds while the node stays fenced, which in turn removes the repeated slow

--- a/docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
@@ -49,6 +49,9 @@ Tavily Hikari 的高可用方案采用单活主备热备，而不是一主多从
 - `control` 只同步控制面小状态，事件流写入 `ha_outbox`，保留窗口为 72 小时；超过窗口必须重新拉取该 channel 的状态基线。
 - `billing` 只同步 `billing_ledger` 完整账本行历史，事件流写入 `ha_billing_outbox`，不再通过 `ha_outbox` 复制账本。
 - `runtime` 只同步 failover 后若不恢复就会影响基础 API/MCP 正确性的最小运行态，事件流写入 `ha_runtime_outbox`。允许的最小运行态包括 quota 当前状态与 bucket、token/account 月额度、MCP 当前会话必要状态、forward proxy 亲和与节点 override、以及主/次 API key affinity。
+- 如果 standby 在某个 channel 的 events apply 中命中 SQLite `FOREIGN KEY constraint failed`，
+  该 channel 必须被视为“增量窗口不再自洽”，立即把 `baseline_applied` 与 `applied_seq`
+  水位重置回 `0`，并要求下一轮重新拉取该 channel baseline；不得无限重试同一批坏 events。
 - `control`/`billing`/`runtime` 三个 channel 的 baseline 和 events 都禁止包含 `request_logs`、`auth_token_logs`、请求体、响应体、path/query/IP/header 明细、dashboard recent logs、OAuth login 临时态、Web session、forward proxy runtime/attempts/hourly weight、维护审计、调度队列、请求限流快照和节点本地观测噪声。
 - `HA_MODE=single` 下不得产生新的 HA 事件写入；仅保留 schema 兼容、显式 one-shot 维护工具与后续切回 `active_standby` 的启动能力。
 - `standby` / `recovery` 启动时不得预热 forward-proxy runtime 或共享 `xray` 子进程；只有

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -451,6 +451,7 @@
         "server::tests::linuxdo_oauth_and_admin_keys::manual_",
         "server::tests::upstream_support_and_manual_jobs::manual_",
         "server::tests::alerts_and_ha::ha_",
+        "server::tests::alerts_and_ha_sync_recovery::ha_",
         "server::tests::alerts_and_ha_node_state::redundant_",
         "server::tests::alerts_and_ha_startup_roles::standby_",
         "server::tests::alerts_and_ha_event_exports::ha_",

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -591,6 +591,34 @@ fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
     });
 }
 
+fn is_ha_retryable_foreign_key_gap(
+    err: &(dyn std::error::Error + 'static),
+) -> bool {
+    let mut current = Some(err);
+    while let Some(source) = current {
+        if let Some(ProxyError::Database(sqlx::Error::Database(db_err))) =
+            source.downcast_ref::<ProxyError>()
+        {
+            if db_err
+                .code()
+                .as_deref()
+                .is_some_and(|code| code == "787" || code == "SQLITE_CONSTRAINT_FOREIGNKEY")
+            {
+                return true;
+            }
+            if db_err
+                .message()
+                .to_ascii_lowercase()
+                .contains("foreign key constraint failed")
+            {
+                return true;
+            }
+        }
+        current = source.source();
+    }
+    false
+}
+
 async fn run_ha_standby_sync_once(
     state: &Arc<AppState>,
     client: &reqwest::Client,
@@ -724,7 +752,36 @@ async fn run_ha_standby_sync_once(
             )
             .into());
         }
-        let result = apply_ha_events_response_stream(&state.proxy, channel, response).await?;
+        let result = match apply_ha_events_response_stream(&state.proxy, channel, response).await {
+            Ok(result) => result,
+            Err(err) if is_ha_retryable_foreign_key_gap(&*err) => {
+                let reset_detail =
+                    "foreign key gap during events apply; baseline required";
+                state
+                    .proxy
+                    .persist_ha_sync_watermark(
+                        &seq_key,
+                        Some(source_url),
+                        Some(&local_node_id),
+                        0,
+                        Some(reset_detail),
+                    )
+                    .await?;
+                state
+                    .proxy
+                    .persist_ha_sync_watermark(
+                        &baseline_key,
+                        Some(source_url),
+                        Some(&local_node_id),
+                        0,
+                        Some(reset_detail),
+                    )
+                    .await?;
+                state.proxy.flush_ha_state_writes().await?;
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
         if result.high_watermark > next_seq {
             next_seq = result.high_watermark;
             state

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -34,6 +34,7 @@ mod tests {
     mod alerts_and_ha;
     mod alerts_and_ha_event_exports;
     mod alerts_and_ha_node_state;
+    mod alerts_and_ha_sync_recovery;
     mod alerts_and_ha_serving_modes;
     mod alerts_and_ha_startup_roles;
     mod api_keys_and_registration;

--- a/src/server/tests/alerts_and_ha_sync_recovery.rs
+++ b/src/server/tests/alerts_and_ha_sync_recovery.rs
@@ -1,0 +1,293 @@
+use super::*;
+use super::core_support_and_parsing::*;
+
+#[tokio::test]
+async fn ha_standby_sync_resets_runtime_baseline_after_foreign_key_gap() {
+    let control_baseline_ndjson = [
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "baseline_start",
+            "channel": "control",
+            "nodeId": "active-fk-gap",
+            "highWatermark": 0
+        })
+        .to_string(),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "baseline_end",
+            "channel": "control",
+            "nodeId": "active-fk-gap",
+            "highWatermark": 0,
+            "rowCount": 0
+        })
+        .to_string(),
+    ]
+    .join("\n");
+    let billing_baseline_ndjson = [
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "baseline_start",
+            "channel": "billing",
+            "nodeId": "active-fk-gap",
+            "highWatermark": 0
+        })
+        .to_string(),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "baseline_end",
+            "channel": "billing",
+            "nodeId": "active-fk-gap",
+            "highWatermark": 0,
+            "rowCount": 0
+        })
+        .to_string(),
+    ]
+    .join("\n");
+    let runtime_baseline_ndjson = [
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "baseline_start",
+            "channel": "runtime",
+            "nodeId": "active-fk-gap",
+            "highWatermark": 0
+        })
+        .to_string(),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "resource",
+            "channel": "runtime",
+            "resource": "mcp_sessions",
+            "op": "upsert",
+            "data": {
+                "proxy_session_id": "sess-fk-gap",
+                "upstream_session_id": "upstream-fk-gap",
+                "upstream_key_id": null,
+                "auth_token_id": null,
+                "user_id": null,
+                "protocol_version": "2025-03-26",
+                "last_event_id": null,
+                "gateway_mode": "upstream_mcp",
+                "experiment_variant": "control",
+                "ab_bucket": null,
+                "routing_subject_hash": null,
+                "fallback_reason": null,
+                "rate_limited_until": null,
+                "last_rate_limited_at": null,
+                "last_rate_limit_reason": null,
+                "created_at": 1,
+                "updated_at": 1,
+                "expires_at": 3600,
+                "revoked_at": null,
+                "revoke_reason": null
+            }
+        })
+        .to_string(),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "baseline_end",
+            "channel": "runtime",
+            "nodeId": "active-fk-gap",
+            "highWatermark": 0,
+            "rowCount": 1
+        })
+        .to_string(),
+    ]
+    .join("\n");
+
+    let empty_events_for = |channel: &str| {
+        [
+            serde_json::json!({
+                "schemaVersion": 2,
+                "kind": "events_start",
+                "channel": channel,
+                "after": 0,
+                "limit": 1000
+            })
+            .to_string(),
+            serde_json::json!({
+                "schemaVersion": 2,
+                "kind": "events_end",
+                "channel": channel,
+                "lastSeq": 0,
+                "eventCount": 0
+            })
+            .to_string(),
+        ]
+        .join("\n")
+    };
+
+    let runtime_fk_gap_events = [
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "events_start",
+            "channel": "runtime",
+            "after": 0,
+            "limit": 1000
+        })
+        .to_string(),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "event",
+            "channel": "runtime",
+            "event": {
+                "seq": 1,
+                "channel": "runtime",
+                "kind": "state",
+                "resource": "mcp_sessions",
+                "resourceId": "sess-fk-gap",
+                "op": "upsert",
+                "payload": {
+                    "proxy_session_id": "sess-fk-gap",
+                    "upstream_session_id": "upstream-fk-gap",
+                    "upstream_key_id": "missing-key",
+                    "auth_token_id": null,
+                    "user_id": null,
+                    "protocol_version": "2025-03-26",
+                    "last_event_id": null,
+                    "gateway_mode": "upstream_mcp",
+                    "experiment_variant": "control",
+                    "ab_bucket": null,
+                    "routing_subject_hash": null,
+                    "fallback_reason": null,
+                    "rate_limited_until": null,
+                    "last_rate_limited_at": null,
+                    "last_rate_limit_reason": null,
+                    "created_at": 1,
+                    "updated_at": 1,
+                    "expires_at": 3600,
+                    "revoked_at": null,
+                    "revoke_reason": null
+                },
+                "createdAt": 1,
+                "checksum": null
+            }
+        })
+        .to_string(),
+        serde_json::json!({
+            "schemaVersion": 2,
+            "kind": "events_end",
+            "channel": "runtime",
+            "lastSeq": 1,
+            "eventCount": 1
+        })
+        .to_string(),
+    ]
+    .join("\n");
+
+    let control_baseline_body = zstd::stream::encode_all(control_baseline_ndjson.as_bytes(), 0)
+        .expect("encode control baseline");
+    let billing_baseline_body = zstd::stream::encode_all(billing_baseline_ndjson.as_bytes(), 0)
+        .expect("encode billing baseline");
+    let runtime_baseline_body = zstd::stream::encode_all(runtime_baseline_ndjson.as_bytes(), 0)
+        .expect("encode runtime baseline");
+    let control_events_body = zstd::stream::encode_all(empty_events_for("control").as_bytes(), 0)
+        .expect("encode control events");
+    let billing_events_body = zstd::stream::encode_all(empty_events_for("billing").as_bytes(), 0)
+        .expect("encode billing events");
+    let runtime_events_body = zstd::stream::encode_all(runtime_fk_gap_events.as_bytes(), 0)
+        .expect("encode runtime events");
+
+    let app = Router::new()
+        .route(
+            "/api/admin/ha/baseline",
+            get(move |Query(params): Query<std::collections::HashMap<String, String>>| {
+                let control_baseline_body = control_baseline_body.clone();
+                let billing_baseline_body = billing_baseline_body.clone();
+                let runtime_baseline_body = runtime_baseline_body.clone();
+                async move {
+                    let body = match params.get("channel").map(String::as_str) {
+                        Some("control") => control_baseline_body,
+                        Some("billing") => billing_baseline_body,
+                        Some("runtime") => runtime_baseline_body,
+                        other => panic!("unexpected baseline channel: {other:?}"),
+                    };
+                    Response::builder()
+                        .header("content-encoding", "zstd")
+                        .body(Body::from(body))
+                        .expect("baseline response")
+                }
+            }),
+        )
+        .route(
+            "/api/admin/ha/events",
+            get(move |Query(params): Query<std::collections::HashMap<String, String>>| {
+                let control_events_body = control_events_body.clone();
+                let billing_events_body = billing_events_body.clone();
+                let runtime_events_body = runtime_events_body.clone();
+                async move {
+                    let body = match params.get("channel").map(String::as_str) {
+                        Some("control") => control_events_body,
+                        Some("billing") => billing_events_body,
+                        Some("runtime") => runtime_events_body,
+                        other => panic!("unexpected events channel: {other:?}"),
+                    };
+                    Response::builder()
+                        .header("content-encoding", "zstd")
+                        .body(Body::from(body))
+                        .expect("events response")
+                }
+            }),
+        )
+        .route("/api/admin/ha/events/ack", post(|| async { StatusCode::OK }));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let source_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    let db_path = temp_db_path("ha-runtime-fk-gap");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-runtime-fk-gap".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let ha = tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+        mode: tavily_hikari::HaMode::ActiveStandby,
+        node_id: "standby-runtime-fk-gap".to_string(),
+        ..tavily_hikari::HaConfig::default()
+    });
+    let state = Arc::new(AppState {
+        proxy: proxy.clone(),
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha,
+        dev_open_admin: true,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    });
+    let source_url = format!("http://{source_addr}");
+    let client = Client::new();
+
+    run_ha_standby_sync_once(&state, &client, &source_url, "test-token")
+        .await
+        .expect("sync should recover by requiring runtime baseline reset");
+
+    assert_eq!(
+        proxy
+            .get_ha_sync_watermark("standby_runtime_baseline_applied")
+            .await
+            .expect("read runtime baseline marker"),
+        Some(0)
+    );
+    assert_eq!(
+        proxy
+            .get_ha_sync_watermark("standby_runtime_applied_seq")
+            .await
+            .expect("read runtime seq"),
+        Some(0)
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}


### PR DESCRIPTION
## Summary
- reproduce the standby HA foreign-key failure with a focused runtime-channel regression test
- reset a standby channel to `baseline required` when HA events apply hits a SQLite foreign-key gap
- sync the active/standby HA spec so the new recovery contract is explicit

## Testing
- `cargo test ha_standby_sync_ -- --nocapture`
- `cargo test ha_apply_ndjson_wrappers_abort_failed_sessions_before_retry -- --nocapture`
- `cargo clippy --bin tavily-hikari --tests -- -D warnings`

## References
- Specs: `docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md`
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`
- Project Docs: `-`
