### PR TITLE
fix: recover dashboard overview snapshot stalls

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -83,6 +83,10 @@ reads:
   disabled-token or recent-job reads fail, keep the core overview payload serving and let the
   optional slice surface `error`/empty coverage semantics on the next snapshot rather than timing
   out the whole admin page.
+- Make dashboard shared-snapshot singleflight cancellation-safe and timeout-bounded. If one
+  snapshot build stalls on a SQLite read, the request may fail fast, but it must clear the in-memory
+  `loading` flag and wake waiters so the next request can retry instead of leaving the whole admin
+  dashboard permanently stuck on `cache_wait`.
 - Keep default structured perf logs on the owner-facing read path itself. Dashboard overview/shared
   snapshot and recent-request list/catalog endpoints should emit stable `component=admin_read event=...` records with `elapsed_ms`, route/scope metadata, and runtime memory headroom so low
   memory protection can be triggered and diagnosed without ad-hoc debug builds.
@@ -150,6 +154,11 @@ reads:
   `HTTP 000 TOTAL 19.999741`, while the real `/admin/dashboard` shell still rendered and multiple
   tiles stayed stuck on `正在加载仪表盘数据…`. That combination is the signal that the dashboard
   shared-snapshot path itself has become the bottleneck, not the shell or auth path.
+- On 2026-07-03 the same failure shape was isolated to the shared-snapshot coordination state:
+  direct in-container `/api/dashboard/overview` requests timed out with zero bytes while other admin
+  APIs returned, and logs showed repeated `phase=cache_wait` without a matching
+  `overview_payload_build` completion. The fix is to bound and release failed snapshot builds,
+  then continue query-level optimization separately.
 
 ## Guardrails / Reuse Notes
 

--- a/docs/specs/66t8u-admin-dashboard-overview-performance/HISTORY.md
+++ b/docs/specs/66t8u-admin-dashboard-overview-performance/HISTORY.md
@@ -4,3 +4,11 @@
 
 - Corrected the dashboard traffic trend default window from a fixed "today" frame to a rolling 24-hour hourly window.
 - Aligned the dashboard overview story copy and tests with the new hourly trend semantics.
+
+## 2026-07-03
+
+- Hardened the shared dashboard overview snapshot singleflight so timed-out or cancelled payload
+  builds release `loading` and wake waiters.
+- Added a regression test that gates payload construction, verifies the build timeout surfaces as
+  an error instead of an indefinite wait, then confirms a later overview request can rebuild a real
+  snapshot.

--- a/docs/specs/66t8u-admin-dashboard-overview-performance/IMPLEMENTATION.md
+++ b/docs/specs/66t8u-admin-dashboard-overview-performance/IMPLEMENTATION.md
@@ -2,16 +2,22 @@
 
 ## Status
 
-- Status: Rolling 24-hour trend window implemented
-- Last: 2026-06-29
+- Status: Shared snapshot timeout recovery implemented
+- Last: 2026-07-03
 
 ## Coverage
 
 - Dashboard overview now uses a rolling 24-hour hourly window for the default traffic trend chart.
 - The window ends at the current visible hour bucket and leaves missing buckets blank.
 - Storybook copy and hourly chart tests were updated to match the chart behavior.
+- The shared dashboard overview snapshot loader is cancellation-safe: an abandoned or timed-out
+  payload build releases the singleflight `loading` state and wakes waiters.
+- Dashboard overview payload builds have a bounded wall-clock budget. A timed-out build returns a
+  clear error for that request, but the next request can rebuild the shared snapshot instead of
+  staying behind a stale `cache_wait`.
 
 ## Notes
 
 - The dashboard overview payload shape and SSE snapshot contract are unchanged.
-- The change is limited to default trend-window construction and the related presentation copy.
+- The timeout guard protects the shared snapshot coordination layer. It does not replace the
+  existing query-level performance work for large SQLite datasets.

