### PR TITLE
fix(admin): recover dashboard overview loader stalls

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -83,6 +83,12 @@ reads:
   disabled-token or recent-job reads fail, keep the core overview payload serving and let the
   optional slice surface `error`/empty coverage semantics on the next snapshot rather than timing
   out the whole admin page.
+- Guard shared admin snapshot loaders with both a drop-time reset and a stale-loading takeover
+  window. A cancelled or wedged request must not leave `loading=true` forever and make every later
+  request wait on a `Notify` that will never fire.
+- Keep optional freshness tokens on a short deadline and derive a conservative token from the
+  already-built optional summary when the dedicated token query is slow or unavailable. Freshness
+  precision is less important than preserving first paint for the owner-facing dashboard.
 - Keep default structured perf logs on the owner-facing read path itself. Dashboard overview/shared
   snapshot and recent-request list/catalog endpoints should emit stable `component=admin_read event=...` records with `elapsed_ms`, route/scope metadata, and runtime memory headroom so low
   memory protection can be triggered and diagnosed without ad-hoc debug builds.

--- a/src/server/handlers/public.rs
+++ b/src/server/handlers/public.rs
@@ -826,6 +826,8 @@ const DASHBOARD_TREND_WINDOW_SIZE: usize = 8;
 const DASHBOARD_RECENT_JOBS_LIMIT: usize = 5;
 const DASHBOARD_DISABLED_TOKENS_LIMIT: usize = 5;
 const DASHBOARD_DISABLED_TOKENS_QUERY_LIMIT: usize = DASHBOARD_DISABLED_TOKENS_LIMIT + 1;
