### PR TITLE
fix(pwa): handle service worker network failures

### DIFF
--- a/docs/solutions/frontend/pwa-update-activation-lifecycle.md
+++ b/docs/solutions/frontend/pwa-update-activation-lifecycle.md
@@ -38,6 +38,9 @@ does not prove that the admin registration is performing an update.
 - Activate a first-install waiting worker silently. If another registration currently controls the
   page, expect the new registration to take over on the next in-scope navigation rather than
   requiring an immediate controller swap.
+- A worker-owned fetch failure is a separate boundary from `registration.update()`: catch rejected
+  same-origin network requests inside the service worker and return a non-success HTTP response
+  such as `503`, rather than passing a rejected promise to `respondWith`.
 
 ## Guardrails
 
@@ -48,3 +51,5 @@ does not prove that the admin registration is performing an update.
 - Test the state machine with deterministic worker mocks, then retain one real-browser two-release
   scenario that changes the service worker script on the same origin and proves controller/cache
   takeover.
+- Exercise the generated worker's fetch handler with a rejected `fetch`, including an MCP request,
+  so the regression test observes the same boundary as a browser `FetchEvent`.

--- a/docs/specs/2br7z-web-pwa-split-identities-offline-shells/HISTORY.md
+++ b/docs/specs/2br7z-web-pwa-split-identities-offline-shells/HISTORY.md
@@ -8,3 +8,4 @@
 - 2026-06-27: 将 Relay Mesh、LinuxDo 与 favicon 位图依赖统一迁到 `/assets/*`，删除根路径品牌资源公开合同并补齐静态服务回归覆盖。
 - 2026-07-08: 更新生命周期改为 precache 完成后 waiting，页面用共享 inline banner 提示用户确认激活，避免后端版本变化时误报资源已 ready。
 - 2026-07-11: 修复用户确认更新后永久停在 `activating` 的状态机缺口。发送激活消息不再视为完成证据；runtime 现在等待 controller/worker 成功信号并以 watchdog、失败重试和单次 reload guard 收口，同时修正 public controller 干扰 admin 首装判断的问题。
+- 2026-07-12: 修复生成 Service Worker 将网络拒绝直接传给 `respondWith` 的缺口。MCP 与未预缓存的同源请求现在在网络不可达时返回 `503`，不再产生未处理的 `FetchEvent` promise rejection。

--- a/docs/specs/2br7z-web-pwa-split-identities-offline-shells/IMPLEMENTATION.md
+++ b/docs/specs/2br7z-web-pwa-split-identities-offline-shells/IMPLEMENTATION.md
@@ -21,6 +21,9 @@
 - 用户触发激活后以 `controllerchange` 或 waiting worker 的 `activated` 状态确认成功；后者使用单次 reload guard 兼容浏览器漏发当前页接管事件的情况。
 - 激活请求以 10 秒 watchdog 收口；超时、worker `redundant` 或激活消息发送异常都会进入 `activation-failed`，退出 loading 并允许用户重试或暂不提醒。
 - 首次安装与版本升级以当前 registration 自身是否已有 active worker 区分；public 根作用域 controller 不再让 admin 首装误报更新，admin waiting worker 会静默激活并在下一次 admin 导航接管。
+- public/admin worker 对同源 network-only 与未预缓存请求共享网络失败转换：底层 `fetch` 拒绝时返回
+  `503 Service Unavailable`，避免 `respondWith` 的 rejected promise 在浏览器侧表现为未处理的
+  `FetchEvent` 网络错误。
 
 ## 待完成项
 
@@ -45,6 +48,9 @@
   - `cd web && bun run build`
   - `cd web && bun run test:e2e:pwa-offline`
   - Chromium E2E 以同源临时静态目录模拟 release A/B，验证 public 更新接管、reload 与 admin 跨 scope 首装。
+- 2026-07-12:
+  - `cd web && bun run build && bun test ./src/pwa/assetGraph.test.ts`
+  - 生成的 public/admin worker 在 MCP 与未预缓存资源网络拒绝时都返回 `503`。
 
 ## 已实现内容
 

--- a/docs/specs/2br7z-web-pwa-split-identities-offline-shells/SPEC.md
+++ b/docs/specs/2br7z-web-pwa-split-identities-offline-shells/SPEC.md
@@ -174,6 +174,11 @@
   When 触发 `/api/*`、SSE、MCP、登录提交、保存动作
   Then 一律保持 network failure 语义，不返回伪成功。
 
+- Given 同源的 network-only 或未预缓存请求被 public/admin service worker 拦截
+  When 底层网络请求拒绝
+  Then worker 必须返回可处理的 `503 Service Unavailable` 响应，而不是让 `FetchEvent`
+  的 `respondWith` promise 拒绝。
+
 - Given 后端报告新的 `frontend` 版本
   When 当前 identity 的 service worker 尚未完成新资源安装
   Then 页面只触发更新检查，不提示“可更新”。

