### PR TITLE
fix: preserve strict startup readiness

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -92,10 +92,10 @@ month-tail public metrics scan.
   whole startup set out in one wave, and keep the fail-closed rule tied to “every subscription
   fetch failed” rather than to a per-batch wall-clock artifact.
 - Align deploy health timing with that stricter contract. In this service the accepted image
-  baseline is `start-period=20s`, `interval=5s`, `timeout=5s`, and `retries=18`, with the
-  healthcheck command itself enforcing the 20-second minimum-success gate. That keeps old Docker
-  builders working while still stopping a fast successful probe from flipping the container healthy
-  before the intended startup hold window has elapsed.
+  baseline is `start-period=20s`, `interval=5s`, `timeout=5s`, and `retries=18`, but the
+  healthcheck command itself should probe only the strict `/health` endpoint. If the service is
+  truly ready, container healthy should flip on that first successful strict probe instead of
+  waiting behind an extra fixed delay.
 - Keep retention cleanup bounded. Large `request_logs` backlogs should be deleted in small batches
   with a runtime/batch budget and a catch-up delay, rather than one daily job holding or repeatedly
   contesting the writer until the whole backlog is gone.
@@ -195,6 +195,15 @@ month-tail public metrics scan.
   connection. Doing both at once makes owner-facing summary flushes and early scheduler enqueues
   contend for one slot, so `/health` may go green while `/api/summary` still returns transient
   500s.
+- Keep startup repairs explicitly partitioned by readiness contract. In this service,
+  `server_pressure_buckets` rebuild is a post-ready best-effort analysis view and belongs in a
+  one-shot background task, while `user_business_calls_1h` history rehydration is an owner-facing
+  startup summary and should be restored cheaply before strict readiness turns green.
+- For legacy one-time startup rewrites such as request-log effect-bucket migration, add a durable
+  completion marker plus a cheap indexed precheck, and commit the rewrite together with that marker
+  in one transaction. Re-running the same full-table `UPDATE` every restart wastes SQLite write
+  budget even when the database is already clean, while a non-atomic marker leaves partial-restart
+  ambiguity behind.
 - When both `main.request_logs` and `observability.request_logs` can coexist temporarily, schema
   probes must target the attached schema explicitly. Generic `pragma_table_info('request_logs')`
   lookups can resolve against the wrong DB and trigger duplicate-column repairs.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -172,6 +172,17 @@
   request-log snapshot.
 - Cold startup subscription refresh now fans out across the whole configured URL set in one wave,
   so 5-8 slow feeds no longer turn strict readiness into multiple 60-second timeout batches.
-- Tightened the image `HEALTHCHECK` timing to a builder-compatible 20-second minimum gate plus
-  `start-period=20s/interval=5s/timeout=5s/retries=18`, so container healthy state still tracks
-  the stricter serving contract without depending on Docker 25-only `--start-interval`.
+
+## 2026-06-28
+
+- Removed the extra image-side 20-second success gate after production follow-up confirmed it was
+  delaying healthy beyond true strict readiness. The image still uses
+  `start-period=20s/interval=5s/timeout=5s/retries=18`, but healthy now flips on the first
+  successful strict `/health` probe.
+- Closed the implementation/spec drift around startup-critical observability work: the sidecar
+  derived-table rebuild path no longer runs `server_pressure_buckets` synchronously, while
+  `user_business_calls_1h` history rehydration is again loaded during startup so owner-facing
+  business-call summaries are already populated when strict readiness turns green.
+- Added a no-op-aware request-log effect-bucket migration guard so steady-state restarts skip the
+  legacy full-table repair once the migration has completed or a cheap indexed precheck proves no
+  remaining rows need rewriting, and the rewrite plus completion marker now commit atomically.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -59,6 +59,13 @@
   roles trigger one background rebuild after the listener is already ready, invalidate the cached
   analysis-pressure snapshot on success, and isolate rebuild failure to logs instead of business
   readiness.
+- `user_business_calls_1h` now rehydrates during proxy construction again so owner-facing dashboard
+  summaries are populated before strict serving readiness can turn green. The rehydrate path keeps
+  the cheap indexed startup snapshot, optional `request_log_id` dedupe, and upper-bound merge
+  logic so later background refreshes can still run safely on HA promotion without double-counting.
+- Request-log effect-bucket repair now short-circuits via a meta marker plus a cheap indexed
+  precheck, and the rewrite plus marker commit now share one transaction so partial restarts cannot
+  leave mixed migrated/unmarked state behind.
 - The same post-ready rebuild hook now runs on later HA promotions that restore a
   `provisional_master` / `full_master` serving role, including the shared admin/internal finalize
   path that persists HA status snapshots.
@@ -72,9 +79,12 @@
   5-8 URL subscription config no longer stretches strict readiness across multiple 60-second
   timeout batches before xray/runtime can finish initializing.
 - The container image `HEALTHCHECK` now polls the stricter `/health` contract with
-  `start-period=20s`, `interval=5s`, `timeout=5s`, and `retries=18`, while a builder-compatible
-  healthcheck gate keeps the first green transition near the intended 20-second floor without
-  relying on Docker 25-only `--start-interval`.
+  `start-period=20s`, `interval=5s`, `timeout=5s`, and `retries=18`, and the healthcheck command
+  itself now probes only `/health`. Container healthy therefore flips on the first successful
+  strict `/health` probe instead of waiting behind an extra fixed 20-second gate.
+- Forward-proxy startup also stopped doing one redundant runtime-store write on the happy path:
+  runtime/xray sync persists the snapshot once, and startup no longer immediately replays the same
+  snapshot back into SQLite a second time before readiness.
 - LinuxDo system tag binding backfill now uses a single indexed startup precheck and only repairs
   mismatched rows before readiness. A background scheduler periodically refreshes the bindings and
   quota snapshots after the service is already listening.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -102,6 +102,11 @@ source when a usable persisted runtime already exists.
   first healthy image status. Once the process is already serving business traffic, it may run once
   as a best-effort background rebuild whose failure is isolated to logs/observability and does not
   turn serving `/health` red.
+- Non-core startup repairs must stay partitioned by contract. `user_business_calls_1h` history
+  backfill is an owner-facing readiness view and must be cheaply rehydrated before serving starts
+  reporting ready, while one-time request-log effect-bucket repair remains a startup maintenance
+  step that must stay cheap/no-op aware on steady-state restarts and must not decide serving
+  `/health`.
 - If a later HA transition promotes the process back into a business-serving role, the same
   best-effort `server_pressure_buckets` rebuild must be scheduled for that serving tenure too.
 - If HA demotes the process out of a business-serving role while that rebuild is still pending, the
@@ -109,8 +114,8 @@ source when a usable persisted runtime already exists.
   recovery process.
 - The default image `HEALTHCHECK` must align with the stricter serving contract by using
   `start-period=20s`, `interval=5s`, `timeout=5s`, and `retries=18`, while the healthcheck command
-  itself keeps the first green transition at or after the intended 20-second hold window without
-  depending on Docker 25-only flags.
+  itself probes only the strict `/health` contract. The first healthy transition must happen on the
+  first successful strict `/health` probe instead of waiting for an extra fixed startup hold window.
 - Scheduled job records must preserve the logical job type and record the trigger source separately
   as `scheduler`, `manual`, or `auto`. Manual runs must not be encoded by appending suffixes to
   `job_type`.
@@ -247,10 +252,10 @@ source when a usable persisted runtime already exists.
   startup.
 - If the node is demoted to `standby` / `recovery` before that rebuild finishes, the detached task
   exits without committing new `server_pressure_buckets` rows from the non-serving role.
-- Under mock/local upstream startup, the image `HEALTHCHECK` becomes healthy only after the stricter
-  serving `/health` is truly green and remains stable within the
-  builder-compatible 20-second minimum-gate plus `start-period=20s/interval=5s/timeout=5s/retries=18`
-  timing contract.
+- Under mock/local upstream startup, the image `HEALTHCHECK` becomes healthy on the first
+  successful probe after the stricter serving `/health` is truly green, with no extra fixed
+  20-second minimum gate layered on top of
+  `start-period=20s/interval=5s/timeout=5s/retries=18`.
 - With a large backlog of old request logs, one scheduler pass records bounded progress instead of
   running indefinitely; later catch-up passes eventually remove all rows older than the retention
   threshold.

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -154,6 +154,7 @@
         "tests::usage_series_and_backfills::startup_",
         "tests::account_usage_rollup_request_days::startup_",
         "tests::user_tokens_and_pending_billing::startup_",
+        "tests::user_tokens_and_pending_billing::effect_",
         "tests::user_tokens_and_pending_billing::pending_",
         "tests::proxy_affinity_and_summary::proxy_",
         "tests::request_rollup::proxy_",

--- a/scripts/container-health-contract-smoke.sh
+++ b/scripts/container-health-contract-smoke.sh
@@ -19,8 +19,9 @@ else
 fi
 
 SCENARIO="${SCENARIO:-positive}"
-POSITIVE_MIN_HEALTHY_SECS="${POSITIVE_MIN_HEALTHY_SECS:-20}"
+POSITIVE_MIN_HEALTHY_SECS="${POSITIVE_MIN_HEALTHY_SECS:-0}"
 POSITIVE_MAX_HEALTHY_SECS="${POSITIVE_MAX_HEALTHY_SECS:-35}"
