### PR TITLE
fix(alerts): harden grouped queries and alert filters

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -74,6 +74,10 @@ reads:
 - Move alert events/groups/recent summary/catalog to SQL-side pagination and aggregation. Pulling
   all matching alert events into Rust and then sorting, grouping, or paginating in memory does not
   survive a retained `auth_token_logs` window.
+- For alert grouped reads on SQLite, avoid parser-sensitive named window clauses when the same
+  partition logic can be expressed inline. Keep the grouped projection in SQL, but prefer inline
+  `OVER (...)` windows plus a final `group_rank = 1` collapse over `WINDOW ... AS (...)` syntax on
+  the production read path.
 - Canonicalize alert `request_kind` inside the SQL projection before filtering or grouping rows.
   Mixed legacy keys such as `tavily_search` / `mcp_search` otherwise drift from the canonical
   request-kind keys returned by the HTTP contract and can make filtered pages appear empty.
@@ -108,6 +112,8 @@ reads:
 - A controlled in-container admin-style request to
   `http://127.0.0.1:8787/api/dashboard/overview` with the production forward-auth headers still
   took about `4.70s` on 2026-06-21.
+- Production 101 grouped-alert reads hit a SQLite parser failure before the compat rewrite:
+  `database error: (code: 1) near "(": syntax error`.
 - Recent production logs from the same container still show overview-adjacent SQLite pressure, for
   example:
   - a retained-window aggregate over `observability.request_logs` logged at about `925ms`

--- a/docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
@@ -254,6 +254,10 @@
 
 ## Visual Evidence
 
+- Alerts 页面筛选区已统一到时间输入的控件语言：
+  - `请求类型`、`用户`、`令牌`、`Key`、`应用时间`、`清空筛选` 与 `datetime-local` 输入现在共享同一套高度、圆角、pressed surface、padding 与 focus ring。
+  - grouped 读侧已改为 SQLite 兼容写法，`/api/alerts/groups` 在 101 上不再依赖命名 `WINDOW` 语法。
+
 - Web demo 真实页面视口：
   - `/admin/alerts?demo=1&view=groups`：direct-open 默认进入 `聚合告警`，`用户请求限流` 以 `母 -> 子 -> 原始事件明细` 两层半结构展示，子窗口不再按 `request_kind` 拆主结构。
 
@@ -292,24 +296,31 @@
    ssh 192.168.31.11 'docker exec ai-tavily-hikari curl -fsS http://127.0.0.1:8787/health'
    ```
 
-4. 验证历史 432 告警已重分类：
+4. 验证 `/api/alerts/groups` 与 `/api/alerts/events` 都可读，且 grouped 查询不再报 SQLite 语法错误：
 
    ```bash
-   ssh 192.168.31.11 "docker exec ai-tavily-hikari curl -fsS 'http://127.0.0.1:8787/api/alerts/events?per_page=50&type=upstream_usage_limit_432' | jq '.items[] | select(.request.id == 972534 or .request.id == 971163 or .request.id == 956970) | {type, request: .request.id, key: .key.id, title}'"
+   ssh 192.168.31.11 "docker exec ai-tavily-hikari curl -fsS -H 'x-forward-user: admin' 'http://127.0.0.1:8787/api/alerts/events?page=1&per_page=20' | jq '.total'"
+   ssh 192.168.31.11 "docker exec ai-tavily-hikari curl -fsS -H 'x-forward-user: admin' 'http://127.0.0.1:8787/api/alerts/groups?page=1&per_page=20' | jq '.total'"
    ```
 
    期望：
-   - `type == "upstream_usage_limit_432"`
-   - `key.id` 已从 `request_logs.api_key_id` 回填
-   - 不再显示为 `user_quota_exhausted`
+   - 两个接口都返回 `200`
+   - `groups` 不再返回 `database error: (code: 1) near "(": syntax error`
+   - `groups.total` 能稳定返回非 0 的聚合结果
 
-5. 验证 dashboard recentAlerts 已包含新类型：
+5. 验证历史 432 告警已重分类：
+
+   ```bash
+   ssh 192.168.31.11 "docker exec ai-tavily-hikari curl -fsS -H 'x-forward-user: admin' 'http://127.0.0.1:8787/api/alerts/events?per_page=50&type=upstream_usage_limit_432' | jq '.items[] | select(.request.id == 972534 or .request.id == 971163 or .request.id == 956970) | {type, request: .request.id, key: .key.id, title}'"
+   ```
+
+6. 验证 dashboard recentAlerts 已包含新类型：
 
    ```bash
    ssh 192.168.31.11 "docker exec ai-tavily-hikari curl -fsS http://127.0.0.1:8787/api/dashboard/overview | jq '.recentAlerts.countsByType[] | select(.type == \"upstream_usage_limit_432\")'"
    ```
 
-6. 验证 stale affinity 自愈：
+7. 验证 stale affinity 自愈：
 
    ```bash
    ssh 192.168.31.11 "docker exec ai-tavily-hikari sqlite3 /srv/app/data/tavily_proxy.db \"select user_id, api_key_id from user_primary_api_key_affinity where user_id='yjPBlIKQ4csL'; select token_id, api_key_id from token_primary_api_key_affinity where token_id='exlD';\""

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -1145,22 +1145,49 @@ impl KeyStore {
             semantic_events AS (
                 SELECT
                     filtered_alerts.*,
-                    LAG(filtered_alerts.semantic_window_key) OVER semantic_partition AS prev_window_key,
-                    LAG(filtered_alerts.semantic_window_kind) OVER semantic_partition AS prev_window_kind,
-                    LAG(filtered_alerts.semantic_window_minutes) OVER semantic_partition AS prev_window_minutes,
-                    LAG(filtered_alerts.semantic_window_end) OVER semantic_partition AS prev_window_end,
-                    LAG(filtered_alerts.occurred_at) OVER semantic_partition AS prev_occurred_at
+                    LAG(filtered_alerts.semantic_window_key) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.semantic_window_kind,
+                                     COALESCE(filtered_alerts.semantic_window_minutes, 0)
+                        ORDER BY filtered_alerts.occurred_at ASC, filtered_alerts.row_sort_id ASC
+                    ) AS prev_window_key,
+                    LAG(filtered_alerts.semantic_window_kind) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.semantic_window_kind,
+                                     COALESCE(filtered_alerts.semantic_window_minutes, 0)
+                        ORDER BY filtered_alerts.occurred_at ASC, filtered_alerts.row_sort_id ASC
+                    ) AS prev_window_kind,
+                    LAG(filtered_alerts.semantic_window_minutes) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.semantic_window_kind,
+                                     COALESCE(filtered_alerts.semantic_window_minutes, 0)
+                        ORDER BY filtered_alerts.occurred_at ASC, filtered_alerts.row_sort_id ASC
+                    ) AS prev_window_minutes,
+                    LAG(filtered_alerts.semantic_window_end) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.semantic_window_kind,
+                                     COALESCE(filtered_alerts.semantic_window_minutes, 0)
+                        ORDER BY filtered_alerts.occurred_at ASC, filtered_alerts.row_sort_id ASC
+                    ) AS prev_window_end,
+                    LAG(filtered_alerts.occurred_at) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.semantic_window_kind,
+                                     COALESCE(filtered_alerts.semantic_window_minutes, 0)
+                        ORDER BY filtered_alerts.occurred_at ASC, filtered_alerts.row_sort_id ASC
+                    ) AS prev_occurred_at
                 FROM filtered_alerts
                 WHERE filtered_alerts.grouping_kind = 'mother'
                   AND filtered_alerts.semantic_window_kind IS NOT NULL