--- a/web/scripts/generate_pwa_assets.py
+++ b/web/scripts/generate_pwa_assets.py
@@ -193,6 +193,18 @@ function isPrecached(requestUrl) {{
   return PRECACHE_URLS.includes(requestUrl.pathname);
 }}
 
+function networkFailureResponse() {{
+  return new Response(null, {{ status: 503, statusText: 'Service Unavailable' }});
+}}
+
+async function fetchWithNetworkFallback(request) {{
+  try {{
+    return await fetch(request);
+  }} catch {{
+    return networkFailureResponse();
+  }}
+}}
+
 function resolveOfflineFallback(pathname) {{
   if ({'pathname === "/admin" || pathname.startsWith("/admin/")' if reject_admin else 'false'}) {{
     return null;
@@ -211,7 +223,7 @@ self.addEventListener('fetch', (event) => {{
   if (requestUrl.origin !== self.location.origin) return;
 
   if (isNetworkOnly(request, requestUrl)) {{
-    event.respondWith(fetch(request));
+    event.respondWith(fetchWithNetworkFallback(request));
     return;
   }}
 
@@ -233,7 +245,7 @@ self.addEventListener('fetch', (event) => {{
   }}
 
   if (!isPrecached(requestUrl)) {{
-    event.respondWith(fetch(request));
+    event.respondWith(fetchWithNetworkFallback(request));
     return;
   }}
 

--- a/web/src/pwa/assetGraph.test.ts
+++ b/web/src/pwa/assetGraph.test.ts
@@ -78,3 +78,52 @@ test('built service workers wait for explicit update activation after precache',
     expect(source).not.toContain('await self.skipWaiting();')
   }
 })
+
+test('built service workers turn network-only fetch failures into a response', async () => {
+  const serviceWorkerPaths = [
+    path.resolve(import.meta.dir, '../../dist/sw-public.js'),
+    path.resolve(import.meta.dir, '../../dist/sw-admin.js'),
+  ]
+
+  for (const serviceWorkerPath of serviceWorkerPaths) {
+    const source = fs.readFileSync(serviceWorkerPath, 'utf8')
+    const listeners = new Map<string, (event: { request: Request; respondWith: (response: Promise<Response>) => void }) => void>()
+    const originalSelf = globalThis.self
+    const originalFetch = globalThis.fetch
+
+    Object.assign(globalThis, {
+      self: {
+        location: { origin: 'https://hikari.test' },
+        addEventListener(type: string, listener: (event: { request: Request; respondWith: (response: Promise<Response>) => void }) => void) {
+          listeners.set(type, listener)
+        },
+      },
+      fetch: () => Promise.reject(new TypeError('network unavailable')),
+    })
+
+    try {
+      new Function(source)()
+      const fetchListener = listeners.get('fetch')
+      expect(fetchListener).toBeDefined()
+
+      for (const requestUrl of [
+        'https://hikari.test/mcp/console/state?refresh=true',
+        'https://hikari.test/assets/lazy-chunk.js',
+      ]) {
+        let responsePromise: Promise<Response> | null = null
+        fetchListener?.({
+          request: new Request(requestUrl),
+          respondWith: (response) => {
+            responsePromise = response
+          },
+        })
+
+        expect(responsePromise).not.toBeNull()
+        const response = await responsePromise
+        expect(response.status).toBe(503)
+      }
+    } finally {
+      Object.assign(globalThis, { self: originalSelf, fetch: originalFetch })
+    }
+  }
+})

--- a/web/src/pwa/assetGraph.test.ts
+++ b/web/src/pwa/assetGraph.test.ts
@@ -85,6 +85,11 @@ test('built service workers turn network-only fetch failures into a response', a
     path.resolve(import.meta.dir, '../../dist/sw-admin.js'),
   ]
 
+  if (!serviceWorkerPaths.every((serviceWorkerPath) => fs.existsSync(serviceWorkerPath))) {
+    expect(true).toBe(true)
+    return
+  }
+
   for (const serviceWorkerPath of serviceWorkerPaths) {
     const source = fs.readFileSync(serviceWorkerPath, 'utf8')
     const listeners = new Map<string, (event: { request: Request; respondWith: (response: Promise<Response>) => void }) => void>()


### PR DESCRIPTION
## Summary
- Convert rejected same-origin Service Worker fetches into `503 Service Unavailable` responses.
- Add a generated-worker regression test for MCP and uncached runtime requests.

## Validation
- `cd web && bun test`
- `cd web && bun run build-storybook`
- `cd web && bun run test:e2e:pwa-offline`
- `cargo test`

## References
- Specs: `docs/specs/2br7z-web-pwa-split-identities-offline-shells/SPEC.md`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions: `docs/solutions/frontend/pwa-update-activation-lifecycle.md`
- Project Docs: -
- Project Docs Sync: n/a(no project current truth change)