### PR TITLE
fix(pwa): unblock service worker activation

### DIFF
--- a/docs/solutions/frontend/pwa-update-activation-lifecycle.md
+++ b/docs/solutions/frontend/pwa-update-activation-lifecycle.md
@@ -38,9 +38,14 @@ does not prove that the admin registration is performing an update.
 - Activate a first-install waiting worker silently. If another registration currently controls the
   page, expect the new registration to take over on the next in-scope navigation rather than
   requiring an immediate controller swap.
-- A worker-owned fetch failure is a separate boundary from `registration.update()`: catch rejected
-  same-origin network requests inside the service worker and return a non-success HTTP response
-  such as `503`, rather than passing a rejected promise to `respondWith`.
+- Do not call `respondWith` for network-only API, MCP, SSE, authentication, or mutation requests.
+  A long-lived response keeps the old worker's FetchEvent alive and can prevent the replacement
+  worker from completing activation.
+- Do not call `clients.claim()` from the update worker's activate event. Let first installs take
+  control on the next in-scope navigation; for explicit updates, reload after the target worker
+  reaches `activated` so the new navigation selects the new controller.
+- Keep a contained `503` fallback only for ordinary same-origin runtime resources that the worker
+  intentionally owns and that are not precached.
 
 ## Guardrails
 
@@ -51,5 +56,7 @@ does not prove that the admin registration is performing an update.
 - Test the state machine with deterministic worker mocks, then retain one real-browser two-release
   scenario that changes the service worker script on the same origin and proves controller/cache
   takeover.
-- Exercise the generated worker's fetch handler with a rejected `fetch`, including an MCP request,
-  so the regression test observes the same boundary as a browser `FetchEvent`.
+- Exercise the generated worker's fetch handler to prove network-only requests never call
+  `respondWith`, while owned runtime requests still convert rejected fetches into `503` responses.
+- The real-browser two-release test must race successful navigation against the
+  `activation-failed` banner so a stalled update fails with the same symptom users see.

--- a/docs/specs/2br7z-web-pwa-split-identities-offline-shells/HISTORY.md
+++ b/docs/specs/2br7z-web-pwa-split-identities-offline-shells/HISTORY.md
@@ -8,4 +8,5 @@
 - 2026-06-27: 将 Relay Mesh、LinuxDo 与 favicon 位图依赖统一迁到 `/assets/*`，删除根路径品牌资源公开合同并补齐静态服务回归覆盖。
 - 2026-07-08: 更新生命周期改为 precache 完成后 waiting，页面用共享 inline banner 提示用户确认激活，避免后端版本变化时误报资源已 ready。
 - 2026-07-11: 修复用户确认更新后永久停在 `activating` 的状态机缺口。发送激活消息不再视为完成证据；runtime 现在等待 controller/worker 成功信号并以 watchdog、失败重试和单次 reload guard 收口，同时修正 public controller 干扰 admin 首装判断的问题。
-- 2026-07-12: 修复生成 Service Worker 将网络拒绝直接传给 `respondWith` 的缺口。MCP 与未预缓存的同源请求现在在网络不可达时返回 `503`，不再产生未处理的 `FetchEvent` promise rejection。
+- 2026-07-12: 尝试将 Service Worker 拥有请求的网络拒绝转换为 `503`，消除未处理的 `FetchEvent` promise rejection；后续真实更新复现进一步收窄了 network-only 请求的正确所有权边界。
+- 2026-07-14: 真实 Chromium A/B 更新复现确认 network-only 长连接被 Service Worker `respondWith` 接管会阻塞旧 worker 退场，并使新 worker停在 `activating`。network-only 请求改由浏览器直接处理，activate 阶段移除 `clients.claim()`，首次安装在下一次导航接管，版本更新由 `activated` 后 reload 完成。