+POSITIVE_MAX_HEALTHY_LAG_SECS="${POSITIVE_MAX_HEALTHY_LAG_SECS:-10}"
 NEGATIVE_OBSERVE_SECS="${NEGATIVE_OBSERVE_SECS:-35}"
 
 TEMP_ROOT="${RUNNER_TEMP:-$(mktemp -d)}"
@@ -68,6 +69,7 @@ POSITIVE_CONTAINER_NAME="${SMOKE_CONTAINER_NAME_PREFIX:-tavily-hikari-health}-po
 NEGATIVE_SEED_CONTAINER_NAME="${SMOKE_CONTAINER_NAME_PREFIX:-tavily-hikari-health}-negative-seed-${MOCK_PORT}-${PROXY_PORT}"
 NEGATIVE_CONTAINER_NAME="${SMOKE_CONTAINER_NAME_PREFIX:-tavily-hikari-health}-negative-${MOCK_PORT}-${PROXY_PORT}"
 NEGATIVE_SHARE_LINK="${NEGATIVE_SHARE_LINK:-vless://0688fa59-e971-4278-8c03-4b35821a71dc@health-smoke.example.com:443?encryption=none#HealthSmoke}"
+SMOKE_DOCKER_RUN_ARGS="${SMOKE_DOCKER_RUN_ARGS:-}"
 MOCK_PID=""
 
 print_section() {
@@ -240,6 +242,11 @@ run_proxy_container() {
   local data_dir="$2"
   shift 2
   mkdir -p "${data_dir}"
+  local extra_run_args=()
+  if [[ -n "${SMOKE_DOCKER_RUN_ARGS}" ]]; then
+    # shellcheck disable=SC2206
+    extra_run_args=(${SMOKE_DOCKER_RUN_ARGS})
+  fi
   docker run -d --rm \
     --name "${name}" \
     --user "$(id -u):$(id -g)" \
@@ -251,6 +258,7 @@ run_proxy_container() {
     -e TAVILY_USAGE_BASE="http://host.docker.internal:${MOCK_PORT}" \
     -e DEV_OPEN_ADMIN=true \
     -e PROXY_DB_PATH=/srv/app/data/tavily_proxy.db \
+    "${extra_run_args[@]}" \
     "$@" \
     "${LOCAL_SMOKE_IMAGE}" \
     >/dev/null
@@ -346,6 +354,10 @@ run_positive_scenario() {
   fi
   if (( healthy_at < ready_at )); then
     echo "container health became healthy before /health was ready: ready_at=${ready_at}s healthy_at=${healthy_at}s" >&2
+    return 1
+  fi
+  if (( healthy_at - ready_at > POSITIVE_MAX_HEALTHY_LAG_SECS )); then
+    echo "container health lagged strict /health too long: ready_at=${ready_at}s healthy_at=${healthy_at}s lag=$((healthy_at - ready_at))s" >&2
     return 1
   fi
   if [[ "$(cat "${body_file}")" != "ok" ]]; then

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -eu
 
-date +%s > /tmp/tavily-hikari-started-at
 exec tavily-hikari "$@"

--- a/scripts/docker-healthcheck.sh
+++ b/scripts/docker-healthcheck.sh
@@ -1,12 +1,4 @@
 #!/bin/sh
 set -eu
 
-started_at_file=/tmp/tavily-hikari-started-at
-
-[ -s "$started_at_file" ]
-
-started_at="$(cat "$started_at_file")"
-now="$(date +%s)"
-[ $((now - started_at)) -ge 20 ]
-
 curl --fail --silent http://127.0.0.1:8787/health >/dev/null

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1015,6 +1015,8 @@ const META_KEY_DASHBOARD_REQUEST_ROLLUP_BUCKETS_V1_DONE: &str =
 const META_KEY_BILLING_LEDGER_STARTUP_HIGH_WATERMARK_V1: &str =
     "billing_ledger_startup_high_watermark_v1";
 const META_KEY_REQUEST_STATS_LAST_FLUSHED_AT_V1: &str = "request_stats_last_flushed_at_v1";
+const META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE: &str =
+    "request_log_effect_bucket_migration_v1_done";
 const META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_DONE: &str = "request_log_catalog_rollup_v1_done";
 const META_KEY_REQUEST_LOG_CATALOG_ROLLUP_V1_RETENTION_DAYS: &str =
     "request_log_catalog_rollup_v1_retention_days";

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -951,7 +951,9 @@ fn spawn_post_ready_serving_tasks_for_role(
         );
         return false;
     }
-    state.proxy.spawn_server_pressure_buckets_rebuild_once()
+    let pressure = state.proxy.spawn_server_pressure_buckets_rebuild_once();
+    let business_calls = state.proxy.spawn_user_business_calls_1h_backfill_once();
+    pressure || business_calls
 }
 
 async fn apply_ha_baseline_response_stream(

--- a/src/server/tests/alerts_and_ha_startup_roles.rs
+++ b/src/server/tests/alerts_and_ha_startup_roles.rs
@@ -79,6 +79,19 @@ async fn persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_servi
     )
     .await
     .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "ha-post-ready-rebuild".to_string(),
+            username: Some("ha_post_ready_rebuild".to_string()),
+            name: Some("HA Post Ready Rebuild".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert post-ready rebuild user");
     let pool = connect_sqlite_test_pool(&db_str).await;
     let now = proxy.backend_time().now_ts();
     sqlx::query(
@@ -100,7 +113,7 @@ async fn persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_servi
         "#,
     )
     .bind("success")
-    .bind("ha-rebuild-user")
+    .bind(&user.user_id)
     .bind("search")
     .bind(tavily_hikari::REQUEST_LOG_VISIBILITY_VISIBLE)
     .bind(now - 60)
@@ -177,6 +190,21 @@ async fn persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_servi
     })
     .await
     .expect("serving HA snapshot should trigger background pressure rebuild");
+
+    tokio::time::timeout(Duration::from_secs(8), async {
+        loop {
+            let summary = proxy
+                .user_dashboard_summary(&user.user_id, None)
+                .await
+                .expect("load user dashboard summary after post-ready backfill");
+            if summary.business_calls_1h.total_count == 1 {
+                return summary;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("serving HA snapshot should trigger background business-call backfill");
 
     pool.close().await;
     let _ = std::fs::remove_file(&db_path);

--- a/src/store/key_store_analysis_pressure.rs
+++ b/src/store/key_store_analysis_pressure.rs
@@ -1,6 +1,6 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ServerPressureBucketsRebuildOutcome {
-    Completed,
+    Completed { upper_bound_request_log_id: i64 },
     Cancelled,
 }
 
@@ -50,16 +50,6 @@ impl KeyStore {
         Ok(())
     }
 
-    pub(crate) async fn rebuild_server_pressure_buckets(&self) -> Result<(), ProxyError> {
-        match self
-            .rebuild_server_pressure_buckets_with_cancel(|| true)
-            .await?
-        {
-            ServerPressureBucketsRebuildOutcome::Completed
-            | ServerPressureBucketsRebuildOutcome::Cancelled => Ok(()),
-        }
-    }
-
     pub(crate) async fn rebuild_server_pressure_buckets_with_cancel<F>(
         &self,
         should_continue: F,
@@ -69,15 +59,36 @@ impl KeyStore {
     {
         self.ensure_server_pressure_bucket_schema().await?;
         if self.uses_legacy_single_db_observability_compatibility() {
-            return Ok(ServerPressureBucketsRebuildOutcome::Completed);
+            return Ok(ServerPressureBucketsRebuildOutcome::Completed {
+                upper_bound_request_log_id: 0,
+            });
         }
         if !self.request_logs_support_server_pressure_rebuild().await? {
-            return Ok(ServerPressureBucketsRebuildOutcome::Completed);
+            return Ok(ServerPressureBucketsRebuildOutcome::Completed {
+                upper_bound_request_log_id: 0,
+            });
         }
 
         let updated_at = self.backend_time.now_ts();
         let five_minute_since = updated_at.saturating_sub(48 * SECS_PER_HOUR);
         let hour_since = updated_at.saturating_sub(8 * SECS_PER_DAY);
+        let upper_bound_request_log_id = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COALESCE(MAX(id), 0)
+            FROM observability.request_logs
+            WHERE visibility = ?
+              AND created_at >= ?
+              AND request_user_id IS NOT NULL
+              AND counts_business_quota = 1
+              AND upstream_operation IS NOT NULL
+              AND result_status != ?
+            "#,
+        )
+        .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
+        .bind(five_minute_since)
+        .bind(OUTCOME_QUOTA_EXHAUSTED)
+        .fetch_one(&self.pool)
+        .await?;
         let insert_sql = r#"
             INSERT INTO observability.server_pressure_buckets (
                 bucket_kind,
@@ -115,6 +126,7 @@ impl KeyStore {
                   AND counts_business_quota = 1
                   AND upstream_operation IS NOT NULL
                   AND result_status != ?
+                  AND id <= ?
                 GROUP BY bucket_start
                 ORDER BY bucket_start
                 "#,
@@ -126,6 +138,7 @@ impl KeyStore {
             .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
             .bind(five_minute_since)
             .bind(OUTCOME_QUOTA_EXHAUSTED)
+            .bind(upper_bound_request_log_id)
             .fetch_all(&mut *conn)
             .await?;
             let hour_rows = sqlx::query_as::<_, (i64, i64, i64)>(
@@ -147,6 +160,7 @@ impl KeyStore {
                   AND counts_business_quota = 1
                   AND upstream_operation IS NOT NULL
                   AND result_status != ?
+                  AND id <= ?
                 GROUP BY bucket_start
                 ORDER BY bucket_start
                 "#,
@@ -156,6 +170,7 @@ impl KeyStore {
             .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
             .bind(hour_since)
             .bind(OUTCOME_QUOTA_EXHAUSTED)
+            .bind(upper_bound_request_log_id)
             .fetch_all(&mut *conn)
             .await?;
 
@@ -192,12 +207,18 @@ impl KeyStore {
                 return Ok(ServerPressureBucketsRebuildOutcome::Cancelled);
             }
             sqlx::query("COMMIT").execute(&mut *conn).await?;
-            Ok(ServerPressureBucketsRebuildOutcome::Completed)
+            Ok(ServerPressureBucketsRebuildOutcome::Completed {
+                upper_bound_request_log_id,
+            })
         }
         .await;
         match result {
-            Ok(ServerPressureBucketsRebuildOutcome::Completed) => {
-                Ok(ServerPressureBucketsRebuildOutcome::Completed)
+            Ok(ServerPressureBucketsRebuildOutcome::Completed {
+                upper_bound_request_log_id,
+            }) => {
+                Ok(ServerPressureBucketsRebuildOutcome::Completed {
+                    upper_bound_request_log_id,
+                })
             }
             Ok(ServerPressureBucketsRebuildOutcome::Cancelled) => {
                 let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;

--- a/src/store/key_store_analysis_pressure.rs
+++ b/src/store/key_store_analysis_pressure.rs
@@ -14,7 +14,13 @@ impl KeyStore {
             "visibility",
             "created_at",
         ] {
-            if !Self::table_column_exists_in_pool(&self.pool, "request_logs", column).await? {
+            let exists = sqlx::query_scalar::<_, i64>(
+                "SELECT 1 FROM observability.pragma_table_info('request_logs') WHERE name = ? LIMIT 1",
+            )
+            .bind(column)
+            .fetch_optional(&self.pool)
+            .await?;
+            if exists.is_none() {
                 return Ok(false);
             }
         }

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -728,7 +728,6 @@ impl KeyStore {
                 self.backend_time.now_ts(),
             )
             .await?;
-            self.rebuild_server_pressure_buckets().await?;
             self.rebuild_request_log_catalog_rollups().await?;
             Ok::<(), ProxyError>(())
         }

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -728,6 +728,13 @@ impl KeyStore {
                 self.backend_time.now_ts(),
             )
             .await?;
+            match self
+                .rebuild_server_pressure_buckets_with_cancel(|| true)
+                .await?
+            {
+                ServerPressureBucketsRebuildOutcome::Completed { .. }
+                | ServerPressureBucketsRebuildOutcome::Cancelled => {}
+            }
             self.rebuild_request_log_catalog_rollups().await?;
             Ok::<(), ProxyError>(())
         }

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -247,8 +247,37 @@ impl KeyStore {
         Ok(())
     }
 
+    async fn log_effect_bucket_migration_needed_for_table(
+        &self,
+        table: &str,
+        target_column: &str,
+        legacy_effect_codes: &[&str],
+    ) -> Result<bool, ProxyError> {
+        let placeholders = std::iter::repeat_n("?", legacy_effect_codes.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT 1 FROM {table}
+             WHERE key_effect_code IN ({placeholders})
+               AND ({target_column} IS NULL OR TRIM({target_column}) = '' OR {target_column} = 'none')
+             LIMIT 1"
+        );
+        let mut query = sqlx::query_scalar::<_, i64>(&sql);
+        for code in legacy_effect_codes {
+            query = query.bind(*code);
+        }
+        Ok(query.fetch_optional(&self.pool).await?.is_some())
+    }
 
     async fn migrate_log_effect_buckets(&self) -> Result<(), ProxyError> {
+        if self
+            .get_meta_i64(META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE)
+            .await?
+            == Some(1)
+        {
+            return Ok(());
+        }
+        let request_logs_table = "observability.request_logs";
         let binding_codes = [
             KEY_EFFECT_HTTP_PROJECT_AFFINITY_BOUND,
             KEY_EFFECT_HTTP_PROJECT_AFFINITY_REUSED,
@@ -292,8 +321,42 @@ impl KeyStore {
             .iter()
             .all(|code| is_key_effect_code(code))
         );
+        let needs_migration = self
+            .log_effect_bucket_migration_needed_for_table(
+                request_logs_table,
+                "binding_effect_code",
+                &binding_codes,
+            )
+            .await?
+            || self
+                .log_effect_bucket_migration_needed_for_table(
+                    request_logs_table,
+                    "selection_effect_code",
+                    &selection_codes,
+                )
+                .await?
+            || self
+                .log_effect_bucket_migration_needed_for_table(
+                    "auth_token_logs",
+                    "binding_effect_code",
+                    &binding_codes,
+                )
+                .await?
+            || self
+                .log_effect_bucket_migration_needed_for_table(
+                    "auth_token_logs",
+                    "selection_effect_code",
+                    &selection_codes,
+                )
+                .await?;
+        if !needs_migration {
+            self.set_meta_i64(META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE, 1)
+                .await?;
+            return Ok(());
+        }
 
-        for table in ["request_logs", "auth_token_logs"] {
+        let mut tx = self.pool.begin().await?;
+        for table in [request_logs_table, "auth_token_logs"] {
             let binding_sql = format!(
                 "UPDATE {table}
                  SET binding_effect_code = key_effect_code,
@@ -301,8 +364,7 @@ impl KeyStore {
                      key_effect_code = 'none',
                      key_effect_summary = NULL
                  WHERE key_effect_code IN (?, ?, ?, ?, ?, ?)
-                   AND (binding_effect_code IS NULL OR TRIM(binding_effect_code) = '' OR binding_effect_code = 'none')
-                   AND (selection_effect_code IS NULL OR TRIM(selection_effect_code) = '' OR selection_effect_code = 'none')"
+                   AND (binding_effect_code IS NULL OR TRIM(binding_effect_code) = '' OR binding_effect_code = 'none')"
             );
             sqlx::query(&binding_sql)
                 .bind(binding_codes[0])
@@ -311,7 +373,7 @@ impl KeyStore {
                 .bind(binding_codes[3])
                 .bind(binding_codes[4])
                 .bind(binding_codes[5])
-                .execute(&self.pool)
+                .execute(&mut *tx)
                 .await?;
 
             let selection_sql = format!(
@@ -321,7 +383,6 @@ impl KeyStore {
                      key_effect_code = 'none',
                      key_effect_summary = NULL
                  WHERE key_effect_code IN (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   AND (binding_effect_code IS NULL OR TRIM(binding_effect_code) = '' OR binding_effect_code = 'none')
                    AND (selection_effect_code IS NULL OR TRIM(selection_effect_code) = '' OR selection_effect_code = 'none')"
             );
             sqlx::query(&selection_sql)
@@ -334,11 +395,25 @@ impl KeyStore {
                 .bind(selection_codes[6])
                 .bind(selection_codes[7])
                 .bind(selection_codes[8])
-                .execute(&self.pool)
+                .execute(&mut *tx)
                 .await?;
         }
+        set_meta_i64_executor(
+            &mut *tx,
+            META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE,
+            1,
+        )
+        .await?;
+        tx.commit().await?;
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn rerun_log_effect_bucket_migration_for_test(
+        &self,
+    ) -> Result<(), ProxyError> {
+        self.migrate_log_effect_buckets().await
     }
 
     fn push_request_logs_scope<'a>(

--- a/src/store/key_store_users_and_oauth.rs
+++ b/src/store/key_store_users_and_oauth.rs
@@ -1347,6 +1347,7 @@ impl KeyStore {
             .await;
         Ok(build_user_business_call_event_write(
             request_user_id,
+            request_log_id,
             counts_business_quota,
             upstream_operation_for_business,
             result_status,
@@ -1531,6 +1532,7 @@ impl KeyStore {
             log_id,
             build_user_business_call_event_write(
                 request_user_id,
+                request_log_id,
                 counts_business_quota,
                 upstream_operation_for_business,
                 result_status,
@@ -2585,6 +2587,7 @@ impl KeyStore {
 
 fn build_user_business_call_event_write(
     request_user_id: Option<String>,
+    request_log_id: Option<i64>,
     counts_business_quota: i64,
     upstream_operation: Option<String>,
     result_status: &str,
@@ -2594,12 +2597,15 @@ fn build_user_business_call_event_write(
     if counts_business_quota != 1 {
         return None;
     }
+    // Only request-log-backed upstream calls participate in business-call and
+    // server-pressure live windows; metadata-free token logs stay excluded.
     upstream_operation.as_ref()?;
     if result_status == OUTCOME_QUOTA_EXHAUSTED {
         return None;
     }
     Some(UserBusinessCallEventWrite {
         user_id,
+        request_log_id,
         created_at,
         result_status: result_status.to_string(),
     })

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1314,6 +1314,7 @@ struct RequestLogDiagnosticMetadata {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct UserBusinessCallEventWrite {
     pub(crate) user_id: String,
+    pub(crate) request_log_id: Option<i64>,
     pub(crate) created_at: i64,
     pub(crate) result_status: String,
 }

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -83,8 +83,17 @@ struct RequestRateSubject {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct UserBusinessCallEvent {
+    request_log_id: Option<i64>,
     created_at: i64,
     outcome: UserBusinessCallOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ServerPressureBufferedEvent {
+    generation: u64,
+    request_log_id: Option<i64>,
+    created_at: i64,
+    result_status: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -101,6 +110,7 @@ struct UserBusinessCallCounts {
 
 #[derive(Clone, Debug)]
 struct UserBusinessCalls1hBackfillRow {
+    request_log_id: Option<i64>,
     user_id: String,
     created_at: i64,
     outcome: UserBusinessCallOutcome,
@@ -686,8 +696,10 @@ pub struct TavilyProxy {
     pub(crate) low_quota_depletion_threshold: i64,
     pub(crate) forward_proxy_runtime_started: Arc<AtomicBool>,
     pub(crate) forward_proxy_runtime_transition_lock: Arc<Mutex<()>>,
+    user_business_calls_backfill_started: Arc<AtomicBool>,
     server_pressure_rebuild_started: Arc<AtomicBool>,
     server_pressure_rebuild_generation: Arc<AtomicU64>,
+    server_pressure_rebuild_buffered_events: Arc<Mutex<Vec<ServerPressureBufferedEvent>>>,
     health_readiness_grace_until: tokio::time::Instant,
     pub(crate) backend_time: BackendTime,
 }
@@ -1665,25 +1677,49 @@ impl UserBusinessCalls1hWindow {
     pub(crate) async fn backfill_recent(&self) -> Result<(), ProxyError> {
         let now_ts = self.backend_time.now_ts();
         let since_ts = now_ts.saturating_sub(self.retention_secs);
-        let rows = sqlx::query(
+        let upper_bound_request_log_id = sqlx::query_scalar::<_, i64>(
             r#"
-            SELECT request_user_id, created_at, result_status
+            SELECT COALESCE(MAX(id), 0)
             FROM request_logs INDEXED BY idx_request_logs_time
             WHERE created_at >= ?
               AND request_user_id IS NOT NULL
               AND counts_business_quota = 1
               AND result_status != ?
               AND upstream_operation IS NOT NULL
+            "#,
+        )
+        .bind(since_ts)
+        .bind(OUTCOME_QUOTA_EXHAUSTED)
+        .fetch_one(&self.store.pool)
+        .await?;
+        if upper_bound_request_log_id == 0 {
+            self.backend
+                .replace_from_backfill(&[], upper_bound_request_log_id, now_ts, self.retention_secs)
+                .await;
+            return Ok(());
+        }
+        let rows = sqlx::query(
+            r#"
+            SELECT id, request_user_id, created_at, result_status
+            FROM request_logs INDEXED BY idx_request_logs_time
+            WHERE created_at >= ?
+              AND request_user_id IS NOT NULL
+              AND counts_business_quota = 1
+              AND result_status != ?
+              AND upstream_operation IS NOT NULL
+              AND id <= ?
             ORDER BY created_at ASC, id ASC
             "#,
         )
         .bind(since_ts)
         .bind(OUTCOME_QUOTA_EXHAUSTED)
+        .bind(upper_bound_request_log_id)
         .fetch_all(&self.store.pool)
         .await?;
         let events: Vec<UserBusinessCalls1hBackfillRow> = rows
             .into_iter()
             .filter_map(|row| {
+                let request_log_id = row.try_get::<i64, _>("id").ok();
                 let user_id = row.try_get::<String, _>("request_user_id").ok()?;
                 let created_at = row.try_get::<i64, _>("created_at").ok()?;
                 let result_status = row.try_get::<String, _>("result_status").ok()?;
@@ -1693,6 +1729,7 @@ impl UserBusinessCalls1hWindow {
                     UserBusinessCallOutcome::Failure
                 };
                 Some(UserBusinessCalls1hBackfillRow {
+                    request_log_id,
                     user_id,
                     created_at,
                     outcome,
@@ -1700,7 +1737,12 @@ impl UserBusinessCalls1hWindow {
             })
             .collect();
         self.backend
-            .replace_from_backfill(&events, now_ts, self.retention_secs)
+            .replace_from_backfill(
+                &events,
+                upper_bound_request_log_id,
+                now_ts,
+                self.retention_secs,
+            )
             .await;
         Ok(())
     }
@@ -1708,6 +1750,7 @@ impl UserBusinessCalls1hWindow {
     pub(crate) async fn record_event(
         &self,
         user_id: &str,
+        request_log_id: Option<i64>,
         created_at: i64,
         outcome: UserBusinessCallOutcome,
     ) {
@@ -1715,6 +1758,7 @@ impl UserBusinessCalls1hWindow {
             .record_event(
                 user_id,
                 UserBusinessCallEvent {
+                    request_log_id,
                     created_at,
                     outcome,
                 },
@@ -1961,13 +2005,14 @@ impl UserBusinessCalls1hBackend {
     async fn replace_from_backfill(
         &self,
         rows: &[UserBusinessCalls1hBackfillRow],
+        upper_bound_request_log_id: i64,
         now_ts: i64,
         retention_secs: i64,
     ) {
         match self {
             Self::Memory(backend) => {
                 backend
-                    .replace_from_backfill(rows, now_ts, retention_secs)
+                    .replace_from_backfill(rows, upper_bound_request_log_id, now_ts, retention_secs)
                     .await
             }
         }
@@ -2188,21 +2233,43 @@ impl MemoryUserBusinessCalls1hBackend {
     async fn replace_from_backfill(
         &self,
         rows: &[UserBusinessCalls1hBackfillRow],
+        upper_bound_request_log_id: i64,
         now_ts: i64,
         retention_secs: i64,
     ) {
         let mut state = self.state.lock().await;
+        Self::maybe_gc(&mut state, now_ts, retention_secs);
+        let preserved_live_events: Vec<(String, UserBusinessCallEvent)> = state
+            .entries
+            .iter()
+            .flat_map(|(user_id, queue)| {
+                queue
+                    .iter()
+                    .filter(move |event| {
+                        event.request_log_id.is_some_and(|request_log_id| {
+                            request_log_id > upper_bound_request_log_id
+                        })
+                    })
+                    .cloned()
+                    .map(|event| (user_id.clone(), event))
+            })
+            .collect();
         state.entries.clear();
         state.next_gc_at = 0;
         for row in rows {
-            state
-                .entries
-                .entry(row.user_id.clone())
-                .or_default()
-                .push_back(UserBusinessCallEvent {
+            let queue = state.entries.entry(row.user_id.clone()).or_default();
+            Self::insert_event_sorted(
+                queue,
+                UserBusinessCallEvent {
+                    request_log_id: row.request_log_id,
                     created_at: row.created_at,
                     outcome: row.outcome,
-                });
+                },
+            );
+        }
+        for (user_id, event) in preserved_live_events {
+            let queue = state.entries.entry(user_id).or_default();
+            Self::insert_event_sorted(queue, event);
         }
         Self::maybe_gc(&mut state, now_ts, retention_secs);
     }
@@ -2323,6 +2390,13 @@ impl MemoryUserBusinessCalls1hBackend {
         queue: &mut VecDeque<UserBusinessCallEvent>,
         event: UserBusinessCallEvent,
     ) {
+        if let Some(request_log_id) = event.request_log_id
+            && queue
+                .iter()
+                .any(|existing| existing.request_log_id == Some(request_log_id))
+        {
+            return;
+        }
         let insert_at = queue
             .iter()
             .position(|existing| existing.created_at > event.created_at)

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -591,15 +591,17 @@ impl TavilyProxy {
             low_quota_depletion_threshold: options.low_quota_depletion_threshold,
             forward_proxy_runtime_started: Arc::new(AtomicBool::new(false)),
             forward_proxy_runtime_transition_lock: Arc::new(Mutex::new(())),
+            user_business_calls_backfill_started: Arc::new(AtomicBool::new(false)),
             server_pressure_rebuild_started: Arc::new(AtomicBool::new(false)),
             server_pressure_rebuild_generation: Arc::new(AtomicU64::new(0)),
+            server_pressure_rebuild_buffered_events: Arc::new(Mutex::new(Vec::new())),
             health_readiness_grace_until: backend_time
                 .deadline_after(options.health_readiness_grace_period),
             backend_time,
         };
+        proxy.user_business_calls_1h_window.backfill_recent().await?;
         proxy.spawn_ha_state_coalescer();
         proxy.spawn_request_stats_coalescer();
-        proxy.user_business_calls_1h_window.backfill_recent().await?;
         info!(
             component = "forward_proxy",
             event = "startup_runtime_graph_deferred",
@@ -718,7 +720,6 @@ impl TavilyProxy {
             );
             let manager = self.forward_proxy.lock().await;
             let manager_endpoint_count = manager.endpoints.len() as u64;
-            forward_proxy::sync_manager_runtime_to_store(&self.key_store, &manager).await?;
             let final_memory = capture_runtime_memory_snapshot();
             info!(
                 component = "forward_proxy",
@@ -907,7 +908,58 @@ impl TavilyProxy {
                     })
                     .await
                 {
-                    Ok(crate::store::ServerPressureBucketsRebuildOutcome::Completed) => {
+                    Ok(crate::store::ServerPressureBucketsRebuildOutcome::Completed {
+                        upper_bound_request_log_id,
+                    }) => {
+                        let buffered_events = {
+                            let mut buffered =
+                                proxy.server_pressure_rebuild_buffered_events.lock().await;
+                            let drained = std::mem::take(&mut *buffered);
+                            let (matching, retained): (Vec<_>, Vec<_>) = drained
+                                .into_iter()
+                                .partition(|event| event.generation == generation);
+                            *buffered = retained;
+                            matching
+                        };
+                        for event in buffered_events {
+                            if event
+                                .request_log_id
+                                .is_some_and(|request_log_id| {
+                                    request_log_id <= upper_bound_request_log_id
+                                })
+                            {
+                                continue;
+                            }
+                            if !proxy.server_pressure_buckets_rebuild_is_active(generation) {
+                                return;
+                            }
+                            if let Err(err) = proxy
+                                .key_store
+                                .upsert_server_pressure_event(
+                                    event.created_at,
+                                    &event.result_status,
+                                )
+                                .await
+                            {
+                                if proxy
+                                    .server_pressure_rebuild_generation
+                                    .load(Ordering::SeqCst)
+                                    == generation
+                                {
+                                    proxy
+                                        .server_pressure_rebuild_started
+                                        .store(false, Ordering::SeqCst);
+                                }
+                                tracing::warn!(
+                                    component = "analysis_pressure",
+                                    event = "server_pressure_buckets_rebuild_failed",
+                                    attempt = attempt + 1,
+                                    err = %err,
+                                    "server pressure buckets rebuild failed while replaying live buffered events"
+                                );
+                                return;
+                            }
+                        }
                         if proxy
                             .server_pressure_rebuild_generation
                             .load(Ordering::SeqCst)
@@ -975,6 +1027,46 @@ impl TavilyProxy {
                         return;
                     }
                 }
+            }
+        });
+        true
+    }
+
+    pub fn spawn_user_business_calls_1h_backfill_once(&self) -> bool {
+        if self
+            .user_business_calls_backfill_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return false;
+        }
+
+        let proxy = self.clone();
+        tokio::spawn(async move {
+            let started = Instant::now();
+            tracing::info!(
+                component = "startup",
+                event = "user_business_calls_1h_backfill_started",
+                "backfilling recent user business-call windows after listener readiness"
+            );
+            let result = proxy.user_business_calls_1h_window.backfill_recent().await;
+            proxy
+                .user_business_calls_backfill_started
+                .store(false, Ordering::SeqCst);
+            match result {
+                Ok(()) => tracing::info!(
+                    component = "startup",
+                    event = "user_business_calls_1h_backfill_completed",
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "user business-call backfill completed"
+                ),
+                Err(err) => tracing::warn!(
+                    component = "startup",
+                    event = "user_business_calls_1h_backfill_failed",
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    err = %err,
+                    "user business-call backfill failed"
+                ),
             }
         });
         true

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -768,7 +768,7 @@ impl TavilyProxy {
     }
 
     async fn shutdown_forward_proxy_runtime_locked(&self) -> Result<(), ProxyError> {
-        self.cancel_server_pressure_buckets_rebuild();
+        self.cancel_server_pressure_buckets_rebuild().await;
         if !self
             .forward_proxy_runtime_started
             .swap(false, Ordering::SeqCst)
@@ -850,11 +850,19 @@ impl TavilyProxy {
         snapshot.shared_process_running && snapshot.active_endpoint_handles > 0
     }
 
-    pub(crate) fn cancel_server_pressure_buckets_rebuild(&self) {
-        self.server_pressure_rebuild_generation
-            .fetch_add(1, Ordering::SeqCst);
+    pub(crate) async fn cancel_server_pressure_buckets_rebuild(&self) {
+        let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
+        let next_generation = self
+            .server_pressure_rebuild_generation
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
         self.server_pressure_rebuild_started
             .store(false, Ordering::SeqCst);
+        for event in buffered.iter_mut() {
+            if event.generation < next_generation {
+                event.generation = next_generation;
+            }
+        }
     }
 
     fn server_pressure_buckets_rebuild_is_active(&self, generation: u64) -> bool {
@@ -864,6 +872,67 @@ impl TavilyProxy {
                 .server_pressure_rebuild_generation
                 .load(Ordering::SeqCst)
                 == generation
+    }
+
+    pub(crate) async fn record_server_pressure_event(
+        &self,
+        request_log_id: Option<i64>,
+        created_at: i64,
+        result_status: &str,
+    ) -> Result<(), ProxyError> {
+        let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
+        let generation = self
+            .server_pressure_rebuild_generation
+            .load(Ordering::SeqCst);
+        if self.server_pressure_buckets_rebuild_is_active(generation) {
+            buffered.push(ServerPressureBufferedEvent {
+                generation,
+                request_log_id,
+                created_at,
+                result_status: result_status.to_string(),
+            });
+            return Ok(());
+        }
+        drop(buffered);
+        self.key_store
+            .upsert_server_pressure_event(created_at, result_status)
+            .await
+    }
+
+    async fn requeue_server_pressure_buffered_events(
+        &self,
+        mut events: Vec<ServerPressureBufferedEvent>,
+    ) {
+        if events.is_empty() {
+            return;
+        }
+        let generation = self
+            .server_pressure_rebuild_generation
+            .load(Ordering::SeqCst);
+        for event in &mut events {
+            event.generation = generation;
+        }
+        let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
+        buffered.extend(events);
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn inject_server_pressure_buffered_event_for_test(
+        &self,
+        request_log_id: Option<i64>,
+        created_at: i64,
+        result_status: &str,
+    ) {
+        let generation = self
+            .server_pressure_rebuild_generation
+            .load(Ordering::SeqCst);
+        let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
+        buffered.push(ServerPressureBufferedEvent {
+            generation,
+            request_log_id,
+            created_at,
+            result_status: result_status.to_string(),
+        });
     }
 
     pub fn spawn_server_pressure_buckets_rebuild_once(&self) -> bool {
@@ -917,20 +986,28 @@ impl TavilyProxy {
                             let drained = std::mem::take(&mut *buffered);
                             let (matching, retained): (Vec<_>, Vec<_>) = drained
                                 .into_iter()
-                                .partition(|event| event.generation == generation);
+                                .partition(|event| event.generation <= generation);
                             *buffered = retained;
                             matching
                         };
-                        for event in buffered_events {
+                        let mut replay_index = 0usize;
+                        while replay_index < buffered_events.len() {
+                            let event = &buffered_events[replay_index];
                             if event
                                 .request_log_id
                                 .is_some_and(|request_log_id| {
                                     request_log_id <= upper_bound_request_log_id
                                 })
                             {
+                                replay_index += 1;
                                 continue;
                             }
                             if !proxy.server_pressure_buckets_rebuild_is_active(generation) {
+                                proxy
+                                    .requeue_server_pressure_buffered_events(
+                                        buffered_events[replay_index..].to_vec(),
+                                    )
+                                    .await;
                                 return;
                             }
                             if let Err(err) = proxy
@@ -941,6 +1018,11 @@ impl TavilyProxy {
                                 )
                                 .await
                             {
+                                proxy
+                                    .requeue_server_pressure_buffered_events(
+                                        buffered_events[replay_index..].to_vec(),
+                                    )
+                                    .await;
                                 if proxy
                                     .server_pressure_rebuild_generation
                                     .load(Ordering::SeqCst)
@@ -959,6 +1041,7 @@ impl TavilyProxy {
                                 );
                                 return;
                             }
+                            replay_index += 1;
                         }
                         if proxy
                             .server_pressure_rebuild_generation

--- a/src/tavily_proxy/proxy_usage_and_metrics.rs
+++ b/src/tavily_proxy/proxy_usage_and_metrics.rs
@@ -402,11 +402,24 @@ impl TavilyProxy {
                 UserBusinessCallOutcome::Failure
             };
             self.user_business_calls_1h_window
-                .record_event(&event.user_id, event.created_at, outcome)
+                .record_event(&event.user_id, event.request_log_id, event.created_at, outcome)
                 .await;
-            self.key_store
-                .upsert_server_pressure_event(event.created_at, &event.result_status)
-                .await?;
+            if self.server_pressure_rebuild_started.load(Ordering::SeqCst) {
+                let generation = self
+                    .server_pressure_rebuild_generation
+                    .load(Ordering::SeqCst);
+                let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
+                buffered.push(ServerPressureBufferedEvent {
+                    generation,
+                    request_log_id: event.request_log_id,
+                    created_at: event.created_at,
+                    result_status: event.result_status.clone(),
+                });
+            } else {
+                self.key_store
+                    .upsert_server_pressure_event(event.created_at, &event.result_status)
+                    .await?;
+            }
         }
         Ok(())
     }
@@ -904,11 +917,24 @@ impl TavilyProxy {
                 UserBusinessCallOutcome::Failure
             };
             self.user_business_calls_1h_window
-                .record_event(&event.user_id, event.created_at, outcome)
+                .record_event(&event.user_id, event.request_log_id, event.created_at, outcome)
                 .await;
-            self.key_store
-                .upsert_server_pressure_event(event.created_at, &event.result_status)
-                .await?;
+            if self.server_pressure_rebuild_started.load(Ordering::SeqCst) {
+                let generation = self
+                    .server_pressure_rebuild_generation
+                    .load(Ordering::SeqCst);
+                let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
+                buffered.push(ServerPressureBufferedEvent {
+                    generation,
+                    request_log_id: event.request_log_id,
+                    created_at: event.created_at,
+                    result_status: event.result_status.clone(),
+                });
+            } else {
+                self.key_store
+                    .upsert_server_pressure_event(event.created_at, &event.result_status)
+                    .await?;
+            }
         }
         Ok(log_id)
     }

--- a/src/tavily_proxy/proxy_usage_and_metrics.rs
+++ b/src/tavily_proxy/proxy_usage_and_metrics.rs
@@ -404,22 +404,12 @@ impl TavilyProxy {
             self.user_business_calls_1h_window
                 .record_event(&event.user_id, event.request_log_id, event.created_at, outcome)
                 .await;
-            if self.server_pressure_rebuild_started.load(Ordering::SeqCst) {
-                let generation = self
-                    .server_pressure_rebuild_generation
-                    .load(Ordering::SeqCst);
-                let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
-                buffered.push(ServerPressureBufferedEvent {
-                    generation,
-                    request_log_id: event.request_log_id,
-                    created_at: event.created_at,
-                    result_status: event.result_status.clone(),
-                });
-            } else {
-                self.key_store
-                    .upsert_server_pressure_event(event.created_at, &event.result_status)
-                    .await?;
-            }
+            self.record_server_pressure_event(
+                event.request_log_id,
+                event.created_at,
+                &event.result_status,
+            )
+            .await?;
         }
         Ok(())
     }
@@ -919,22 +909,12 @@ impl TavilyProxy {
             self.user_business_calls_1h_window
                 .record_event(&event.user_id, event.request_log_id, event.created_at, outcome)
                 .await;
-            if self.server_pressure_rebuild_started.load(Ordering::SeqCst) {
-                let generation = self
-                    .server_pressure_rebuild_generation
-                    .load(Ordering::SeqCst);
-                let mut buffered = self.server_pressure_rebuild_buffered_events.lock().await;
-                buffered.push(ServerPressureBufferedEvent {
-                    generation,
-                    request_log_id: event.request_log_id,
-                    created_at: event.created_at,
-                    result_status: event.result_status.clone(),
-                });
-            } else {
-                self.key_store
-                    .upsert_server_pressure_event(event.created_at, &event.result_status)
-                    .await?;
-            }
+            self.record_server_pressure_event(
+                event.request_log_id,
+                event.created_at,
+                &event.result_status,
+            )
+            .await?;
         }
         Ok(log_id)
     }

--- a/src/tests/observability_and_lifecycle.rs
+++ b/src/tests/observability_and_lifecycle.rs
@@ -517,10 +517,13 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         CREATE TABLE request_logs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             api_key_id TEXT,
+            request_user_id TEXT,
             method TEXT NOT NULL,
             path TEXT NOT NULL,
             result_status TEXT NOT NULL DEFAULT 'success',
             failure_kind TEXT,
+            counts_business_quota INTEGER,
+            upstream_operation TEXT,
             request_kind_key TEXT,
             visibility TEXT NOT NULL DEFAULT 'visible',
             created_at INTEGER NOT NULL,
@@ -603,11 +606,25 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
     .execute(&pool)
     .await
     .expect("insert api key");
-    for (id, created_at) in [(1_i64, 100_i64), (2, 200), (4, 400)] {
+    let now_ts = Utc::now().timestamp();
+    for (id, created_at) in [(1_i64, now_ts - 400), (2, now_ts - 300), (4, now_ts - 100)] {
         sqlx::query(
             r#"
-            INSERT INTO request_logs (id, api_key_id, method, path, result_status, failure_kind, request_kind_key, visibility, created_at)
-            VALUES (?, 'k1', 'POST', '/api/tavily/search', 'success', NULL, 'api:search', 'visible', ?)
+            INSERT INTO request_logs (
+                id,
+                api_key_id,
+                request_user_id,
+                method,
+                path,
+                result_status,
+                failure_kind,
+                counts_business_quota,
+                upstream_operation,
+                request_kind_key,
+                visibility,
+                created_at
+            )
+            VALUES (?, 'k1', 'user-k1', 'POST', '/api/tavily/search', 'success', NULL, 1, 'search', 'api:search', 'visible', ?)
             "#,
         )
         .bind(id)
@@ -617,8 +634,9 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
         .expect("seed request log");
     }
     sqlx::query(
-        "INSERT INTO request_logs (id, api_key_id, method, path, result_status, failure_kind, request_kind_key, visibility, created_at) VALUES (3, 'k1', 'POST', '/api/tavily/search', 'error', 'upstream_rate_limited_429', 'api:search', 'visible', 300)",
+        "INSERT INTO request_logs (id, api_key_id, request_user_id, method, path, result_status, failure_kind, counts_business_quota, upstream_operation, request_kind_key, visibility, created_at) VALUES (3, 'k1', 'user-k1', 'POST', '/api/tavily/search', 'error', 'upstream_rate_limited_429', 1, 'search', 'api:search', 'visible', ?)",
     )
+    .bind(now_ts - 200)
     .execute(&pool)
     .await
     .expect("seed 429 request log");
@@ -695,6 +713,20 @@ async fn observability_sidecar_migrate_moves_large_legacy_request_logs_offline()
     .await
     .expect("query api key usage 429 count");
     assert_eq!(api_key_usage_429_count, 1);
+    let pressure_bucket_total: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(success_count + failure_count), 0)
+        FROM server_pressure_buckets
+        WHERE bucket_kind = 'five_minute'
+        "#,
+    )
+    .fetch_one(&migrated_pool)
+    .await
+    .expect("query migrated server pressure buckets");
+    assert_eq!(
+        pressure_bucket_total, 4,
+        "offline sidecar rebuild should repopulate server pressure buckets from migrated request logs"
+    );
     drop(migrated_pool);
 
     let rerun = run_observability_sidecar_migrate(&db_str, 2, false)

--- a/src/tests/user_business_calls_1h.rs
+++ b/src/tests/user_business_calls_1h.rs
@@ -348,10 +348,37 @@ async fn user_business_calls_1h_backfill_rehydrates_recent_request_logs() {
     .await
     .expect("reopen proxy");
 
-    let summary = reopened
+    let initial_summary = reopened
         .user_dashboard_summary(&user.user_id, None)
         .await
-        .expect("load backfilled summary");
+        .expect("load summary after startup backfill");
+    assert_eq!(initial_summary.business_calls_1h.success_count, 1);
+    assert_eq!(initial_summary.business_calls_1h.failure_count, 1);
+    assert_eq!(initial_summary.business_calls_1h.total_count, 2);
+
+    assert!(
+        reopened.spawn_user_business_calls_1h_backfill_once(),
+        "post-startup background backfill attempt should still schedule"
+    );
+    assert!(
+        !reopened.spawn_user_business_calls_1h_backfill_once(),
+        "concurrent background backfill attempts should dedupe"
+    );
+
+    let summary = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let summary = reopened
+                .user_dashboard_summary(&user.user_id, None)
+                .await
+                .expect("load post-startup refreshed summary");
+            if summary.business_calls_1h.total_count == 2 {
+                return summary;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("post-startup business-call refresh should complete in time");
     assert_eq!(summary.business_calls_1h.success_count, 1);
     assert_eq!(summary.business_calls_1h.failure_count, 1);
     assert_eq!(summary.business_calls_1h.total_count, 2);
@@ -539,6 +566,345 @@ async fn user_business_calls_1h_series_keeps_late_arriving_older_events_in_order
     assert_eq!(older_point.bars.failure, Some(0));
     assert_eq!(newer_point.bars.success, Some(0));
     assert_eq!(newer_point.bars.failure, Some(1));
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn user_business_calls_1h_backfill_preserves_live_events_after_snapshot_upper_bound() {
+    let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_300_000);
+    let db_path = temp_db_path("user-business-calls-1h-backfill-preserves-live-events");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time.clone(),
+    )
+    .await
+    .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "business-calls-backfill-live-race".to_string(),
+            username: Some("business_calls_backfill_live_race".to_string()),
+            name: Some("Business Calls Backfill Live Race".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("business-calls-backfill-live-race"))
+        .await
+        .expect("bind token");
+    let request_kind = TokenRequestKind::new("api:search", "API | search", None);
+    let now = manual_clock.now_ts();
+
+    let historical_request_log_id: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO request_logs (
+            method,
+            path,
+            status_code,
+            tavily_status_code,
+            result_status,
+            request_kind_key,
+            request_kind_label,
+            counts_business_quota,
+            request_user_id,
+            upstream_operation,
+            created_at
+        ) VALUES ('POST', '/api/tavily/search', 200, 200, 'success', 'api:search', 'API | search', 1, ?, 'http_search', ?)
+        RETURNING id
+        "#,
+    )
+    .bind(&user.user_id)
+    .bind(now - 20 * 60)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("insert historical request log");
+
+    let initial_summary = proxy
+        .user_dashboard_summary(&user.user_id, None)
+        .await
+        .expect("load summary before background backfill");
+    assert_eq!(initial_summary.business_calls_1h.total_count, 0);
+
+    assert!(
+        proxy.spawn_user_business_calls_1h_backfill_once(),
+        "initial background backfill should schedule"
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let summary = proxy
+                .user_dashboard_summary(&user.user_id, None)
+                .await
+                .expect("load summary after initial backfill");
+            if summary.business_calls_1h.total_count == 1 {
+                return summary;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("initial background backfill should complete in time");
+
+    let live_request_log_id: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO request_logs (
+            method,
+            path,
+            status_code,
+            tavily_status_code,
+            result_status,
+            request_kind_key,
+            request_kind_label,
+            counts_business_quota,
+            request_user_id,
+            upstream_operation,
+            created_at
+        ) VALUES ('POST', '/api/tavily/search', 500, 500, 'error', 'api:search', 'API | search', 1, ?, 'http_search', ?)
+        RETURNING id
+        "#,
+    )
+    .bind(&user.user_id)
+    .bind(now - 5 * 60)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("insert live request log");
+    manual_clock.set_now_ts(now);
+    proxy
+        .record_token_attempt_with_kind_request_log_metadata(
+            &token.id,
+            &Method::POST,
+            "/api/tavily/search",
+            Some("q=live"),
+            Some(500),
+            Some(500),
+            true,
+            "error",
+            Some("live startup request"),
+            &request_kind,
+            Some("upstream_error"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(live_request_log_id),
+        )
+        .await
+        .expect("record live request");
+
+    assert!(
+        proxy.spawn_user_business_calls_1h_backfill_once(),
+        "second background backfill should schedule"
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let summary = proxy
+                .user_dashboard_summary(&user.user_id, None)
+                .await
+                .expect("load summary after second backfill");
+            if summary.business_calls_1h.total_count == 2 {
+                return summary;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("second background backfill should preserve newer live event");
+
+    let summary = proxy
+        .user_dashboard_summary(&user.user_id, None)
+        .await
+        .expect("load summary after replay-safe backfill");
+    assert_eq!(historical_request_log_id + 1, live_request_log_id);
+    assert_eq!(summary.business_calls_1h.success_count, 1);
+    assert_eq!(summary.business_calls_1h.failure_count, 1);
+    assert_eq!(summary.business_calls_1h.total_count, 2);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn user_business_calls_1h_backfill_dedupes_same_request_log_event() {
+    let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_400_000);
+    let db_path = temp_db_path("user-business-calls-1h-backfill-dedupes-same-log");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time.clone(),
+    )
+    .await
+    .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "business-calls-backfill-dedupe".to_string(),
+            username: Some("business_calls_backfill_dedupe".to_string()),
+            name: Some("Business Calls Backfill Dedupe".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("business-calls-backfill-dedupe"))
+        .await
+        .expect("bind token");
+    let request_kind = TokenRequestKind::new("api:search", "API | search", None);
+    let now = manual_clock.now_ts();
+
+    let request_log_id: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO request_logs (
+            method,
+            path,
+            status_code,
+            tavily_status_code,
+            result_status,
+            request_kind_key,
+            request_kind_label,
+            counts_business_quota,
+            request_user_id,
+            upstream_operation,
+            created_at
+        ) VALUES ('POST', '/api/tavily/search', 200, 200, 'success', 'api:search', 'API | search', 1, ?, 'http_search', ?)
+        RETURNING id
+        "#,
+    )
+    .bind(&user.user_id)
+    .bind(now - 6 * 60)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("insert request log");
+    manual_clock.set_now_ts(now);
+    proxy
+        .record_token_attempt_with_kind_request_log_metadata(
+            &token.id,
+            &Method::POST,
+            "/api/tavily/search",
+            Some("q=dedupe"),
+            Some(200),
+            Some(200),
+            true,
+            OUTCOME_SUCCESS,
+            None,
+            &request_kind,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(request_log_id),
+        )
+        .await
+        .expect("record live request");
+
+    assert!(
+        proxy.spawn_user_business_calls_1h_backfill_once(),
+        "background backfill should schedule"
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let summary = proxy
+                .user_dashboard_summary(&user.user_id, None)
+                .await
+                .expect("load deduped summary while backfill runs");
+            if summary.business_calls_1h.total_count == 1 {
+                return summary;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("backfill should not double-count same request log");
+
+    let summary = proxy
+        .user_dashboard_summary(&user.user_id, None)
+        .await
+        .expect("load deduped summary");
+    assert_eq!(summary.business_calls_1h.success_count, 1);
+    assert_eq!(summary.business_calls_1h.failure_count, 0);
+    assert_eq!(summary.business_calls_1h.total_count, 1);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn user_business_calls_1h_metadata_free_token_logs_stay_out_of_live_business_window() {
+    let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_500_000);
+    let db_path = temp_db_path("user-business-calls-1h-no-request-log-metadata");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time,
+    )
+    .await
+    .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "business-calls-no-request-log-metadata".to_string(),
+            username: Some("business_calls_no_request_log_metadata".to_string()),
+            name: Some("Business Calls No Request Log Metadata".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(
+            &user.user_id,
+            Some("business-calls-no-request-log-metadata"),
+        )
+        .await
+        .expect("bind token");
+    let request_kind = TokenRequestKind::new("api:search", "API | search", None);
+    let now = manual_clock.now_ts();
+
+    manual_clock.set_now_ts(now);
+    proxy
+        .record_token_attempt_with_kind(
+            &token.id,
+            &Method::POST,
+            "/api/tavily/search",
+            Some("q=legacy-live"),
+            Some(200),
+            Some(200),
+            true,
+            OUTCOME_SUCCESS,
+            None,
+            &request_kind,
+        )
+        .await
+        .expect("record metadata-free token log");
+
+    let summary = proxy
+        .user_dashboard_summary(&user.user_id, None)
+        .await
+        .expect("load summary after metadata-free token log");
+    assert_eq!(summary.business_calls_1h.success_count, 0);
+    assert_eq!(summary.business_calls_1h.failure_count, 0);
+    assert_eq!(summary.business_calls_1h.total_count, 0);
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -360,6 +360,14 @@ async fn analysis_pressure_snapshot_background_rebuild_rehydrates_server_pressur
         !reopened.spawn_server_pressure_buckets_rebuild_once(),
         "background rebuild scheduling should be idempotent"
     );
+    assert!(
+        reopened.spawn_user_business_calls_1h_backfill_once(),
+        "reopened proxy should also schedule one business-call backfill"
+    );
+    assert!(
+        !reopened.spawn_user_business_calls_1h_backfill_once(),
+        "business-call backfill scheduling should be idempotent"
+    );
 
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
@@ -389,10 +397,22 @@ async fn analysis_pressure_snapshot_background_rebuild_rehydrates_server_pressur
         "expected rebuilt server pressure buckets, got {bucket_count}"
     );
 
-    let snapshot = reopened
-        .analysis_pressure_snapshot()
-        .await
-        .expect("analysis pressure snapshot after backfill");
+    let snapshot = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let snapshot = reopened
+                .analysis_pressure_snapshot()
+                .await
+                .expect("analysis pressure snapshot after backfill");
+            if snapshot.current_user_distribution.rows.len() == 1
+                && snapshot.current_user_distribution.rows[0].pressure == 2
+            {
+                return snapshot;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("analysis pressure user distribution should recover after background tasks");
     let current_point = snapshot
         .server_24h
         .current

--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -590,7 +590,7 @@ async fn analysis_pressure_background_rebuild_cancels_and_can_be_rescheduled() {
         reopened.spawn_server_pressure_buckets_rebuild_once(),
         "first background rebuild attempt should schedule"
     );
-    reopened.cancel_server_pressure_buckets_rebuild();
+    reopened.cancel_server_pressure_buckets_rebuild().await;
     lock_handle
         .await
         .expect("held sqlite write lock should release cleanly");
@@ -738,7 +738,7 @@ async fn analysis_pressure_background_rebuild_releases_latch_after_success() {
     })
     .await
     .expect("successful rebuild should release the latch so a later serving promotion can reschedule it");
-    reopened.cancel_server_pressure_buckets_rebuild();
+    reopened.cancel_server_pressure_buckets_rebuild().await;
 
     tokio::time::timeout(Duration::from_secs(8), async {
         loop {
@@ -766,6 +766,112 @@ async fn analysis_pressure_background_rebuild_releases_latch_after_success() {
         .current
         .last()
         .expect("latest current pressure point after reschedule");
+    assert_eq!(current_point.pressure, 2);
+    assert_eq!(current_point.success_count, 1);
+    assert_eq!(current_point.failure_count, 1);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn analysis_pressure_cancel_requeues_buffered_events_for_next_generation() {
+    let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_460_000);
+    let db_path = temp_db_path("analysis-pressure-cancel-requeues-buffered-events");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time.clone(),
+    )
+    .await
+    .expect("proxy created");
+
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "analysis-pressure-cancel-requeue".to_string(),
+            username: Some("cancel-requeue".to_string()),
+            name: Some("Cancel Requeue".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert cancel requeue user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("analysis-pressure-cancel-requeue"))
+        .await
+        .expect("bind cancel requeue token");
+    let request_kind = TokenRequestKind::new("api:search", "API | search", None);
+    let now = manual_clock.now_ts();
+
+    seed_pressure_attempt(
+        &proxy,
+        &manual_clock,
+        now,
+        &token.id,
+        &user.user_id,
+        now - 180,
+        OUTCOME_SUCCESS,
+        Some("search"),
+        &request_kind,
+    )
+    .await;
+    drop(proxy);
+
+    let reopened = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time,
+    )
+    .await
+    .expect("reopen proxy");
+
+    assert!(
+        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        "first background rebuild attempt should schedule"
+    );
+    reopened
+        .inject_server_pressure_buffered_event_for_test(Some(9_999), now - 30, OUTCOME_ERROR)
+        .await;
+    reopened.cancel_server_pressure_buckets_rebuild().await;
+
+    assert!(
+        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        "next serving generation should be able to reschedule rebuild"
+    );
+
+    tokio::time::timeout(Duration::from_secs(8), async {
+        loop {
+            let total_pressure: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(SUM(success_count + failure_count), 0) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
+            )
+            .fetch_one(&reopened.key_store.pool)
+            .await
+            .expect("sum rebuilt server pressure buckets after cancelled replay");
+            if total_pressure >= 2 {
+                return total_pressure;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("requeued buffered pressure event should be replayed by the next rebuild generation");
+
+    let snapshot = reopened
+        .analysis_pressure_snapshot()
+        .await
+        .expect("analysis pressure snapshot after requeued replay");
+    let current_point = snapshot
+        .server_24h
+        .current
+        .last()
+        .expect("latest current pressure point after requeued replay");
     assert_eq!(current_point.pressure, 2);
     assert_eq!(current_point.success_count, 1);
     assert_eq!(current_point.failure_count, 1);

--- a/src/tests/user_tokens_and_pending_billing.rs
+++ b/src/tests/user_tokens_and_pending_billing.rs
@@ -1031,6 +1031,8 @@ async fn startup_migration_preserves_legacy_mcp_session_retry_key_effects() {
     let _ = std::fs::remove_file(db_path);
 }
 
+include!("user_tokens_and_pending_billing_effect_bucket_cases.rs");
+
 #[tokio::test]
 async fn request_log_catalog_rollup_feeds_catalog_and_legacy_page() {
     let _guard = env_lock().lock_owned().await;

--- a/src/tests/user_tokens_and_pending_billing_effect_bucket_cases.rs
+++ b/src/tests/user_tokens_and_pending_billing_effect_bucket_cases.rs
@@ -1,0 +1,257 @@
+#[tokio::test]
+async fn startup_migration_repairs_partially_migrated_effect_bucket_rows() {
+    let db_path = temp_db_path("partial-effect-bucket-migration");
+    let db_str = db_path.to_string_lossy().to_string();
+
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let token = proxy
+        .create_access_token(Some("partial-effect-bucket-migration"))
+        .await
+        .expect("create token");
+    drop(proxy);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = Utc::now().timestamp();
+
+    sqlx::query(
+        r#"
+        INSERT INTO request_logs (
+            auth_token_id,
+            method,
+            path,
+            result_status,
+            key_effect_code,
+            key_effect_summary,
+            binding_effect_code,
+            binding_effect_summary,
+            visibility,
+            created_at
+        ) VALUES (?, 'POST', '/api/tavily/search', 'success', ?, 'legacy bound', ?, 'already bound', 'visible', ?)
+        "#,
+    )
+    .bind(&token.id)
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_PRESSURE_AVOIDED)
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_BOUND)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert partially migrated request log");
+
+    sqlx::query(
+        r#"
+        INSERT INTO auth_token_logs (
+            token_id,
+            method,
+            path,
+            result_status,
+            key_effect_code,
+            key_effect_summary,
+            selection_effect_code,
+            selection_effect_summary,
+            created_at
+        ) VALUES (?, 'POST', '/api/tavily/search', 'success', ?, 'legacy rebound', ?, 'already selected', ?)
+        "#,
+    )
+    .bind(&token.id)
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_REBOUND)
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_PRESSURE_AVOIDED)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert partially migrated token log");
+    sqlx::query("DELETE FROM meta WHERE key = ?")
+        .bind(META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE)
+        .execute(&pool)
+        .await
+        .expect("clear migration marker to simulate interrupted migration");
+    drop(pool);
+
+    let migrated_proxy =
+        TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+            .await
+            .expect("proxy reopened for partial migration repair");
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let request_row = sqlx::query(
+        r#"
+        SELECT key_effect_code, binding_effect_code, selection_effect_code
+        FROM request_logs
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read repaired request log");
+    assert_eq!(
+        request_row
+            .try_get::<String, _>("key_effect_code")
+            .expect("request key effect code"),
+        KEY_EFFECT_NONE
+    );
+    assert_eq!(
+        request_row
+            .try_get::<String, _>("binding_effect_code")
+            .expect("request binding effect code"),
+        KEY_EFFECT_HTTP_PROJECT_AFFINITY_BOUND
+    );
+    assert_eq!(
+        request_row
+            .try_get::<String, _>("selection_effect_code")
+            .expect("request selection effect code"),
+        KEY_EFFECT_HTTP_PROJECT_AFFINITY_PRESSURE_AVOIDED
+    );
+
+    let token_row = sqlx::query(
+        r#"
+        SELECT key_effect_code, binding_effect_code, selection_effect_code
+        FROM auth_token_logs
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read repaired token log");
+    assert_eq!(
+        token_row
+            .try_get::<String, _>("key_effect_code")
+            .expect("token key effect code"),
+        KEY_EFFECT_NONE
+    );
+    assert_eq!(
+        token_row
+            .try_get::<String, _>("binding_effect_code")
+            .expect("token binding effect code"),
+        KEY_EFFECT_HTTP_PROJECT_AFFINITY_REBOUND
+    );
+    assert_eq!(
+        token_row
+            .try_get::<String, _>("selection_effect_code")
+            .expect("token selection effect code"),
+        KEY_EFFECT_HTTP_PROJECT_AFFINITY_PRESSURE_AVOIDED
+    );
+
+    assert_eq!(
+        migrated_proxy
+            .key_store
+            .get_meta_i64(META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE)
+            .await
+            .expect("read migration marker"),
+        Some(1)
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn effect_bucket_migration_precheck_ignores_main_request_logs_leftovers() {
+    let db_path = temp_db_path("effect-bucket-migration-observability-precheck");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = Utc::now().timestamp();
+
+    sqlx::query(
+        r#"
+        CREATE TABLE request_logs AS
+        SELECT * FROM observability.request_logs WHERE 0
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create misleading main request_logs leftover");
+
+    sqlx::query(
+        r#"
+        INSERT INTO request_logs (
+            method,
+            path,
+            result_status,
+            key_effect_code,
+            binding_effect_code,
+            selection_effect_code,
+            visibility,
+            created_at
+        ) VALUES ('POST', '/api/tavily/search', 'success', 'none', ?, ?, 'visible', ?)
+        "#,
+    )
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_BOUND)
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_PRESSURE_AVOIDED)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert clean leftover main request log");
+
+    sqlx::query(
+        r#"
+        INSERT INTO observability.request_logs (
+            method,
+            path,
+            result_status,
+            key_effect_code,
+            key_effect_summary,
+            binding_effect_code,
+            selection_effect_code,
+            visibility,
+            created_at
+        ) VALUES ('POST', '/api/tavily/search', 'success', ?, 'legacy bound', 'none', 'none', 'visible', ?)
+        "#,
+    )
+    .bind(KEY_EFFECT_HTTP_PROJECT_AFFINITY_BOUND)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("insert dirty observability request log");
+
+    sqlx::query("DELETE FROM meta WHERE key = ?")
+        .bind(META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE)
+        .execute(&pool)
+        .await
+        .expect("clear migration marker");
+
+    proxy
+        .key_store
+        .rerun_log_effect_bucket_migration_for_test()
+        .await
+        .expect("rerun effect-bucket migration");
+
+    let observability_row = sqlx::query(
+        r#"
+        SELECT key_effect_code, binding_effect_code
+        FROM observability.request_logs
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read repaired observability row");
+    assert_eq!(
+        observability_row
+            .try_get::<String, _>("key_effect_code")
+            .expect("observability key effect code"),
+        KEY_EFFECT_NONE
+    );
+    assert_eq!(
+        observability_row
+            .try_get::<String, _>("binding_effect_code")
+            .expect("observability binding effect code"),
+        KEY_EFFECT_HTTP_PROJECT_AFFINITY_BOUND
+    );
+
+    assert_eq!(
+        proxy
+            .key_store
+            .get_meta_i64(META_KEY_REQUEST_LOG_EFFECT_BUCKET_MIGRATION_V1_DONE)
+            .await
+            .expect("read migration marker"),
+        Some(1)
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
## Summary
- keep serving `/health` strict: no startup grace for serving roles, but preserve standby/recovery carve-out
- align container healthy with first strict `/health` success instead of an extra fixed success floor
- remove remaining startup-path pressure rebuild and harden cheap startup repairs for owner-facing usage views

## Validation
- `cargo clippy -- -D warnings`
- `cargo test tests::user_business_calls_1h::user_business_calls_1h_backfill_rehydrates_recent_request_logs -- --exact`
- `cargo test tests::user_tokens_and_pending_billing::startup_migration_repairs_partially_migrated_effect_bucket_rows -- --exact`
- `cargo test tests::user_tokens_and_pending_billing::effect_bucket_migration_precheck_ignores_main_request_logs_leftovers -- --exact`
- `cargo test server::tests::system_settings_and_forward_proxy::serving_health_ignores_startup_grace_and_requires_xray_readiness -- --exact`
- shared testbox `codex-testbox` isolated run `20260628_0806_6949c0fe_p1r2`
  - positive smoke: `readyAtSec=2`, `healthyAtSec=5`
  - negative-xray smoke: `firstUnreadyAtSec=2`, `observedSec=35`
- codex review proof on `6949c0fe44e33f2125ccb8f85f6930ab1ba69c85`: no findings

## References
Spec: docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
Spec Disposition: update
Spec Sync: done
Spec Drift: resolved
Solutions: docs/solutions/operations/sqlite-write-lock-contention.md
Solutions Sync: done
Project Docs: -
Project Docs Sync: n/a(no project-doc change)

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
