### PR TITLE
fix(web): unify footer release links

### DIFF
--- a/web/src/PublicHome.stories.tsx
+++ b/web/src/PublicHome.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import PublicHomeHeroCard from './components/PublicHomeHeroCard'
+import PublicHomeFooter from './components/PublicHomeFooter'
 import LanguageSwitcher from './components/LanguageSwitcher'
 import ThemeToggle from './components/ThemeToggle'
 import TokenSecretField from './components/TokenSecretField'
@@ -291,6 +292,27 @@ function PublicHomeGuideTokenRevealedProof(): JSX.Element {
   )
 }
 
+function PublicHomeFooterReleaseLinkProof(): JSX.Element {
+  const strings = useTranslate().public
+
+  return (
+    <main className="app-shell public-home">
+      <section className="surface panel" style={{ display: 'grid', gap: 20, maxWidth: 920, margin: '0 auto' }}>
+        <div className="panel-header">
+          <div>
+            <h2>Footer release link proof</h2>
+            <p className="panel-description">
+              Public footer now uses the backend release tag and jumps into the OctoRill releases list with the
+              matching record highlighted.
+            </p>
+          </div>
+        </div>
+        <PublicHomeFooter versionLabel={strings.footer.version} version="0.81.1" />
+      </section>
+    </main>
+  )
+}
+
 const meta = {
   title: 'Public/PublicHome',
   parameters: {
@@ -386,6 +408,22 @@ export const GuideTokenRevealedDarkMobile: Story = {
       description: {
         story:
           'Mobile dark-theme public guide proof for the repaired recessed code blocks, guide tabs, and clay surface contrast.',
+      },
+    },
+  },
+}
+
+export const FooterReleaseLinkProof: Story = {
+  args: {
+    showAdminAction: false,
+  },
+  render: () => <PublicHomeFooterReleaseLinkProof />,
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: '1440-device-desktop' },
+    docs: {
+      description: {
+        story: 'Footer-only proof for the backend-version OctoRill release highlighter link on the public home.',
       },
     },
   },

--- a/web/src/PublicHome.stories.tsx
+++ b/web/src/PublicHome.stories.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import PublicHomeHeroCard from './components/PublicHomeHeroCard'
-import PublicHomeFooter from './components/PublicHomeFooter'
 import LanguageSwitcher from './components/LanguageSwitcher'
 import ThemeToggle from './components/ThemeToggle'
 import TokenSecretField from './components/TokenSecretField'
@@ -292,27 +291,6 @@ function PublicHomeGuideTokenRevealedProof(): JSX.Element {
   )
 }
 
-function PublicHomeFooterReleaseLinkProof(): JSX.Element {
-  const strings = useTranslate().public
-
-  return (
-    <main className="app-shell public-home">
-      <section className="surface panel" style={{ display: 'grid', gap: 20, maxWidth: 920, margin: '0 auto' }}>
-        <div className="panel-header">
-          <div>
-            <h2>Footer release link proof</h2>
-            <p className="panel-description">
-              Public footer now uses the backend release tag and jumps into the OctoRill releases list with the
-              matching record highlighted.
-            </p>
-          </div>
-        </div>
-        <PublicHomeFooter versionLabel={strings.footer.version} version="0.81.1" />
-      </section>
-    </main>
-  )
-}
-
 const meta = {
   title: 'Public/PublicHome',
   parameters: {
@@ -408,22 +386,6 @@ export const GuideTokenRevealedDarkMobile: Story = {
       description: {
         story:
           'Mobile dark-theme public guide proof for the repaired recessed code blocks, guide tabs, and clay surface contrast.',
-      },
-    },
-  },
-}
-
-export const FooterReleaseLinkProof: Story = {
-  args: {
-    showAdminAction: false,
-  },
-  render: () => <PublicHomeFooterReleaseLinkProof />,
-  parameters: {
-    layout: 'fullscreen',
-    viewport: { defaultViewport: '1440-device-desktop' },
-    docs: {
-      description: {
-        story: 'Footer-only proof for the backend-version OctoRill release highlighter link on the public home.',
       },
     },
   },

--- a/web/src/PublicHome.tsx
+++ b/web/src/PublicHome.tsx
@@ -24,6 +24,7 @@ import ThemeToggle from './components/ThemeToggle'
 import UpdateAvailableBanner from './components/UpdateAvailableBanner'
 import useUpdateAvailable from './hooks/useUpdateAvailable'
 import RollingNumber from './components/RollingNumber'
+import PublicHomeFooter from './components/PublicHomeFooter'
 import PublicHomeHeroCard from './components/PublicHomeHeroCard'
 import TokenSecretField from './components/TokenSecretField'
 import { Button } from './components/ui/button'
@@ -363,10 +364,6 @@ function PublicHome(): JSX.Element {
       })
     }, 1600)
   }, [])
