### PR TITLE
fix(ci): install pillow for release web build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,9 @@ jobs:
         with:
           bun-version-file: .bun-version
 
+      - name: Install PWA asset dependencies
+        run: python3 -m pip install --user Pillow
+
       - name: Build web assets
         working-directory: web
         env:


### PR DESCRIPTION
## Summary
- install `Pillow` in the release workflow before `web` production build
- unblock `web/scripts/generate_pwa_assets.py` during `Release` workflow runs
- keep the fix scoped to release-web-assets parity with CI

## Validation
- `cd web && bun run build`

## References
- Spec: -
- Spec Disposition: not_needed
- Spec Sync: n/a(spec-free)
- Spec Drift: none
- Solutions: -
- Solutions Sync: n/a(no solution change)
- Project Docs: -
- Project Docs Sync: n/a(no project-doc change)

## Notes
- Root cause: release run `28104716413` failed in `Build web assets` with `ModuleNotFoundError: No module named 'PIL'`.
- After merge, backfill release for `206a81e58b43ae12083f577e4f73c2307910e320` via `workflow_dispatch`.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
