### PR TITLE
fix: repair alerts groups SQLite compatibility

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -139,6 +139,11 @@ reads:
   embedded in rollup triggers; prefer canonicalizing retained legacy rows before rollup rebuild,
   using a focused canonicalization trigger for legacy write-path rows, then keeping rollup triggers
   on stored canonical columns only.
+- When an admin read path embeds `CASE` classification inside SQLite scalar or aggregate
+  expressions, avoid adding wrapper parentheses around the `CASE` inside `COALESCE`,
+  `COUNT(DISTINCT ...)`, `MIN(...)`, or `MAX(...)`. Production-grade older SQLite parsers can
+  reject forms such as `COUNT(DISTINCT (CASE ...))`, `MIN((CASE ...))`, or
+  `COALESCE((CASE ...), ...)` with `near "("` even when newer local SQLite builds accept them.
 - Add query-plan regression tests for admin read hot paths when the fix depends on SQLite choosing a
   specific index. Local small databases may return quickly even when the planner would be disastrous
   on production data volume.

--- a/docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
@@ -257,6 +257,7 @@
 - Alerts 页面筛选区已统一到时间输入的控件语言：
   - `请求类型`、`用户`、`令牌`、`Key`、`应用时间`、`清空筛选` 与 `datetime-local` 输入现在共享同一套高度、圆角、pressed surface、padding 与 focus ring。
   - grouped 读侧已改为 SQLite 兼容写法，`/api/alerts/groups` 在 101 上不再依赖命名 `WINDOW` 语法。
+  - grouped 读侧的 request-kind canonicalization 也必须避免为 `COALESCE`、`COUNT(DISTINCT ...)`、`MIN(...)` 包裹旧版 SQLite 会在 `near "("` 处拒绝的多余 `CASE` 外层括号；`/api/alerts/groups` 的外部接口契约保持不变。
 
 - Web demo 真实页面视口：
   - `/admin/alerts?demo=1&view=groups`：direct-open 默认进入 `聚合告警`，`用户请求限流` 以 `母 -> 子 -> 原始事件明细` 两层半结构展示，子窗口不再按 `request_kind` 拆主结构。
@@ -332,3 +333,4 @@
 
 - 2026-04-18: 初始化 spec，冻结 Admin 告警中心、告警读模型、24h 仪表盘摘要、共享 URL 语义与验证门禁。
 - 2026-04-22: 热修复补充 `upstream_usage_limit_432`，明确 Tavily 432 通过查询层重分类，不再误报为 `user_quota_exhausted`；同时要求 affinity 仅粘 active key，成功请求需回写 primary affinity。
+- 2026-06-24: 修复 101 生产 `/api/alerts/groups` 的旧版 SQLite parser 兼容性；batch request-kind canonicalization 不再生成 `COALESCE((CASE ...))`、`COUNT(DISTINCT (CASE ...))`、`MIN((CASE ...))` 形式的聚合 SQL，并补充回归断言。

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1444,7 +1444,7 @@ pub(crate) fn request_log_request_kind_key_sql(
         "
         CASE
             WHEN {path} = '/mcp' AND json_valid({body_json}) AND json_type({body_json}) = 'object'
-                THEN COALESCE(({object_kind}), 'mcp:unknown-payload')
+                THEN COALESCE({object_kind}, 'mcp:unknown-payload')
             WHEN {path} = '/mcp' AND json_valid({body_json}) AND json_type({body_json}) = 'array'
                 THEN CASE
                     WHEN NOT EXISTS (SELECT 1 FROM json_each({body_json}) AS items)
@@ -1454,10 +1454,10 @@ pub(crate) fn request_log_request_kind_key_sql(
                         WHERE ({array_item_kind}) IS NULL
                     ) THEN 'mcp:unknown-payload'
                     WHEN (
-                        SELECT COUNT(DISTINCT ({array_item_kind}))
+                        SELECT COUNT(DISTINCT {array_item_kind})
                         FROM json_each({body_json}) AS items
                     ) = 1 THEN (
-                        SELECT MIN(({array_item_kind}))
+                        SELECT MIN({array_item_kind})
                         FROM json_each({body_json}) AS items
                     )
                     ELSE 'mcp:batch'

--- a/src/tests/request_kind_and_core.rs
+++ b/src/tests/request_kind_and_core.rs
@@ -107,6 +107,18 @@ fn extract_usage_credits_from_json_bytes_finds_nested_usage_and_rounds_up() {
 }
 
 #[test]
+fn request_log_request_kind_key_sql_avoids_extra_parentheses_in_mcp_batch_aggregates() {
+    let sql = request_log_request_kind_key_sql("path", "request_body", "request_kind_key");
+
+    assert!(!sql.contains("COUNT(DISTINCT ("));
+    assert!(!sql.contains("MIN(("));
+    assert!(!sql.contains("COALESCE(("));
+    assert!(sql.contains("COUNT(DISTINCT "));
+    assert!(sql.contains("MIN("));
+    assert!(sql.contains("COALESCE("));
+}
+
+#[test]
 fn map_forward_proxy_validation_error_code_distinguishes_invalid_subscriptions() {
     assert_eq!(
         map_forward_proxy_validation_error_code(&ProxyError::Other(


### PR DESCRIPTION
## Summary
- remove extra parentheses around grouped alerts batch request-kind SQL so older production SQLite parsers no longer fail near `("`
- add a regression around the generated SQL and keep grouped alerts behavior coverage green
- sync the owning spec and SQLite operations solution note with the compatibility constraint

## Validation
- `cargo test request_log_request_kind_key_sql_avoids_extra_parentheses_in_mcp_batch_aggregates -- --nocapture`
- `cargo test fetch_alert_groups_page_executes_sqlite_grouped_query_for_mother_and_compat_groups -- --nocapture`
- `cargo test alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_stays_24h -- --nocapture`
- `cargo clippy -- -D warnings`
- read-only production evidence before fix: `src/server/handlers/admin_resources/alerts.rs:123` logged `alert groups error: database error: error returned from database: (code: 1) near "(": syntax error` on `2026-06-24T01:09:13Z` and `2026-06-24T01:14:06Z`
- read-only GitHub transport check: `ssh -T -p 443 git@ssh.github.com` succeeded after plain port 22 SSH was closed by the network path

## References
- Specs
  - `docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md`
- Solutions
  - `docs/solutions/operations/sqlite-admin-read-containment.md`
- Project Docs
  - `-`
