### PR TITLE
fix(admin): sync rankings tab route state

### DIFF
--- a/docs/specs/p7n4k-admin-user-rankings/HISTORY.md
+++ b/docs/specs/p7n4k-admin-user-rankings/HISTORY.md
@@ -20,6 +20,7 @@
 - 2026-06-25: 根据最新验收反馈，彻底否定“双轴 tabs”解读，合同锁定为六个独立单选 tab；路由改为单一 `tab` 查询参数，缺失或非法值统一规范化为 `last24h`。
 - 2026-06-25: 根据“返回过来后数据不能丢”的要求，排行 snapshot 真相源上提到 runtime；从用户详情返回、浏览器前进后退与 tab 切换都复用已有 snapshot，只做后台刷新，不再回骨架首屏。
 - 2026-06-25: 根据交互验收，排行项新增 click 跳转用户详情，以及 hover / focus 同用户跨三榜联动高亮，联动范围只限当前可见 tab 下的三张榜。
+- 2026-07-09: 修复排行 runtime 在 `analysis` 父模块迁移后仍按旧 `module='rankings'` 判断的遗留问题；现在 `/admin/analysis?tab=*`、`/admin/rankings?tab=*` 与 `/admin/analysis/rankings?tab=*` 都会把地址栏 `tab` 查询参数同步回受控 `rankingsTab`，点击、浏览器前进后退与别名路由切换不再出现“URL 已变但激活态卡住”的假死，同时保留 `demo=true` 等非 `tab` 查询参数。
 
 ## Key Reasons / Replacements
 
@@ -33,6 +34,7 @@
 - 用户明确要求截图必须来自 `web demo` 而不是 Storybook，因此最终 owner-facing 视觉证据统一切到 demo 路由，旧的 story/live 中间图不再保留在 spec 资产里。
 - admin 运营入口现在需要把排行、用量与压力放到同一分析语义下，因此排行不再单独占据一级导航位，避免 admin 模块粒度继续分叉。
 - 用户明确指出“这是六个独立 Tab”，因此旧的“指标 tab 只切单选态、不切内容”定义被彻底废弃，避免后续再次误读成双轴模型。
+- `分析 -> 排行` 父子路由迁移后，runtime 若继续依赖旧模块名判断，就会让 `tab` 查询参数失去真相源地位；因此排行 tab 同步必须锚定到 `module='analysis' && analysisView='rankings'` 这一收敛后的 canonical route 语义，而不是历史一级模块名。
 
 ## References
 

--- a/docs/specs/p7n4k-admin-user-rankings/IMPLEMENTATION.md
+++ b/docs/specs/p7n4k-admin-user-rankings/IMPLEMENTATION.md
@@ -25,6 +25,7 @@
 - 排行页已补充 DOM 语义 fallback、实时连接状态、最后更新时间、断连降级提示与显式重试入口。
 - 排行页已补齐行级交互层：任一排行项支持 click 跳转用户详情，hover/focus 时当前三张榜内同用户联动高亮；离开时立即清除。
 - runtime 保持最近一次 `rankingsSnapshot`，因此 Tab 切换、浏览器前进后退、从用户详情返回排行时都会先复用现有数据，只在后台 refresh / reconnect，不会回到“从 0 开始”的 blocking skeleton。
+- 排行 Tab 的 URL 同步现在只在 `analysis/rankings` 语义路由下生效，不再误判历史一级模块名；因此点击 tab、浏览器前进后退以及 `/admin/analysis`、`/admin/analysis/rankings` 与旧 `/admin/rankings` alias 间切换时，地址栏 `tab` 参数与激活态都会保持一致，同时 `demo=true` 这类非 `tab` 查询参数不会被规范化流程吞掉。
 - 空态已改为等高内容舞台，不再使用单个普通提示框；三张卡在无数据时保持统一高度。
 - loading 期间已改为仅榜单内容区骨架屏；页头状态与六个单选 tab 保持真实文案，不再只显示纯文本 loading。
 - 之前出现“两种实现”的根因已确认是证据层级混用：一部分截图来自 story 内容模块，一部分来自真实页面。当前 owner-facing 排行证据已统一收敛为 `web demo` 路由截图；Storybook 仅保留开发验证用途。

