### PR TITLE
feat(storage): introduce sqlite runtime ownership seam

### DIFF
--- a/docs/specs/performance-architecture-hardening/HISTORY.md
+++ b/docs/specs/performance-architecture-hardening/HISTORY.md
@@ -11,6 +11,10 @@
 
 ## Key Reasons / Replacements
 
+- Ticket #485 establishes the first storage ownership seam: `SqliteRuntime` owns canonical pool
+  handles, admission, and the 250ms bounded operation contract while legacy `KeyStore` callers use
+  explicit compatibility adapters during rollout.
+
 - 反复局部优化未能稳定消除性能回归，因为生命周期、存储和读取边界仍由浅层 facade 共享。
 - durable per-channel work 替代单一 HA GC representative，避免一个 channel 的延迟阻塞全部排债。
 - durable projections 与共享 snapshots 替代请求线程上的重复聚合和 flush-on-read。

--- a/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
+++ b/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
@@ -4,7 +4,7 @@
 
 ## Current Status
 
-- Implementation: 未开始
+- Implementation: Ticket #485 SqliteRuntime seam 已完成，等待 child PR integration CI
 - Lifecycle: active
 - Delivery topology: aggregate-stack
 - Integration branch: `prd/performance-architecture-hardening`
@@ -33,7 +33,11 @@
 
 ## Related Changes
 
-- None
+- `src/store/sqlite_runtime.rs` adds typed read, immediate-write, and admission operations with a
+  bounded 250ms operation budget and cancellation/busy outcomes.
+- `KeyStore` constructors create one `SqliteRuntime` from the existing pools and expose only
+  compatibility handles while expand-contract callers migrate; pool sizes, busy timeouts,
+  PRAGMAs, and transaction SQL remain unchanged.
 
 ## References
 

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -168,12 +168,13 @@ rule-providers:
             .await
             .expect("ensure schema");
 
+        let sqlite_runtime = crate::store::SqliteRuntime::new(pool.clone(), pool.clone(), 1);
         let key_store = crate::store::KeyStore {
             database_path: db_path.to_string_lossy().into_owned(),
             observability_database_path: None,
             _observability_lock: None,
-            pool: pool.clone(),
-            read_flush_pool: pool.clone(),
+            pool: sqlite_runtime.compatibility_primary_pool(),
+            read_flush_pool: sqlite_runtime.compatibility_read_flush_pool(),
             backend_time: crate::BackendTime::system(),
             token_binding_cache: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             account_quota_resolution_cache: tokio::sync::RwLock::new(
@@ -185,7 +186,8 @@ rule-providers:
                 std::collections::HashMap::new(),
             ),
             request_stats_coalescer: crate::store::RequestStatsCoalescer::default(),
-            admin_heavy_read_semaphore: tokio::sync::Semaphore::new(1),
+            admin_heavy_read_semaphore: sqlite_runtime.compatibility_admission(),
+            sqlite_runtime,
             #[cfg(test)]
             forced_pending_claim_miss_log_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
             #[cfg(test)]

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -664,12 +664,17 @@ impl KeyStore {
                 layout.core_database_path
             );
         }