+const DASHBOARD_OVERVIEW_LOADING_STALE_AFTER: Duration = Duration::from_secs(30);
+const DASHBOARD_RECENT_ALERTS_TOKEN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Serialize)]
 struct DashboardTrendView {
@@ -866,6 +868,39 @@ struct DashboardOverviewPayload {
 struct DashboardOverviewSnapshot {
     payload: DashboardOverviewPayload,
     freshness: DashboardOverviewFreshness,
+}
+
+struct DashboardOverviewLoadGuard {
+    state: Arc<Mutex<DashboardOverviewCacheState>>,
+    armed: bool,
+}
+
+impl DashboardOverviewLoadGuard {
+    fn new(state: Arc<Mutex<DashboardOverviewCacheState>>) -> Self {
+        Self { state, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for DashboardOverviewLoadGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            let mut cache = state.lock().await;
+            if cache.loading {
+                cache.loading = false;
+                cache.loading_started_at = None;
+                cache.notify.notify_waiters();
+            }
+        });
+    }
 }
 
 #[cfg(test)]
@@ -1243,7 +1278,7 @@ async fn build_dashboard_overview_payload(
         .dashboard_recent_alerts_summary(24)
         .await
         .unwrap_or_else(|_| tavily_hikari::RecentAlertsSummary::default());
-    let recent_alerts_token = state.proxy.dashboard_recent_alerts_token(24).await?;
+    let recent_alerts_token = dashboard_recent_alerts_token_or_fallback(state, 24, &recent_alerts).await;
     let (mut disabled_tokens, token_coverage) = match state
         .proxy
         .list_dashboard_disabled_tokens(DASHBOARD_DISABLED_TOKENS_QUERY_LIMIT)
@@ -1376,6 +1411,58 @@ async fn dashboard_recent_alerts_freshness(
     window_hours: i64,
 ) -> Result<tavily_hikari::RecentAlertsSummary, ProxyError> {
     state.proxy.dashboard_recent_alerts_summary(window_hours).await
+}
+
+fn fallback_recent_alerts_token(summary: &tavily_hikari::RecentAlertsSummary) -> [i64; 4] {
+    let top_group_last_seen_sum = summary
+        .top_groups
+        .iter()
+        .map(|group| group.last_seen)
+        .sum::<i64>();
+    let typed_count_sum = summary
+        .counts_by_type
+        .iter()
+        .map(|item| item.count)
+        .sum::<i64>();
+    [
+        summary.total_events,
+        summary.grouped_count,
+        top_group_last_seen_sum,
+        typed_count_sum,
+    ]
+}
+
+async fn dashboard_recent_alerts_token_or_fallback(
+    state: &Arc<AppState>,
+    window_hours: i64,
+    summary: &tavily_hikari::RecentAlertsSummary,
+) -> [i64; 4] {
+    match tokio::time::timeout(
+        DASHBOARD_RECENT_ALERTS_TOKEN_TIMEOUT,
+        state.proxy.dashboard_recent_alerts_token(window_hours),
+    )
+    .await
+    {
+        Ok(Ok(token)) => token,
+        Ok(Err(err)) => {
+            tracing::warn!(
+                component = "admin_read",
+                event = "dashboard_recent_alerts_token_degraded",
+                err = %err,
+                "dashboard recent-alerts token degraded to summary-derived freshness"
+            );
+            fallback_recent_alerts_token(summary)
+        }
+        Err(_) => {
+            tracing::warn!(
+                component = "admin_read",
+                event = "dashboard_recent_alerts_token_timeout",
+                timeout_ms = DASHBOARD_RECENT_ALERTS_TOKEN_TIMEOUT.as_millis() as u64,
+                "dashboard recent-alerts token timed out; using summary-derived freshness"
+            );
+            fallback_recent_alerts_token(summary)
+        }
+    }
 }
 
 fn dashboard_retention_since(retention_days: i64, now: chrono::DateTime<Local>) -> i64 {
@@ -1540,7 +1627,7 @@ async fn compute_dashboard_overview_freshness(
     let recent_alerts = dashboard_recent_alerts_freshness(state, 24)
         .await
         .unwrap_or_else(|_| tavily_hikari::RecentAlertsSummary::default());
-    let recent_alerts_token = state.proxy.dashboard_recent_alerts_token(24).await?;
+    let recent_alerts_token = dashboard_recent_alerts_token_or_fallback(state, 24, &recent_alerts).await;
     Ok(DashboardOverviewFreshness {
         summary: [
             summary.total_requests,
@@ -1603,9 +1690,25 @@ async fn load_dashboard_overview_snapshot(
     loop {
         let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
         let waiter = {
-            let cache = cache_handle.lock().await;
+            let mut cache = cache_handle.lock().await;
             if cache.loading {
-                Some(cache.notify.clone().notified_owned())
+                let stale = cache
+                    .loading_started_at
+                    .is_some_and(|started_at| started_at.elapsed() >= DASHBOARD_OVERVIEW_LOADING_STALE_AFTER);
+                if stale {
+                    tracing::warn!(
+                        component = "admin_read",
+                        event = "dashboard_overview_loading_stale",
+                        stale_after_ms = DASHBOARD_OVERVIEW_LOADING_STALE_AFTER.as_millis() as u64,
+                        "dashboard overview shared snapshot loader was stale; allowing a new request to rebuild"
+                    );
+                    cache.loading = false;
+                    cache.loading_started_at = None;
+                    cache.notify.notify_waiters();
+                    None
+                } else {
+                    Some(cache.notify.clone().notified_owned())
+                }
             } else {
                 None
             }
@@ -1676,9 +1779,25 @@ async fn load_dashboard_overview_snapshot(
                 return Ok(cached.snapshot.clone());
             }
             if cache.loading {
-                Some(cache.notify.clone().notified_owned())
+                let stale = cache
+                    .loading_started_at
+                    .is_some_and(|started_at| started_at.elapsed() >= DASHBOARD_OVERVIEW_LOADING_STALE_AFTER);
+                if stale {
+                    tracing::warn!(
+                        component = "admin_read",
+                        event = "dashboard_overview_loading_stale",
+                        stale_after_ms = DASHBOARD_OVERVIEW_LOADING_STALE_AFTER.as_millis() as u64,
+                        "dashboard overview shared snapshot loader was stale after freshness probe; taking over rebuild"
+                    );
+                    cache.loading = true;
+                    cache.loading_started_at = Some(tokio::time::Instant::now());
+                    None
+                } else {
+                    Some(cache.notify.clone().notified_owned())
+                }
             } else {
                 cache.loading = true;
+                cache.loading_started_at = Some(tokio::time::Instant::now());
                 None
             }
         };
@@ -1689,6 +1808,7 @@ async fn load_dashboard_overview_snapshot(
         }
 
         let payload_started = Instant::now();
+        let mut load_guard = DashboardOverviewLoadGuard::new(cache_handle.clone());
         let result = build_dashboard_overview_payload(state).await;
         tavily_hikari::emit_perf_log(
             tavily_hikari::DbLogStatus::Info,
@@ -1705,6 +1825,7 @@ async fn load_dashboard_overview_snapshot(
         );
         let mut cache = cache_handle.lock().await;
         cache.loading = false;
+        cache.loading_started_at = None;
         if let Ok(snapshot) = result.as_ref() {
             cache.cached = Some(CachedDashboardOverviewSnapshot {
                 snapshot: snapshot.clone(),
@@ -1737,6 +1858,7 @@ async fn load_dashboard_overview_snapshot(
             );
         }
         cache.notify.notify_waiters();
+        load_guard.disarm();
         return result;
     }
 }

--- a/src/server/handlers/public.rs
+++ b/src/server/handlers/public.rs
@@ -872,12 +872,17 @@ struct DashboardOverviewSnapshot {
 
 struct DashboardOverviewLoadGuard {
     state: Arc<Mutex<DashboardOverviewCacheState>>,
+    generation: u64,
     armed: bool,
 }
 
 impl DashboardOverviewLoadGuard {
-    fn new(state: Arc<Mutex<DashboardOverviewCacheState>>) -> Self {
-        Self { state, armed: true }
+    fn new(state: Arc<Mutex<DashboardOverviewCacheState>>, generation: u64) -> Self {
+        Self {
+            state,
+            generation,
+            armed: true,
+        }
     }
 
     fn disarm(&mut self) {
@@ -892,9 +897,10 @@ impl Drop for DashboardOverviewLoadGuard {
         }
 
         let state = self.state.clone();
+        let generation = self.generation;
         tokio::spawn(async move {
             let mut cache = state.lock().await;
-            if cache.loading {
+            if cache.loading && cache.loading_generation == generation {
                 cache.loading = false;
                 cache.loading_started_at = None;
                 cache.notify.notify_waiters();
@@ -1748,6 +1754,7 @@ async fn load_dashboard_overview_snapshot(
             },
         );
 
+        let mut load_generation = None;
         let waiter = {
             let mut cache = cache_handle.lock().await;
             if let Some(cached) = cache.cached.as_ref()
@@ -1790,14 +1797,18 @@ async fn load_dashboard_overview_snapshot(
                         "dashboard overview shared snapshot loader was stale after freshness probe; taking over rebuild"
                     );
                     cache.loading = true;
+                    cache.loading_generation = cache.loading_generation.wrapping_add(1);
                     cache.loading_started_at = Some(tokio::time::Instant::now());
+                    load_generation = Some(cache.loading_generation);
                     None
                 } else {
                     Some(cache.notify.clone().notified_owned())
                 }
             } else {
                 cache.loading = true;
+                cache.loading_generation = cache.loading_generation.wrapping_add(1);
                 cache.loading_started_at = Some(tokio::time::Instant::now());
+                load_generation = Some(cache.loading_generation);
                 None
             }
         };
@@ -1807,8 +1818,9 @@ async fn load_dashboard_overview_snapshot(
             continue;
         }
 
+        let load_generation = load_generation.expect("dashboard overview loader generation should be assigned");
         let payload_started = Instant::now();
-        let mut load_guard = DashboardOverviewLoadGuard::new(cache_handle.clone());
+        let mut load_guard = DashboardOverviewLoadGuard::new(cache_handle.clone(), load_generation);
         let result = build_dashboard_overview_payload(state).await;
         tavily_hikari::emit_perf_log(
             tavily_hikari::DbLogStatus::Info,
@@ -1824,6 +1836,18 @@ async fn load_dashboard_overview_snapshot(
             },
         );
         let mut cache = cache_handle.lock().await;
+        if cache.loading_generation != load_generation {
+            tracing::warn!(
+                component = "admin_read",
+                event = "dashboard_overview_loader_superseded",
+                loader_generation = load_generation,
+                current_generation = cache.loading_generation,
+                "dashboard overview loader finished after a newer loader took ownership"
+            );
+            load_guard.disarm();
+            return result;
+        }
+
         cache.loading = false;
         cache.loading_started_at = None;
         if let Ok(snapshot) = result.as_ref() {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -56,6 +56,7 @@ struct CachedDashboardOverviewSnapshot {
 struct DashboardOverviewCacheState {
     cached: Option<CachedDashboardOverviewSnapshot>,
     loading: bool,
+    loading_started_at: Option<tokio::time::Instant>,
     notify: Arc<tokio::sync::Notify>,
     #[cfg(test)]
     build_count: usize,
@@ -66,6 +67,7 @@ impl Default for DashboardOverviewCacheState {
         Self {
             cached: None,
             loading: false,
+            loading_started_at: None,
             notify: Arc::new(tokio::sync::Notify::new()),
             #[cfg(test)]
             build_count: 0,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -57,6 +57,7 @@ struct DashboardOverviewCacheState {
     cached: Option<CachedDashboardOverviewSnapshot>,
     loading: bool,
     loading_started_at: Option<tokio::time::Instant>,
+    loading_generation: u64,
     notify: Arc<tokio::sync::Notify>,
     #[cfg(test)]
     build_count: usize,
@@ -68,6 +69,7 @@ impl Default for DashboardOverviewCacheState {
             cached: None,
             loading: false,
             loading_started_at: None,
+            loading_generation: 0,
             notify: Arc::new(tokio::sync::Notify::new()),
             #[cfg(test)]
             build_count: 0,

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -124,6 +124,61 @@ async fn dashboard_overview_snapshot_is_reused_within_the_same_freshness_wave() 
 }
 
 #[tokio::test]
+async fn dashboard_overview_snapshot_recovers_from_stale_loading_flag() {
+    let db_path = temp_db_path("dashboard-overview-stale-loading-flag");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-dashboard-overview-stale-loading-flag".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let state = Arc::new(AppState {
+        proxy,
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+        dev_open_admin: false,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    });
+
+    {
+        let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
+        let mut cache = cache_handle.lock().await;
+        cache.loading = true;
+        cache.loading_started_at =
+            Some(tokio::time::Instant::now() - DASHBOARD_OVERVIEW_LOADING_STALE_AFTER - Duration::from_secs(1));
+    }
+
+    let snapshot = tokio::time::timeout(
+        Duration::from_secs(5),
+        load_dashboard_overview_snapshot(&state),
+    )
+    .await
+    .expect("stale loading flag should not block forever")
+    .expect("overview snapshot should rebuild after stale loading flag");
+
+    assert!(
+        !snapshot.payload.month_series.current.is_empty(),
+        "recovered overview should still include normal dashboard data",
+    );
+    assert!(
+        dashboard_overview_build_count(&state).await >= 1,
+        "stale loading recovery should take over and rebuild the shared snapshot",
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn dashboard_overview_freshness_advances_on_five_minute_window_anchor() {
     let first_anchor = dashboard_hourly_window_anchor(1_774_070_520);
     let second_anchor = dashboard_hourly_window_anchor(1_774_070_700);

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -179,6 +179,40 @@ async fn dashboard_overview_snapshot_recovers_from_stale_loading_flag() {
 }
 
 #[tokio::test]
+async fn dashboard_overview_load_guard_does_not_clear_newer_loader_generation() {
+    let cache_handle = new_dashboard_overview_cache();
+    {
+        let mut cache = cache_handle.lock().await;
+        cache.loading = true;
+        cache.loading_generation = 1;
+        cache.loading_started_at = Some(tokio::time::Instant::now());
+    }
+
+    let guard = DashboardOverviewLoadGuard::new(cache_handle.clone(), 1);
+
+    {
+        let mut cache = cache_handle.lock().await;
+        cache.loading = true;
+        cache.loading_generation = 2;
+        cache.loading_started_at = Some(tokio::time::Instant::now());
+    }
+
+    drop(guard);
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    let cache = cache_handle.lock().await;
+    assert!(cache.loading, "old loader guard must not clear a newer loader");
+    assert_eq!(
+        cache.loading_generation, 2,
+        "old loader guard must preserve the newer loader generation",
+    );
+    assert!(
+        cache.loading_started_at.is_some(),
+        "old loader guard must not erase newer loader start time",
+    );
+}
+
+#[tokio::test]
 async fn dashboard_overview_freshness_advances_on_five_minute_window_anchor() {
     let first_anchor = dashboard_hourly_window_anchor(1_774_070_520);
     let second_anchor = dashboard_hourly_window_anchor(1_774_070_700);


### PR DESCRIPTION
## Summary
- recover the admin dashboard shared snapshot loader when an old loader leaves `loading=true`
- degrade recent-alerts freshness token reads on a short timeout so optional freshness cannot block first paint
- guard stale-loader takeover with loader ownership generations so old loaders cannot clear or overwrite newer rebuilds
- add regression coverage for stale dashboard loader recovery and superseded loader guards

## Validation
- `cargo test dashboard_overview_snapshot_recovers_from_stale_loading_flag -- --nocapture`
- `cargo test dashboard_overview -- --nocapture`
- `cargo fmt`
- `git diff --check`
- `cargo clippy -- -D warnings`
- commit hooks: `cargo fmt`, `cargo clippy -- -D warnings`, Markdown format, commitlint
- merge-proof review: clear for `37a374fec7bca7e6b5841118b362ed1c66ffc67c`
- GitHub CI: all checks passed for `37a374fec7bca7e6b5841118b362ed1c66ffc67c`

## Production Evidence
- Chrome showed `/admin/dashboard` stuck on `正在加载仪表盘数据…`
- container-local replay of `/api/dashboard/overview` timed out without headers/body
- logs showed repeated `dashboard_overview_phase cache_wait` after the active loader reached recent-alerts rebuild

## References
- Spec: -
- Spec Disposition: not_needed
- Spec Sync: n/a(spec-free)
- Spec Drift: none
- Solutions: `docs/solutions/operations/sqlite-admin-read-containment.md`
- Solutions Sync: done
- Project Docs: -
- Project Docs Sync: n/a(no-project-docs)
