### PR TITLE
fix: gate post-ready background tasks

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -171,6 +171,10 @@ month-tail public metrics scan.
   authority stayed unchanged could still enqueue the same `ha_node_state` row every five seconds;
   deduplicating identical coalesced snapshots removed both the slow-statement noise and an
   otherwise needless writer competitor.
+- Apply the same edge-trigger rule to post-ready derived work. If a writable HA status refresh
+  repeats every few seconds, it must not rerun best-effort rebuild/backfill tasks that scan
+  retained request logs; run them once for the writable tenure, suppress repeated refreshes with a
+  low-frequency decision log, and re-arm only after the node leaves writable and later returns.
 - Keep `HA_MODE=single` truly silent for HA replication writes. Leaving replication triggers enabled
   on a single live node creates unbounded local-only backlog with no standby consumer.
 - Treat large retained HA event cleanup like request-log cleanup: bounded online GC for freshness,

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md
@@ -186,3 +186,12 @@
 - Added a no-op-aware request-log effect-bucket migration guard so steady-state restarts skip the
   legacy full-table repair once the migration has completed or a cheap indexed precheck proves no
   remaining rows need rewriting, and the rewrite plus completion marker now commit atomically.
+
+## 2026-07-05
+
+- Production inspection showed the node healthy while HA authority refreshes were retriggering
+  post-ready `server_pressure_buckets` rebuild and `user_business_calls_1h` backfill work roughly
+  every five seconds, creating repeated SQLite slow statements on large retained databases.
+- Tightened post-ready scheduling to a writable-tenure edge: first startup or promotion into a
+  writable role can run the non-core derived work once, repeated writable refreshes are suppressed,
+  and demotion out of writable resets the gate for a later promotion.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -69,6 +69,11 @@
 - The same post-ready rebuild hook now runs on later HA promotions that restore a
   `provisional_master` / `full_master` serving role, including the shared admin/internal finalize
   path that persists HA status snapshots.
+- The post-ready hook is now gated per writable tenure. Startup or a later transition from
+  non-writable to writable may start one `server_pressure_buckets` rebuild and one
+  `user_business_calls_1h` backfill, but the repeating HA authority refresh while the node remains
+  writable only emits one suppressed decision log instead of rerunning the derived work every
+  refresh interval.
 - HA demotion now cancels any in-flight `server_pressure_buckets` rebuild generation before the
   node finishes leaving business-serving mode, so standby/recovery do not keep detached rebuild
   writes alive.

--- a/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md
@@ -4,7 +4,7 @@
 
 - Lifecycle: active
 - Created: 2026-05-07
-- Last: 2026-06-22
+- Last: 2026-07-05
 
 ## Background
 
@@ -109,6 +109,11 @@ source when a usable persisted runtime already exists.
   `/health`.
 - If a later HA transition promotes the process back into a business-serving role, the same
   best-effort `server_pressure_buckets` rebuild must be scheduled for that serving tenure too.
+- Post-ready derived work must be scheduled on writable-tenure edges, not on every persisted HA
+  authority refresh. Initial startup or the first observed transition into `provisional_master` /
+  `full_master` may run one `server_pressure_buckets` rebuild and one `user_business_calls_1h`
+  backfill; repeated writable observations in the same tenure must suppress new task launches, and
+  any observed non-writable role must re-arm the gate for a later writable promotion.
 - If HA demotes the process out of a business-serving role while that rebuild is still pending, the
   rebuild must cancel or roll back instead of committing new pressure buckets from a standby or
   recovery process.
@@ -250,6 +255,9 @@ source when a usable persisted runtime already exists.
 - Manual or internal HA promotions that return the node to `provisional_master` / `full_master`
   still trigger the same post-ready `server_pressure_buckets` rebuild path as initial serving
   startup.
+- Repeated HA authority refreshes for the same writable tenure do not repeatedly run post-ready
+  `server_pressure_buckets` rebuilds or `user_business_calls_1h` backfills; after observing
+  `standby` / `recovery`, the next writable promotion is allowed to run them once again.
 - If the node is demoted to `standby` / `recovery` before that rebuild finishes, the detached task
   exits without committing new `server_pressure_buckets` rows from the non-serving role.
 - Under mock/local upstream startup, the image `HEALTHCHECK` becomes healthy on the first

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -469,6 +469,7 @@
         "server::tests::alerts_and_ha_sync_recovery::dual_active_",
         "server::tests::alerts_and_ha_node_state::redundant_",
         "server::tests::alerts_and_ha_node_state::dual_active_",