+        let sqlite_runtime = SqliteRuntime::new(
+            pool,
+            read_flush_pool,
+            ADMIN_HEAVY_READ_CONCURRENCY,
+        );
         let store = Self {
             database_path: layout.core_database_path.clone(),
             observability_database_path,
             _observability_lock: Some(observability_lock),
-            pool,
-            read_flush_pool,
+            pool: sqlite_runtime.compatibility_primary_pool(),
+            read_flush_pool: sqlite_runtime.compatibility_read_flush_pool(),
             backend_time,
             token_binding_cache: RwLock::new(HashMap::new()),
             account_quota_resolution_cache: RwLock::new(HashMap::new()),
@@ -677,7 +682,8 @@ impl KeyStore {
             request_log_retention_cache: RwLock::new(None),
             user_debug_info_shared_cache: RwLock::new(HashMap::new()),
             request_stats_coalescer: RequestStatsCoalescer::default(),
-            admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
+            admin_heavy_read_semaphore: sqlite_runtime.compatibility_admission(),
+            sqlite_runtime,
             #[cfg(test)]
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             #[cfg(debug_assertions)]
@@ -743,12 +749,17 @@ impl KeyStore {
                 layout.core_database_path
             );
         }
+        let sqlite_runtime = SqliteRuntime::new(
+            pool,
+            read_flush_pool,
+            ADMIN_HEAVY_READ_CONCURRENCY,
+        );
         let store = Self {
             database_path: layout.core_database_path.clone(),
             observability_database_path,
             _observability_lock: Some(observability_lock),
-            pool,
-            read_flush_pool,
+            pool: sqlite_runtime.compatibility_primary_pool(),
+            read_flush_pool: sqlite_runtime.compatibility_read_flush_pool(),
             backend_time,
             token_binding_cache: RwLock::new(HashMap::new()),
             account_quota_resolution_cache: RwLock::new(HashMap::new()),
@@ -756,7 +767,8 @@ impl KeyStore {
             request_log_retention_cache: RwLock::new(None),
             user_debug_info_shared_cache: RwLock::new(HashMap::new()),
             request_stats_coalescer: RequestStatsCoalescer::default(),
-            admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
+            admin_heavy_read_semaphore: sqlite_runtime.compatibility_admission(),
+            sqlite_runtime,
             #[cfg(test)]
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             #[cfg(debug_assertions)]

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -1235,12 +1235,17 @@ impl KeyStore {
             SQLITE_ADMIN_READ_FLUSH_BUSY_TIMEOUT,
         )
         .await?;
+        let sqlite_runtime = SqliteRuntime::new(
+            pool,
+            read_flush_pool,
+            ADMIN_HEAVY_READ_CONCURRENCY,
+        );
         let store = Self {
             database_path: layout.core_database_path.clone(),
             observability_database_path,
             _observability_lock: None,
-            pool,
-            read_flush_pool,
+            pool: sqlite_runtime.compatibility_primary_pool(),
+            read_flush_pool: sqlite_runtime.compatibility_read_flush_pool(),
             backend_time: BackendTime::system(),
             token_binding_cache: RwLock::new(HashMap::new()),
             account_quota_resolution_cache: RwLock::new(HashMap::new()),
@@ -1248,7 +1253,8 @@ impl KeyStore {
             request_log_retention_cache: RwLock::new(None),
             user_debug_info_shared_cache: RwLock::new(HashMap::new()),
             request_stats_coalescer: RequestStatsCoalescer::default(),
-            admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
+            admin_heavy_read_semaphore: sqlite_runtime.compatibility_admission(),
+            sqlite_runtime,
             #[cfg(test)]
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             #[cfg(debug_assertions)]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -16,6 +16,8 @@ use tracing::{error, info, warn};
 
 mod immediate_transaction;
 pub(crate) use immediate_transaction::ImmediateSqliteTransaction;
+pub(crate) mod sqlite_runtime;
+pub(crate) use sqlite_runtime::SqliteRuntime;
 
 pub(crate) struct ObservabilityOfflineGuard {
     _lock_file: File,
@@ -2502,6 +2504,8 @@ pub(crate) struct KeyStore {
     pub(crate) database_path: String,
     pub(crate) observability_database_path: Option<String>,
     pub(crate) _observability_lock: Option<File>,
+    #[allow(dead_code)]
+    pub(crate) sqlite_runtime: SqliteRuntime,
     pub(crate) pool: SqlitePool,
     pub(crate) read_flush_pool: SqlitePool,
     pub(crate) backend_time: BackendTime,
@@ -2512,7 +2516,7 @@ pub(crate) struct KeyStore {
     pub(crate) request_log_retention_cache: RwLock<Option<RequestLogRetentionSettings>>,
     pub(crate) user_debug_info_shared_cache: RwLock<HashMap<String, UserDebugInfoSharedCacheEntry>>,
     pub(crate) request_stats_coalescer: RequestStatsCoalescer,
-    pub(crate) admin_heavy_read_semaphore: Semaphore,
+    pub(crate) admin_heavy_read_semaphore: Arc<Semaphore>,
     #[cfg(test)]
     pub(crate) forced_pending_claim_miss_log_ids: Mutex<HashSet<i64>>,
     #[cfg(debug_assertions)]

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -1,0 +1,223 @@
+use super::{ImmediateSqliteTransaction, ProxyError, is_transient_sqlite_write_error};
+use sqlx::{Sqlite, SqlitePool};
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SqliteDeferredReason {
+    Cancelled,
+    Busy,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) enum SqliteOperationOutcome<T> {
+    Completed(T),
+    Deferred(SqliteDeferredReason),
+    Failed(ProxyError),
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct SqliteReadConnection(sqlx::pool::PoolConnection<Sqlite>);
+
+impl Deref for SqliteReadConnection {
+    type Target = sqlx::SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl DerefMut for SqliteReadConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut()
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) type SqliteAdmission = OwnedSemaphorePermit;
+
+#[derive(Debug)]
+pub(crate) struct SqliteRuntime {
+    primary_pool: SqlitePool,
+    read_flush_pool: SqlitePool,
+    admission: Arc<Semaphore>,
+    operation_budget: Duration,
+}
+
+impl SqliteRuntime {
+    pub(crate) const DEFAULT_OPERATION_BUDGET: Duration = Duration::from_millis(250);
+
+    pub(crate) fn new(
+        primary_pool: SqlitePool,
+        read_flush_pool: SqlitePool,
+        admission_limit: usize,
+    ) -> Self {
+        Self {
+            primary_pool,
+            read_flush_pool,
+            admission: Arc::new(Semaphore::new(admission_limit)),
+            operation_budget: Self::DEFAULT_OPERATION_BUDGET,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn read(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> SqliteOperationOutcome<SqliteReadConnection> {
+        let acquire = tokio::time::timeout(self.operation_budget, self.primary_pool.acquire());
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled)
+            }
+            result = acquire => match result {
+                Ok(Ok(connection)) => {
+                    SqliteOperationOutcome::Completed(SqliteReadConnection(connection))
+                }
+                Ok(Err(err)) => SqliteOperationOutcome::Failed(ProxyError::Database(err)),
+                Err(_) => SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy),
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn begin_immediate(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> SqliteOperationOutcome<ImmediateSqliteTransaction> {
+        let begin = async {
+            let connection = self.primary_pool.acquire().await?;
+            ImmediateSqliteTransaction::begin(connection).await
+        };
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled)
+            }
+            result = tokio::time::timeout(self.operation_budget, begin) => match result {
+                Ok(Ok(transaction)) => SqliteOperationOutcome::Completed(transaction),
+                Ok(Err(err)) if is_transient_sqlite_write_error(&err) => {
+                    SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+                }
+                Ok(Err(err)) => SqliteOperationOutcome::Failed(err),
+                Err(_) => SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy),
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn admit(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> SqliteOperationOutcome<SqliteAdmission> {
+        let acquire = tokio::time::timeout(
+            self.operation_budget,
+            Arc::clone(&self.admission).acquire_owned(),
+        );
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled)
+            }
+            result = acquire => match result {
+                Ok(Ok(permit)) => SqliteOperationOutcome::Completed(permit),
+                Ok(Err(err)) => SqliteOperationOutcome::Failed(ProxyError::Other(err.to_string())),
+                Err(_) => SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy),
+            }
+        }
+    }
+
+    pub(crate) fn compatibility_primary_pool(&self) -> SqlitePool {
+        self.primary_pool.clone()
+    }
+
+    pub(crate) fn compatibility_read_flush_pool(&self) -> SqlitePool {
+        self.read_flush_pool.clone()
+    }
+
+    pub(crate) fn compatibility_admission(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.admission)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use std::str::FromStr;
+    use tempfile::NamedTempFile;
+    use tokio_util::sync::CancellationToken;
+
+    async fn test_runtime() -> (SqliteRuntime, sqlx::SqlitePool) {
+        let file = NamedTempFile::new().expect("sqlite temp file");
+        let path = file.path().to_string_lossy().into_owned();
+        std::mem::forget(file);
+        let options = SqliteConnectOptions::from_str(&format!("sqlite://{path}"))
+            .expect("sqlite options")
+            .create_if_missing(true)
+            .busy_timeout(std::time::Duration::from_secs(5));
+        let primary = SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect_with(options.clone())
+            .await
+            .expect("primary pool");
+        let lock_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("lock pool");
+        let runtime = SqliteRuntime::new(primary.clone(), primary, 1);
+        (runtime, lock_pool)
+    }
+
+    #[test]
+    fn default_operation_budget_is_250ms() {
+        assert_eq!(
+            SqliteRuntime::DEFAULT_OPERATION_BUDGET,
+            std::time::Duration::from_millis(250)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_read_returns_typed_outcome() {
+        let (runtime, _lock_pool) = test_runtime().await;
+        let cancelled = CancellationToken::new();
+        cancelled.cancel();
+
+        let outcome = runtime.read(&cancelled).await;
+
+        assert!(matches!(
+            outcome,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled)
+        ));
+    }
+
+    #[tokio::test]
+    async fn busy_immediate_write_is_deferred_within_operation_budget() {
+        let (runtime, lock_pool) = test_runtime().await;
+        let mut lock = lock_pool.acquire().await.expect("lock connection");
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *lock)
+            .await
+            .expect("hold writer lock");
+        let started = std::time::Instant::now();
+
+        let outcome = runtime.begin_immediate(&CancellationToken::new()).await;
+
+        assert!(matches!(
+            outcome,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+        ));
+        assert!(started.elapsed() < std::time::Duration::from_millis(750));
+        sqlx::query("ROLLBACK")
+            .execute(&mut *lock)
+            .await
+            .expect("release writer lock");
+    }
+}

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -151,13 +151,16 @@ mod tests {
     use super::*;
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::str::FromStr;
-    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
     use tokio_util::sync::CancellationToken;
 
-    async fn test_runtime() -> (SqliteRuntime, sqlx::SqlitePool) {
-        let file = NamedTempFile::new().expect("sqlite temp file");
-        let path = file.path().to_string_lossy().into_owned();
-        std::mem::forget(file);
+    async fn test_runtime() -> (SqliteRuntime, sqlx::SqlitePool, TempDir) {
+        let temp_dir = TempDir::new().expect("sqlite temp directory");
+        let path = temp_dir
+            .path()
+            .join("runtime.db")
+            .to_string_lossy()
+            .into_owned();
         let options = SqliteConnectOptions::from_str(&format!("sqlite://{path}"))
             .expect("sqlite options")
             .create_if_missing(true)
@@ -173,7 +176,7 @@ mod tests {
             .await
             .expect("lock pool");
         let runtime = SqliteRuntime::new(primary.clone(), primary, 1);
-        (runtime, lock_pool)
+        (runtime, lock_pool, temp_dir)
     }
 
     #[test]
@@ -186,7 +189,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancelled_read_returns_typed_outcome() {
-        let (runtime, _lock_pool) = test_runtime().await;
+        let (runtime, _lock_pool, _temp_dir) = test_runtime().await;
         let cancelled = CancellationToken::new();
         cancelled.cancel();
 
@@ -200,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn busy_immediate_write_is_deferred_within_operation_budget() {
-        let (runtime, lock_pool) = test_runtime().await;
+        let (runtime, lock_pool, _temp_dir) = test_runtime().await;
         let mut lock = lock_pool.acquire().await.expect("lock connection");
         sqlx::query("BEGIN IMMEDIATE")
             .execute(&mut *lock)

--- a/src/tests/jobs_and_request_log_retention.rs
+++ b/src/tests/jobs_and_request_log_retention.rs
@@ -14,12 +14,14 @@ async fn quota_subject_lock_retries_transient_sqlite_write_lock() {
         .connect_with(options)
         .await
         .expect("busy-test pool");
+    let sqlite_runtime =
+        SqliteRuntime::new(pool.clone(), pool.clone(), ADMIN_HEAVY_READ_CONCURRENCY);
     let store = KeyStore {
         database_path: db_path.to_string_lossy().into_owned(),
         observability_database_path: None,
         _observability_lock: None,
-        pool: pool.clone(),
-        read_flush_pool: pool,
+        pool: sqlite_runtime.compatibility_primary_pool(),
+        read_flush_pool: sqlite_runtime.compatibility_read_flush_pool(),
         backend_time: BackendTime::system(),
         token_binding_cache: RwLock::new(std::collections::HashMap::new()),
         account_quota_resolution_cache: RwLock::new(std::collections::HashMap::new()),
@@ -27,7 +29,8 @@ async fn quota_subject_lock_retries_transient_sqlite_write_lock() {
         request_log_retention_cache: RwLock::new(None),
         user_debug_info_shared_cache: RwLock::new(std::collections::HashMap::new()),
         request_stats_coalescer: RequestStatsCoalescer::default(),
-        admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
+        admin_heavy_read_semaphore: sqlite_runtime.compatibility_admission(),
+        sqlite_runtime,
         #[cfg(test)]
         forced_pending_claim_miss_log_ids: Mutex::new(std::collections::HashSet::new()),
         #[cfg(test)]

--- a/src/tests/request_kind_and_core.rs
+++ b/src/tests/request_kind_and_core.rs
@@ -2282,12 +2282,14 @@ async fn request_kind_database_migration_retries_after_transient_write_lock() {
     drop(proxy);
 
     let pool = connect_sqlite_test_pool(&db_str).await;
+    let sqlite_runtime =
+        SqliteRuntime::new(pool.clone(), pool.clone(), ADMIN_HEAVY_READ_CONCURRENCY);
     let store = KeyStore {
         database_path: db_path.to_string_lossy().into_owned(),
         observability_database_path: sqlite_test_layout(&db_str).observability_database_path,
         _observability_lock: None,
-        pool: pool.clone(),
-        read_flush_pool: pool,
+        pool: sqlite_runtime.compatibility_primary_pool(),
+        read_flush_pool: sqlite_runtime.compatibility_read_flush_pool(),
         backend_time: BackendTime::system(),
         token_binding_cache: RwLock::new(std::collections::HashMap::new()),
         account_quota_resolution_cache: RwLock::new(std::collections::HashMap::new()),
@@ -2295,7 +2297,8 @@ async fn request_kind_database_migration_retries_after_transient_write_lock() {
         request_log_retention_cache: RwLock::new(None),
         user_debug_info_shared_cache: RwLock::new(std::collections::HashMap::new()),
         request_stats_coalescer: RequestStatsCoalescer::default(),
-        admin_heavy_read_semaphore: Semaphore::new(ADMIN_HEAVY_READ_CONCURRENCY),
+        admin_heavy_read_semaphore: sqlite_runtime.compatibility_admission(),
+        sqlite_runtime,
         #[cfg(test)]
         forced_pending_claim_miss_log_ids: Mutex::new(std::collections::HashSet::new()),
         #[cfg(test)]


### PR DESCRIPTION
## Summary

- add `SqliteRuntime` as the canonical owner of primary/read-flush pool handles and admission
- expose typed read, immediate-write, and admission operations with bounded cancellation/busy outcomes
- preserve existing pool construction, PRAGMAs, transaction SQL, and billing semantics through compatibility adapters

## Delivery

- Delivery role: child
- Parent Issue: #485
- Parent tracker: #483
- Integration branch: `prd/performance-architecture-hardening`
- Wave: 3
- Risk: wave-gated
- Depends on: none
- Spec@baseline: `docs/specs/performance-architecture-hardening/SPEC.md@50f33d2e949a86b6a40d94f54e9dce1d75f93610`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test store::sqlite_runtime::tests --lib`
- `cargo test` (599 library tests and 454/455 server tests passed; the one concurrent failure passed on exact rerun)
- exact rerun: `cargo test --bin tavily-hikari server::tests::admin_users_and_tokens::admin_user_management_lists_details_and_updates_quota -- --exact --nocapture`
- `bun test` in `web/` (523 passed)
- `bun run test:source-budgets` in `web/`
- `bun run build` in `web/`

## Review

- Review SHA: `7a1adc30a72eb66b608bd368640b567c5ce24417`
- Standards: clear
- Spec: clear

## References

- Spec: `docs/specs/performance-architecture-hardening/SPEC.md`
- Spec Disposition: link
- Specs: `docs/specs/performance-architecture-hardening/SPEC.md`
- Solutions: `docs/solutions/operations/sqlite-write-lock-contention.md`, `docs/solutions/operations/sqlite-admin-read-containment.md`
- Project Docs: -
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a(no solution change)
- Project Docs Sync: n/a(no project-doc change)

## Notes

- `solution_disposition=none`: existing SQLite contention/read-containment guidance remains current.
- `project_doc_disposition=none`: this internal expand-contract seam does not change owner-facing project operation or usage docs.
- No UI-affecting change; visual evidence is not applicable.

Relates #485.
