### PR TITLE
fix(release): align smoke assets contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,7 +508,8 @@ jobs:
           curl -fsS "http://127.0.0.1:${port}/console" | grep -qi '<html'
           curl -fsS "http://127.0.0.1:${port}/version.json" | grep -q '"version"'
           curl -fsS "http://127.0.0.1:${port}/favicon.svg" >/dev/null
-          curl -fsS "http://127.0.0.1:${port}/linuxdo-logo.svg" >/dev/null
+          curl -fsS "http://127.0.0.1:${port}/assets/linuxdo-logo.svg" >/dev/null
+          curl -fsS "http://127.0.0.1:${port}/assets/relay-mesh-lockup-light.png" >/dev/null
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v7
@@ -688,7 +689,8 @@ jobs:
           curl -fsS "http://127.0.0.1:${port}/console" | grep -qi '<html'
           curl -fsS "http://127.0.0.1:${port}/version.json" | grep -q '"version"'
           curl -fsS "http://127.0.0.1:${port}/favicon.svg" >/dev/null
-          curl -fsS "http://127.0.0.1:${port}/linuxdo-logo.svg" >/dev/null
+          curl -fsS "http://127.0.0.1:${port}/assets/linuxdo-logo.svg" >/dev/null
+          curl -fsS "http://127.0.0.1:${port}/assets/relay-mesh-lockup-light.png" >/dev/null
 
       - name: Upload portable binary artifacts
         uses: actions/upload-artifact@v7

--- a/docs/specs/xxgfb-release-binary-assets/IMPLEMENTATION.md
+++ b/docs/specs/xxgfb-release-binary-assets/IMPLEMENTATION.md
@@ -14,6 +14,7 @@
 - release workflow 新增 `binary-portable` matrix：在 `ubuntu-24.04` 与 `ubuntu-24.04-arm` 上安装 Zig 与固定版本的 `cargo-zigbuild`，分别构建 `x86_64-unknown-linux-musl` / `aarch64-unknown-linux-musl` 版本，并打包为 `*-portable.tar.gz` 与 `.sha256`。
 - `prepare` job 额外从被 checkout 的目标源码树读取 release contract marker；只有目标树声明 `portable_release_contract=v1` 时才启用 `binary-portable` 与 portable 资产文案。这样当前 workflow 仍可用 `workflow_dispatch(head_sha=...)` 回填 pre-portable 历史提交，而不会把新 portable 构建强加到旧依赖树上。
 - portable matrix 在 smoke 前额外执行链接面检查：同时读取 `file`、`readelf -d` 与 `readelf -l`，要求产物保持 static/static-pie、没有 `PT_INTERP`、没有 `DT_NEEDED`，并显式拒绝 `glibc` / `OpenSSL` / `libsqlite3` 运行时依赖，避免仅靠 `ldd` 文本匹配漏过 glibc 动态链接回归。
+- 2026-06-27 的品牌资源 `/assets` 迁移后，release workflow 的 native/portable binary smoke 也同步改为探测 `/assets/linuxdo-logo.svg` 与 `/assets/relay-mesh-lockup-light.png`，不再保留失效的根路径 `/linuxdo-logo.svg` 断言；embedded HTTP 合同测试同步覆盖 PNG + SVG 品牌资产。
 - GitHub Release job 下载 binary artifacts 后用 `gh release upload --clobber --repo "${GITHUB_REPOSITORY}"` 上传资产；该 job 没有 checkout，不能依赖本地 `.git` 推断仓库。PR release comment 列出 binary
   资产名称，并包含新增的 portable 资产。
 - CI workflow 增加 embedded asset contract coverage，避免无外部静态目录的 binary 路径回归。

--- a/tests/server_http_contract.rs
+++ b/tests/server_http_contract.rs
@@ -898,7 +898,11 @@ async fn embedded_public_assets_are_served_without_static_dir() {
         "version.json should expose a version string"
     );
 
-    for path in ["/favicon.svg", "/assets/linuxdo-logo.svg"] {
+    for (path, content_type_prefix) in [
+        ("/favicon.svg", "image/svg+xml"),
+        ("/assets/linuxdo-logo.svg", "image/svg+xml"),
+        ("/assets/relay-mesh-lockup-light.png", "image/png"),
+    ] {
         let response = client
             .get(format!("http://127.0.0.1:{port}{path}"))
             .send()
@@ -910,8 +914,8 @@ async fn embedded_public_assets_are_served_without_static_dir() {
                 .headers()
                 .get(reqwest::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
-                .is_some_and(|value| value.starts_with("image/svg+xml")),
-            "asset content type should be svg: {path}"
+                .is_some_and(|value| value.starts_with(content_type_prefix)),
+            "asset content type should match {content_type_prefix}: {path}"
         );
         assert!(
             !response.bytes().await.expect("asset body").is_empty(),


### PR DESCRIPTION
## Summary
- align native and portable release smoke checks with the `/assets/*` brand asset contract
- add the representative lockup PNG probe so packaged binaries cover the exact logo path that regressed on the admin shell
- extend the embedded static-asset contract test to cover both SVG and PNG branded assets

## Validation
- `cargo test embedded_public_assets_are_served_without_static_dir -- --nocapture`
- local release-smoke reproduction against `target/release/tavily-hikari` covering `/favicon.svg`, `/assets/linuxdo-logo.svg`, `/assets/relay-mesh-lockup-light.png`

## References
- Specs: `docs/specs/xxgfb-release-binary-assets/IMPLEMENTATION.md`
- Solutions: `-`
- Project Docs: `-`