### PR TITLE
feat(ha): cache peer observations for admin reads

### DIFF
--- a/src/ha.rs
+++ b/src/ha.rs
@@ -607,6 +607,7 @@ pub struct HaStatusView {
 #[derive(Clone, Debug)]
 pub struct HaPeerObservation {
     pub observed_at: i64,
+    pub last_good_observed_at: Option<i64>,
     pub status: Option<HaStatusView>,
     pub error: Option<String>,
     pub capabilities: Option<String>,
@@ -623,6 +624,7 @@ impl HaPeerObservation {
             .unwrap_or_default();
         Self {
             observed_at,
+            last_good_observed_at: Some(observed_at),
             status: Some(status),
             error: None,
             capabilities,
@@ -633,6 +635,7 @@ impl HaPeerObservation {
     pub fn failure(observed_at: i64, error: impl Into<String>) -> Self {
         Self {
             observed_at,
+            last_good_observed_at: None,
             status: None,
             error: Some(error.into()),
             capabilities: None,
@@ -656,6 +659,25 @@ impl HaPeerObservationStore {
             .write()
             .await
             .insert(node_id.into(), observation);
+    }
+
+    pub async fn record_failure(
+        &self,
+        node_id: impl Into<String>,
+        observed_at: i64,
+        error: impl Into<String>,
+    ) {
+        let node_id = node_id.into();
+        let error = error.into();
+        let mut observations = self.observations.write().await;
+        if let Some(observation) = observations.get_mut(&node_id)
+            && observation.status.is_some()
+        {
+            observation.observed_at = observed_at;
+            observation.error = Some(error);
+            return;
+        }
+        observations.insert(node_id, HaPeerObservation::failure(observed_at, error));
     }
 
     pub async fn get(&self, node_id: &str) -> Option<HaPeerObservation> {
@@ -2039,16 +2061,19 @@ mod tests {
         assert_eq!(success.channel_health[0].cursor_state, "healthy");
 
         store
-            .record(
-                "peer-a",
-                HaPeerObservation::failure(101, "peer unavailable"),
-            )
+            .record_failure("peer-a", 101, "peer unavailable")
             .await;
         let failure = store.get("peer-a").await.expect("failure observation");
         assert_eq!(failure.observed_at, 101);
-        assert!(failure.status.is_none());
+        assert_eq!(failure.last_good_observed_at, Some(100));
+        assert!(failure.status.is_some());
         assert_eq!(failure.error.as_deref(), Some("peer unavailable"));
-        assert!(failure.channel_health.is_empty());
+        assert_eq!(
+            failure.capabilities.as_deref(),
+            Some(WRITABLE_TENURE_CAPABILITY)
+        );
+        assert_eq!(failure.channel_health.len(), 1);
+        assert_eq!(failure.channel_health[0].cursor_state, "healthy");
     }
 
     #[tokio::test]

--- a/src/ha.rs
+++ b/src/ha.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::sync::Arc;
+use std::{collections::HashMap, path::PathBuf};
 
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use ring::hmac;
@@ -604,6 +604,69 @@ pub struct HaStatusView {
     pub planned_cutover_eligible: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct HaPeerObservation {
+    pub observed_at: i64,
+    pub status: Option<HaStatusView>,
+    pub error: Option<String>,
+    pub capabilities: Option<String>,
+    pub channel_health: Vec<HaChannelHealthView>,
+}
+
+impl HaPeerObservation {
+    pub fn success(observed_at: i64, status: HaStatusView, capabilities: Option<String>) -> Self {
+        let channel_health = status
+            .peer_nodes
+            .iter()
+            .find(|peer| peer.node_id == status.node_id)
+            .map(|peer| peer.channel_health.clone())
+            .unwrap_or_default();
+        Self {
+            observed_at,
+            status: Some(status),
+            error: None,
+            capabilities,
+            channel_health,
+        }
+    }
+
+    pub fn failure(observed_at: i64, error: impl Into<String>) -> Self {
+        Self {
+            observed_at,
+            status: None,
+            error: Some(error.into()),
+            capabilities: None,
+            channel_health: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct HaPeerObservationStore {
+    observations: Arc<RwLock<HashMap<String, HaPeerObservation>>>,
+}
+
+impl HaPeerObservationStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn record(&self, node_id: impl Into<String>, observation: HaPeerObservation) {
+        self.observations
+            .write()
+            .await
+            .insert(node_id.into(), observation);
+    }
+
+    pub async fn get(&self, node_id: &str) -> Option<HaPeerObservation> {
+        self.observations.read().await.get(node_id).cloned()
+    }
+
+    pub async fn snapshot(&self) -> HashMap<String, HaPeerObservation> {
+        self.observations.read().await.clone()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HaControlPlaneEventView {
@@ -696,6 +759,7 @@ pub struct HaRuntime {
     backend_time: BackendTime,
     writable_authority: WritableTenureSupervisor,
     writable_business_admission: Arc<RwLock<()>>,
+    peer_observation_store: HaPeerObservationStore,
 }
 
 impl HaRuntime {
@@ -728,7 +792,12 @@ impl HaRuntime {
                 0,
             )),
             writable_business_admission: Arc::new(RwLock::new(())),
+            peer_observation_store: HaPeerObservationStore::new(),
         }
+    }
+
+    pub fn peer_observation_store(&self) -> HaPeerObservationStore {
+        self.peer_observation_store.clone()
     }
 
     pub async fn acquire_writable_business_admission(&self) -> OwnedRwLockReadGuard<()> {
@@ -1890,7 +1959,85 @@ impl HaConfig {
 
 #[cfg(test)]
 mod tests {
+    use crate::WRITABLE_TENURE_CAPABILITY;
+
     use super::*;
+
+    #[tokio::test]
+    async fn peer_observation_store_keeps_success_and_failure_states_explicit() {
+        let store = HaPeerObservationStore::new();
+        let runtime = HaRuntime::new(HaConfig::default());
+        let mut status = runtime.status().await;
+        status.peer_nodes.push(HaPeerNodeView {
+            node_id: status.node_id.clone(),
+            public_origin: None,
+            source_config_target: None,
+            role: Some(status.role),
+            allows_basic_business: status.allows_basic_business,
+            allows_full_writes: status.allows_full_writes,
+            last_sync_at: status.last_sync_at,
+            sync_lag_seconds: status.sync_lag_seconds,
+            recovery_status: status.recovery_status.clone(),
+            message: status.message.clone(),
+            last_seen_at: Some(100),
+            stale: false,
+            role_hint: HaPeerRoleHint::Observer,
+            planned_cutover_eligible: false,
+            channel_health: vec![HaChannelHealthView {
+                channel: HaSyncChannel::Control,
+                acked_seq: Some(7),
+                high_watermark: 7,
+                ack_lag: Some(0),
+                cursor_state: "healthy".to_string(),
+                retention_secs: 72 * 60 * 60,
+                expired_backlog: false,
+                gc_state: "idle".to_string(),
+                oldest_age_secs: Some(0),
+                last_progress_at: Some(100),
+                last_defer_reason: None,
+                next_retry_at: None,
+                batch_size: 250,
+                gc_debt_mode: "normal".to_string(),
+                gc_observed_at: Some(100),
+                gc_deleted_rows_per_minute: 0.0,
+                gc_recovery_deadline_at: None,
+                gc_slo_state: "healthy".to_string(),
+                gc_foreground_rps: 0,
+            }],
+        });
+        store
+            .record(
+                "peer-a",
+                HaPeerObservation::success(
+                    100,
+                    status,
+                    Some(WRITABLE_TENURE_CAPABILITY.to_string()),
+                ),
+            )
+            .await;
+
+        let success = store.get("peer-a").await.expect("success observation");
+        assert_eq!(success.observed_at, 100);
+        assert!(success.status.is_some());
+        assert_eq!(
+            success.capabilities.as_deref(),
+            Some(WRITABLE_TENURE_CAPABILITY)
+        );
+        assert_eq!(success.channel_health.len(), 1);
+        assert_eq!(success.channel_health[0].cursor_state, "healthy");
+
+        store
+            .record(
+                "peer-a",
+                HaPeerObservation::failure(101, "peer unavailable"),
+            )
+            .await;
+        let failure = store.get("peer-a").await.expect("failure observation");
+        assert_eq!(failure.observed_at, 101);
+        assert!(failure.status.is_none());
+        assert_eq!(failure.error.as_deref(), Some("peer unavailable"));
+        assert!(failure.channel_health.is_empty());
+    }
 
     #[tokio::test]
     async fn single_mode_starts_full_master() {

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -1,4 +1,5 @@
 const HA_CAPABILITIES_HEADER: &str = "x-tavily-ha-capabilities";
+const HA_PEER_ERROR_BODY_MAX_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -396,7 +397,7 @@ async fn fetch_internal_ha_status_with_metadata(
         .map(str::to_string);
     if !response.status().is_success() {
         let status = response.status();
-        let detail = response.text().await.unwrap_or_default();
+        let detail = read_bounded_response_detail(response).await;
         return Err(format!(
             "peer {} returned {} for internal HA status: {}",
             peer.node_id, status, detail
@@ -410,6 +411,32 @@ async fn fetch_internal_ha_status_with_metadata(
         status,
         capabilities,
     })
+}
+
+async fn read_bounded_response_detail(response: reqwest::Response) -> String {
+    let mut body = response.bytes_stream();
+    let mut detail = Vec::with_capacity(HA_PEER_ERROR_BODY_MAX_BYTES);
+    let mut truncated = false;
+    while let Some(chunk) = body.next().await {
+        let Ok(chunk) = chunk else {
+            break;
+        };
+        let remaining = HA_PEER_ERROR_BODY_MAX_BYTES.saturating_sub(detail.len());
+        if chunk.len() > remaining {
+            detail.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        detail.extend_from_slice(&chunk);
+        if detail.len() == HA_PEER_ERROR_BODY_MAX_BYTES {
+            break;
+        }
+    }
+    let mut detail = String::from_utf8_lossy(&detail).into_owned();
+    if truncated {
+        detail.push_str("... [truncated]");
+    }
+    detail
 }
 
 async fn fetch_internal_ha_status_for_planned_transition(

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -1,5 +1,3 @@
-use futures_util::stream;
-
 const HA_CAPABILITIES_HEADER: &str = "x-tavily-ha-capabilities";
 
 #[derive(Debug, Deserialize)]
@@ -249,9 +247,7 @@ fn peer_view_from_status(
     last_seen_at: i64,
     now_ts: i64,
 ) -> tavily_hikari::HaPeerNodeView {
-    let stale = latest_probe_timestamp(status)
-        .map(|value| now_ts.saturating_sub(value) > HA_PEER_STALE_SECS)
-        .unwrap_or(true);
+    let stale = now_ts.saturating_sub(last_seen_at) > HA_PEER_STALE_SECS;
     let planned_cutover_eligible = config.role_hint == tavily_hikari::HaPeerRoleHint::StandbyCandidate
         && !stale
         && local_planned_cutover_eligible(status, now_ts);
@@ -305,12 +301,84 @@ fn peer_view_from_error(
     }
 }
 
+fn peer_view_from_observation(
+    config: &tavily_hikari::HaPeerNodeConfig,
+    observation: &tavily_hikari::HaPeerObservation,
+    now_ts: i64,
+) -> tavily_hikari::HaPeerNodeView {
+    match observation.status.as_ref() {
+        Some(status) => peer_view_from_status(config, status, observation.observed_at, now_ts),
+        None => {
+            let mut view = peer_view_from_error(
+                config,
+                observation
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "peer observation is unavailable".to_string()),
+            );
+            view.last_seen_at = Some(observation.observed_at);
+            view
+        }
+    }
+}
+
+fn peer_channel_retention_secs(channel: tavily_hikari::HaSyncChannel) -> i64 {
+    match channel {
+        tavily_hikari::HaSyncChannel::Control => 72 * 60 * 60,
+        tavily_hikari::HaSyncChannel::Billing | tavily_hikari::HaSyncChannel::Runtime => {
+            14 * 24 * 60 * 60
+        }
+    }
+}
+
+fn unknown_peer_channel_health(
+    channel: tavily_hikari::HaSyncChannel,
+) -> tavily_hikari::HaChannelHealthView {
+    tavily_hikari::HaChannelHealthView {
+        channel,
+        acked_seq: None,
+        high_watermark: 0,
+        ack_lag: None,
+        cursor_state: "unknown".to_string(),
+        retention_secs: peer_channel_retention_secs(channel),
+        expired_backlog: false,
+        gc_state: "unknown".to_string(),
+        oldest_age_secs: None,
+        last_progress_at: None,
+        last_defer_reason: None,
+        next_retry_at: None,
+        batch_size: 250,
+        gc_debt_mode: "unknown".to_string(),
+        gc_observed_at: None,
+        gc_deleted_rows_per_minute: 0.0,
+        gc_recovery_deadline_at: None,
+        gc_slo_state: "unknown".to_string(),
+        gc_foreground_rps: 0,
+    }
+}
+
 async fn fetch_internal_ha_status(
     client: &Client,
     peer: &tavily_hikari::HaPeerNodeConfig,
     internal_token: &str,
     local_node_id: &str,
 ) -> Result<tavily_hikari::HaStatusView, String> {
+    fetch_internal_ha_status_with_metadata(client, peer, internal_token, local_node_id)
+        .await
+        .map(|probe| probe.status)
+}
+
+struct HaPeerStatusProbe {
+    status: tavily_hikari::HaStatusView,
+    capabilities: Option<String>,
+}
+
+async fn fetch_internal_ha_status_with_metadata(
+    client: &Client,
+    peer: &tavily_hikari::HaPeerNodeConfig,
+    internal_token: &str,
+    local_node_id: &str,
+) -> Result<HaPeerStatusProbe, String> {
     let response = client
         .get(format!("{}/api/internal/ha/status", peer.admin_base_url))
         .query(&[
@@ -321,6 +389,11 @@ async fn fetch_internal_ha_status(
         .send()
         .await
         .map_err(|err| format!("peer {} unreachable: {err}", peer.node_id))?;
+    let capabilities = response
+        .headers()
+        .get(HA_CAPABILITIES_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     if !response.status().is_success() {
         let status = response.status();
         let detail = response.text().await.unwrap_or_default();
@@ -329,10 +402,14 @@ async fn fetch_internal_ha_status(
             peer.node_id, status, detail
         ));
     }
-    response
+    let status = response
         .json::<tavily_hikari::HaStatusView>()
         .await
-        .map_err(|err| format!("peer {} returned invalid HA status: {err}", peer.node_id))
+        .map_err(|err| format!("peer {} returned invalid HA status: {err}", peer.node_id))?;
+    Ok(HaPeerStatusProbe {
+        status,
+        capabilities,
+    })
 }
 
 async fn fetch_internal_ha_status_for_planned_transition(
@@ -341,36 +418,12 @@ async fn fetch_internal_ha_status_for_planned_transition(
     internal_token: &str,
     local_node_id: &str,
 ) -> Result<tavily_hikari::HaStatusView, String> {
-    let response = client
-        .get(format!("{}/api/internal/ha/status", peer.admin_base_url))
-        .query(&[
-            ("refreshAuthority", "true"),
-            ("peerNodeId", local_node_id),
-        ])
-        .header("x-ha-internal-token", internal_token)
-        .send()
-        .await
-        .map_err(|err| format!("peer {} unreachable: {err}", peer.node_id))?;
-    let capability = response
-        .headers()
-        .get(HA_CAPABILITIES_HEADER)
-        .and_then(|value| value.to_str().ok());
+    let probe = fetch_internal_ha_status_with_metadata(client, peer, internal_token, local_node_id).await?;
     tavily_hikari::require_writable_tenure_capability([(
         peer.node_id.as_str(),
-        capability,
+        probe.capabilities.as_deref(),
     )])?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let detail = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "peer {} returned {} for internal HA status: {}",
-            peer.node_id, status, detail
-        ));
-    }
-    response
-        .json::<tavily_hikari::HaStatusView>()
-        .await
-        .map_err(|err| format!("peer {} returned invalid HA status: {err}", peer.node_id))
+    Ok(probe.status)
 }
 
 async fn require_configured_peer_writable_tenure_capabilities(
@@ -522,43 +575,25 @@ async fn attach_internal_source_channel_health(
 async fn build_admin_ha_status(state: &Arc<AppState>) -> tavily_hikari::HaStatusView {
     let now_ts = state.proxy.backend_time().now_ts();
     let mut status = build_internal_ha_status(state).await;
-    if let Some(internal_token) = state.ha.internal_token() {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build()
-            .unwrap_or_else(|_| Client::new());
-        let peers: Vec<_> = state
-            .ha
-            .peer_nodes()
-            .into_iter()
-            .filter(|peer| peer.node_id != status.node_id)
-            .collect();
-        let local_node_id = status.node_id.clone();
-        status.peer_nodes = stream::iter(peers)
-            .map(|peer| {
-                let client = client.clone();
-                let internal_token = internal_token.to_string();
-                let local_node_id = local_node_id.clone();
-                async move {
-                    let last_seen_at = now_ts;
-                    match fetch_internal_ha_status(&client, &peer, &internal_token, &local_node_id).await {
-                        Ok(peer_status) => peer_view_from_status(&peer, &peer_status, last_seen_at, now_ts),
-                        Err(err) => peer_view_from_error(&peer, err),
-                    }
-                }
-            })
-            .buffer_unordered(8)
-            .collect()
-            .await;
-    } else {
-        status.peer_nodes = state
-            .ha
-            .peer_nodes()
-            .into_iter()
-            .filter(|peer| peer.node_id != status.node_id)
-            .map(|peer| peer_view_from_error(&peer, "HA_INTERNAL_TOKEN is required for peer probing".to_string()))
-            .collect();
-    }
+    let observations = state.ha.peer_observation_store().snapshot().await;
+    status.peer_nodes = state
+        .ha
+        .peer_nodes()
+        .into_iter()
+        .filter(|peer| peer.node_id != status.node_id)
+        .map(|peer| {
+            observations
+                .get(&peer.node_id)
+                .map(|observation| peer_view_from_observation(&peer, observation, now_ts))
+                .unwrap_or_else(|| {
+                    peer_view_from_error(
+                        &peer,
+                        "peer observation is unavailable; background probe has not completed"
+                            .to_string(),
+                    )
+                })
+        })
+        .collect();
     for peer in &mut status.peer_nodes {
         let mut health = Vec::with_capacity(3);
         let peer_probe_succeeded = peer.role.is_some() && peer.last_seen_at.is_some();
@@ -678,7 +713,13 @@ async fn build_admin_ha_status(state: &Arc<AppState>) -> tavily_hikari::HaStatus
                     gc_foreground_rps: source_health.as_ref().map(|health| health.gc_foreground_rps).unwrap_or(0),
                 })
             } else {
-                state.proxy.ha_peer_channel_health(channel, &peer.node_id).await.ok()
+                Some(
+                    peer.channel_health
+                        .iter()
+                        .find(|health| health.channel == channel)
+                        .cloned()
+                        .unwrap_or_else(|| unknown_peer_channel_health(channel)),
+                )
             };
             if let Some(value) = value {
                 health.push(value);

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -639,13 +639,13 @@ async fn build_admin_ha_status(state: &Arc<AppState>) -> tavily_hikari::HaStatus
     }
     for peer in &mut status.peer_nodes {
         let mut health = Vec::with_capacity(3);
-        let peer_probe_succeeded = peer.role.is_some() && peer.last_seen_at.is_some() && !peer.stale;
+        let peer_has_last_good = peer.role.is_some() && peer.last_seen_at.is_some();
         for channel in [
             tavily_hikari::HaSyncChannel::Control,
             tavily_hikari::HaSyncChannel::Billing,
             tavily_hikari::HaSyncChannel::Runtime,
         ] {
-            let value = if !peer_probe_succeeded {
+            let value = if !peer_has_last_good {
                 Some(tavily_hikari::HaChannelHealthView {
                     channel,
                     acked_seq: None,
@@ -671,6 +671,14 @@ async fn build_admin_ha_status(state: &Arc<AppState>) -> tavily_hikari::HaStatus
                     gc_slo_state: "unknown".to_string(),
                     gc_foreground_rps: 0,
                 })
+            } else if peer.stale {
+                Some(
+                    peer.channel_health
+                        .iter()
+                        .find(|health| health.channel == channel)
+                        .cloned()
+                        .unwrap_or_else(|| unknown_peer_channel_health(channel)),
+                )
             } else if status.role == tavily_hikari::HaNodeRole::Standby {
                 let source_health = peer
                     .channel_health

--- a/src/server/handlers/admin_resources/ha.rs
+++ b/src/server/handlers/admin_resources/ha.rs
@@ -247,6 +247,7 @@ fn peer_view_from_status(
     status: &tavily_hikari::HaStatusView,
     last_seen_at: i64,
     now_ts: i64,
+    channel_health: &[tavily_hikari::HaChannelHealthView],
 ) -> tavily_hikari::HaPeerNodeView {
     let stale = now_ts.saturating_sub(last_seen_at) > HA_PEER_STALE_SECS;
     let planned_cutover_eligible = config.role_hint == tavily_hikari::HaPeerRoleHint::StandbyCandidate
@@ -270,12 +271,7 @@ fn peer_view_from_status(
         stale,
         role_hint: config.role_hint,
         planned_cutover_eligible,
-        channel_health: status
-            .peer_nodes
-            .iter()
-            .find(|node| node.node_id == status.node_id)
-            .map(|node| node.channel_health.clone())
-            .unwrap_or_default(),
+        channel_health: channel_health.to_vec(),
     }
 }
 
@@ -308,18 +304,31 @@ fn peer_view_from_observation(
     now_ts: i64,
 ) -> tavily_hikari::HaPeerNodeView {
     match observation.status.as_ref() {
-        Some(status) => peer_view_from_status(config, status, observation.observed_at, now_ts),
-        None => {
-            let mut view = peer_view_from_error(
+        Some(status) => {
+            let last_good_observed_at = observation
+                .last_good_observed_at
+                .unwrap_or(observation.observed_at);
+            let mut view = peer_view_from_status(
                 config,
-                observation
-                    .error
-                    .clone()
-                    .unwrap_or_else(|| "peer observation is unavailable".to_string()),
+                status,
+                last_good_observed_at,
+                now_ts,
+                &observation.channel_health,
             );
-            view.last_seen_at = Some(observation.observed_at);
+            if let Some(error) = &observation.error {
+                view.message = Some(format!("last-good peer observation is stale: {error}"));
+                view.stale = true;
+                view.planned_cutover_eligible = false;
+            }
             view
         }
+        None => peer_view_from_error(
+            config,
+            observation
+                .error
+                .clone()
+                .unwrap_or_else(|| "peer observation is unavailable".to_string()),
+        ),
     }
 }
 
@@ -621,9 +630,16 @@ async fn build_admin_ha_status(state: &Arc<AppState>) -> tavily_hikari::HaStatus
                 })
         })
         .collect();
+    if status
+        .peer_nodes
+        .iter()
+        .any(|peer| peer.role.is_none() || peer.stale)
+    {
+        status.degraded = true;
+    }
     for peer in &mut status.peer_nodes {
         let mut health = Vec::with_capacity(3);
-        let peer_probe_succeeded = peer.role.is_some() && peer.last_seen_at.is_some();
+        let peer_probe_succeeded = peer.role.is_some() && peer.last_seen_at.is_some() && !peer.stale;
         for channel in [
             tavily_hikari::HaSyncChannel::Control,
             tavily_hikari::HaSyncChannel::Billing,

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -820,11 +820,93 @@ async fn sync_forward_proxy_runtime_for_status(
     .map_err(|err| ProxyError::Other(format!("forward-proxy runtime role sync join failed: {err}")))?
 }
 
+async fn observe_ha_peer_statuses_once(
+    state: &Arc<AppState>,
+    client: &reqwest::Client,
+    internal_token: Option<&str>,
+) {
+    let local_node_id = state.ha.node_id();
+    let peers = state
+        .ha
+        .peer_nodes()
+        .into_iter()
+        .filter(|peer| peer.node_id != local_node_id)
+        .collect::<Vec<_>>();
+    if peers.is_empty() {
+        return;
+    }
+    let store = state.ha.peer_observation_store();
+    let Some(internal_token) = internal_token else {
+        for peer in peers {
+            store
+                .record(
+                    peer.node_id,
+                    tavily_hikari::HaPeerObservation::failure(
+                        state.proxy.backend_time().now_ts(),
+                        "HA_INTERNAL_TOKEN is required for peer observation",
+                    ),
+                )
+                .await;
+        }
+        return;
+    };
+    let probes = futures_stream::iter(peers.into_iter().map(|peer| {
+        let client = client.clone();
+        let internal_token = internal_token.to_string();
+        async move {
+            let result = fetch_internal_ha_status_with_metadata(
+                &client,
+                &peer,
+                &internal_token,
+                local_node_id,
+            )
+            .await;
+            (peer, result)
+        }
+    }))
+    .buffer_unordered(8)
+    .collect::<Vec<_>>()
+    .await;
+    for (peer, result) in probes {
+        let observed_at = state.proxy.backend_time().now_ts();
+        let observation = match result {
+            Ok(probe) => tavily_hikari::HaPeerObservation::success(
+                observed_at,
+                probe.status,
+                probe.capabilities,
+            ),
+            Err(err) => tavily_hikari::HaPeerObservation::failure(observed_at, err),
+        };
+        store.record(peer.node_id, observation).await;
+    }
+}
+
+fn spawn_ha_peer_observation_task(state: Arc<AppState>) {
+    if !state
+        .ha
+        .peer_nodes()
+        .into_iter()
+        .any(|peer| peer.node_id != state.ha.node_id())
+    {
+        return;
+    }
+    let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        loop {
+            let internal_token = state.ha.internal_token();
+            observe_ha_peer_statuses_once(&state, &client, internal_token.as_deref()).await;
+            state.proxy.backend_time().sleep(interval).await;
+        }
+    });
+}
+
 fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
     if state.ha.dual_active_enabled() {
         spawn_ha_peer_sync_task(state);
         return;
     }
+    spawn_ha_peer_observation_task(state.clone());
     let Some(source_url) = state.ha.sync_source_url() else {
         return;
     };
@@ -883,6 +965,7 @@ fn spawn_ha_peer_sync_task(state: Arc<AppState>) {
             reason = "missing_internal_token",
             "HA peer sync disabled because HA_INTERNAL_TOKEN is required in dual-active mode"
         );
+        spawn_ha_peer_observation_task(state);
         return;
     };
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
@@ -1292,14 +1375,38 @@ async fn run_ha_peer_sync_once(
         return Err("HA peer sync has no configured peers".into());
     }
     for peer in peer_configs {
-        match fetch_internal_ha_status(client, &peer, internal_token, &local_node_id).await {
-            Ok(peer_status) => {
+        match fetch_internal_ha_status_with_metadata(client, &peer, internal_token, &local_node_id).await {
+            Ok(probe) => {
+                state
+                    .ha
+                    .peer_observation_store()
+                    .record(
+                        peer.node_id.clone(),
+                        tavily_hikari::HaPeerObservation::success(
+                            state.proxy.backend_time().now_ts(),
+                            probe.status.clone(),
+                            probe.capabilities,
+                        ),
+                    )
+                    .await;
+                let peer_status = probe.status;
                 if peer_status.allows_full_writes && control_source_node_id.is_none() {
                     control_source_node_id = Some(peer.node_id.clone());
                 }
                 peer_views.push((peer, peer_status));
             }
             Err(err) => {
+                state
+                    .ha
+                    .peer_observation_store()
+                    .record(
+                        peer.node_id.clone(),
+                        tavily_hikari::HaPeerObservation::failure(
+                            state.proxy.backend_time().now_ts(),
+                            err.clone(),
+                        ),
+                    )
+                    .await;
                 tracing::warn!(
                     component = "ha",
                     event = "peer_status_discovery_failed",

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -892,16 +892,20 @@ fn spawn_ha_peer_observation_task(state: Arc<AppState>) {
     }
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
     tokio::spawn(async move {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build()
-            .expect("HA peer observation client configuration is valid");
+        let client = build_ha_peer_probe_client();
         loop {
             let internal_token = state.ha.internal_token();
             observe_ha_peer_statuses_once(&state, &client, internal_token.as_deref()).await;
             state.proxy.backend_time().sleep(interval).await;
         }
     });
+}
+
+fn build_ha_peer_probe_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("HA peer probe client configuration is valid")
 }
 
 fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
@@ -925,7 +929,7 @@ fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
     };
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
     tokio::spawn(async move {
-        let client = reqwest::Client::new();
+        let client = build_ha_peer_probe_client();
         loop {
             if state.ha.role().await == tavily_hikari::HaNodeRole::Standby
                 && let Err(err) =

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -839,12 +839,10 @@ async fn observe_ha_peer_statuses_once(
     let Some(internal_token) = internal_token else {
         for peer in peers {
             store
-                .record(
+                .record_failure(
                     peer.node_id,
-                    tavily_hikari::HaPeerObservation::failure(
-                        state.proxy.backend_time().now_ts(),
-                        "HA_INTERNAL_TOKEN is required for peer observation",
-                    ),
+                    state.proxy.backend_time().now_ts(),
+                    "HA_INTERNAL_TOKEN is required for peer observation",
                 )
                 .await;
         }
@@ -875,7 +873,12 @@ async fn observe_ha_peer_statuses_once(
                 probe.status,
                 probe.capabilities,
             ),
-            Err(err) => tavily_hikari::HaPeerObservation::failure(observed_at, err),
+            Err(err) => {
+                store
+                    .record_failure(peer.node_id, observed_at, err)
+                    .await;
+                continue;
+            }
         };
         store.record(peer.node_id, observation).await;
     }
@@ -1424,12 +1427,10 @@ async fn run_ha_peer_sync_once(
                 state
                     .ha
                     .peer_observation_store()
-                    .record(
+                    .record_failure(
                         peer.node_id.clone(),
-                        tavily_hikari::HaPeerObservation::failure(
-                            state.proxy.backend_time().now_ts(),
-                            err.clone(),
-                        ),
+                        state.proxy.backend_time().now_ts(),
+                        err.clone(),
                     )
                     .await;
                 tracing::warn!(

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -929,7 +929,7 @@ fn spawn_ha_standby_sync_task(state: Arc<AppState>) {
     };
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
     tokio::spawn(async move {
-        let client = build_ha_peer_probe_client();
+        let client = reqwest::Client::new();
         loop {
             if state.ha.role().await == tavily_hikari::HaNodeRole::Standby
                 && let Err(err) =
@@ -977,11 +977,19 @@ fn spawn_ha_peer_sync_task(state: Arc<AppState>) {
     };
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
     tokio::spawn(async move {
-        let client = build_ha_peer_probe_client();
+        let client = reqwest::Client::new();
+        let probe_client = build_ha_peer_probe_client();
         loop {
             let status = state.ha.status().await;
             if ha_peer_sync_should_run(&status) {
-                if let Err(err) = run_ha_peer_sync_once(&state, &client, &internal_token).await {
+                if let Err(err) = run_ha_peer_sync_once(
+                    &state,
+                    &client,
+                    &probe_client,
+                    &internal_token,
+                )
+                .await
+                {
                     tracing::warn!(
                         component = "ha",
                         event = "peer_sync_failed",
@@ -990,7 +998,7 @@ fn spawn_ha_peer_sync_task(state: Arc<AppState>) {
                     );
                 }
             } else {
-                observe_ha_peer_statuses_once(&state, &client, Some(&internal_token)).await;
+                observe_ha_peer_statuses_once(&state, &probe_client, Some(&internal_token)).await;
             }
             state.proxy.backend_time().sleep(interval).await;
         }
@@ -1368,6 +1376,7 @@ async fn run_ha_standby_sync_once(
 async fn run_ha_peer_sync_once(
     state: &Arc<AppState>,
     client: &reqwest::Client,
+    probe_client: &reqwest::Client,
     internal_token: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let status = state.ha.status().await;
@@ -1384,7 +1393,14 @@ async fn run_ha_peer_sync_once(
         return Err("HA peer sync has no configured peers".into());
     }
     for peer in peer_configs {
-        match fetch_internal_ha_status_with_metadata(client, &peer, internal_token, &local_node_id).await {
+        match fetch_internal_ha_status_with_metadata(
+            probe_client,
+            &peer,
+            internal_token,
+            &local_node_id,
+        )
+        .await
+        {
             Ok(probe) => {
                 state
                     .ha

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -892,7 +892,10 @@ fn spawn_ha_peer_observation_task(state: Arc<AppState>) {
     }
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
     tokio::spawn(async move {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("HA peer observation client configuration is valid");
         loop {
             let internal_token = state.ha.internal_token();
             observe_ha_peer_statuses_once(&state, &client, internal_token.as_deref()).await;
@@ -973,15 +976,17 @@ fn spawn_ha_peer_sync_task(state: Arc<AppState>) {
         let client = reqwest::Client::new();
         loop {
             let status = state.ha.status().await;
-            if ha_peer_sync_should_run(&status)
-                && let Err(err) = run_ha_peer_sync_once(&state, &client, &internal_token).await
-            {
-                tracing::warn!(
-                    component = "ha",
-                    event = "peer_sync_failed",
-                    err = %err,
-                    "HA peer sync failed"
-                );
+            if ha_peer_sync_should_run(&status) {
+                if let Err(err) = run_ha_peer_sync_once(&state, &client, &internal_token).await {
+                    tracing::warn!(
+                        component = "ha",
+                        event = "peer_sync_failed",
+                        err = %err,
+                        "HA peer sync failed"
+                    );
+                }
+            } else {
+                observe_ha_peer_statuses_once(&state, &client, Some(&internal_token)).await;
             }
             state.proxy.backend_time().sleep(interval).await;
         }
@@ -2240,6 +2245,7 @@ const DEFAULT_LOG_LIMIT: usize = 200;
 mod serve_tests {
     use super::*;
     use tavily_hikari::DEFAULT_UPSTREAM;
+    use tokio::net::TcpListener;
 
     #[tokio::test]
     async fn ha_control_apply_refreshes_in_memory_admin_password_state() {
@@ -2486,5 +2492,100 @@ mod serve_tests {
         let result = post_admin_passkey_authentication_start(State(state)).await;
 
         assert_eq!(result.expect_err("no passkey credentials yet"), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn ha_peer_observation_probe_populates_cache_for_admin_reads() {
+        let peer_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let peer_hits_for_route = peer_hits.clone();
+        let peer_status = tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+            mode: tavily_hikari::HaMode::ActiveStandby,
+            node_id: "node-peer".to_string(),
+            ..tavily_hikari::HaConfig::default()
+        })
+        .status()
+        .await;
+        let peer_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind peer listener");
+        let peer_addr = peer_listener.local_addr().expect("peer addr");
+        let peer_app = Router::new().route(
+            "/api/internal/ha/status",
+            get(move || {
+                let peer_hits = peer_hits_for_route.clone();
+                let peer_status = peer_status.clone();
+                async move {
+                    peer_hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    (
+                        [("x-tavily-ha-capabilities", tavily_hikari::WRITABLE_TENURE_CAPABILITY)],
+                        Json(peer_status),
+                    )
+                }
+            }),
+        );
+        tokio::spawn(async move {
+            axum::serve(peer_listener, peer_app.into_make_service())
+                .await
+                .expect("serve peer status");
+        });
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("ha-peer-observation-probe.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+            .await
+            .expect("proxy created");
+        let state = Arc::new(AppState {
+            proxy,
+            static_dir: None,
+            forward_auth: ForwardAuthConfig::new(None, None, None, None),
+            forward_auth_enabled: false,
+            builtin_admin: BuiltinAdminAuth::new(false, None, None),
+            admin_passkey: AdminPasskeyOptions::disabled(),
+            linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+            linuxdo_credit: LinuxDoCreditOptions::disabled(),
+            ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+                mode: tavily_hikari::HaMode::ActiveStandby,
+                node_id: "node-active".to_string(),
+                database_path: Some(db_str),
+                internal_token: Some("peer-token".to_string()),
+                peer_nodes: vec![tavily_hikari::HaPeerNodeConfig {
+                    node_id: "node-peer".to_string(),
+                    admin_base_url: format!("http://{peer_addr}"),
+                    public_origin: "peer-public-origin:443".to_string(),
+                    role_hint: tavily_hikari::HaPeerRoleHint::StandbyCandidate,
+                }],
+                ..tavily_hikari::HaConfig::default()
+            }),
+            dev_open_admin: false,
+            usage_base: "http://127.0.0.1:58088".to_string(),
+            api_key_ip_geo_origin: "https://api.country.is".to_string(),
+            dashboard_overview_cache: new_dashboard_overview_cache(),
+        });
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("probe client");
+
+        observe_ha_peer_statuses_once(&state, &client, Some("peer-token")).await;
+
+        let observation = state
+            .ha
+            .peer_observation_store()
+            .get("node-peer")
+            .await
+            .expect("peer observation");
+        assert_eq!(observation.capabilities.as_deref(), Some(tavily_hikari::WRITABLE_TENURE_CAPABILITY));
+        assert_eq!(
+            observation
+                .status
+                .as_ref()
+                .map(|status| status.node_id.as_str()),
+            Some("node-peer")
+        );
+        let admin_status = build_admin_ha_status(&state).await;
+        assert_eq!(admin_status.peer_nodes[0].node_id, "node-peer");
+        assert_eq!(admin_status.peer_nodes[0].role, Some(tavily_hikari::HaNodeRole::Standby));
+        assert_eq!(peer_hits.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -977,7 +977,7 @@ fn spawn_ha_peer_sync_task(state: Arc<AppState>) {
     };
     let interval = std::time::Duration::from_secs(state.ha.sync_interval_secs().max(1));
     tokio::spawn(async move {
-        let client = reqwest::Client::new();
+        let client = build_ha_peer_probe_client();
         loop {
             let status = state.ha.status().await;
             if ha_peer_sync_should_run(&status) {

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -646,6 +646,42 @@ async fn admin_ha_status_surfaces_peer_source_config_target() {
         }],
         ..tavily_hikari::HaConfig::default()
     });
+    let peer_runtime = tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+        mode: tavily_hikari::HaMode::ActiveStandby,
+        node_id: "node-peer".to_string(),
+        ..tavily_hikari::HaConfig::default()
+    });
+    let mut peer_status = peer_runtime.status().await;
+    peer_status.role = tavily_hikari::HaNodeRole::Standby;
+    peer_status.allows_basic_business = false;
+    peer_status.allows_full_writes = false;
+    peer_status.node_public_origin = Some("peer-public-origin:443".to_string());
+    peer_status.edgeone_domain = Some("api.example.com".to_string());
+    peer_status.edgeone_origin = Some("edgeone-live-route:443".to_string());
+    peer_status.edgeone_current_target = Some("edgeone-live-route:443".to_string());
+    peer_status.edgeone_current_source_kind = Some(tavily_hikari::HaSourceKind::Direct);
+    peer_status.ha_source_effective = Some(tavily_hikari::HaSourceSettingsView {
+        source_kind: tavily_hikari::HaSourceKind::Direct,
+        direct_origin_scheme: Some(tavily_hikari::OriginScheme::Https),
+        direct_origin_host: Some("peer-source-config".to_string()),
+        direct_origin_port: Some(53844),
+        origin_group_id: None,
+        target: Some("peer-source-config:53844".to_string()),
+    });
+    peer_status.last_edgeone_check_at = Some(1_700_000_000);
+    peer_status.last_sync_at = Some(1_700_000_001);
+    peer_status.sync_lag_seconds = Some(1);
+    peer_status.message = Some("peer ready".to_string());
+    ha.peer_observation_store()
+        .record(
+            "node-peer",
+            tavily_hikari::HaPeerObservation::success(
+                Utc::now().timestamp(),
+                peer_status,
+                None,
+            ),
+        )
+        .await;
     let addr = spawn_ha_admin_server(proxy, ha, true).await;
 
     let response = Client::new()
@@ -662,10 +698,7 @@ async fn admin_ha_status_surfaces_peer_source_config_target() {
         "unknown",
         "a reachable older peer without optional channel telemetry must not appear unavailable"
     );
-    assert_eq!(
-        observed_peer_node_id.lock().await.as_deref(),
-        Some("node-active")
-    );
+    assert_eq!(observed_peer_node_id.lock().await.as_deref(), None);
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -672,11 +672,13 @@ async fn admin_ha_status_surfaces_peer_source_config_target() {
     peer_status.last_sync_at = Some(1_700_000_001);
     peer_status.sync_lag_seconds = Some(1);
     peer_status.message = Some("peer ready".to_string());
-    ha.peer_observation_store()
+    let observation_store = ha.peer_observation_store();
+    let observation_time = proxy.backend_time().now_ts();
+    observation_store
         .record(
             "node-peer",
             tavily_hikari::HaPeerObservation::success(
-                Utc::now().timestamp(),
+                observation_time,
                 peer_status,
                 None,
             ),
@@ -699,6 +701,52 @@ async fn admin_ha_status_surfaces_peer_source_config_target() {
         "a reachable older peer without optional channel telemetry must not appear unavailable"
     );
     assert_eq!(observed_peer_node_id.lock().await.as_deref(), None);
+
+    let mut cached = observation_store
+        .get("node-peer")
+        .await
+        .expect("cached peer observation");
+    cached.channel_health.push(tavily_hikari::HaChannelHealthView {
+        channel: tavily_hikari::HaSyncChannel::Control,
+        acked_seq: Some(7),
+        high_watermark: 7,
+        ack_lag: Some(0),
+        cursor_state: "healthy".to_string(),
+        retention_secs: 72 * 60 * 60,
+        expired_backlog: false,
+        gc_state: "idle".to_string(),
+        oldest_age_secs: Some(0),
+        last_progress_at: Some(observation_time),
+        last_defer_reason: None,
+        next_retry_at: None,
+        batch_size: 250,
+        gc_debt_mode: "normal".to_string(),
+        gc_observed_at: Some(observation_time),
+        gc_deleted_rows_per_minute: 0.0,
+        gc_recovery_deadline_at: None,
+        gc_slo_state: "healthy".to_string(),
+        gc_foreground_rps: 0,
+    });
+    observation_store.record("node-peer", cached).await;
+    observation_store
+        .record_failure(
+            "node-peer",
+            observation_time + 1,
+            "peer probe failed after last-good observation",
+        )
+        .await;
+    let response = Client::new()
+        .get(format!("http://{addr}/api/admin/ha/status"))
+        .send()
+        .await
+        .expect("stale ha status response");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("stale ha status body");
+    assert_eq!(body["peerNodes"][0]["stale"], true);
+    assert!(body["peerNodes"][0]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("last-good peer observation is stale")));
+    assert_eq!(body["peerNodes"][0]["channelHealth"][0]["cursorState"], "healthy");
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/server/tests/alerts_and_ha_sync_recovery.rs
+++ b/src/server/tests/alerts_and_ha_sync_recovery.rs
@@ -51,7 +51,7 @@ async fn dual_active_peer_sync_does_not_mark_success_when_no_peer_is_reached() {
         .build()
         .expect("client");
 
-    let err = run_ha_peer_sync_once(&state, &client, "test-token")
+    let err = run_ha_peer_sync_once(&state, &client, &client, "test-token")
         .await
         .expect_err("peer sync should fail when no peer can be reached");
     assert!(


### PR DESCRIPTION
## Summary

Introduce `HaPeerObservationStore` as the background-owned source for ordinary administrator HA reads. Peer observations retain observed-at timestamps, last-good status/error state, capabilities, and channel health; dangerous HA operations continue to use live probes and capability gates.

Warm admin HA status and node-detail reads use the observation cache without waiting for peer HTTP or issuing peer probes. Missing, stale, unavailable, and unknown telemetry remain explicit and never become healthy zeroes. Refresh failures retain last-good coverage with stale/error markers. Probe clients are bounded and separated from long-running HA sync stream clients.

## Ticket Envelope

- Initiative: performance-architecture-hardening
- Issue: #488 https://github.com/IvanLi-CN/tavily-hikari/issues/488
- Approved plan: #483
- Spec@baseline: `docs/specs/performance-architecture-hardening/SPEC.md@50f33d2e949a86b6a40d94f54e9dce1d75f93610`
- Integration base at Ticket registration: `prd/performance-architecture-hardening@71cf979b8e780fadf01d645e1727638bf5f5f6cd`
- Final base: `main`
- Depends on: #484 (closed)
- Wave: 4
- Risk: wave-gated
- PR role: child
- Stop condition: merge-ready

## Validation

- `cargo fmt --all -- --check`, pre-commit hooks, and `cargo clippy -- -D warnings`
- `cargo test --lib peer_observation_store_keeps_success_and_failure_states_explicit` (1 passed)
- `cargo test --bin tavily-hikari ha_peer_observation_probe_populates_cache_for_admin_reads` (1 passed)
- `cargo test --bin tavily-hikari admin_ha_status_` (2 passed, including stale last-good coverage)
- `cargo test --bin tavily-hikari dual_active` (14 passed)
- Full validation after conflict resolution: library 608/609 and server binary 459/460 passed in parallel runs; one known timing-sensitive test in each run failed once and passed on isolated rerun:
  - `analysis_pressure_snapshot_live_local_mcp_logs_update_server_buckets`
  - `dashboard_overview_snapshot_keeps_one_stale_boundary_when_background_flush_finishes_mid_build`
- Final post-fix targeted validation passed; no production or server-101 validation was run.

## Review

- Fixed review base: `a500dd8a6d0f4fdbdde47995b2dced4842408399`
- Standards review: passed at exact head `4238b9220218d2d43a57138ab52ae189416298dd`; no hard findings.
- Spec review: passed at exact head `4238b9220218d2d43a57138ab52ae189416298dd`; no findings.
- Prior owner approval was invalidated by the changed head; fresh approval must bind to `4238b9220218d2d43a57138ab52ae189416298dd`.

## References

- Specs: `docs/specs/performance-architecture-hardening/SPEC.md`
- Solutions: -
- Project Docs: -

## Handover

- Child head: `4238b9220218d2d43a57138ab52ae189416298dd`
- PR base: `prd/performance-architecture-hardening`
- Current integration frontier / merge base: `prd/performance-architecture-hardening@a500dd8a6d0f4fdbdde47995b2dced4842408399`
- Integration CI: not run for this child PR; it must run after child merge and bind to the resulting integration SHA before Issue closure or downstream unlock.
- Aggregate PR: initiative-owned and not modified by this child handover.
- Next hard gate: fresh owner approval for exact head `4238b9220218d2d43a57138ab52ae189416298dd`, then the risk-gated child merge and matching integration CI.
