### PR TITLE
fix: repair alerts groups mother filter

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -81,6 +81,10 @@ reads:
   partition logic can be expressed inline. Keep the grouped projection in SQL, but prefer inline
   `OVER (...)` windows plus a final `group_rank = 1` collapse over `WINDOW ... AS (...)` syntax on
   the production read path.
+- When expanding a selected mother-group page back into raw alert events, ensure every
+  subject/time predicate block is added through the `separated(" OR ")` boundary itself. If the
+  whole block is emitted with `push_unseparated(...)`, SQLite receives adjacent predicates like
+  `(...)(...)` and `/api/alerts/groups` fails with `near "("`.
 - Canonicalize alert `request_kind` inside the SQL projection before filtering or grouping rows.
   Mixed legacy keys such as `tavily_search` / `mcp_search` otherwise drift from the canonical
   request-kind keys returned by the HTTP contract and can make filtered pages appear empty.

--- a/docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
@@ -258,6 +258,7 @@
   - `请求类型`、`用户`、`令牌`、`Key`、`应用时间`、`清空筛选` 与 `datetime-local` 输入现在共享同一套高度、圆角、pressed surface、padding 与 focus ring。
   - grouped 读侧已改为 SQLite 兼容写法，`/api/alerts/groups` 在 101 上不再依赖命名 `WINDOW` 语法。
   - grouped 读侧的 request-kind canonicalization 也必须避免为 `COALESCE`、`COUNT(DISTINCT ...)`、`MIN(...)` 包裹旧版 SQLite 会在 `near "("` 处拒绝的多余 `CASE` 外层括号；`/api/alerts/groups` 的外部接口契约保持不变。
+  - grouped 读侧在补全 mother group 子事件时，面向多个 mother group 的 `OR` 条件块必须通过 `QueryBuilder::separated(" OR ")` 正确插入分隔符；若把整段条件块都写成 `push_unseparated(...)`，SQLite 会收到 `(...)(...)` 这种非法谓词并在 `/api/alerts/groups` 上报 `near "("`。
 
 - Web demo 真实页面视口：
   - `/admin/alerts?demo=1&view=groups`：direct-open 默认进入 `聚合告警`，`用户请求限流` 以 `母 -> 子 -> 原始事件明细` 两层半结构展示，子窗口不再按 `request_kind` 拆主结构。

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -1645,7 +1645,7 @@ impl KeyStore {
         {
             let mut separated = query.separated(" OR ");
             for (alert_type, subject_kind, subject_id, first_seen, last_seen) in &selected_subjects {
-                separated.push_unseparated("(");
+                separated.push("(");
                 separated
                     .push_unseparated("alerts.alert_type = ")
                     .push_bind_unseparated(alert_type);
@@ -2684,5 +2684,89 @@ mod alert_grouping_tests {
             compat.request_kind.as_ref().map(|value| value.key.as_str()),
             Some("api:search")
         );
+    }
+
+    #[tokio::test]
+    async fn fetch_alert_groups_page_supports_multiple_mother_groups_without_sqlite_syntax_errors() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let db_path = temp_dir.path().join("alerts-groups-multi-mother.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let store = KeyStore::new_with_time(&db_str, BackendTime::system())
+            .await
+            .expect("create key store");
+
+        for (user_id, token_id, created_at) in [
+            ("usr_alerts_multi_a", "tok_alerts_multi_a", 1_700_000_000_i64),
+            ("usr_alerts_multi_b", "tok_alerts_multi_b", 1_700_010_000_i64),
+        ] {
+            seed_bound_user_and_token(
+                &store,
+                user_id,
+                token_id,
+                "SQLite Alerts",
+                "sqlite-alerts",
+                created_at.saturating_sub(120),
+            )
+            .await;
+        }
+
+        for (token_id, created_at, request_kind_key, request_kind_label) in [
+            (
+                "tok_alerts_multi_a",
+                1_700_000_000_i64,
+                "mcp_initialize",
+                "MCP initialize",
+            ),
+            (
+                "tok_alerts_multi_a",
+                1_700_000_060_i64,
+                "mcp_tools_list",
+                "MCP tools/list",
+            ),
+            (
+                "tok_alerts_multi_b",
+                1_700_010_000_i64,
+                "mcp_initialize",
+                "MCP initialize",
+            ),
+            (
+                "tok_alerts_multi_b",
+                1_700_010_060_i64,
+                "mcp_tools_list",
+                "MCP tools/list",
+            ),
+        ] {
+            insert_request_rate_alert(
+                &store,
+                token_id,
+                created_at,
+                request_kind_key,
+                request_kind_label,
+            )
+            .await;
+        }
+
+        let page = store
+            .fetch_alert_groups_page(
+                Some(ALERT_TYPE_USER_REQUEST_RATE_LIMITED),
+                None,
+                None,
+                None,
+                None,
+                None,
+                &[],
+                1,
+                20,
+            )
+            .await
+            .expect("fetch grouped alerts page with multiple mother groups");
+
+        let mother_groups = page
+            .items
+            .iter()
+            .filter(|item| item.grouping_kind == "mother")
+            .collect::<Vec<_>>();
+        assert_eq!(mother_groups.len(), 2);
+        assert!(mother_groups.iter().all(|group| group.children.len() == 1));
     }
 }


### PR DESCRIPTION
Summary:
- repair the mother-group hydration filter assembly for `/api/alerts/groups`
- add a SQLite regression test covering multiple mother groups on the same page
- record the SQLite guardrail in the related spec and solution docs

Test Plan:
- `cargo test fetch_alert_groups_page_executes_sqlite_grouped_query_for_mother_and_compat_groups -- --nocapture`
- `cargo test fetch_alert_groups_page_supports_multiple_mother_groups_without_sqlite_syntax_errors -- --nocapture`
- `cargo test alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_stays_24h -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Spec: docs/specs/9tbyq-admin-alert-center-24h-summary/SPEC.md
Spec Disposition: update
Solutions: docs/solutions/operations/sqlite-admin-read-containment.md
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: done
Project Docs Sync: n/a(no project-doc change)

Notes:
- Production root cause was a missing `OR` separator between generated mother-group predicate blocks.
- Non-UI backend fix; visual evidence is not applicable for this PR.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
