### PR TITLE
fix(analysis): record local pressure events live

### DIFF
--- a/src/store/key_store_analysis_pressure.rs
+++ b/src/store/key_store_analysis_pressure.rs
@@ -27,6 +27,43 @@ impl KeyStore {
         Ok(true)
     }
 
+    pub(crate) async fn fetch_server_pressure_event_for_request_log(
+        &self,
+        request_log_id: i64,
+    ) -> Result<Option<UserBusinessCallEventWrite>, ProxyError> {
+        sqlx::query_as::<_, (i64, String, i64, String)>(
+            r#"
+            SELECT id, request_user_id, created_at, result_status
+            FROM observability.request_logs
+            WHERE id = ?
+              AND visibility = ?
+              AND request_user_id IS NOT NULL
+              AND counts_business_quota = 1
+              AND upstream_operation IS NOT NULL
+              AND result_status != ?
+            LIMIT 1
+            "#,
+        )
+        .bind(request_log_id)
+        .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
+        .bind(OUTCOME_QUOTA_EXHAUSTED)
+        .fetch_optional(&self.pool)
+        .await
+        .map(|row| {
+            row.map(
+                |(request_log_id, user_id, created_at, result_status)| {
+                    UserBusinessCallEventWrite {
+                        user_id,
+                        request_log_id: Some(request_log_id),
+                        created_at,
+                        result_status,
+                    }
+                },
+            )
+        })
+        .map_err(ProxyError::from)
+    }
+
     pub(crate) async fn ensure_server_pressure_bucket_schema(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"

--- a/src/tavily_proxy/proxy_usage_and_metrics.rs
+++ b/src/tavily_proxy/proxy_usage_and_metrics.rs
@@ -64,7 +64,8 @@ impl TavilyProxy {
         dropped_headers: &[String],
         client_ip: Option<&ClientIpInfo>,
     ) -> Result<i64, ProxyError> {
-        self.key_store
+        let request_log_id = self
+            .key_store
             .log_attempt(AttemptLog {
                 key_id: None,
                 auth_token_id,
@@ -94,7 +95,49 @@ impl TavilyProxy {
                 dropped_headers,
                 client_ip,
             })
+            .await?;
+
+        if let Err(err) = self
+            .record_local_request_log_pressure_event(request_log_id)
             .await
+        {
+            tracing::warn!(
+                component = "analysis_pressure",
+                event = "server_pressure_local_request_log_upsert_failed",
+                request_log_id,
+                error = %err,
+                "failed to update server pressure buckets for local request log"
+            );
+        }
+
+        Ok(request_log_id)
+    }
+
+    async fn record_local_request_log_pressure_event(
+        &self,
+        request_log_id: i64,
+    ) -> Result<(), ProxyError> {
+        if let Some(event) = self
+            .key_store
+            .fetch_server_pressure_event_for_request_log(request_log_id)
+            .await?
+        {
+            let outcome = if event.result_status == OUTCOME_SUCCESS {
+                UserBusinessCallOutcome::Success
+            } else {
+                UserBusinessCallOutcome::Failure
+            };
+            self.user_business_calls_1h_window
+                .record_event(&event.user_id, event.request_log_id, event.created_at, outcome)
+                .await;
+            self.record_server_pressure_event(
+                event.request_log_id,
+                event.created_at,
+                &event.result_status,
+            )
+                .await?;
+        }
+        Ok(())
     }
 
     pub async fn create_or_replace_mcp_session_binding(

--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -1,5 +1,5 @@
 use super::*;
-use axum::http::Method;
+use axum::http::{Method, StatusCode};
 
 #[allow(clippy::too_many_arguments)]
 async fn seed_pressure_attempt(
@@ -259,6 +259,164 @@ async fn analysis_pressure_snapshot_uses_rolling_1h_and_excludes_non_upstream_ev
             .saturating_sub(previous_last.bucket_start),
         SECS_PER_DAY
     );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn analysis_pressure_snapshot_live_local_mcp_logs_update_server_buckets() {
+    let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_200_000);
+    let db_path = temp_db_path("analysis-pressure-local-mcp-live");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time,
+    )
+    .await
+    .expect("proxy created");
+
+    let user = proxy
+        .upsert_oauth_account(&OAuthAccountProfile {
+            provider: "github".to_string(),
+            provider_user_id: "analysis-pressure-local-mcp".to_string(),
+            username: Some("local-mcp".to_string()),
+            name: Some("Local MCP".to_string()),
+            avatar_template: None,
+            active: true,
+            trust_level: None,
+            raw_payload_json: None,
+        })
+        .await
+        .expect("upsert user");
+    let token = proxy
+        .ensure_user_token_binding(&user.user_id, Some("analysis-pressure-local-mcp"))
+        .await
+        .expect("bind token");
+    let now = manual_clock.now_ts();
+    manual_clock.set_now_ts(now);
+    let headers: [String; 0] = [];
+
+    let request_log_id = proxy
+        .record_local_request_log_without_key_with_diagnostics(
+            Some(&token.id),
+            &Method::POST,
+            "/mcp",
+            None,
+            StatusCode::OK,
+            None,
+            br#"{"jsonrpc":"2.0","method":"ping","id":1}"#,
+            br#"{"jsonrpc":"2.0","result":{},"id":1}"#,
+            OUTCOME_SUCCESS,
+            None,
+            Some(MCP_GATEWAY_MODE_REBALANCE),
+            Some(MCP_EXPERIMENT_VARIANT_REBALANCE),
+            Some("analysis-pressure-local-mcp-session"),
+            None,
+            Some("mcp"),
+            None,
+            &headers,
+            &headers,
+            None,
+        )
+        .await
+        .expect("record local mcp request log");
+
+    let canonical_rows: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM observability.request_logs
+        WHERE id = ?
+          AND visibility = ?
+          AND request_user_id IS NOT NULL
+          AND counts_business_quota = 1
+          AND upstream_operation IS NOT NULL
+          AND result_status != ?
+        "#,
+    )
+    .bind(request_log_id)
+    .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
+    .bind(OUTCOME_QUOTA_EXHAUSTED)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count canonical pressure request logs");
+    assert_eq!(canonical_rows, 1);
+
+    let five_minute_pressure: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(success_count + failure_count), 0)
+        FROM observability.server_pressure_buckets
+        WHERE bucket_kind = 'five_minute'
+        "#,
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("sum live five-minute pressure");
+    assert_eq!(five_minute_pressure, 1);
+
+    let hour_pressure: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(success_count + failure_count), 0)
+        FROM observability.server_pressure_buckets
+        WHERE bucket_kind = 'hour'
+        "#,
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("sum live hour pressure");
+    assert_eq!(hour_pressure, 1);
+
+    let snapshot = proxy
+        .analysis_pressure_snapshot()
+        .await
+        .expect("analysis pressure snapshot after live local mcp log");
+    assert_eq!(
+        snapshot
+            .server_24h
+            .current
+            .last()
+            .expect("latest current pressure point")
+            .pressure,
+        1
+    );
+    assert_eq!(snapshot.current_user_distribution.rows.len(), 1);
+    assert_eq!(
+        snapshot.current_user_distribution.rows[0].user_id,
+        user.user_id
+    );
+    assert_eq!(snapshot.current_user_distribution.rows[0].pressure, 1);
+
+    proxy
+        .key_store
+        .rebuild_server_pressure_buckets_with_cancel(|| true)
+        .await
+        .expect("rebuild server pressure buckets");
+
+    let five_minute_pressure_after_rebuild: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(success_count + failure_count), 0)
+        FROM observability.server_pressure_buckets
+        WHERE bucket_kind = 'five_minute'
+        "#,
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("sum rebuilt five-minute pressure");
+    assert_eq!(five_minute_pressure_after_rebuild, 1);
+
+    let hour_pressure_after_rebuild: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(success_count + failure_count), 0)
+        FROM observability.server_pressure_buckets
+        WHERE bucket_kind = 'hour'
+        "#,
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("sum rebuilt hour pressure");
+    assert_eq!(hour_pressure_after_rebuild, 1);
 
     let _ = std::fs::remove_file(db_path);
 }