--- a/web/src/admin/AdminDashboardRuntime.route-switch.test.tsx
+++ b/web/src/admin/AdminDashboardRuntime.route-switch.test.tsx
@@ -11,6 +11,7 @@ import { LanguageProvider } from '../i18n'
 import { ThemeProvider } from '../theme'
 import AdminDashboard from './AdminDashboardRuntime'
 import {
+  analysisPath,
   buildAdminKeysPath,
   buildAdminTokensPath,
   buildAdminUsersOverviewPath,
@@ -36,7 +37,10 @@ interface MockMediaQueryList {
 }
 
 interface RouteExpectation {
+  pathname?: string
+  search?: string
   selector?: string
+  selectorText?: string
   text?: string
 }
 
@@ -126,6 +130,42 @@ const routeSwitchCases: RouteSwitchCase[] = [
     returnExpectation: {
       selector: '.admin-rankings-tab.is-active',
       text: 'IP',
+    },
+  },
+  {
+    name: 'rankings -> rankings syncs the selected tab from location and preserves demo params',
+    startPath: `${analysisPath('rankings')}?demo=true&tab=last7d`,
+    nextPath: `${analysisPath('rankings')}?demo=true&tab=businessCredits`,
+    nextExpectation: {
+      pathname: analysisPath('rankings'),
+      search: '?demo=true&tab=businessCredits',
+      selector: '.admin-rankings-tab.is-active',
+      selectorText: 'Credits',
+    },
+    returnPath: `${analysisPath('rankings')}?demo=true&tab=uniqueIp`,
+    returnExpectation: {
+      pathname: analysisPath('rankings'),
+      search: '?demo=true&tab=uniqueIp',
+      selector: '.admin-rankings-tab.is-active',
+      selectorText: 'IP',
+    },
+  },
+  {
+    name: 'rankings analysis alias preserves alias path and demo params',
+    startPath: '/admin/analysis?demo=true&tab=last7d',
+    nextPath: '/admin/analysis?demo=true&tab=businessCredits',
+    nextExpectation: {
+      pathname: '/admin/analysis',
+      search: '?demo=true&tab=businessCredits',
+      selector: '.admin-rankings-tab.is-active',
+      selectorText: 'Credits',
+    },
+    returnPath: '/admin/analysis?demo=true&tab=uniqueIp',
+    returnExpectation: {
+      pathname: '/admin/analysis',
+      search: '?demo=true&tab=uniqueIp',
+      selector: '.admin-rankings-tab.is-active',
+      selectorText: 'IP',
     },
   },
   {
@@ -227,8 +267,18 @@ function assertRouteRendered(container: HTMLElement, expectation: RouteExpectati
   const main = container.querySelector<HTMLElement>('[role="main"]')
   expect(main).not.toBeNull()
   expect(main?.textContent?.replace(/\s+/g, ' ').trim().length ?? 0).toBeGreaterThan(0)
+  if (expectation.pathname) {
+    expect(window.location.pathname).toBe(expectation.pathname)
+  }
+  if (expectation.search) {
+    expect(window.location.search).toBe(expectation.search)
+  }
   if (expectation.selector) {
-    expect(main?.querySelector(expectation.selector)).not.toBeNull()
+    const selected = main?.querySelector<HTMLElement>(expectation.selector) ?? null
+    expect(selected).not.toBeNull()
+    if (expectation.selectorText) {
+      expect(selected?.textContent).toContain(expectation.selectorText)
+    }
   }
   if (expectation.text) {
     expect(main?.textContent).toContain(expectation.text)

--- a/web/src/admin/AdminDashboardRuntime.tsx
+++ b/web/src/admin/AdminDashboardRuntime.tsx
@@ -1071,6 +1071,21 @@ function getAdminRankingsTabFromLocation(): RankingTabKey {
   return getRankingsTabFromSearch(window.location.search)
 }
 
+function buildRankingsRoutePath(
+  tab: RankingTabKey,
+  options?: { canonical?: boolean; pathname?: string | null; search?: string | null },
+): string {
+  const search = new URLSearchParams(options?.search ?? '')
+  search.set('tab', tab)
+  const pathname = options?.pathname?.trim()
+  const parsedPath = pathname ? parseAdminPath(pathname) : null
+  const preservesRankingsPath =
+    parsedPath?.name === 'module' && parsedPath.module === 'analysis' && parsedPath.analysisView === 'rankings'
+  const basePath =
+    options?.canonical ? analysisPath('rankings') : preservesRankingsPath && pathname ? pathname : rankingsPath().split('?')[0]
+  return `${basePath}?${search.toString()}`
+}
+
 function getUserTagIconSrc(icon: string | null | undefined): string | null {
   if (icon === 'linuxdo') {
     return '/assets/linuxdo-logo.svg'
@@ -2862,14 +2877,17 @@ function AdminDashboard(): JSX.Element {
   }, [route])
 
   useEffect(() => {
-    if (route.name !== 'module' || route.module !== 'rankings') {
+    if (!(route.name === 'module' && route.module === 'analysis' && route.analysisView === 'rankings')) {
       return
     }
 
     const nextTab = getRankingsTabFromSearch(locationSearch)
     setRankingsTab(nextTab)
 
-    const normalizedLocation = rankingsPath(nextTab)
+    const normalizedLocation = buildRankingsRoutePath(nextTab, {
+      pathname: window.location.pathname,
+      search: locationSearch,
+    })
     const currentLocation = `${window.location.pathname}${window.location.search}`
     if (currentLocation !== normalizedLocation) {
       window.history.replaceState(null, '', normalizedLocation)
@@ -4517,7 +4535,16 @@ function AdminDashboard(): JSX.Element {
           route.name === 'module' && route.module === 'analysis' && route.analysisView === 'rankings'
           ? rankingsTab
           : getAdminRankingsTabFromLocation()
-        navigateToPath(rankingsPath(currentTab))
+        const rememberedRankingsUrl = lastRankingsPathRef.current
+          ? new URL(lastRankingsPathRef.current, window.location.origin)
+          : null
+        const nextPath = lastRankingsPathRef.current
+          ? buildRankingsRoutePath(currentTab, {
+            pathname: rememberedRankingsUrl?.pathname,
+            search: rememberedRankingsUrl?.search,
+          })
+          : buildRankingsRoutePath(currentTab, { canonical: true })
+        navigateToPath(nextPath)
         return
       }
       if (target === 'tokens') {
@@ -4699,7 +4726,10 @@ function AdminDashboard(): JSX.Element {
   const navigateUser = useCallback(
     (id: string, options?: { preserveUsersContext?: boolean }) => {
       if (route.name === 'module' && route.module === 'analysis' && route.analysisView === 'rankings') {
-        lastRankingsPathRef.current = rankingsPath(rankingsTab)
+        lastRankingsPathRef.current = buildRankingsRoutePath(rankingsTab, {
+          pathname: window.location.pathname,
+          search: window.location.search,
+        })
       }
       if (options?.preserveUsersContext) {
         const collection = isAnalysisUsageRoute || getAdminUsersCollectionFromLocation() === 'usage' ? 'usage' : undefined
@@ -4713,7 +4743,10 @@ function AdminDashboard(): JSX.Element {
 
   const navigateRankingsTab = useCallback(
     (tab: RankingTabKey) => {
-      const nextPath = rankingsPath(tab)
+      const nextPath = buildRankingsRoutePath(tab, {
+        pathname: window.location.pathname,
+        search: window.location.search,
+      })
       lastRankingsPathRef.current = nextPath
       navigateToPath(nextPath)
     },


### PR DESCRIPTION
## Summary
- fix rankings tab state sync after the analysis parent-route migration
- add a runtime regression for rankings-to-rankings tab query updates
- record the route-state fix in the rankings spec implementation notes

## Validation
- `cd web && bun test src/admin/AdminDashboardRuntime.route-switch.test.tsx`
- `cd web && bun test src/admin/AdminUserRankingsPage.render.test.tsx`
- `cd web && bun test src/admin/routes.test.ts`
- `cd web && bun run build`

Spec: docs/specs/p7n4k-admin-user-rankings/SPEC.md
Spec Disposition: update
Spec Sync: done
Spec Drift: none
Solutions: -
Solutions Sync: n/a(no solution change)
Project Docs: -
Project Docs Sync: n/a(no project-doc change)

Notes:
- Visual evidence was reviewed in chat and is not embedded in the PR body.