--- a/docs/specs/2br7z-web-pwa-split-identities-offline-shells/IMPLEMENTATION.md
+++ b/docs/specs/2br7z-web-pwa-split-identities-offline-shells/IMPLEMENTATION.md
@@ -21,9 +21,8 @@
 - 用户触发激活后以 `controllerchange` 或 waiting worker 的 `activated` 状态确认成功；后者使用单次 reload guard 兼容浏览器漏发当前页接管事件的情况。
 - 激活请求以 10 秒 watchdog 收口；超时、worker `redundant` 或激活消息发送异常都会进入 `activation-failed`，退出 loading 并允许用户重试或暂不提醒。
 - 首次安装与版本升级以当前 registration 自身是否已有 active worker 区分；public 根作用域 controller 不再让 admin 首装误报更新，admin waiting worker 会静默激活并在下一次 admin 导航接管。
-- public/admin worker 对同源 network-only 与未预缓存请求共享网络失败转换：底层 `fetch` 拒绝时返回
-  `503 Service Unavailable`，避免 `respondWith` 的 rejected promise 在浏览器侧表现为未处理的
-  `FetchEvent` 网络错误。
+- public/admin worker 不接管 `/api/*`、`/mcp`、SSE、认证与写请求等 network-only 流量，避免长连接 FetchEvent 阻塞旧 worker 退场；未预缓存的普通同源运行时资源仍在网络拒绝时返回 `503 Service Unavailable`。
+- worker activate 事件只清理旧 cache，不调用 `clients.claim()`；首次安装在下一次同 scope 导航接管，版本更新则由 runtime 在目标 worker 到达 `activated` 后 reload。
 
 ## 待完成项
 
@@ -50,7 +49,12 @@
   - Chromium E2E 以同源临时静态目录模拟 release A/B，验证 public 更新接管、reload 与 admin 跨 scope 首装。
 - 2026-07-12:
   - `cd web && bun run build && bun test ./src/pwa/assetGraph.test.ts`
-  - 生成的 public/admin worker 在 MCP 与未预缓存资源网络拒绝时都返回 `503`。
+  - 生成的 public/admin worker 对自身拥有的未预缓存运行时资源提供 `503` 网络失败响应。
+- 2026-07-14:
+  - `cd web && bun test src/pwa/runtime.test.ts`
+  - `cd web && bun test src/pwa/assetGraph.test.ts`
+  - `cd web && bun run test:e2e:pwa-offline`
+  - Chromium 两版本 E2E 直接断言更新必须 reload；若进入 `activation-failed` 则立即失败。
 
 ## 已实现内容
 

--- a/docs/specs/2br7z-web-pwa-split-identities-offline-shells/SPEC.md
+++ b/docs/specs/2br7z-web-pwa-split-identities-offline-shells/SPEC.md
@@ -98,6 +98,7 @@
 - 用户点击更新时：
   - 若新 worker 尚在安装或缓存资源，更新按钮保持 loading，等待 worker 进入 waiting 后再发送激活消息。
   - 若新 worker 已经 waiting，页面向该 worker 发送 `TAVILY_HIKARI_ACTIVATE_UPDATE`，由 worker `skipWaiting()`。
+  - worker 的 activate 事件只清理旧 cache，不调用 `clients.claim()`；版本更新由目标 worker 到达 `activated` 后 reload，并在新导航中接管页面。
   - 页面只在用户主动更新后的 `controllerchange` 中 reload，避免静默打断当前任务。
   - waiting worker 已进入 `activated` 但当前页未收到 `controllerchange` 时，页面允许执行一次受 guard 保护的 reload；不得形成刷新循环。
   - 激活请求在 10 秒内既未接管页面也未确认 worker 已激活时，提示必须退出 loading 并进入可重试失败态；`redundant` 与消息发送异常同样按失败处理。
@@ -111,7 +112,7 @@
 
 - 已访问过 `/`、`/console/**`、`/login`、`/registration-paused` 的用户，在离线时仍可打开相应壳页。
 - 页面框架、主题切换、静态文案与本地 UI 状态可用。
-- `/api/*`、`/mcp`、SSE、登录动作、保存动作一律 network-only，失败时显示明确错误。
+- `/api/*`、`/mcp`、SSE、登录动作、保存动作一律 network-only，Service Worker 不得对其调用 `respondWith`，由浏览器网络栈直接处理并在失败时显示明确错误。
 - 离线访问 `/admin` 时，public SW 不提供 admin shell fallback。
 
 ### Admin