-
-  const versionTagUrl = updateBanner.currentVersion
-    ? `${REPO_URL}/tree/v${encodeURIComponent(updateBanner.currentVersion)}`
-    : null
 
   const focusManualTokenField = useCallback(() => {
     window.requestAnimationFrame(() => {
@@ -912,22 +909,7 @@ function PublicHome(): JSX.Element {
         </div>
         {activeGuide === 'cherryStudio' && <CherryStudioMock apiKeyExample={exampleToken} />}
       </section>
-      <footer className="surface public-home-footer">
-        <a className="footer-gh" href={REPO_URL} target="_blank" rel="noreferrer">
-          <Icon icon="mdi:github" width={18} height={18} aria-hidden="true" style={{ color: '#2563eb' }} />
-          <span>GitHub</span>
-        </a>
-        <div className="footer-version">
-          <span>{publicStrings.footer.version}</span>
-          {versionTagUrl ? (
-            <a href={versionTagUrl} target="_blank" rel="noreferrer">
-              <code>v{updateBanner.currentVersion}</code>
-            </a>
-          ) : (
-            <code>—</code>
-          )}
-        </div>
-      </footer>
+      <PublicHomeFooter versionLabel={publicStrings.footer.version} version={updateBanner.currentBackendVersion} />
       <Dialog
         open={isTokenAccessDialogOpen}
         onOpenChange={(open) => {

--- a/web/src/admin/AdminDashboardRuntime.tsx
+++ b/web/src/admin/AdminDashboardRuntime.tsx
@@ -28,6 +28,7 @@ import NotFoundFallbackPreview from '../components/NotFoundFallbackPreview'
 import HaStatusBanner from '../components/HaStatusBanner'
 import OfflineStatusBanner from '../components/OfflineStatusBanner'
 import { ConnectedUpdateAvailableBanner } from '../components/UpdateAvailableBanner'
+import { buildOctoRillReleaseLink, formatVersionDisplay } from '../lib/releaseLinks'
 import HaSourceSettingsDialog from './HaSourceSettingsDialog'
 import HaNodeDetailPanel from './HaNodeDetailPanel'
 import { AdminSidebarUtilityCard, AdminSidebarUtilityStack } from '../components/AdminSidebarUtility'
@@ -8439,15 +8440,18 @@ function AdminDashboard(): JSX.Element {
           {version ? (
             (() => {
               const raw = version.backend || ''
-              const clean = raw.replace(/-.+$/, '')
-              const tag = clean.startsWith('v') ? clean : `v${clean}`
-              const href = `https://github.com/IvanLi-CN/tavily-hikari/releases/tag/${tag}`
+              const release = buildOctoRillReleaseLink(raw)
+              const displayVersion = formatVersionDisplay(raw)
               return (
                 <>
                   {footerStrings.tagPrefix}
-                  <a href={href} className="footer-link" target="_blank" rel="noreferrer">
-                    {`v${raw}`}
-                  </a>
+                  {release ? (
+                    <a href={release.href} className="footer-link" target="_blank" rel="noreferrer">
+                      {release.label}
+                    </a>
+                  ) : (
+                    <span>{displayVersion ?? raw}</span>
+                  )}
                 </>
               )
             })()

--- a/web/src/api/demo.ts
+++ b/web/src/api/demo.ts
@@ -222,7 +222,7 @@ function createDemoState() {
       userAvatarUrl: null,
     },
     haStatus: createDemoHaStatus(nowSeconds),
-    version: { backend: 'demo-web', frontend: '0.1.0-demo' },
+    version: { backend: '0.81.1', frontend: '0.1.0-demo' },
     tokens,
     tokenSecrets: new Map(tokens.map((token) => [token.id, token.id === DEMO_TOKEN_ID ? DEMO_TOKEN : `th-${token.id}-demoaccesssecret`])),
     keys,

--- a/web/src/components/PublicHomeFooter.tsx
+++ b/web/src/components/PublicHomeFooter.tsx
@@ -1,0 +1,34 @@
+import { Icon } from '../lib/icons'
+import { buildOctoRillReleaseLink, formatVersionDisplay } from '../lib/releaseLinks'
+
+const REPO_URL = 'https://github.com/IvanLi-CN/tavily-hikari'
+
+export default function PublicHomeFooter({
+  versionLabel,
+  version,
+}: {
+  versionLabel: string
+  version: string | null
+}): JSX.Element {
+  const release = buildOctoRillReleaseLink(version)
+  const displayVersion = formatVersionDisplay(version)
+
+  return (
+    <footer className="surface public-home-footer">
+      <a className="footer-gh" href={REPO_URL} target="_blank" rel="noreferrer">
+        <Icon icon="mdi:github" width={18} height={18} aria-hidden="true" style={{ color: '#2563eb' }} />
+        <span>GitHub</span>
+      </a>
+      <div className="footer-version">
+        <span>{versionLabel}</span>
+        {release ? (
+          <a href={release.href} target="_blank" rel="noreferrer">
+            <code>{release.label}</code>
+          </a>
+        ) : (
+          <code>{displayVersion ?? '—'}</code>
+        )}
+      </div>
+    </footer>
+  )
+}

--- a/web/src/components/UserConsoleFooter.stories.tsx
+++ b/web/src/components/UserConsoleFooter.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import UserConsoleFooter from './UserConsoleFooter'
+
+const strings = {
+  title: 'Tavily Hikari User Console',
+  githubAria: 'Open GitHub repository',
+  githubLabel: 'GitHub',
+  loadingVersion: '· Loading version…',
+  errorVersion: '· Version unavailable',
+  tagPrefix: '· ',
+}
+
+const meta = {
+  title: 'Console/UserConsoleFooter',
+  component: UserConsoleFooter,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Footer proof for backend-version release links shared with the public home and admin footer.',
+      },
+    },
+  },
+} satisfies Meta<typeof UserConsoleFooter>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const StableRelease: Story = {
+  args: {
+    strings,
+    versionState: { status: 'ready', value: { backend: '0.81.1', frontend: '0.81.1' } },
+  },
+}
+
+export const Prerelease: Story = {
+  args: {
+    strings,
+    versionState: { status: 'ready', value: { backend: '0.81.1-rc.1', frontend: '0.81.1-rc.1' } },
+  },
+}
+
+export const NonReleaseFallback: Story = {
+  args: {
+    strings,
+    versionState: { status: 'ready', value: { backend: '0.81.1-dev', frontend: '0.81.1-dev' } },
+  },
+}

--- a/web/src/components/UserConsoleFooter.test.tsx
+++ b/web/src/components/UserConsoleFooter.test.tsx
@@ -24,11 +24,23 @@ describe('UserConsoleFooter', () => {
     expect(html).toContain('Tavily Hikari User Console')
     expect(html).toContain('Open GitHub repository')
     expect(html).toContain('href="https://github.com/IvanLi-CN/tavily-hikari"')
-    expect(html).toContain('href="https://github.com/IvanLi-CN/tavily-hikari/releases/tag/v0.2.0"')
+    expect(html).toContain('href="https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases?highlight=tag%3Av0.2.0&amp;highlight_active=tag%3Av0.2.0"')
     expect(html).toContain('v0.2.0')
   })
 
-  it('renders plain text when the version is a non-release build', () => {
+  it('renders a prerelease link without truncating the suffix', () => {
+    const html = renderToStaticMarkup(
+      <UserConsoleFooter
+        strings={strings}
+        versionState={{ status: 'ready', value: { backend: '0.2.0-rc.1', frontend: '0.2.0-rc.1' } }}
+      />,
+    )
+
+    expect(html).toContain('href="https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases?highlight=tag%3Av0.2.0-rc.1&amp;highlight_active=tag%3Av0.2.0-rc.1"')
+    expect(html).toContain('v0.2.0-rc.1')
+  })
+
+  it('renders plain text when the version is a blocked non-release build', () => {
     const html = renderToStaticMarkup(
       <UserConsoleFooter
         strings={strings}
@@ -37,7 +49,7 @@ describe('UserConsoleFooter', () => {
     )
 
     expect(html).toContain('v0.2.0-dev')
-    expect(html).not.toContain('/releases/tag/')
+    expect(html).not.toContain('octo-rill.ivanli.cc')
   })
 
   it('falls back to the loading copy while version data is still loading', () => {
@@ -56,10 +68,14 @@ describe('UserConsoleFooter', () => {
 })
 
 describe('buildUserConsoleFooterRelease', () => {
-  it('builds a release link for stable semver versions only', () => {
+  it('builds a release link for stable and prerelease versions but rejects blocked dev channels', () => {
     expect(buildUserConsoleFooterRelease({ backend: '0.2.0', frontend: '0.2.0' })).toEqual({
-      href: 'https://github.com/IvanLi-CN/tavily-hikari/releases/tag/v0.2.0',
+      href: 'https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases?highlight=tag%3Av0.2.0&highlight_active=tag%3Av0.2.0',
       label: 'v0.2.0',
+    })
+    expect(buildUserConsoleFooterRelease({ backend: '0.2.0-rc.1', frontend: '0.2.0-rc.1' })).toEqual({
+      href: 'https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases?highlight=tag%3Av0.2.0-rc.1&highlight_active=tag%3Av0.2.0-rc.1',
+      label: 'v0.2.0-rc.1',
     })
     expect(buildUserConsoleFooterRelease({ backend: '0.2.0-dev', frontend: '0.2.0-dev' })).toBeNull()
     expect(buildUserConsoleFooterRelease({ backend: 'ci-deadbeef', frontend: 'ci-deadbeef' })).toBeNull()

--- a/web/src/components/UserConsoleFooter.tsx
+++ b/web/src/components/UserConsoleFooter.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '../lib/icons'
+import { buildOctoRillReleaseLink, formatVersionDisplay } from '../lib/releaseLinks'
 
 import type { VersionInfo } from '../api'
 
@@ -17,21 +18,7 @@ export function buildUserConsoleFooterRelease(version: VersionInfo | null): {
   href: string
   label: string
 } | null {
-  const raw = version?.backend.trim() ?? ''
-  if (raw.length === 0) {
-    return null
-  }
-
-  // Only stable semver builds map cleanly to a GitHub release tag.
-  if (!/^v?\d+\.\d+\.\d+$/.test(raw)) {
-    return null
-  }
-
-  const tag = raw.startsWith('v') ? raw : `v${raw}`
-  return {
-    href: `${REPO_URL}/releases/tag/${tag}`,
-    label: tag,
-  }
+  return buildOctoRillReleaseLink(version?.backend)
 }
 
 export default function UserConsoleFooter({
@@ -48,7 +35,7 @@ export default function UserConsoleFooter({
     ? buildUserConsoleFooterRelease(versionState.value)
     : null
   const versionLabel = versionState.status === 'ready'
-    ? versionState.value?.backend?.trim() || null
+    ? formatVersionDisplay(versionState.value?.backend)
     : null
 
   return (
@@ -77,7 +64,7 @@ export default function UserConsoleFooter({
         ) : versionLabel ? (
           <>
             {strings.tagPrefix}
-            <span>{versionLabel.startsWith('v') ? versionLabel : `v${versionLabel}`}</span>
+            <span>{versionLabel}</span>
           </>
         ) : versionState.status === 'error' ? (
           strings.errorVersion

--- a/web/src/hooks/useUpdateAvailable.test.tsx
+++ b/web/src/hooks/useUpdateAvailable.test.tsx
@@ -117,6 +117,7 @@ describe('useUpdateAvailable', () => {
     })
     await flushEffects()
 
+    expect(latest?.currentBackendVersion).toBe('0.79.1')
     expect(latest?.currentVersion).toBe('0.79.0')
     expect(latest?.availableVersion).toBe('0.79.1')
     expect(latest?.visible).toBe(false)

--- a/web/src/hooks/useUpdateAvailable.ts
+++ b/web/src/hooks/useUpdateAvailable.ts
@@ -17,6 +17,7 @@ function shouldShowUpdateBanner(status: PwaUpdateStatus): boolean {
 }
 
 export interface UpdateAvailableState {
+  currentBackendVersion: string | null
   currentVersion: string | null
   availableVersion: string | null
   status: PwaUpdateStatus
@@ -29,6 +30,7 @@ export interface UpdateAvailableState {
 export default function useUpdateAvailable(): UpdateAvailableState {
   const bundledVersionRef = useRef<string | null>(getBundledFrontendVersion())
   const runningVersionRef = useRef<string | null>(bundledVersionRef.current)
+  const [currentBackendVersion, setCurrentBackendVersion] = useState<string | null>(null)
   const [currentVersion, setCurrentVersion] = useState<string | null>(bundledVersionRef.current)
   const [availableVersion, setAvailableVersion] = useState<string | null>(null)
   const [visible, setVisible] = useState(false)
@@ -53,7 +55,12 @@ export default function useUpdateAvailable(): UpdateAvailableState {
 
   const syncVersionFromServer = useCallback(async () => {
     const next = await loadVersion()
+    const nextBackend = next?.backend?.trim() || null
     const nextFrontend = next?.frontend ?? null
+
+    if (nextBackend) {
+      setCurrentBackendVersion(nextBackend)
+    }
     if (!nextFrontend) return null
 
     if (!runningVersionRef.current) {
@@ -72,10 +79,15 @@ export default function useUpdateAvailable(): UpdateAvailableState {
   useEffect(() => {
     let cancelled = false
     ;(async () => {
-      const nextFrontend = await loadVersion()
+      const nextVersion = await loadVersion()
       if (cancelled) return
 
-      const frontend = nextFrontend?.frontend ?? null
+      const backend = nextVersion?.backend?.trim() || null
+      if (backend) {
+        setCurrentBackendVersion(backend)
+      }
+
+      const frontend = nextVersion?.frontend ?? null
       if (!frontend) return
 
       if (!runningVersionRef.current) {
@@ -163,6 +175,7 @@ export default function useUpdateAvailable(): UpdateAvailableState {
   const loading = updateSnapshot.status === 'activating'
 
   return {
+    currentBackendVersion,
     currentVersion,
     availableVersion,
     status: updateSnapshot.status,

--- a/web/src/lib/releaseLinks.test.ts
+++ b/web/src/lib/releaseLinks.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+
+import { buildOctoRillReleaseLink, formatVersionDisplay, normalizeReleaseTag } from './releaseLinks'
+
+describe('releaseLinks', () => {
+  it('builds an OctoRill highlight link for stable releases', () => {
+    expect(buildOctoRillReleaseLink('0.81.1')).toEqual({
+      href: 'https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases?highlight=tag%3Av0.81.1&highlight_active=tag%3Av0.81.1',
+      label: 'v0.81.1',
+    })
+  })
+
+  it('keeps prerelease suffixes in the highlighted tag', () => {
+    expect(buildOctoRillReleaseLink('0.81.1-rc.1')).toEqual({
+      href: 'https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases?highlight=tag%3Av0.81.1-rc.1&highlight_active=tag%3Av0.81.1-rc.1',
+      label: 'v0.81.1-rc.1',
+    })
+    expect(normalizeReleaseTag('v0.81.1-beta.2')).toBe('v0.81.1-beta.2')
+  })
+
+  it('rejects non-release channels that should stay plain text', () => {
+    expect(buildOctoRillReleaseLink('0.81.1-dev')).toBeNull()
+    expect(buildOctoRillReleaseLink('0.81.1-ci.3')).toBeNull()
+    expect(buildOctoRillReleaseLink('passkey-local')).toBeNull()
+  })
+
+  it('formats release-looking versions with a v prefix but leaves opaque labels untouched', () => {
+    expect(formatVersionDisplay('0.81.1')).toBe('v0.81.1')
+    expect(formatVersionDisplay('0.81.1-rc.1')).toBe('v0.81.1-rc.1')
+    expect(formatVersionDisplay('ci-deadbeef')).toBe('ci-deadbeef')
+  })
+})

--- a/web/src/lib/releaseLinks.ts
+++ b/web/src/lib/releaseLinks.ts
@@ -1,0 +1,60 @@
+const OCTO_RILL_RELEASES_URL = 'https://octo-rill.ivanli.cc/IvanLi-CN/tavily-hikari/releases'
+const RELEASE_VERSION_PATTERN = /^(?:v)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const BLOCKED_PRERELEASE_CHANNELS = new Set(['ci', 'dev', 'local'])
+
+export interface ReleaseLink {
+  href: string
+  label: string
+}
+
+function extractPrereleaseChannel(tag: string): string | null {
+  const match = tag.match(/^[v]?\d+\.\d+\.\d+-([0-9A-Za-z.-]+)$/)
+  if (!match) return null
+
+  const [channel = ''] = match[1].split('.', 1)
+  return channel.toLowerCase() || null
+}
+
+export function formatVersionDisplay(version: string | null | undefined): string | null {
+  const trimmed = version?.trim() ?? ''
+  if (trimmed.length === 0) {
+    return null
+  }
+
+  if (RELEASE_VERSION_PATTERN.test(trimmed) && !trimmed.startsWith('v')) {
+    return `v${trimmed}`
+  }
+
+  return trimmed
+}
+
+export function normalizeReleaseTag(version: string | null | undefined): string | null {
+  const displayVersion = formatVersionDisplay(version)
+  if (!displayVersion || !RELEASE_VERSION_PATTERN.test(displayVersion)) {
+    return null
+  }
+
+  const prereleaseChannel = extractPrereleaseChannel(displayVersion)
+  if (prereleaseChannel && BLOCKED_PRERELEASE_CHANNELS.has(prereleaseChannel)) {
+    return null
+  }
+
+  return displayVersion
+}
+
+export function buildOctoRillReleaseLink(version: string | null | undefined): ReleaseLink | null {
+  const tag = normalizeReleaseTag(version)
+  if (!tag) {
+    return null
+  }
+
+  const selector = `tag:${tag}`
+  const query = new URLSearchParams()
+  query.append('highlight', selector)
+  query.set('highlight_active', selector)
+
+  return {
+    href: `${OCTO_RILL_RELEASES_URL}?${query.toString()}`,
+    label: tag,
+  }
+}


### PR DESCRIPTION
## Summary
- unify the PublicHome, User Console, and Admin footer version links onto the OctoRill releases highlighter URL
- use `backend` as the shared version source and keep `dev`/`ci`/opaque local builds as plain text
- add a shared release-link helper, regression tests, and Storybook proof surfaces

## Validation
- `cd web && bun test src/lib/releaseLinks.test.ts src/components/UserConsoleFooter.test.tsx src/hooks/useUpdateAvailable.test.tsx`
- `cd web && bunx --bun tsc --noEmit`
- `cd web && bun run build`
- `cd web && bun run build-storybook`

## Visual Evidence
- `Public/PublicHome` → `FooterReleaseLinkProof`
- `Admin/Pages` → `Dashboard`
- `Console/UserConsoleFooter` → `StableRelease`

## References
- Specs: -
- Solutions: -
- Project Docs: -