+        "server::tests::alerts_and_ha_startup_roles::post_ready_",
         "server::tests::alerts_and_ha_startup_roles::persist_",
         "server::tests::alerts_and_ha_startup_roles::startup_",
         "server::tests::alerts_and_ha_startup_roles::standby_",

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -383,6 +383,11 @@ async fn persist_ha_status_snapshot(
     state: &Arc<AppState>,
     status: &tavily_hikari::HaStatusView,
 ) -> Result<(), (StatusCode, String)> {
+    if !status.allows_full_writes {
+        state
+            .proxy
+            .reset_post_ready_serving_tasks_for_writable_tenure();
+    }
     sync_forward_proxy_runtime_for_status(state.proxy.clone(), status)
         .await
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1595,6 +1595,11 @@ fn spawn_ha_edgeone_authority_task(state: Arc<AppState>) {
                         }
                         status = state.ha.status().await;
                     }
+                    if !status.allows_full_writes {
+                        state
+                            .proxy
+                            .reset_post_ready_serving_tasks_for_writable_tenure();
+                    }
                     if let Err(err) =
                         sync_forward_proxy_runtime_for_status(state.proxy.clone(), &status).await
                     {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1376,6 +1376,9 @@ fn spawn_post_ready_serving_tasks_for_status(
     status: &tavily_hikari::HaStatusView,
 ) -> bool {
     if !status.allows_full_writes {
+        state
+            .proxy
+            .reset_post_ready_serving_tasks_for_writable_tenure();
         return false;
     }
     if background_tasks_disabled_via_env() {
@@ -1386,8 +1389,39 @@ fn spawn_post_ready_serving_tasks_for_status(
         );
         return false;
     }
+    match state
+        .proxy
+        .claim_post_ready_serving_tasks_for_writable_tenure()
+    {
+        tavily_hikari::PostReadyServingTasksClaim::Start => {}
+        tavily_hikari::PostReadyServingTasksClaim::Suppressed { should_log } => {
+            if should_log {
+                tracing::info!(
+                    component = "startup",
+                    event = "post_ready_tasks_suppressed",
+                    role = status.role.as_str(),
+                    node_id = %status.node_id,
+                    pressure_spawned = false,
+                    business_calls_spawned = false,
+                    reason = "already_started_for_writable_tenure",
+                    "post-ready non-core tasks already started for current writable tenure"
+                );
+            }
+            return false;
+        }
+    }
     let pressure = state.proxy.spawn_server_pressure_buckets_rebuild_once();
     let business_calls = state.proxy.spawn_user_business_calls_1h_backfill_once();
+    tracing::info!(
+        component = "startup",
+        event = "post_ready_tasks_started",
+        role = status.role.as_str(),
+        node_id = %status.node_id,
+        pressure_spawned = pressure,
+        business_calls_spawned = business_calls,
+        reason = "writable_tenure_entered",
+        "post-ready non-core tasks started for writable tenure"
+    );
     pressure || business_calls
 }
 

--- a/src/server/tests/alerts_and_ha_startup_roles.rs
+++ b/src/server/tests/alerts_and_ha_startup_roles.rs
@@ -426,3 +426,167 @@ async fn persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_servi
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
 }