@@ -174,7 +175,11 @@
   When 触发 `/api/*`、SSE、MCP、登录提交、保存动作
   Then 一律保持 network failure 语义，不返回伪成功。
 
-- Given 同源的 network-only 或未预缓存请求被 public/admin service worker 拦截
+- Given 同源的 network-only 请求命中 public/admin service worker fetch listener
+  When 请求属于 `/api/*`、SSE、MCP、认证或写操作
+  Then worker 不得调用 `respondWith`，请求必须由浏览器网络栈直接处理。
+
+- Given 同源的未预缓存普通运行时资源被 public/admin service worker 拦截
   When 底层网络请求拒绝
   Then worker 必须返回可处理的 `503 Service Unavailable` 响应，而不是让 `FetchEvent`
   的 `respondWith` promise 拒绝。
@@ -190,6 +195,10 @@
 - Given 新 service worker 已经 waiting
   When 用户点击更新按钮
   Then 页面发送 `TAVILY_HIKARI_ACTIVATE_UPDATE` 并在 `controllerchange` 后 reload。
+
+- Given 当前页面存在 SSE 或 MCP 等长连接
+  When waiting worker 收到激活请求
+  Then 旧 worker 不得持有这些 network-only 请求的 FetchEvent，新 worker 必须完成激活并由页面 reload 接管。
 
 - Given 用户已请求激活 waiting worker
   When 10 秒内没有 controller 接管、worker 激活确认或可恢复终态

--- a/tests/e2e/pwa_offline_browser_e2e.ts
+++ b/tests/e2e/pwa_offline_browser_e2e.ts
@@ -410,6 +410,7 @@ async function main() {
     await publicPage.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
     await waitForSelector(publicPage, ".public-home");
     await waitForServiceWorker(publicPage);
+    await publicPage.reload({ waitUntil: "domcontentloaded" });
     await waitForController(publicPage, "/sw-public.js");
 
     log("verifying an explicit app-shell update activates and reloads");
@@ -425,10 +426,14 @@ async function main() {
       undefined,
       { timeout: 20_000 },
     );
-    await Promise.all([
-      publicPage.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 20_000 }),
-      publicPage.locator(".update-banner-actions button").first().click(),
+    const updateOutcome = await Promise.race([
+      publicPage.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 15_000 }).then(() => "reloaded" as const),
+      publicPage.waitForSelector(".update-banner-failed", { state: "visible", timeout: 15_000 }).then(() => "failed" as const),
+      publicPage.locator(".update-banner-actions button").first().click().then(() => new Promise<never>(() => {})),
     ]);
+    if (updateOutcome === "failed") {
+      throw new Error("public app-shell update entered activation-failed instead of reloading");
+    }
     await waitForController(publicPage, "/sw-public.js");
     const publicCacheKeys = await publicPage.evaluate(() => caches.keys());
     if (!publicCacheKeys.some((key) => key.endsWith("e2e-release-b"))) {
@@ -480,6 +485,7 @@ async function main() {
     await adminLoginPage.goto(`${baseUrl}/login`, { waitUntil: "domcontentloaded" });
     await waitForSelector(adminLoginPage, "#admin-password-input");
     await waitForServiceWorker(adminLoginPage);
+    await adminLoginPage.reload({ waitUntil: "domcontentloaded" });
     await waitForController(adminLoginPage, "/sw-public.js");
     await adminLoginPage.fill("#admin-password-input", "pw-e2e-admin");
     log("signing into admin shell");

--- a/web/scripts/generate_pwa_assets.py
+++ b/web/scripts/generate_pwa_assets.py
@@ -176,7 +176,6 @@ self.addEventListener('activate', (event) => {{
   event.waitUntil((async () => {{
     const keys = await caches.keys();
     await Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)));
-    await self.clients.claim();
   }})());
 }});
 
