### PR TITLE
ci: cover sqlite runtime tests in lib shard

### DIFF
--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -90,6 +90,7 @@
         "runtime_logging::tests::",
         "store::admin_passkey_store_tests::",
         "store::alert_grouping_tests::",
+        "store::sqlite_runtime::tests::",
         "store::tests::",
         "tavily_proxy::tests::",
         "tests::request_kind_and_core::parse_",


### PR DESCRIPTION
## Summary

- add the store::sqlite_runtime::tests:: namespace to the existing lib-core shard
- preserve current shard classification and runner behavior; no production code changes

## Integration failure evidence

- Failed integration SHA: 9487992724e8ff4ed5550ae90742a2a9d5d61380
- Deterministic failure: scripts/ci_backend_tests.py verify reported three unmatched SQLiteRuntime lib tests.

## Validation

- prepare-artifacts plus shard verify
- three exact SQLiteRuntime targeted tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check and JSON parse

## Review

- Review SHA: 89f4c9bba96ba3cd0f067d11bfba989fa033e7c0
- Standards: clear
- Spec: clear

## Delivery

- PR role: child
- Parent Issue: #485
- Parent tracker: #483
- Integration branch: prd/performance-architecture-hardening
- Risk: wave-gated
- Depends on: none

## References

- Spec: docs/specs/performance-architecture-hardening/SPEC.md
- Spec Disposition: link
- Specs: docs/specs/performance-architecture-hardening/SPEC.md
- Solutions: -
- Project Docs: -
- Spec Sync: done
- Spec Drift: none
- Solutions Sync: n/a(no solution change)
- Project Docs Sync: n/a(no project-doc change)

## Notes

This is the minimal child repair for the failed integration shard-coverage gate. Do not merge without owner approval bound to the exact head SHA.
