### PR TITLE
fix(ha): send provider-compatible EdgeOne direct origin type

### DIFF
--- a/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/HISTORY.md
@@ -101,6 +101,18 @@ HA source settings originally drifted across layers: the frontend, demo fixtures
 
 The HA source settings dialog previously dumped raw backend failure text straight into the modal body, which was both visually inconsistent and hard to scan. The accepted interaction keeps local input validation beside the affected field and reserves form-level remote failures for a formal destructive alert with operator-friendly copy plus a default-collapsed technical-details disclosure.
 
+## EdgeOne Direct-Origin Payload Compatibility Revision
+
+Production validation on 101 showed that the HA admin “save and switch” path could not move a
+direct origin to a new `host:port` even when the target itself was reachable. The failure was not
+XP ingress routing; it was the downstream EdgeOne control-plane payload using lowercase
+`OriginInfo.OriginType=ip_domain`, which Tencent now rejects for direct origins.
+
+- The accepted direct-origin contract is provider-compatible `OriginInfo.OriginType=IP_DOMAIN`.
+- This compatibility detail is part of the HA source-switching control-plane contract and must stay
+  covered by regression tests, because a rejected switch leaves the node unable to adopt the new
+  effective source target without entering HA role drift.
+
 ## HA Control Plane Revision
 
 The earlier HA admin UI mixed real local state with inferred remote placeholders derived from

--- a/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/IMPLEMENTATION.md
@@ -107,6 +107,7 @@
   silently miss the production request-log/read-model layout.
 - Added recovery batch idempotency, HA sync watermarks, failover operation persistence, EdgeOne request/response audit persistence, and node state persistence.
 - Adjusted EdgeOne origin switching to require explicit origin protocol, host, and port configuration, send them as top-level EdgeOne API fields, and normalize EdgeOne describe responses that omit default ports.
+- Updated direct-origin EdgeOne switch payloads to send the provider-compatible `OriginInfo.OriginType=IP_DOMAIN`, and added regression coverage so admin HA source switching no longer sends the rejected lowercase literal.
 - Added full-master fencing for system settings, upstream key creation, user token management, user quota changes, registration settings, OAuth login start, recharge order creation, and payment notify.
 - Added basic-business fencing for external Tavily HTTP API, MCP root/subpaths, and Tavily usage routes; `standby` and `recovery` return 503 before auth/quota/upstream work.
 - Restricted non-force promote to `standby` callers so an active node cannot demote itself through an accidental promote operation.

--- a/docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
+++ b/docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
@@ -28,6 +28,7 @@ Tavily Hikari 的高可用方案采用单活主备热备，而不是一主多从
 
 - `DescribeAccelerationDomains` 用于查询加速域名当前源站，并判断当前 active 节点。
 - `ModifyAccelerationDomain` 用于将源站切换到目标节点 `IP:port`。
+- 直连源站切换到 EdgeOne 控制面时，`OriginInfo.OriginType` 必须发送 provider 兼容的字面值 `IP_DOMAIN`；小写 `ip_domain` 视为无效请求。
 - 节点切换必须记录 operation、请求、响应、错误和操作者审计。
 - 首个上线门槛是验证 EdgeOne 是否接受带端口的 origin；若不支持，主备节点必须监听相同端口。
 

--- a/src/ha.rs
+++ b/src/ha.rs
@@ -1263,7 +1263,7 @@ impl EdgeOneClient {
                     .unwrap_or_else(|| scheme.default_port());
                 payload["OriginProtocol"] = json!(scheme.edgeone_value());
                 payload["OriginInfo"] = json!({
-                    "OriginType": "ip_domain",
+                    "OriginType": "IP_DOMAIN",
                     "Origin": host,
                     "BackupOrigin": ""
                 });

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -2137,6 +2137,11 @@ async fn ha_promote_records_edgeone_request_response_audit() {
         row.1
     );
     assert!(
+        row.1.contains("\"OriginType\":\"IP_DOMAIN\""),
+        "request audit should contain provider-compatible origin type: {}",
+        row.1
+    );
+    assert!(
         row.1.contains("\"HttpsOriginPort\":58101"),
         "request audit should contain origin port: {}",
         row.1


### PR DESCRIPTION
## Summary
- send `OriginInfo.OriginType=IP_DOMAIN` when switching EdgeOne direct origins
- cover the provider-compatible payload in HA request-audit regression tests
- record the direct-origin payload contract update in the HA spec implementation/history docs

## Test Plan
- cargo test ha_promote_records_edgeone_request_response_audit -- --nocapture
- cargo test promote_without_force_allows_expected_primary_to_fail_over -- --nocapture
- bash /Users/ivan/.codex/skills/spec-sync/scripts/spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md

Spec: docs/specs/f36b4-edgeone-active-standby-ha/SPEC.md
Spec Disposition: update
Solutions: -
Project Docs: -
Spec Sync: done
Spec Drift: none
Solutions Sync: n/a(no solution change)
Project Docs Sync: n/a(no project-doc change)