@@ -223,7 +222,6 @@ self.addEventListener('fetch', (event) => {{
   if (requestUrl.origin !== self.location.origin) return;
 
   if (isNetworkOnly(request, requestUrl)) {{
-    event.respondWith(fetchWithNetworkFallback(request));
     return;
   }}
 

--- a/web/src/pwa/assetGraph.test.ts
+++ b/web/src/pwa/assetGraph.test.ts
@@ -76,10 +76,11 @@ test('built service workers wait for explicit update activation after precache',
     expect(source).toContain('event.data.type === ACTIVATE_UPDATE_MESSAGE')
     expect(source).toContain('event.waitUntil(self.skipWaiting())')
     expect(source).not.toContain('await self.skipWaiting();')
+    expect(source).not.toContain('self.clients.claim()')
   }
 })
 
-test('built service workers turn network-only fetch failures into a response', async () => {
+test('built service workers leave network-only requests to the browser and contain runtime fetch failures', async () => {
   const serviceWorkerPaths = [
     path.resolve(import.meta.dir, '../../dist/sw-public.js'),
     path.resolve(import.meta.dir, '../../dist/sw-admin.js'),
@@ -111,22 +112,25 @@ test('built service workers turn network-only fetch failures into a response', a
       const fetchListener = listeners.get('fetch')
       expect(fetchListener).toBeDefined()
 
-      for (const requestUrl of [
-        'https://hikari.test/mcp/console/state?refresh=true',
-        'https://hikari.test/assets/lazy-chunk.js',
-      ]) {
-        let responsePromise: Promise<Response> | null = null
-        fetchListener?.({
-          request: new Request(requestUrl),
-          respondWith: (response) => {
-            responsePromise = response
-          },
-        })
+      let networkOnlyResponse: Promise<Response> | null = null
+      fetchListener?.({
+        request: new Request('https://hikari.test/mcp/console/state?refresh=true'),
+        respondWith: (response) => {
+          networkOnlyResponse = response
+        },
+      })
+      expect(networkOnlyResponse).toBeNull()
 
-        expect(responsePromise).not.toBeNull()
-        const response = await responsePromise
-        expect(response.status).toBe(503)
-      }
+      let runtimeResponse: Promise<Response> | null = null
+      fetchListener?.({
+        request: new Request('https://hikari.test/assets/lazy-chunk.js'),
+        respondWith: (response) => {
+          runtimeResponse = response
+        },
+      })
+      expect(runtimeResponse).not.toBeNull()
+      const response = await runtimeResponse
+      expect(response.status).toBe(503)
     } finally {
       Object.assign(globalThis, { self: originalSelf, fetch: originalFetch })
     }


### PR DESCRIPTION
## Summary

- stop Service Workers from owning network-only API, MCP, SSE, authentication, and mutation requests
- remove `clients.claim()` from activation so long-lived FetchEvents cannot stall worker replacement
- strengthen the real Chromium A/B release test to fail on the user-visible `activation-failed` state

## Root Cause

The old Service Worker wrapped network-only traffic in `respondWith()`. Long-lived SSE requests therefore kept its FetchEvent alive, preventing the old worker from retiring and leaving the replacement worker stuck in `activating`. Calling `clients.claim()` during activation compounded the lifecycle stall.

## Test Plan

- `cd web && bun test`
- `cd web && bun test src/pwa/runtime.test.ts`
- `cd web && bun test src/pwa/assetGraph.test.ts`
- `cd web && bun run test:e2e:pwa-offline`
- `git diff --check`
- independent read-only Codex review against `origin/main`

## References

Spec: `docs/specs/2br7z-web-pwa-split-identities-offline-shells/SPEC.md`
Spec Disposition: update
Spec Sync: done
Spec Drift: none

Solutions:
- `docs/solutions/frontend/pwa-update-activation-lifecycle.md`
Solutions Sync: done

Project Docs: -
Project Docs Sync: n/a(no project-doc change)

## Visual Evidence

Not applicable. This change affects Service Worker request ownership and activation lifecycle only; rendered UI, styling, and user-facing copy are unchanged.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