### PR DESCRIPTION
## Summary
- Fixes live undercounting for local MCP/control request logs that already match the canonical pressure rebuild predicate.
- Adds a canonical request-log eligibility lookup after local request-log writes, then records the same event into server pressure buckets and the user 1h pressure window.
- Keeps the generic keyed/token logging path unchanged to avoid double-counting existing HTTP/API pressure events.

## Validation
- `cargo test analysis_pressure_snapshot_live_local_mcp_logs_update_server_buckets -- --nocapture`
- `cargo test analysis_pressure -- --nocapture`
- `cargo test request_log -- --nocapture`
- `cargo test mcp -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `codex review --uncommitted` after fixes: no actionable correctness issues
- commit hook: `cargo fmt`, `cargo clippy -- -D warnings`, `commitlint`

## References
- Spec: `docs/specs/qwwgt-admin-pressure-curves/SPEC.md`
- Spec Disposition: link
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`
- Project Docs: -

## Sync State
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a(no solution update)
- Project Docs Sync: n/a(project-doc-disposition-none)

## Visual Evidence

- Spec: `docs/specs/qwwgt-admin-pressure-curves/SPEC.md`
  ![Analysis pressure desktop](https://github.com/IvanLi-CN/tavily-hikari/blob/7db2617018975f1be4dc9138ae79b4f2c10a2c5b/docs/specs/qwwgt-admin-pressure-curves/assets/pressure-desktop.png?raw=1)
  ![Analysis pressure mobile](https://github.com/IvanLi-CN/tavily-hikari/blob/7db2617018975f1be4dc9138ae79b4f2c10a2c5b/docs/specs/qwwgt-admin-pressure-curves/assets/pressure-mobile.png?raw=1)

## Notes
- No pressure UI or `/api/analysis/pressure` response-shape changes.
- No production restart, deploy, or manual bucket rebuild was performed.
- Project docs disposition: none; this is a backend live aggregation bugfix with no operator contract change.