-                WINDOW semantic_partition AS (
-                    PARTITION BY filtered_alerts.alert_type,
-                                 filtered_alerts.subject_kind,
-                                 filtered_alerts.subject_id,
-                                 filtered_alerts.semantic_window_kind,
-                                 COALESCE(filtered_alerts.semantic_window_minutes, 0)
-                    ORDER BY filtered_alerts.occurred_at ASC, filtered_alerts.row_sort_id ASC
-                )
             ),
             semantic_children AS (
                 SELECT
@@ -1197,11 +1224,46 @@ impl KeyStore {
             semantic_child_ranges AS (
                 SELECT
                     semantic_children.*,
-                    MIN(semantic_children.occurred_at) OVER child_partition AS child_first_seen,
-                    MAX(semantic_children.occurred_at) OVER child_partition AS child_last_seen,
-                    COUNT(*) OVER child_partition AS child_event_count,
-                    MIN(semantic_children.semantic_window_start) OVER child_partition AS child_window_start,
-                    MAX(semantic_children.semantic_window_end) OVER child_partition AS child_window_end,
+                    MIN(semantic_children.occurred_at) OVER (
+                        PARTITION BY semantic_children.alert_type,
+                                     semantic_children.subject_kind,
+                                     semantic_children.subject_id,
+                                     semantic_children.semantic_window_kind,
+                                     COALESCE(semantic_children.semantic_window_minutes, 0),
+                                     semantic_children.child_ordinal
+                    ) AS child_first_seen,
+                    MAX(semantic_children.occurred_at) OVER (
+                        PARTITION BY semantic_children.alert_type,
+                                     semantic_children.subject_kind,
+                                     semantic_children.subject_id,
+                                     semantic_children.semantic_window_kind,
+                                     COALESCE(semantic_children.semantic_window_minutes, 0),
+                                     semantic_children.child_ordinal
+                    ) AS child_last_seen,
+                    COUNT(*) OVER (
+                        PARTITION BY semantic_children.alert_type,
+                                     semantic_children.subject_kind,
+                                     semantic_children.subject_id,
+                                     semantic_children.semantic_window_kind,
+                                     COALESCE(semantic_children.semantic_window_minutes, 0),
+                                     semantic_children.child_ordinal
+                    ) AS child_event_count,
+                    MIN(semantic_children.semantic_window_start) OVER (
+                        PARTITION BY semantic_children.alert_type,
+                                     semantic_children.subject_kind,
+                                     semantic_children.subject_id,
+                                     semantic_children.semantic_window_kind,
+                                     COALESCE(semantic_children.semantic_window_minutes, 0),
+                                     semantic_children.child_ordinal
+                    ) AS child_window_start,
+                    MAX(semantic_children.semantic_window_end) OVER (
+                        PARTITION BY semantic_children.alert_type,
+                                     semantic_children.subject_kind,
+                                     semantic_children.subject_id,
+                                     semantic_children.semantic_window_kind,
+                                     COALESCE(semantic_children.semantic_window_minutes, 0),
+                                     semantic_children.child_ordinal
+                    ) AS child_window_end,
                     ROW_NUMBER() OVER (
                         PARTITION BY semantic_children.alert_type,
                                      semantic_children.subject_kind,
@@ -1212,14 +1274,6 @@ impl KeyStore {
                         ORDER BY semantic_children.occurred_at DESC, semantic_children.row_sort_id DESC
                     ) AS child_latest_rank
                 FROM semantic_children
-                WINDOW child_partition AS (
-                    PARTITION BY semantic_children.alert_type,
-                                 semantic_children.subject_kind,
-                                 semantic_children.subject_id,
-                                 semantic_children.semantic_window_kind,
-                                 COALESCE(semantic_children.semantic_window_minutes, 0),
-                                 semantic_children.child_ordinal
-                )
             ),
             semantic_child_heads AS (
                 SELECT
@@ -1235,19 +1289,26 @@ impl KeyStore {
                     semantic_child_ranges.child_event_count,
                     semantic_child_ranges.child_window_start,
                     semantic_child_ranges.child_window_end,
-                    LAG(semantic_child_ranges.child_window_end) OVER child_head_partition AS prev_child_window_end,
-                    LAG(semantic_child_ranges.child_last_seen) OVER child_head_partition AS prev_child_last_seen
+                    LAG(semantic_child_ranges.child_window_end) OVER (
+                        PARTITION BY semantic_child_ranges.alert_type,
+                                     semantic_child_ranges.subject_kind,
+                                     semantic_child_ranges.subject_id,
+                                     semantic_child_ranges.semantic_window_kind,
+                                     COALESCE(semantic_child_ranges.semantic_window_minutes, 0)
+                        ORDER BY semantic_child_ranges.child_first_seen ASC,
+                                 semantic_child_ranges.child_ordinal ASC
+                    ) AS prev_child_window_end,
+                    LAG(semantic_child_ranges.child_last_seen) OVER (
+                        PARTITION BY semantic_child_ranges.alert_type,
+                                     semantic_child_ranges.subject_kind,
+                                     semantic_child_ranges.subject_id,
+                                     semantic_child_ranges.semantic_window_kind,
+                                     COALESCE(semantic_child_ranges.semantic_window_minutes, 0)
+                        ORDER BY semantic_child_ranges.child_first_seen ASC,
+                                 semantic_child_ranges.child_ordinal ASC
+                    ) AS prev_child_last_seen
                 FROM semantic_child_ranges
                 WHERE semantic_child_ranges.child_latest_rank = 1
-                WINDOW child_head_partition AS (
-                    PARTITION BY semantic_child_ranges.alert_type,
-                                 semantic_child_ranges.subject_kind,
-                                 semantic_child_ranges.subject_id,
-                                 semantic_child_ranges.semantic_window_kind,
-                                 COALESCE(semantic_child_ranges.semantic_window_minutes, 0)
-                    ORDER BY semantic_child_ranges.child_first_seen ASC,
-                             semantic_child_ranges.child_ordinal ASC
-                )
             ),
             semantic_mother_heads AS (
                 SELECT
@@ -1281,7 +1342,7 @@ impl KeyStore {
                         ORDER BY semantic_child_heads.child_first_seen ASC,
                                  semantic_child_heads.child_ordinal ASC
                         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                    ) AS mother_ordinal
+                        ) AS mother_ordinal
                 FROM semantic_child_heads
             ),
             semantic_grouped_alerts AS (
@@ -1292,14 +1353,56 @@ impl KeyStore {
                     semantic_mother_heads.subject_kind AS subject_kind,
                     semantic_mother_heads.subject_id AS subject_id,
                     NULL AS request_kind_key_normalized,
-                    SUM(semantic_mother_heads.child_event_count) OVER mother_partition AS total_count,
-                    MIN(semantic_mother_heads.child_first_seen) OVER mother_partition AS first_seen,
-                    MAX(semantic_mother_heads.child_last_seen) OVER mother_partition AS last_seen,
+                    SUM(semantic_mother_heads.child_event_count) OVER (
+                        PARTITION BY semantic_mother_heads.alert_type,
+                                     semantic_mother_heads.subject_kind,
+                                     semantic_mother_heads.subject_id,
+                                     semantic_mother_heads.semantic_window_kind,
+                                     COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
+                                     semantic_mother_heads.mother_ordinal
+                    ) AS total_count,
+                    MIN(semantic_mother_heads.child_first_seen) OVER (
+                        PARTITION BY semantic_mother_heads.alert_type,
+                                     semantic_mother_heads.subject_kind,
+                                     semantic_mother_heads.subject_id,
+                                     semantic_mother_heads.semantic_window_kind,
+                                     COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
+                                     semantic_mother_heads.mother_ordinal
+                    ) AS first_seen,
+                    MAX(semantic_mother_heads.child_last_seen) OVER (
+                        PARTITION BY semantic_mother_heads.alert_type,
+                                     semantic_mother_heads.subject_kind,
+                                     semantic_mother_heads.subject_id,
+                                     semantic_mother_heads.semantic_window_kind,
+                                     COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
+                                     semantic_mother_heads.mother_ordinal
+                    ) AS last_seen,
                     semantic_mother_heads.semantic_window_kind AS semantic_window_kind,
                     semantic_mother_heads.semantic_window_minutes AS semantic_window_minutes,
-                    MIN(semantic_mother_heads.child_window_start) OVER mother_partition AS semantic_window_start,
-                    MAX(semantic_mother_heads.child_window_end) OVER mother_partition AS semantic_window_end,
-                    COUNT(*) OVER mother_partition AS child_count,
+                    MIN(semantic_mother_heads.child_window_start) OVER (
+                        PARTITION BY semantic_mother_heads.alert_type,
+                                     semantic_mother_heads.subject_kind,
+                                     semantic_mother_heads.subject_id,
+                                     semantic_mother_heads.semantic_window_kind,
+                                     COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
+                                     semantic_mother_heads.mother_ordinal
+                    ) AS semantic_window_start,
+                    MAX(semantic_mother_heads.child_window_end) OVER (
+                        PARTITION BY semantic_mother_heads.alert_type,
+                                     semantic_mother_heads.subject_kind,
+                                     semantic_mother_heads.subject_id,
+                                     semantic_mother_heads.semantic_window_kind,
+                                     COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
+                                     semantic_mother_heads.mother_ordinal
+                    ) AS semantic_window_end,
+                    COUNT(*) OVER (
+                        PARTITION BY semantic_mother_heads.alert_type,
+                                     semantic_mother_heads.subject_kind,
+                                     semantic_mother_heads.subject_id,
+                                     semantic_mother_heads.semantic_window_kind,
+                                     COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
+                                     semantic_mother_heads.mother_ordinal
+                    ) AS child_count,
                     ROW_NUMBER() OVER (
                         PARTITION BY semantic_mother_heads.alert_type,
                                      semantic_mother_heads.subject_kind,
@@ -1311,14 +1414,6 @@ impl KeyStore {
                                  semantic_mother_heads.row_sort_id DESC
                     ) AS group_rank
                 FROM semantic_mother_heads
-                WINDOW mother_partition AS (
-                    PARTITION BY semantic_mother_heads.alert_type,
-                                 semantic_mother_heads.subject_kind,
-                                 semantic_mother_heads.subject_id,
-                                 semantic_mother_heads.semantic_window_kind,
-                                 COALESCE(semantic_mother_heads.semantic_window_minutes, 0),
-                                 semantic_mother_heads.mother_ordinal
-                )
             ),
             compat_grouped_alerts AS (
                 SELECT
@@ -1328,9 +1423,24 @@ impl KeyStore {
                     filtered_alerts.subject_kind AS subject_kind,
                     filtered_alerts.subject_id AS subject_id,
                     filtered_alerts.request_kind_key_normalized AS request_kind_key_normalized,
-                    COUNT(*) OVER compat_partition AS total_count,
-                    MIN(filtered_alerts.occurred_at) OVER compat_partition AS first_seen,
-                    MAX(filtered_alerts.occurred_at) OVER compat_partition AS last_seen,
+                    COUNT(*) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.request_kind_key_normalized
+                    ) AS total_count,
+                    MIN(filtered_alerts.occurred_at) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.request_kind_key_normalized
+                    ) AS first_seen,
+                    MAX(filtered_alerts.occurred_at) OVER (
+                        PARTITION BY filtered_alerts.alert_type,
+                                     filtered_alerts.subject_kind,
+                                     filtered_alerts.subject_id,
+                                     filtered_alerts.request_kind_key_normalized
+                    ) AS last_seen,
                     NULL AS semantic_window_kind,
                     NULL AS semantic_window_minutes,
                     NULL AS semantic_window_start,
@@ -1345,17 +1455,11 @@ impl KeyStore {
                     ) AS group_rank
                 FROM filtered_alerts
                 WHERE filtered_alerts.grouping_kind = 'compat'
-                WINDOW compat_partition AS (
-                    PARTITION BY filtered_alerts.alert_type,
-                                 filtered_alerts.subject_kind,
-                                 filtered_alerts.subject_id,
-                                 filtered_alerts.request_kind_key_normalized
-                )
             ),
             grouped_alerts AS (
-                SELECT * FROM semantic_grouped_alerts
+                SELECT * FROM semantic_grouped_alerts WHERE group_rank = 1
                 UNION ALL
-                SELECT * FROM compat_grouped_alerts
+                SELECT * FROM compat_grouped_alerts WHERE group_rank = 1
             )"#
         ));
     }
@@ -1466,12 +1570,12 @@ impl KeyStore {
         let offset = (page - 1) * per_page;
         let mut count_query = QueryBuilder::new("");
         Self::push_alert_groups_cte(&mut count_query, filters);
-        count_query.push(" SELECT COUNT(*) FROM grouped_alerts WHERE group_rank = 1");
+        count_query.push(" SELECT COUNT(*) FROM grouped_alerts");
         let total: i64 = count_query.build_query_scalar().fetch_one(&self.pool).await?;
 
         let mut query = QueryBuilder::new("");
         Self::push_alert_groups_cte(&mut query, filters);
-        query.push(" SELECT * FROM grouped_alerts WHERE group_rank = 1");
+        query.push(" SELECT * FROM grouped_alerts");
         query.push(
             " ORDER BY last_seen DESC, total_count DESC, alert_type DESC, row_sort_id DESC LIMIT ",
         );
@@ -2010,6 +2114,156 @@ impl KeyStore {
 #[cfg(test)]
 mod alert_grouping_tests {
     use super::*;
+    use crate::BackendTime;
+    use tempfile::tempdir;
+
+    async fn seed_bound_user_and_token(
+        store: &KeyStore,
+        user_id: &str,
+        token_id: &str,
+        display_name: &str,
+        username: &str,
+        created_at: i64,
+    ) {
+        sqlx::query(
+            "INSERT INTO users (id, display_name, username, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(user_id)
+        .bind(display_name)
+        .bind(username)
+        .bind(created_at)
+        .bind(created_at)
+        .execute(&store.pool)
+        .await
+        .expect("insert user");
+
+        sqlx::query("INSERT INTO auth_tokens (id, secret, created_at) VALUES (?, ?, ?)")
+            .bind(token_id)
+            .bind(format!("secret-{token_id}"))
+            .bind(created_at)
+            .execute(&store.pool)
+            .await
+            .expect("insert auth token");
+
+        sqlx::query(
+            "INSERT INTO user_token_bindings (user_id, token_id, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        )
+        .bind(user_id)
+        .bind(token_id)
+        .bind(created_at)
+        .bind(created_at)
+        .execute(&store.pool)
+        .await
+        .expect("insert user token binding");
+    }
+
+    async fn insert_request_log(
+        store: &KeyStore,
+        token_id: &str,
+        key_id: &str,
+        created_at: i64,
+    ) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            INSERT INTO observability.request_logs (
+                api_key_id,
+                auth_token_id,
+                method,
+                path,
+                query,
+                tavily_status_code,
+                result_status,
+                request_kind_key,
+                request_kind_label,
+                request_kind_detail,
+                counts_business_quota,
+                created_at
+            ) VALUES (?, ?, 'POST', '/api/tavily/search', 'max_results=5', 432, 'quota_exhausted', 'tavily_search', 'Tavily Search', 'POST /api/tavily/search', 1, ?)
+            RETURNING id
+            "#,
+        )
+        .bind(key_id)
+        .bind(token_id)
+        .bind(created_at)
+        .fetch_one(&store.pool)
+        .await
+        .expect("insert request log")
+    }
+
+    async fn insert_request_rate_alert(
+        store: &KeyStore,
+        token_id: &str,
+        created_at: i64,
+        request_kind_key: &str,
+        request_kind_label: &str,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO auth_token_logs (
+                token_id,
+                method,
+                path,
+                request_kind_key,
+                request_kind_label,
+                request_kind_detail,
+                result_status,
+                error_message,
+                key_effect_code,
+                binding_effect_code,
+                selection_effect_code,
+                counts_business_quota,
+                created_at
+            ) VALUES (?, 'POST', '/mcp', ?, ?, ?, 'quota_exhausted', 'user request rate limit exceeded on rolling 5m window (limit 25, used 25)', 'none', 'none', 'none', 0, ?)
+            "#,
+        )
+        .bind(token_id)
+        .bind(request_kind_key)
+        .bind(request_kind_label)
+        .bind(request_kind_label)
+        .bind(created_at)
+        .execute(&store.pool)
+        .await
+        .expect("insert request-rate alert");
+    }
+
+    async fn insert_upstream_usage_limit_alert(
+        store: &KeyStore,
+        token_id: &str,
+        key_id: &str,
+        created_at: i64,
+    ) {
+        let request_log_id = insert_request_log(store, token_id, key_id, created_at).await;
+        sqlx::query(
+            r#"
+            INSERT INTO auth_token_logs (
+                token_id,
+                method,
+                path,
+                query,
+                http_status,
+                request_kind_key,
+                request_kind_label,
+                request_kind_detail,
+                result_status,
+                error_message,
+                key_effect_code,
+                binding_effect_code,
+                selection_effect_code,
+                counts_business_quota,
+                api_key_id,
+                request_log_id,
+                created_at
+            ) VALUES (?, 'POST', '/api/tavily/search', 'max_results=5', 432, 'tavily_search', 'Tavily Search', 'POST /api/tavily/search', 'quota_exhausted', 'This request exceeds your plan''s set usage limit.', 'none', 'none', 'none', 1, ?, ?, ?)
+            "#,
+        )
+        .bind(token_id)
+        .bind(key_id)
+        .bind(request_log_id)
+        .bind(created_at)
+        .execute(&store.pool)
+        .await
+        .expect("insert upstream usage-limit alert");
+    }
 
     fn make_alert_event(
         id: &str,
@@ -2350,6 +2604,85 @@ mod alert_grouping_tests {
         assert_eq!(
             group.request_kind.as_ref().map(|value| value.key.as_str()),
             Some("tavily_search")
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_alert_groups_page_executes_sqlite_grouped_query_for_mother_and_compat_groups() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let db_path = temp_dir.path().join("alerts-groups.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let store = KeyStore::new_with_time(&db_str, BackendTime::system())
+            .await
+            .expect("create key store");
+
+        let user_id = "usr_alerts_sql";
+        let token_id = "tok_alerts_sql";
+        let key_id = "key_alerts_sql";
+        seed_bound_user_and_token(
+            &store,
+            user_id,
+            token_id,
+            "SQLite Alerts",
+            "sqlite-alerts",
+            1_700_000_000,
+        )
+        .await;
+
+        for (created_at, request_kind_key, request_kind_label) in [
+            (1_700_000_000_i64, "mcp_initialize", "MCP initialize"),
+            (1_700_000_060_i64, "mcp_tools_list", "MCP tools/list"),
+            (
+                1_700_000_420_i64,
+                "mcp_notifications_initialized",
+                "MCP notifications/initialized",
+            ),
+            (1_700_000_480_i64, "mcp_resources_list", "MCP resources/list"),
+        ] {
+            insert_request_rate_alert(
+                &store,
+                token_id,
+                created_at,
+                request_kind_key,
+                request_kind_label,
+            )
+            .await;
+        }
+
+        insert_upstream_usage_limit_alert(&store, token_id, key_id, 1_700_100_000).await;
+        insert_upstream_usage_limit_alert(&store, token_id, key_id, 1_700_100_120).await;
+
+        let page = store
+            .fetch_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
+            .await
+            .expect("fetch grouped alerts page");
+
+        assert_eq!(page.total, 2);
+
+        let mother = page
+            .items
+            .iter()
+            .find(|item| item.grouping_kind == "mother")
+            .expect("semantic mother group");
+        assert_eq!(mother.alert_type, ALERT_TYPE_USER_REQUEST_RATE_LIMITED);
+        assert_eq!(mother.subject_kind, ALERT_SUBJECT_USER);
+        assert_eq!(mother.child_count, 2);
+        assert_eq!(mother.event_count, 4);
+        assert_eq!(mother.children.len(), 2);
+        assert!(mother.request_kind.is_none());
+
+        let compat = page
+            .items
+            .iter()
+            .find(|item| item.grouping_kind == "compat")
+            .expect("compat group");
+        assert_eq!(compat.alert_type, ALERT_TYPE_UPSTREAM_USAGE_LIMIT_432);
+        assert_eq!(compat.subject_kind, ALERT_SUBJECT_KEY);
+        assert_eq!(compat.count, 2);
+        assert_eq!(compat.event_count, 2);
+        assert_eq!(
+            compat.request_kind.as_ref().map(|value| value.key.as_str()),
+            Some("api:search")
         );
     }
 }

--- a/web/src/admin/AdminPages.stories.test.ts
+++ b/web/src/admin/AdminPages.stories.test.ts
@@ -31,7 +31,8 @@ describe('AdminPages Storybook proofs', () => {
     expect(adminPageStories.UserDetailCompact).toMatchObject({})
     expect(adminPageStories.UserDetailSingleTokenGuard).toMatchObject({})
     expect(adminPageStories.UserDetailBusinessCalls1h).toMatchObject({})
-    expect('Alerts' in adminPageStories).toBe(false)
+    expect(adminPageStories.Alerts).toMatchObject({})
+    expect(adminPageStories.AlertsMobile).toMatchObject({})
   })
 
   it('renders the sync-progress story with the progress bubble copy', () => {

--- a/web/src/admin/AdminPages.stories.tsx
+++ b/web/src/admin/AdminPages.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta } from '@storybook/react-vite'
 
 import * as HaStories from './storySupport/AdminPagesHaStories'
+import * as AlertsStories from './storySupport/AdminPagesAlertsStories'
 import * as RuntimeStories from './storySupport/AdminPagesStoryRuntime'
 
 const meta = {
@@ -55,6 +56,8 @@ export const KeysRegistrationFilters = { ...RuntimeStories.KeysRegistrationFilte
 export const KeysTemporaryIsolationFilter = { ...RuntimeStories.KeysTemporaryIsolationFilter }
 export const Requests = { ...RuntimeStories.Requests }
 export const RequestsResultFilterOpen = { ...RuntimeStories.RequestsResultFilterOpen }
+export const Alerts = { ...AlertsStories.Alerts }
+export const AlertsMobile = { ...AlertsStories.AlertsMobile }
 export const KeyDetailRecentRequests = { ...RuntimeStories.KeyDetailRecentRequests }
 export const TokenDetailRecentRequests = { ...RuntimeStories.TokenDetailRecentRequests }
 export const RequestsTokenDrawerDesktop = { ...RuntimeStories.RequestsTokenDrawerDesktop }

--- a/web/src/admin/AlertsCenter.render.test.tsx
+++ b/web/src/admin/AlertsCenter.render.test.tsx
@@ -594,6 +594,25 @@ describe('AlertsCenter loading behavior', () => {
     })
   })
 
+  it('applies the same control class to the grouped filter triggers and time inputs', async () => {
+    const { container, root } = await mountAlertsCenter({
+      search: alertsPath({ view: 'groups' }).replace('/admin/alerts', ''),
+      initialCatalog: storyCatalog,
+      initialGroupsPage: semanticGroups,
+      groupsLoader: async () => semanticGroups,
+    })
+
+    expect(container.querySelectorAll('.alerts-center-filter-control').length).toBe(7)
+    expect(container.querySelectorAll('.alerts-center-panel .alerts-center-filter-control.searchable-facet-select__trigger').length).toBe(5)
+    expect(container.querySelectorAll('.alerts-center-panel .alerts-center-time-input.alerts-center-filter-control').length).toBe(2)
+    expect(container.querySelectorAll('.alerts-center-panel .alerts-center-filter-action-button').length).toBe(2)
+    expect(container.querySelector('.alerts-center-request-kinds-trigger')?.classList.contains('alerts-center-filter-control')).toBe(true)
+
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
   it('keeps alert view tabs as segmented buttons even when the viewport is compact', async () => {
     installMatchMediaMock(true)
 

--- a/web/src/admin/AlertsCenter.tsx
+++ b/web/src/admin/AlertsCenter.tsx
@@ -820,6 +820,7 @@ export default function AlertsCenter({
                 searchAriaLabel={copy.filters.type}
                 triggerAriaLabel={copy.filters.type}
                 listAriaLabel={copy.filters.type}
+                triggerClassName="alerts-center-filter-control"
                 onChange={(nextType) => navigateWith({ type: nextType, page: 1 })}
               />
             </div>
@@ -830,7 +831,7 @@ export default function AlertsCenter({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="searchable-facet-select__trigger alerts-center-request-kinds-trigger"
+                    className="searchable-facet-select__trigger alerts-center-request-kinds-trigger alerts-center-filter-control"
                     aria-label={copy.filters.requestKinds}
                   >
                     <span className="searchable-facet-select__summary">{requestKindsSummary}</span>
@@ -870,7 +871,7 @@ export default function AlertsCenter({
               <span className="alerts-center-filter-label">{copy.filters.since}</span>
               <Input
                 type="datetime-local"
-                className="alerts-center-time-input"
+                className="alerts-center-time-input alerts-center-filter-control"
                 value={draftSince}
                 onChange={(event) => setDraftSince(event.target.value)}
               />
@@ -879,7 +880,7 @@ export default function AlertsCenter({
               <span className="alerts-center-filter-label">{copy.filters.until}</span>
               <Input
                 type="datetime-local"
-                className="alerts-center-time-input"
+                className="alerts-center-time-input alerts-center-filter-control"
                 value={draftUntil}
                 onChange={(event) => setDraftUntil(event.target.value)}
               />
@@ -896,6 +897,7 @@ export default function AlertsCenter({
                 searchAriaLabel={copy.filters.user}
                 triggerAriaLabel={copy.filters.user}
                 listAriaLabel={copy.filters.user}
+                triggerClassName="alerts-center-filter-control"
                 onChange={(nextUserId) => navigateWith({ userId: nextUserId, page: 1 })}
               />
             </div>
@@ -911,6 +913,7 @@ export default function AlertsCenter({
                 searchAriaLabel={copy.filters.token}
                 triggerAriaLabel={copy.filters.token}
                 listAriaLabel={copy.filters.token}
+                triggerClassName="alerts-center-filter-control"
                 onChange={(nextTokenId) => navigateWith({ tokenId: nextTokenId, page: 1 })}
                 labelVariant="mono"
               />
@@ -927,6 +930,7 @@ export default function AlertsCenter({
                 searchAriaLabel={copy.filters.key}
                 triggerAriaLabel={copy.filters.key}
                 listAriaLabel={copy.filters.key}
+                triggerClassName="alerts-center-filter-control"
                 onChange={(nextKeyId) => navigateWith({ keyId: nextKeyId, page: 1 })}
                 labelVariant="mono"
               />
@@ -935,6 +939,7 @@ export default function AlertsCenter({
               <Button
                 type="button"
                 variant="outline"
+                className="alerts-center-filter-action-button"
                 onClick={() =>
                   navigateWith({
                     since: dateTimeLocalToIso(draftSince),
@@ -945,7 +950,12 @@ export default function AlertsCenter({
               >
                 {copy.filters.applyTime}
               </Button>
-              <Button type="button" variant="outline" className="alerts-center-clear-button" onClick={() => onNavigate(alertsPath({ view: 'groups' }))}>
+              <Button
+                type="button"
+                variant="outline"
+                className="alerts-center-filter-action-button alerts-center-clear-button"
+                onClick={() => onNavigate(alertsPath({ view: 'groups' }))}
+              >
                 {copy.filters.clear}
               </Button>
             </div>

--- a/web/src/admin/storySupport/AdminPagesAlertsStories.tsx
+++ b/web/src/admin/storySupport/AdminPagesAlertsStories.tsx
@@ -1,0 +1,263 @@
+import type { StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+
+import type { AlertCatalog, AlertEvent, AlertGroup, AlertsPage } from '../../api'
+import AlertsCenter from '../AlertsCenter'
+import { alertsPath } from '../routes'
+import { useLanguage } from '../../i18n'
+import SegmentedTabs from '../../components/ui/SegmentedTabs'
+import { AdminPageFrame } from './AdminPagesStoryRuntime'
+
+const STORY_ALERTS_CATALOG: AlertCatalog = {
+  retentionDays: 30,
+  types: [
+    { value: 'upstream_usage_limit_432', count: 2 },
+    { value: 'user_request_rate_limited', count: 2 },
+  ],
+  requestKindOptions: [
+    { key: 'tavily_search', label: 'Tavily Search', protocol_group: 'api', billing_group: 'billable', count: 2 },
+    { key: 'mcp_initialize', label: 'MCP initialize', protocol_group: 'mcp', billing_group: 'non_billable', count: 1 },
+    { key: 'mcp_resources_list', label: 'MCP resources/list', protocol_group: 'mcp', billing_group: 'non_billable', count: 1 },
+  ],
+  users: [{ value: 'usr_alice', label: 'Alice Wang', count: 2 }],
+  tokens: [{ value: 'tok_ops_01', label: 'tok_ops_01', count: 2 }],
+  keys: [{ value: 'key_001', label: 'key_001', count: 1 }],
+}
+
+function storyTime(timestamp: number | null): string {
+  if (timestamp == null) return '—'
+  const date = new Date(timestamp * 1000)
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${month}/${day} ${hours}:${minutes}`
+}
+
+const STORY_RATE_EVENT_OLD: AlertEvent = {
+  id: 'alert_evt_rate_old',
+  type: 'user_request_rate_limited',
+  title: '用户请求限流',
+  summary: 'Alice Wang hit the local rolling request-rate window for MCP initialize.',
+  occurredAt: 1_762_379_280,
+  subjectKind: 'user',
+  subjectId: 'usr_alice',
+  subjectLabel: 'Alice Wang',
+  user: { userId: 'usr_alice', displayName: 'Alice Wang', username: 'alice' },
+  token: { id: 'tok_ops_01', label: 'tok_ops_01' },
+  key: null,
+  request: { id: 801, method: 'POST', path: '/mcp', query: null },
+  requestKind: { key: 'mcp_initialize', label: 'MCP initialize', detail: 'initialize' },
+  failureKind: null,
+  resultStatus: 'quota_exhausted',
+  errorMessage: 'user request rate limit exceeded on rolling 5m window (limit 25, used 25)',
+  reasonCode: null,
+  reasonSummary: null,
+  reasonDetail: null,
+  source: { kind: 'auth_token_log', id: 'alert-rate-old' },
+  semanticWindow: {
+    kind: 'request_rate',
+    windowMinutes: 5,
+    windowStart: 1_762_379_100,
+    windowEnd: 1_762_379_280,
+    windowKey: 'request_rate:story:0',
+  },
+}
+
+const STORY_RATE_EVENT_NEW: AlertEvent = {
+  ...STORY_RATE_EVENT_OLD,
+  id: 'alert_evt_rate_new',
+  summary: 'Alice Wang hit the local rolling request-rate window for MCP resources/list.',
+  occurredAt: 1_762_379_340,
+  request: { id: 802, method: 'POST', path: '/mcp', query: null },
+  requestKind: { key: 'mcp_resources_list', label: 'MCP resources/list', detail: 'resources/list' },
+  source: { kind: 'auth_token_log', id: 'alert-rate-new' },
+  semanticWindow: {
+    kind: 'request_rate',
+    windowMinutes: 5,
+    windowStart: 1_762_379_160,
+    windowEnd: 1_762_379_340,
+    windowKey: 'request_rate:story:0',
+  },
+}
+
+const STORY_USAGE_EVENT_OLD: AlertEvent = {
+  id: 'alert_evt_usage_old',
+  type: 'upstream_usage_limit_432',
+  title: '上游用量限制 432',
+  summary: 'Alice Wang 的 Tavily Search 请求命中了上游 Tavily 用量限制。',
+  occurredAt: 1_762_379_460,
+  subjectKind: 'key',
+  subjectId: 'key_001',
+  subjectLabel: 'key_001',
+  user: { userId: 'usr_alice', displayName: 'Alice Wang', username: 'alice' },
+  token: { id: 'tok_ops_01', label: 'tok_ops_01' },
+  key: { id: 'key_001', label: 'key_001' },
+  request: { id: 901, method: 'POST', path: '/api/tavily/search', query: 'max_results=5' },
+  requestKind: { key: 'tavily_search', label: 'Tavily Search', detail: 'POST /api/tavily/search' },
+  failureKind: null,
+  resultStatus: 'quota_exhausted',
+  errorMessage: "This request exceeds your plan's set usage limit.",
+  reasonCode: null,
+  reasonSummary: null,
+  reasonDetail: null,
+  source: { kind: 'auth_token_log', id: 'alert-usage-old' },
+  semanticWindow: null,
+}
+
+const STORY_USAGE_EVENT_NEW: AlertEvent = {
+  ...STORY_USAGE_EVENT_OLD,
+  id: 'alert_evt_usage_new',
+  summary: 'Alice Wang 的 Tavily Search 请求继续命中上游 Tavily 用量限制。',
+  occurredAt: 1_762_379_580,
+  request: { id: 902, method: 'POST', path: '/api/tavily/search', query: 'max_results=5' },
+  source: { kind: 'auth_token_log', id: 'alert-usage-new' },
+}
+
+const STORY_ALERTS_EVENTS_PAGE: AlertsPage<AlertEvent> = {
+  page: 1,
+  perPage: 20,
+  total: 4,
+  items: [STORY_USAGE_EVENT_NEW, STORY_USAGE_EVENT_OLD, STORY_RATE_EVENT_NEW, STORY_RATE_EVENT_OLD],
+}
+
+const STORY_ALERTS_GROUPS_PAGE: AlertsPage<AlertGroup> = {
+  page: 1,
+  perPage: 20,
+  total: 2,
+  items: [
+    {
+      id: 'group:user_request_rate_limited:user:usr_alice:request_rate:mother:0',
+      type: 'user_request_rate_limited',
+      subjectKind: 'user',
+      subjectId: 'usr_alice',
+      subjectLabel: 'Alice Wang',
+      user: { userId: 'usr_alice', displayName: 'Alice Wang', username: 'alice' },
+      token: { id: 'tok_ops_01', label: 'tok_ops_01' },
+      key: null,
+      requestKind: null,
+      count: 2,
+      firstSeen: STORY_RATE_EVENT_OLD.occurredAt,
+      lastSeen: STORY_RATE_EVENT_NEW.occurredAt,
+      latestEvent: STORY_RATE_EVENT_NEW,
+      groupingKind: 'mother',
+      semanticWindowKind: 'request_rate',
+      semanticWindowMinutes: 5,
+      semanticWindowStart: STORY_RATE_EVENT_OLD.semanticWindow?.windowStart ?? null,
+      semanticWindowEnd: STORY_RATE_EVENT_NEW.semanticWindow?.windowEnd ?? null,
+      semanticWindowKey: STORY_RATE_EVENT_NEW.semanticWindow?.windowKey ?? null,
+      childCount: 1,
+      eventCount: 2,
+      children: [
+        {
+          id: 'group:user_request_rate_limited:user:usr_alice:request_rate:child:0',
+          type: 'user_request_rate_limited',
+          subjectKind: 'user',
+          subjectId: 'usr_alice',
+          subjectLabel: 'Alice Wang',
+          user: { userId: 'usr_alice', displayName: 'Alice Wang', username: 'alice' },
+          token: { id: 'tok_ops_01', label: 'tok_ops_01' },
+          key: null,
+          requestKind: null,
+          count: 2,
+          firstSeen: STORY_RATE_EVENT_OLD.occurredAt,
+          lastSeen: STORY_RATE_EVENT_NEW.occurredAt,
+          latestEvent: STORY_RATE_EVENT_NEW,
+          groupingKind: 'child',
+          semanticWindowKind: 'request_rate',
+          semanticWindowMinutes: 5,
+          semanticWindowStart: STORY_RATE_EVENT_OLD.semanticWindow?.windowStart ?? null,
+          semanticWindowEnd: STORY_RATE_EVENT_NEW.semanticWindow?.windowEnd ?? null,
+          semanticWindowKey: STORY_RATE_EVENT_NEW.semanticWindow?.windowKey ?? null,
+          childCount: 0,
+          eventCount: 2,
+          children: [],
+          childEvents: [STORY_RATE_EVENT_NEW, STORY_RATE_EVENT_OLD],
+        },
+      ],
+      childEvents: [],
+    },
+    {
+      id: 'group:upstream_usage_limit_432:key:key_001:tavily_search',
+      type: 'upstream_usage_limit_432',
+      subjectKind: 'key',
+      subjectId: 'key_001',
+      subjectLabel: 'key_001',
+      user: { userId: 'usr_alice', displayName: 'Alice Wang', username: 'alice' },
+      token: { id: 'tok_ops_01', label: 'tok_ops_01' },
+      key: { id: 'key_001', label: 'key_001' },
+      requestKind: { key: 'tavily_search', label: 'Tavily Search', detail: 'POST /api/tavily/search' },
+      count: 2,
+      firstSeen: STORY_USAGE_EVENT_OLD.occurredAt,
+      lastSeen: STORY_USAGE_EVENT_NEW.occurredAt,
+      latestEvent: STORY_USAGE_EVENT_NEW,
+      groupingKind: 'compat',
+      semanticWindowKind: null,
+      semanticWindowMinutes: null,
+      semanticWindowStart: null,
+      semanticWindowEnd: null,
+      semanticWindowKey: null,
+      childCount: 0,
+      eventCount: 2,
+      children: [],
+      childEvents: [],
+    },
+  ],
+}
+
+function AlertsPageCanvas({ inlineTabsVariant = 'all' }: { inlineTabsVariant?: 'all' | 'mobile' } = {}): JSX.Element {
+  const { language } = useLanguage()
+  const [search, setSearch] = useState(alertsPath({ view: 'groups' }).replace('/admin/alerts', ''))
+  const currentView = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search).get('view') === 'events'
+    ? 'events'
+    : 'groups'
+  const headerTabs = inlineTabsVariant === 'all' ? (
+    <SegmentedTabs<'events' | 'groups'>
+      className="alerts-center-tabs alerts-center-tabs--header"
+      value={currentView}
+      onChange={(nextView) => setSearch(alertsPath({ view: nextView }).replace('/admin/alerts', ''))}
+      options={[
+        { value: 'events', label: language === 'zh' ? '事件记录' : 'Events' },
+        { value: 'groups', label: language === 'zh' ? '聚合告警' : 'Groups' },
+      ]}
+      ariaLabel="告警视图"
+    />
+  ) : null
+
+  return (
+    <AdminPageFrame activeModule="alerts" actions={headerTabs ?? undefined}>
+      <AlertsCenter
+        language={language}
+        search={search}
+        refreshToken={0}
+        onNavigate={(path) => setSearch(path.replace('/admin/alerts', ''))}
+        onOpenUser={() => {}}
+        onOpenToken={() => {}}
+        onOpenKey={() => {}}
+        formatTime={storyTime}
+        formatTimeDetail={storyTime}
+        initialCatalog={STORY_ALERTS_CATALOG}
+        initialEventsPage={STORY_ALERTS_EVENTS_PAGE}
+        initialGroupsPage={STORY_ALERTS_GROUPS_PAGE}
+        disableAutoLoad
+        inlineTabsVariant={inlineTabsVariant}
+      />
+    </AdminPageFrame>
+  )
+}
+
+type Story = StoryObj
+
+export const Alerts: Story = {
+  render: () => <AlertsPageCanvas />,
+  parameters: {
+    viewport: { defaultViewport: '1440-device-desktop' },
+  },
+}
+
+export const AlertsMobile: Story = {
+  render: () => <AlertsPageCanvas inlineTabsVariant="mobile" />,
+  parameters: {
+    viewport: { defaultViewport: '375-mobile' },
+  },
+}

--- a/web/src/admin/storySupport/AdminPagesStoryRuntime.tsx
+++ b/web/src/admin/storySupport/AdminPagesStoryRuntime.tsx
@@ -63,7 +63,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui/too
 import { UserTagBindingControls } from '../UserTagBindingControls'
 import { Card } from '../../components/ui/card'
 import { Badge } from '../../components/ui/badge'
-import { useLanguage, useTranslate, type AdminTranslations } from '../../i18n'
+import { translations, useLanguage, type AdminTranslations } from '../../i18n'
 import { KeyDetails } from '../../AdminDashboard'
 import { TokenDetailStoryCanvas } from '../../pages/TokenDetail.stories'
 import { useAdminStackedLayout } from '../../lib/responsive'
@@ -81,7 +81,6 @@ import {
 
 import AdminShell, { AdminShellSidebarUtility, type AdminNavItem, type AdminNavTarget } from '../AdminShell'
 import AdminJobTriggerMenu from '../AdminJobTriggerMenu'
-import AlertsCenter from '../AlertsCenter'
 import AdminUserRankingsPage, { RankingsMeta } from '../AdminUserRankingsPage'
 import DashboardOverview, { type DashboardMetricCard } from '../DashboardOverview'
 import { UserDetailQuotaBreakdown } from '../UserDetailQuotaBreakdown'
@@ -155,6 +154,11 @@ const defaultDashboardHourlyRequestWindow = buildDashboardHourlyRequestWindowFix
     apiBillable: (index % 5) + 4,
   }),
 })
+
+function useAdminTranslations(): AdminTranslations {
+  const { language } = useLanguage()
+  return translations[language].admin
+}
 
 function createRequestRate(
   used: number,
@@ -2014,7 +2018,7 @@ function StoryMonthlyBrokenDrawer({
   items: MonthlyBrokenKeyDetail[]
   onOpenChange: (open: boolean) => void
 }): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const users = admin.users
   const keyStrings = admin.keys
   const [copiedKeyId, setCopiedKeyId] = useState<string | null>(null)
@@ -3074,7 +3078,7 @@ export function AdminPageFrame({
   introActions,
   introOverride,
 }: AdminPageFrameProps): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const isStackedAdminLayout = useAdminStackedLayout()
   const headerActions = actions ?? introActions
   const intro = introOverride ?? (() => {
@@ -3230,7 +3234,7 @@ export function AdminPageFrame({
 }
 
 export function DashboardPageCanvas({ beforeIntro }: { beforeIntro?: ReactNode } = {}): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
 
   const totalRequests = MOCK_KEYS.reduce((sum, item) => sum + item.total_requests, 0)
   const successCount = MOCK_KEYS.reduce((sum, item) => sum + item.success_count, 0)
@@ -3495,7 +3499,7 @@ export function DashboardPageCanvas({ beforeIntro }: { beforeIntro?: ReactNode }
 }
 
 function TokensPageCanvas(): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const tokenStrings = admin.tokens
   const tokenToolbar = (
     <div className="admin-module-toolbar admin-module-toolbar--tokens">
@@ -3660,7 +3664,7 @@ function RankingsPageCanvas({
   loading?: React.ComponentProps<typeof AdminUserRankingsPage>['loading']
   connectionState?: React.ComponentProps<typeof AdminUserRankingsPage>['connectionState']
 } = {}): JSX.Element {
-  const { admin } = useTranslate()
+  const admin = useAdminTranslations()
   const { language } = useLanguage()
   const rankingsHeaderMeta = (
     <RankingsMeta
@@ -3705,7 +3709,7 @@ function KeysPageCanvas({
   bulkSyncProgress?: ApiKeyBulkSyncProgressState | null
   bulkFeedback?: { kind: 'success' | 'error'; message: string } | null
 } = {}): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const keyStrings = admin.keys
   const [selectedGroups, setSelectedGroups] = useState<string[]>([])
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>(initialStatuses)
@@ -4271,7 +4275,7 @@ function RequestsPageCanvas({
 }: {
   initialDrawerTarget?: { kind: 'key' | 'token'; id: string } | null
 } = {}): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const { language } = useLanguage()
   const logStrings = admin.logs
   const [currentPage, setCurrentPage] = useState(1)
@@ -4448,7 +4452,7 @@ function RequestsPageCanvas({
 }
 
 function JobsPageCanvas(): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const jobsStrings = admin.jobs
   const keyStrings = admin.keys
   const [jobFilter, setJobFilter] = useState<JobGroup>('all')
@@ -4686,7 +4690,7 @@ function UsersPageCanvas({
   initialQuery?: string
   defaultActiveUsersOnly?: boolean
 } = {}): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const { language } = useLanguage()
   const users = admin.users
   const [sortField, setSortField] = useState<AdminUsersSortField | null>(null)
@@ -4936,7 +4940,7 @@ function UsersUsagePageCanvas({
   initialQuery?: string
   defaultActiveUsersOnly?: boolean
 } = {}): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const { language } = useLanguage()
   const users = admin.users
   const usageDailyRateLabel = language === 'zh' ? users.usage.table.dailySuccessRate : 'Daily'
@@ -5311,7 +5315,7 @@ function UnboundTokenUsagePageCanvas({
   initialSortField?: AdminUnboundTokenUsageSortField | null
   initialSortOrder?: SortDirection | null
 } = {}): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
   const { language } = useLanguage()
   const users = admin.users
   const tokenStrings = admin.tokens
@@ -5709,7 +5713,7 @@ function UnboundTokenUsagePageCanvas({
 
 function UsersUsageTooltipProofCanvas(): JSX.Element {
   const { language } = useLanguage()
-  const users = useTranslate().admin.users
+  const users = useAdminTranslations().users
   const dailySuccessLabel = language === 'zh' ? users.usage.table.dailySuccessRate : 'Daily'
   const monthlySuccessLabel = language === 'zh' ? users.usage.table.monthlySuccessRate : 'Monthly'
   const dailySuccessTooltip = language === 'zh' ? '按最近 24 小时成功率排序' : 'Sort by 24h success rate'
@@ -5805,7 +5809,7 @@ function UsersUsageTooltipProofCanvas(): JSX.Element {
 }
 
 function UserTagsPageCanvas({ editorMode = 'view' }: { editorMode?: StoryTagCardMode }): JSX.Element {
-  const users = useTranslate().admin.users
+  const users = useAdminTranslations().users
   const cards: Array<AdminUserTag | null> = editorMode === 'new' ? [null, ...MOCK_TAG_CATALOG] : MOCK_TAG_CATALOG
   const editableTagId = 'team_lead'
 
@@ -5869,7 +5873,7 @@ function UserDetailPageCanvas({
   initialUsageSeries?: AdminUserUsageSeriesKey | 'ip'
   initialDetail?: AdminUserDetail
 } = {}): JSX.Element {
-  const admin = useTranslate().admin, users = admin.users
+  const admin = useAdminTranslations(), users = admin.users
   const { language } = useLanguage()
   const [detail, setDetail] = useState<AdminUserDetail>(initialDetail)
   const quotaSnapshot = buildStoryQuotaSnapshot(detail)
@@ -6289,7 +6293,7 @@ function AnnouncementsPageCanvas(): JSX.Element {
 }
 
 function ProxySettingsPageCanvas(): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
 
   return (
     <AdminPageFrame activeModule="proxy-settings">
@@ -6321,7 +6325,7 @@ function ProxySettingsPageCanvas(): JSX.Element {
 }
 
 function SystemSettingsPageCanvas(): JSX.Element {
-  const admin = useTranslate().admin
+  const admin = useAdminTranslations()
 
   return (
     <AdminPageFrame activeModule="system-settings">

--- a/web/src/styles/alerts.css
+++ b/web/src/styles/alerts.css
@@ -120,10 +120,80 @@
   width: 100%;
 }
 
+.alerts-center-panel .alerts-center-filter-control.searchable-facet-select__trigger,
+.alerts-center-panel .alerts-center-request-kinds-trigger.alerts-center-filter-control,
+.alerts-center-panel .alerts-center-filter-action-button,
+.alerts-center-panel .alerts-center-time-input.alerts-center-filter-control {
+  min-height: 48px;
+  height: 48px;
+  border: 1px solid hsl(var(--input) / 0.35);
+  border-radius: 20px;
+  background: hsl(var(--muted) / 0.6);
+  color: hsl(var(--foreground));
+  box-shadow: var(--shadow-clay-pressed);
+  font-size: 0.875rem;
+  font-weight: 650;
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    background-color 0.18s ease,
+    color 0.18s ease;
+}
+
+.alerts-center-panel .alerts-center-filter-control.searchable-facet-select__trigger,
+.alerts-center-panel .alerts-center-request-kinds-trigger.alerts-center-filter-control {
+  align-items: center;
+  padding-left: 1rem;
+  padding-right: 0.92rem;
+}
+
+.alerts-center-panel .alerts-center-time-input.alerts-center-filter-control {
+  display: block;
+  width: 100%;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.alerts-center-panel .alerts-center-filter-action-button {
+  justify-content: center;
+  padding-inline: 1rem;
+  border-color: hsl(var(--input) / 0.35);
+  background: hsl(var(--muted) / 0.6);
+  color: hsl(var(--foreground));
+  box-shadow: var(--shadow-clay-pressed);
+  letter-spacing: 0;
+}
+
+.alerts-center-panel .alerts-center-filter-control.searchable-facet-select__trigger:hover,
+.alerts-center-panel .alerts-center-request-kinds-trigger.alerts-center-filter-control:hover,
+.alerts-center-panel .alerts-center-filter-action-button:hover,
+.alerts-center-panel .alerts-center-time-input.alerts-center-filter-control:hover {
+  border-color: hsl(var(--ring) / 0.42);
+  background: hsl(var(--card) / 0.9);
+  box-shadow: var(--shadow-clay-pressed);
+  transform: none;
+}
+
+.alerts-center-panel .alerts-center-filter-control.searchable-facet-select__trigger:focus-visible,
+.alerts-center-panel .alerts-center-request-kinds-trigger.alerts-center-filter-control:focus-visible,
+.alerts-center-panel .alerts-center-filter-action-button:focus-visible,
+.alerts-center-panel .alerts-center-time-input.alerts-center-filter-control:focus-visible {
+  outline: none;
+  border-color: hsl(var(--ring) / 0.45);
+  background: hsl(var(--card) / 0.9);
+  box-shadow:
+    0 0 0 2px hsl(var(--background)),
+    0 0 0 4px hsl(var(--ring) / 0.2),
+    var(--shadow-clay-pressed);
+}
+
+.alerts-center-panel .alerts-center-filter-action-button:active {
+  transform: none;
+  box-shadow: var(--shadow-clay-pressed);
+}
+
 .alerts-center-request-kinds-trigger {
   width: 100%;
-  min-height: 40px;
-  border-radius: 20px;
   justify-content: space-between;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -132,7 +202,6 @@
 .alerts-center-time-input {
   display: block;
   min-width: 0;
-  padding-right: 0.8rem;
 }
 
 .alerts-center-time-input::-webkit-datetime-edit {


### PR DESCRIPTION
Summary:
- Hardened `/api/alerts/groups` grouped SQL for SQLite compatibility while preserving event/group semantics.
- Aligned `/admin/alerts` filter controls with the time input surface.
- Added DB-backed regression coverage and refreshed alert-center spec/solution docs.

Specs:
- docs/specs/9tbyq-admin-alert-center-24h-summary

Solutions:
- docs/solutions/operations/sqlite-admin-read-containment.md

Validation:
- `cargo clippy -- -D warnings`
- `cd web && bun test`
- `cd web && bun run build`
- `cd web && bun run build-storybook`

Visual evidence:
- Verified locally in the alert-center Storybook/admin surface.