--- a/src/server/handlers/public.rs
+++ b/src/server/handlers/public.rs
@@ -826,6 +826,10 @@ const DASHBOARD_TREND_WINDOW_SIZE: usize = 8;
 const DASHBOARD_RECENT_JOBS_LIMIT: usize = 5;
 const DASHBOARD_DISABLED_TOKENS_LIMIT: usize = 5;
 const DASHBOARD_DISABLED_TOKENS_QUERY_LIMIT: usize = DASHBOARD_DISABLED_TOKENS_LIMIT + 1;
+#[cfg(not(test))]
+const DASHBOARD_OVERVIEW_BUILD_TIMEOUT: Duration = Duration::from_secs(15);
+#[cfg(test)]
+const DASHBOARD_OVERVIEW_BUILD_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Clone, Serialize)]
 struct DashboardTrendView {
@@ -866,6 +870,35 @@ struct DashboardOverviewPayload {
 struct DashboardOverviewSnapshot {
     payload: DashboardOverviewPayload,
     freshness: DashboardOverviewFreshness,
+}
+
+struct DashboardOverviewLoadingGuard {
+    cache_handle: Option<Arc<Mutex<DashboardOverviewCacheState>>>,
+}
+
+impl DashboardOverviewLoadingGuard {
+    fn new(cache_handle: Arc<Mutex<DashboardOverviewCacheState>>) -> Self {
+        Self {
+            cache_handle: Some(cache_handle),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.cache_handle = None;
+    }
+}
+
+impl Drop for DashboardOverviewLoadingGuard {
+    fn drop(&mut self) {
+        let Some(cache_handle) = self.cache_handle.take() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let mut cache = cache_handle.lock().await;
+            cache.loading = false;
+            cache.notify.notify_waiters();
+        });
+    }
 }
 
 #[cfg(test)]
@@ -1152,8 +1185,14 @@ async fn build_dashboard_overview_payload(
     #[cfg(test)]
     {
         let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
-        let mut cache = cache_handle.lock().await;
-        cache.build_count = cache.build_count.saturating_add(1);
+        let build_gate = {
+            let mut cache = cache_handle.lock().await;
+            cache.build_count = cache.build_count.saturating_add(1);
+            cache.build_gate.clone()
+        };
+        if let Some(build_gate) = build_gate {
+            build_gate.notified().await;
+        }
     }
 
     let summary = state.proxy.summary().await?;
@@ -1688,8 +1727,28 @@ async fn load_dashboard_overview_snapshot(
             continue;
         }
 
+        let mut loading_guard = DashboardOverviewLoadingGuard::new(cache_handle.clone());
         let payload_started = Instant::now();
-        let result = build_dashboard_overview_payload(state).await;
+        let result = match tokio::time::timeout(
+            DASHBOARD_OVERVIEW_BUILD_TIMEOUT,
+            build_dashboard_overview_payload(state),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(ProxyError::Other(
+                "dashboard overview snapshot build timed out".to_string(),
+            )),
+        };
+        let build_degraded = match result.as_ref() {
+            Ok(_) => "rebuilt",
+            Err(ProxyError::Other(message))
+                if message == "dashboard overview snapshot build timed out" =>
+            {
+                "timeout"
+            }
+            Err(_) => "error",
+        };
         tavily_hikari::emit_perf_log(
             tavily_hikari::DbLogStatus::Info,
             "admin_read",
@@ -1699,7 +1758,7 @@ async fn load_dashboard_overview_snapshot(
                 route: Some("/api/dashboard/overview"),
                 scope: Some("dashboard"),
                 phase: Some("overview_payload_build"),
-                degraded: Some("rebuilt"),
+                degraded: Some(build_degraded),
                 ..Default::default()
             },
         );
@@ -1737,6 +1796,7 @@ async fn load_dashboard_overview_snapshot(
             );
         }
         cache.notify.notify_waiters();
+        loading_guard.disarm();
         return result;
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -58,6 +58,8 @@ struct DashboardOverviewCacheState {
     loading: bool,
     notify: Arc<tokio::sync::Notify>,
     #[cfg(test)]
+    build_gate: Option<Arc<tokio::sync::Notify>>,
+    #[cfg(test)]
     build_count: usize,
 }
 
@@ -67,6 +69,8 @@ impl Default for DashboardOverviewCacheState {
             cached: None,
             loading: false,
             notify: Arc::new(tokio::sync::Notify::new()),
+            #[cfg(test)]
+            build_gate: None,
             #[cfg(test)]
             build_count: 0,
         }

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -3,6 +3,39 @@ use super::core_support_and_parsing::*;
 use super::linuxdo_oauth_and_admin_keys::*;
 use super::upstream_support_and_manual_jobs::*;
 
+fn dashboard_overview_test_state(proxy: TavilyProxy) -> Arc<AppState> {
+    Arc::new(AppState {
+        proxy,
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+        dev_open_admin: false,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    })
+}
+
+async fn install_dashboard_overview_build_gate(
+    state: &Arc<AppState>,
+) -> Arc<tokio::sync::Notify> {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
+    let mut cache = cache_handle.lock().await;
+    cache.build_gate = Some(gate.clone());
+    gate
+}
+
+async fn clear_dashboard_overview_build_gate(state: &Arc<AppState>) {
+    let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
+    let mut cache = cache_handle.lock().await;
+    cache.build_gate = None;
+}
+
 #[tokio::test]
 async fn compute_signatures_reuses_dashboard_boundary_contract() {
     let db_path = temp_db_path("summary-signatures-dashboard-boundaries");
@@ -64,6 +97,47 @@ async fn compute_signatures_reuses_dashboard_boundary_contract() {
         "SSE freshness should inherit the same pending dashboard rollup signature that the rebuilt snapshot stores",
     );
     assert_eq!(latest_id, snapshot.freshness.latest_request_log_id);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn dashboard_overview_snapshot_recovers_after_timed_out_build() {
+    let db_path = temp_db_path("dashboard-overview-timed-out-build");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-dashboard-overview-timed-out-build".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let state = dashboard_overview_test_state(proxy);
+    let gate = install_dashboard_overview_build_gate(&state).await;
+
+    let timed_out = tokio::time::timeout(Duration::from_secs(2), load_dashboard_overview_snapshot(&state))
+    .await
+    .expect("dashboard overview should fail on its internal build timeout instead of hanging forever");
+    assert!(
+        timed_out
+            .expect_err("gated dashboard overview build should time out")
+            .to_string()
+            .contains("dashboard overview snapshot build timed out"),
+        "timed-out dashboard overview should surface a clear timeout error",
+    );
+
+    clear_dashboard_overview_build_gate(&state).await;
+    gate.notify_waiters();
+
+    let recovered = tokio::time::timeout(Duration::from_secs(2), load_dashboard_overview_snapshot(&state))
+        .await
+        .expect("dashboard overview should recover instead of waiting forever after a timed-out build")
+        .expect("recovered dashboard overview snapshot");
+
+    assert!(
+        !recovered.payload.month_series.current.is_empty(),
+        "recovered snapshot should be a real dashboard overview payload",
+    );
 
     let _ = std::fs::remove_file(db_path);
 }


### PR DESCRIPTION
## Summary
- Add a timeout-bounded, cancellation-safe guard around the shared dashboard overview snapshot build.
- Add a regression test proving a timed-out build does not leave later dashboard overview requests stuck behind `cache_wait`.
- Update the dashboard performance spec and SQLite admin read containment solution notes.

## Validation
- `cargo test dashboard_overview_snapshot_recovers_after_timed_out_build -- --nocapture`
- `cargo test dashboard_overview_snapshot -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- commit hook: `fmt`, `format-markdown`, `clippy`, `commitlint`

## References
Spec: `docs/specs/66t8u-admin-dashboard-overview-performance/SPEC.md`
Spec Disposition: update
Spec Sync: done
Spec Drift: none

Solutions:
- `docs/solutions/operations/sqlite-admin-read-containment.md`

Solutions Sync: done

Project Docs: -
Project Docs Sync: n/a(no project-doc change)

## Notes
This change does not restart or deploy the production service. The live dashboard still needs a deployment, and the currently stuck in-memory loader on production may need a restart after owner approval.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