+
+#[tokio::test]
+async fn post_ready_serving_tasks_run_once_per_writable_tenure() {
+    let db_path = temp_db_path("ha-post-ready-writable-tenure");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-post-ready-writable-tenure".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "ha-post-ready-writable-tenure".to_string(),
+            username: Some("ha_post_ready_writable_tenure".to_string()),
+            name: Some("HA Post Ready Writable Tenure".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert post-ready writable tenure user");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = proxy.backend_time().now_ts();
+    sqlx::query(
+        r#"
+        INSERT INTO observability.request_logs (
+            method,
+            path,
+            status_code,
+            tavily_status_code,
+            result_status,
+            request_kind_key,
+            request_kind_label,
+            counts_business_quota,
+            request_user_id,
+            upstream_operation,
+            visibility,
+            created_at
+        ) VALUES ('POST', '/api/tavily/search', 200, 200, ?, 'api:search', 'API | search', 1, ?, ?, ?, ?)
+        "#,
+    )
+    .bind("success")
+    .bind(&user.user_id)
+    .bind("search")
+    .bind(tavily_hikari::REQUEST_LOG_VISIBILITY_VISIBLE)
+    .bind(now - 60)
+    .execute(&pool)
+    .await
+    .expect("insert pressure request log for post-ready tenure");
+
+    let state = Arc::new(AppState {
+        proxy: proxy.clone(),
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+            mode: tavily_hikari::HaMode::ActiveStandby,
+            node_id: "node-post-ready-writable-tenure".to_string(),
+            database_path: Some(db_str.clone()),
+            ..tavily_hikari::HaConfig::default()
+        }),
+        dev_open_admin: true,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    });
+    let writable_status = tavily_hikari::HaStatusView {
+        mode: tavily_hikari::HaMode::ActiveStandby,
+        node_id: "node-post-ready-writable-tenure".to_string(),
+        node_public_origin: None,
+        role: tavily_hikari::HaNodeRole::FullMaster,
+        dual_active_enabled: false,
+        full_master_node_id: None,
+        degraded: false,
+        allows_basic_business: true,
+        allows_full_writes: true,
+        edgeone_domain: None,
+        edgeone_origin: None,
+        edgeone_expected_origin: None,
+        edgeone_current_target: None,
+        edgeone_expected_target: None,
+        edgeone_current_source_kind: None,
+        edgeone_expected_source_kind: None,
+        edgeone_current_origin_group_id: None,
+        edgeone_expected_origin_group_id: None,
+        ha_source_defaults: None,
+        ha_source_override: None,
+        ha_source_effective: None,
+        edgeone_api_configured: false,
+        last_edgeone_check_at: None,
+        last_sync_at: None,
+        sync_lag_seconds: None,
+        recovery_status: None,
+        message: Some("promoted into business-serving role".to_string()),
+        peer_nodes: Vec::new(),
+        planned_cutover_eligible: false,
+    };
+
+    assert!(
+        spawn_post_ready_serving_tasks_for_status(state.clone(), &writable_status),
+        "first writable tenure should start post-ready tasks"
+    );
+
+    tokio::time::timeout(Duration::from_secs(8), async {
+        loop {
+            let bucket_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("count rebuilt server pressure buckets");
+            let summary = proxy
+                .user_dashboard_summary(&user.user_id, None)
+                .await
+                .expect("load user dashboard summary after post-ready backfill");
+            if bucket_count >= 1 && summary.business_calls_1h.total_count == 1 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("first post-ready tasks should complete");
+
+    assert!(
+        !spawn_post_ready_serving_tasks_for_status(state.clone(), &writable_status),
+        "same writable tenure must not restart completed post-ready tasks"
+    );
+    assert!(
+        !spawn_post_ready_serving_tasks_for_status(state.clone(), &writable_status),
+        "same writable tenure must keep suppressing repeated HA refreshes"
+    );
+
+    let standby_status = tavily_hikari::HaStatusView {
+        role: tavily_hikari::HaNodeRole::Standby,
+        allows_full_writes: false,
+        message: Some("demoted out of business-serving role".to_string()),
+        ..writable_status.clone()
+    };
+    assert!(
+        !spawn_post_ready_serving_tasks_for_status(state.clone(), &standby_status),
+        "non-writable status should only reset the tenure gate"
+    );
+    assert!(
+        spawn_post_ready_serving_tasks_for_status(state.clone(), &writable_status),
+        "returning to writable should re-arm one post-ready run"
+    );
+    assert!(
+        !spawn_post_ready_serving_tasks_for_status(state.clone(), &writable_status),
+        "re-armed writable tenure should suppress subsequent refreshes"
+    );
+
+    pool.close().await;
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -696,12 +696,20 @@ pub struct TavilyProxy {
     pub(crate) low_quota_depletion_threshold: i64,
     pub(crate) forward_proxy_runtime_started: Arc<AtomicBool>,
     pub(crate) forward_proxy_runtime_transition_lock: Arc<Mutex<()>>,
+    post_ready_serving_tasks_started: Arc<AtomicBool>,
+    post_ready_serving_tasks_suppressed_logged: Arc<AtomicBool>,
     user_business_calls_backfill_started: Arc<AtomicBool>,
     server_pressure_rebuild_started: Arc<AtomicBool>,
     server_pressure_rebuild_generation: Arc<AtomicU64>,
     server_pressure_rebuild_buffered_events: Arc<Mutex<Vec<ServerPressureBufferedEvent>>>,
     health_readiness_grace_until: tokio::time::Instant,
     pub(crate) backend_time: BackendTime,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PostReadyServingTasksClaim {
+    Start,
+    Suppressed { should_log: bool },
 }
 
 #[derive(Clone, Debug)]

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -591,6 +591,8 @@ impl TavilyProxy {
             low_quota_depletion_threshold: options.low_quota_depletion_threshold,
             forward_proxy_runtime_started: Arc::new(AtomicBool::new(false)),
             forward_proxy_runtime_transition_lock: Arc::new(Mutex::new(())),
+            post_ready_serving_tasks_started: Arc::new(AtomicBool::new(false)),
+            post_ready_serving_tasks_suppressed_logged: Arc::new(AtomicBool::new(false)),
             user_business_calls_backfill_started: Arc::new(AtomicBool::new(false)),
             server_pressure_rebuild_started: Arc::new(AtomicBool::new(false)),
             server_pressure_rebuild_generation: Arc::new(AtomicU64::new(0)),
@@ -933,6 +935,33 @@ impl TavilyProxy {
             created_at,
             result_status: result_status.to_string(),
         });
+    }
+
+    pub fn reset_post_ready_serving_tasks_for_writable_tenure(&self) {
+        self.post_ready_serving_tasks_started
+            .store(false, Ordering::SeqCst);
+        self.post_ready_serving_tasks_suppressed_logged
+            .store(false, Ordering::SeqCst);
+    }
+
+    pub fn claim_post_ready_serving_tasks_for_writable_tenure(
+        &self,
+    ) -> PostReadyServingTasksClaim {
+        if self
+            .post_ready_serving_tasks_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.post_ready_serving_tasks_suppressed_logged
+                .store(false, Ordering::SeqCst);
+            return PostReadyServingTasksClaim::Start;
+        }
+
+        let should_log = self
+            .post_ready_serving_tasks_suppressed_logged
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok();
+        PostReadyServingTasksClaim::Suppressed { should_log }
     }
 
     pub fn spawn_server_pressure_buckets_rebuild_once(&self) -> bool {


### PR DESCRIPTION
## Summary
- Gate post-ready derived work by writable HA tenure so repeated authority refreshes do not rerun pressure rebuild/backfill.
- Keep first startup/promotion behavior intact and re-arm after leaving writable.
- Add low-frequency startup decision logs for started/suppressed post-ready work.
- Update the 2wdrp spec implementation/history and SQLite write-lock solution guardrail.

## Validation
- `cargo test persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_serving_roles -- --nocapture`
- `cargo test post_ready_serving_tasks_run_once_per_writable_tenure -- --nocapture`
- `cargo test user_pressure_analysis -- --nocapture`
- `cargo test user_business_calls_1h -- --nocapture`
- `cargo test ha_outbox_and_compaction -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `bash /Users/ivan/.codex/skills/spec-sync/scripts/spec_drift_check.sh --base-ref origin/main --spec-path docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`
- `codex -m gpt-5.5 -c model_reasoning_effort="low" --sandbox read-only -a never review --base origin/main`

## Sync Gates
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: done
- Project Docs Sync: n/a(no project-doc changes)

## References
- Specs: `docs/specs/2wdrp-sqlite-write-lock-hardening/SPEC.md`, `docs/specs/2wdrp-sqlite-write-lock-hardening/IMPLEMENTATION.md`, `docs/specs/2wdrp-sqlite-write-lock-hardening/HISTORY.md`
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`
- Project Docs: -

## Notes
- No public HTTP/MCP/API schema changes.
- No Compose healthcheck changes.
- No 101 deployment or production data cleanup in this PR.
