### PR TITLE
feat(maintenance): centralize scheduler lifecycle

### DIFF
--- a/src/ha.rs
+++ b/src/ha.rs
@@ -6,7 +6,7 @@ use ring::hmac;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
-use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+use tokio::sync::{Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
 use crate::{BackendTime, MaintenanceRuntime, WritableAuthorityState, WritableTenureSupervisor};
 
@@ -696,7 +696,7 @@ pub struct HaRuntime {
     backend_time: BackendTime,
     writable_authority: WritableTenureSupervisor,
     writable_business_admission: Arc<RwLock<()>>,
-    maintenance: MaintenanceRuntime,
+    maintenance: Arc<Mutex<MaintenanceRuntime>>,
 }
 
 impl HaRuntime {
@@ -729,7 +729,7 @@ impl HaRuntime {
                 0,
             )),
             writable_business_admission: Arc::new(RwLock::new(())),
-            maintenance: MaintenanceRuntime::new(),
+            maintenance: Arc::new(Mutex::new(MaintenanceRuntime::new())),
         }
     }
 
@@ -756,8 +756,14 @@ impl HaRuntime {
         self.writable_authority.clone()
     }
 
-    pub fn maintenance_runtime(&self) -> MaintenanceRuntime {
-        self.maintenance.clone()
+    pub async fn maintenance_runtime(&self) -> MaintenanceRuntime {
+        self.maintenance.lock().await.clone()
+    }
+
+    pub async fn start_maintenance_runtime(&self) -> MaintenanceRuntime {
+        let runtime = MaintenanceRuntime::new();
+        *self.maintenance.lock().await = runtime.clone();
+        runtime
     }
 
     pub async fn refresh_startup_role(&self) -> Result<(), String> {
@@ -1905,6 +1911,19 @@ mod tests {
         assert_eq!(status.role, HaNodeRole::FullMaster);
         assert!(status.allows_basic_business);
         assert!(status.allows_full_writes);
+    }
+
+    #[tokio::test]
+    async fn maintenance_runtime_replacement_is_tenure_scoped() {
+        let runtime = HaRuntime::new(HaConfig::default());
+        let first = runtime.maintenance_runtime().await;
+        let _first_slot = first
+            .try_acquire_remote_io_slot()
+            .expect("first tenure remote-I/O slot");
+
+        let second = runtime.start_maintenance_runtime().await;
+        assert!(second.try_acquire_remote_io_slot().is_some());
+        assert!(first.try_acquire_remote_io_slot().is_none());
     }
 
     #[tokio::test]

--- a/src/ha.rs
+++ b/src/ha.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
-use crate::{BackendTime, WritableAuthorityState, WritableTenureSupervisor};
+use crate::{BackendTime, MaintenanceRuntime, WritableAuthorityState, WritableTenureSupervisor};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -696,6 +696,7 @@ pub struct HaRuntime {
     backend_time: BackendTime,
     writable_authority: WritableTenureSupervisor,
     writable_business_admission: Arc<RwLock<()>>,
+    maintenance: MaintenanceRuntime,
 }
 
 impl HaRuntime {
@@ -728,6 +729,7 @@ impl HaRuntime {
                 0,
             )),
             writable_business_admission: Arc::new(RwLock::new(())),
+            maintenance: MaintenanceRuntime::new(),
         }
     }
 
@@ -752,6 +754,10 @@ impl HaRuntime {
 
     pub fn writable_tenure_supervisor(&self) -> WritableTenureSupervisor {
         self.writable_authority.clone()
+    }
+
+    pub fn maintenance_runtime(&self) -> MaintenanceRuntime {
+        self.maintenance.clone()
     }
 
     pub async fn refresh_startup_role(&self) -> Result<(), String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod backend_time;
 mod forward_proxy;
 mod ha;
 mod linuxdo_credit_recharge;
+mod maintenance_runtime;
 mod models;
 mod store;
 mod tavily_proxy;
@@ -44,6 +45,7 @@ pub use forward_proxy::{
 };
 pub use ha::*;
 pub use linuxdo_credit_recharge::*;
+pub use maintenance_runtime::*;
 pub use models::*;
 pub use runtime_logging::{
     LegacyStdIoLevel, RuntimeLogFormat, RuntimeMemorySnapshot, RuntimePerfScope,

--- a/src/maintenance_runtime.rs
+++ b/src/maintenance_runtime.rs
@@ -1,0 +1,192 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, Notify, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct MaintenanceRuntime {
+    wake: Arc<Notify>,
+    remote_io_slot: Arc<Semaphore>,
+    maintenance_lease: Arc<Mutex<()>>,
+    remote_tasks: Arc<Mutex<JoinSet<()>>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaintenanceRuntimeCompletion {
+    Cancelled,
+    TasksExhausted,
+}
+
+impl MaintenanceRuntime {
+    pub fn new() -> Self {
+        Self {
+            wake: Arc::new(Notify::new()),
+            remote_io_slot: Arc::new(Semaphore::new(1)),
+            maintenance_lease: Arc::new(Mutex::new(())),
+            remote_tasks: Arc::new(Mutex::new(JoinSet::new())),
+        }
+    }
+
+    pub fn wake(&self) -> Arc<Notify> {
+        self.wake.clone()
+    }
+
+    pub fn try_acquire_remote_io_slot(&self) -> Option<OwnedSemaphorePermit> {
+        self.remote_io_slot.clone().try_acquire_owned().ok()
+    }
+
+    pub fn try_acquire_maintenance_lease(&self) -> Option<OwnedMutexGuard<()>> {
+        self.maintenance_lease.clone().try_lock_owned().ok()
+    }
+
+    pub async fn supervise(
+        &self,
+        cancellation: CancellationToken,
+        tasks: Vec<JoinHandle<()>>,
+    ) -> MaintenanceRuntimeCompletion {
+        if tasks.is_empty() {
+            cancellation.cancelled().await;
+            self.abort_remote_tasks().await;
+            return MaintenanceRuntimeCompletion::Cancelled;
+        }
+
+        let mut task_set = JoinSet::new();
+        for task in tasks {
+            let task_cancellation = cancellation.clone();
+            task_set.spawn(async move {
+                // Keep the adopted handle abort-safe if the coordinator itself is dropped.
+                let mut task = tokio_util::task::AbortOnDropHandle::new(task);
+                tokio::select! {
+                    _ = task_cancellation.cancelled() => {
+                        task.abort();
+                        let _ = task.await;
+                    }
+                    result = &mut task => {
+                        let _ = result;
+                    }
+                }
+            });
+        }
+
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    while task_set.join_next().await.is_some() {}
+                    self.abort_remote_tasks().await;
+                    return MaintenanceRuntimeCompletion::Cancelled;
+                }
+                result = task_set.join_next() => {
+                    match result {
+                        Some(_) => {}
+                        None => {
+                            self.abort_remote_tasks().await;
+                            return MaintenanceRuntimeCompletion::TasksExhausted;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn spawn_remote_task<F>(&self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.remote_tasks.lock().await.spawn(task);
+    }
+
+    pub async fn reap_remote_tasks(&self) {
+        let mut tasks = self.remote_tasks.lock().await;
+        while tasks.try_join_next().is_some() {}
+    }
+
+    pub async fn abort_remote_tasks(&self) {
+        let mut tasks = self.remote_tasks.lock().await;
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+    }
+
+    #[cfg(test)]
+    async fn remote_task_count(&self) -> usize {
+        self.remote_tasks.lock().await.len()
+    }
+}
+
+impl Default for MaintenanceRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn runtime_owns_independent_remote_slots_and_maintenance_leases() {
+        let first = MaintenanceRuntime::new();
+        let second = MaintenanceRuntime::new();
+
+        let first_remote = first
+            .try_acquire_remote_io_slot()
+            .expect("first runtime remote slot");
+        assert!(first.try_acquire_remote_io_slot().is_none());
+        assert!(second.try_acquire_remote_io_slot().is_some());
+        drop(first_remote);
+
+        let first_lease = first
+            .try_acquire_maintenance_lease()
+            .expect("first runtime maintenance lease");
+        assert!(first.try_acquire_maintenance_lease().is_none());
+        assert!(second.try_acquire_maintenance_lease().is_some());
+        drop(first_lease);
+    }
+
+    #[tokio::test]
+    async fn runtime_cancellation_aborts_and_drains_adopted_tasks() {
+        let runtime = MaintenanceRuntime::new();
+        let cancellation = CancellationToken::new();
+        let stopped = Arc::new(AtomicBool::new(false));
+        let task_stopped = stopped.clone();
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            task_stopped.store(true, Ordering::SeqCst);
+        });
+
+        cancellation.cancel();
+        let completion = runtime.supervise(cancellation, vec![task]).await;
+
+        assert_eq!(completion, MaintenanceRuntimeCompletion::Cancelled);
+        assert!(!stopped.load(Ordering::SeqCst));
+        assert_eq!(runtime.remote_task_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn runtime_cancellation_aborts_dynamic_remote_tasks() {
+        let runtime = MaintenanceRuntime::new();
+        let cancellation = CancellationToken::new();
+        let remote_started = Arc::new(Notify::new());
+        let remote_started_signal = remote_started.clone();
+        runtime
+            .spawn_remote_task(async move {
+                remote_started_signal.notify_one();
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            })
+            .await;
+        remote_started.notified().await;
+
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        cancellation.cancel();
+        assert_eq!(
+            runtime.supervise(cancellation, vec![task]).await,
+            MaintenanceRuntimeCompletion::Cancelled
+        );
+        assert_eq!(runtime.remote_task_count().await, 0);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -84,7 +84,7 @@ use tavily_hikari::{
 use tokio::signal;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
-use tokio::sync::{Mutex, OwnedMutexGuard, RwLock, Semaphore};
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 use tokio_util::io::{ReaderStream, StreamReader};
 include!("state.rs");
 include!("schedulers.rs");

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -127,24 +127,23 @@ struct LegacySchedulerAdapter {
 }
 
 impl LegacySchedulerAdapter {
-    fn for_state(state: &AppState) -> Self {
+    async fn for_state(state: &AppState) -> Self {
         Self {
-            runtime: state.ha.maintenance_runtime(),
+            runtime: state.ha.maintenance_runtime().await,
         }
     }
-
+    fn wake(&self) -> Arc<tokio::sync::Notify> {
+        self.runtime.wake()
+    }
     fn notify_worker(&self) {
         self.runtime.wake().notify_one();
     }
-
     fn try_acquire_remote_io_slot(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
         self.runtime.try_acquire_remote_io_slot()
     }
-
     fn try_acquire_maintenance_lease(&self) -> Option<OwnedMutexGuard<()>> {
         self.runtime.try_acquire_maintenance_lease()
     }
-
     async fn spawn_remote_task<F>(&self, task: F)
     where
         F: std::future::Future<Output = ()> + Send + 'static,
@@ -158,6 +157,21 @@ impl LegacySchedulerAdapter {
 
     async fn abort_remote_tasks(&self) {
         self.runtime.abort_remote_tasks().await;
+    }
+
+    fn record_completion(
+        &self,
+        job_id: i64,
+        job_type: &str,
+        completion: ScheduledJobCompletion,
+    ) {
+        tracing::debug!(
+            component = "scheduler",
+            event = "scheduled_job_completion",
+            job_id,
+            job_type,
+            ?completion,
+        );
     }
 
     fn completion_for(
@@ -184,7 +198,9 @@ async fn enqueue_scheduled_job_result(
         .proxy
         .scheduled_job_enqueue(job_type, trigger_source, key_id, 1)
         .await?;
-    LegacySchedulerAdapter::for_state(state).notify_worker();
+    LegacySchedulerAdapter::for_state(state)
+        .await
+        .notify_worker();
     Ok(result)
 }
 
@@ -210,7 +226,9 @@ async fn enqueue_scheduled_job_at(
         .proxy
         .scheduled_job_enqueue_at(job_type, trigger_source, key_id, 1, available_at)
         .await?;
-    LegacySchedulerAdapter::for_state(state).notify_worker();
+    LegacySchedulerAdapter::for_state(state)
+        .await
+        .notify_worker();
     Ok(result.job_id)
 }
 
@@ -457,19 +475,25 @@ fn legacy_scheduler_adapter_exposes_typed_completion() {
 
 async fn dequeue_next_scheduled_job(
     state: &AppState,
+    cancellation: &tokio_util::sync::CancellationToken,
 ) -> Result<Option<(JobLog, Option<tokio::sync::OwnedSemaphorePermit>)>, ProxyError> {
+    if cancellation.is_cancelled() {
+        return Ok(None);
+    }
+    let adapter = LegacySchedulerAdapter::for_state(state).await;
     let candidates = state.proxy.fetch_queued_scheduled_jobs(16).await?;
-    if candidates.is_empty() {
+    if candidates.is_empty() || cancellation.is_cancelled() {
         return Ok(None);
     }
 
     let mut selected = None;
     let mut remote_io_permit = None;
     for candidate in candidates {
+        if cancellation.is_cancelled() {
+            return Ok(None);
+        }
         if scheduled_job_uses_remote_io(&candidate.job_type) {
-            if let Some(permit) = LegacySchedulerAdapter::for_state(state)
-                .try_acquire_remote_io_slot()
-            {
+            if let Some(permit) = adapter.try_acquire_remote_io_slot() {
                 remote_io_permit = Some(permit);
                 selected = Some(candidate);
                 break;
@@ -484,6 +508,9 @@ async fn dequeue_next_scheduled_job(
     let Some(candidate) = selected else {
         return Ok(None);
     };
+    if cancellation.is_cancelled() {
+        return Ok(None);
+    }
 
     let now = state.proxy.backend_time().now_ts();
     let queue_age_secs = now.saturating_sub(candidate.queued_at);
@@ -518,6 +545,17 @@ async fn dequeue_next_scheduled_job(
     }
 
     match state.proxy.scheduled_job_mark_running(candidate.id).await? {
+        Some(job) if cancellation.is_cancelled() => {
+            tracing::debug!(
+                component = "scheduler",
+                event = "job_claim_deferred",
+                job_id = job.id,
+                job_type = %job.job_type,
+                claim_generation = job.claim_generation,
+                reason = "writable_demotion",
+            );
+            Ok(None)
+        }
         Some(job) => Ok(Some((job, remote_io_permit))),
         None => Ok(None),
     }
@@ -741,13 +779,14 @@ fn spawn_maintenance_worker_with_cancellation(
     cancellation: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let adapter = LegacySchedulerAdapter::for_state(state.as_ref());
-        let wake = state.ha.maintenance_runtime().wake();
+        let adapter = LegacySchedulerAdapter::for_state(state.as_ref()).await;
+        let wake = adapter.wake();
         'worker: loop {
             adapter.reap_remote_tasks().await;
             let next_job = tokio::select! {
+                biased;
                 _ = cancellation.cancelled() => break 'worker,
-                result = dequeue_next_scheduled_job(state.as_ref()) => result,
+                result = dequeue_next_scheduled_job(state.as_ref(), &cancellation) => result,
             };
             match next_job {
                 Ok(Some((job, remote_io_permit))) => {
@@ -755,18 +794,29 @@ fn spawn_maintenance_worker_with_cancellation(
                         let run_state = state.clone();
                         let run_wake = wake.clone();
                         let run_cancellation = cancellation.clone();
+                        let run_adapter = adapter.clone();
+                        let job_id = job.id;
+                        let job_type = job.job_type.clone();
                         adapter.spawn_remote_task(async move {
                             let _remote_io_permit = remote_io_permit;
                             tokio::select! {
+                                biased;
                                 _ = run_cancellation.cancelled() => {}
-                                _ = run_queued_scheduled_job(run_state, job) => {}
+                                completion = run_queued_scheduled_job(run_state, job) => {
+                                    run_adapter.record_completion(job_id, &job_type, completion);
+                                }
                             }
                             run_wake.notify_one();
                         }).await;
                     } else {
+                        let job_id = job.id;
+                        let job_type = job.job_type.clone();
                         tokio::select! {
+                            biased;
                             _ = cancellation.cancelled() => break 'worker,
-                            _ = run_queued_scheduled_job(state.clone(), job) => {}
+                            completion = run_queued_scheduled_job(state.clone(), job) => {
+                                adapter.record_completion(job_id, &job_type, completion);
+                            }
                         }
                     }
                 }
@@ -781,6 +831,7 @@ fn spawn_maintenance_worker_with_cancellation(
                         .map(|available_at| available_at.saturating_sub(now).max(1) as u64)
                         .unwrap_or(60 * 60);
                     tokio::select! {
+                        biased;
                         _ = cancellation.cancelled() => break 'worker,
                         _ = wake.notified() => {}
                         _ = state.proxy.backend_time().sleep(Duration::from_secs(delay_secs)) => {}
@@ -793,6 +844,7 @@ fn spawn_maintenance_worker_with_cancellation(
                         err = %err,
                     );
                     tokio::select! {
+                        biased;
                         _ = cancellation.cancelled() => break 'worker,
                         _ = state.proxy.backend_time().sleep(Duration::from_secs(1)) => {}
                     }
@@ -816,7 +868,9 @@ fn spawn_scheduled_job_stale_reaper(state: Arc<AppState>) -> tokio::task::JoinHa
                         recovered,
                         continuation_delay_secs = 30_i64,
                     );
-                    LegacySchedulerAdapter::for_state(state.as_ref()).notify_worker();
+                    LegacySchedulerAdapter::for_state(state.as_ref())
+                        .await
+                        .notify_worker();
                 }
                 Err(err) => tracing::error!(
                     component = "scheduler",
@@ -1391,6 +1445,7 @@ async fn run_ha_outbox_gc_claimed_job(
     drop(_job_execution_gate);
 
     let Some(_gc_lease) = LegacySchedulerAdapter::for_state(state.as_ref())
+        .await
         .try_acquire_maintenance_lease()
     else {
         tracing::debug!(

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -114,6 +114,66 @@ struct ClaimedScheduledJob {
     _job_execution_gate: Option<OwnedMutexGuard<()>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ScheduledJobCompletion {
+    Completed,
+    Deferred,
+    Failed,
+}
+
+#[derive(Clone)]
+struct LegacySchedulerAdapter {
+    runtime: tavily_hikari::MaintenanceRuntime,
+}
+
+impl LegacySchedulerAdapter {
+    fn for_state(state: &AppState) -> Self {
+        Self {
+            runtime: state.ha.maintenance_runtime(),
+        }
+    }
+
+    fn notify_worker(&self) {
+        self.runtime.wake().notify_one();
+    }
+
+    fn try_acquire_remote_io_slot(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
+        self.runtime.try_acquire_remote_io_slot()
+    }
+
+    fn try_acquire_maintenance_lease(&self) -> Option<OwnedMutexGuard<()>> {
+        self.runtime.try_acquire_maintenance_lease()
+    }
+
+    async fn spawn_remote_task<F>(&self, task: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        self.runtime.spawn_remote_task(task).await;
+    }
+
+    async fn reap_remote_tasks(&self) {
+        self.runtime.reap_remote_tasks().await;
+    }
+
+    async fn abort_remote_tasks(&self) {
+        self.runtime.abort_remote_tasks().await;
+    }
+
+    fn completion_for(
+        job_type: &str,
+        completed: bool,
+    ) -> ScheduledJobCompletion {
+        if completed {
+            ScheduledJobCompletion::Completed
+        } else if matches!(job_type, "ha_outbox_gc" | "request_logs_gc") {
+            ScheduledJobCompletion::Deferred
+        } else {
+            ScheduledJobCompletion::Failed
+        }
+    }
+}
+
 async fn enqueue_scheduled_job_result(
     state: &AppState,
     job_type: &str,
@@ -124,7 +184,7 @@ async fn enqueue_scheduled_job_result(
         .proxy
         .scheduled_job_enqueue(job_type, trigger_source, key_id, 1)
         .await?;
-    maintenance_worker_wake_for_state(state).notify_one();
+    LegacySchedulerAdapter::for_state(state).notify_worker();
     Ok(result)
 }
 
@@ -150,7 +210,7 @@ async fn enqueue_scheduled_job_at(
         .proxy
         .scheduled_job_enqueue_at(job_type, trigger_source, key_id, 1, available_at)
         .await?;
-    maintenance_worker_wake_for_state(state).notify_one();
+    LegacySchedulerAdapter::for_state(state).notify_worker();
     Ok(result.job_id)
 }
 
@@ -378,6 +438,23 @@ fn upstream_reconciliation_does_not_wait_for_db_execution_gate() {
     assert!(scheduled_job_uses_db_execution_gate("ha_outbox_gc"));
 }
 
+#[cfg(test)]
+#[test]
+fn legacy_scheduler_adapter_exposes_typed_completion() {
+    assert_eq!(
+        LegacySchedulerAdapter::completion_for("token_usage_rollup", true),
+        ScheduledJobCompletion::Completed
+    );
+    assert_eq!(
+        LegacySchedulerAdapter::completion_for("ha_outbox_gc", false),
+        ScheduledJobCompletion::Deferred
+    );
+    assert_eq!(
+        LegacySchedulerAdapter::completion_for("token_usage_rollup", false),
+        ScheduledJobCompletion::Failed
+    );
+}
+
 async fn dequeue_next_scheduled_job(
     state: &AppState,
 ) -> Result<Option<(JobLog, Option<tokio::sync::OwnedSemaphorePermit>)>, ProxyError> {
@@ -390,7 +467,9 @@ async fn dequeue_next_scheduled_job(
     let mut remote_io_permit = None;
     for candidate in candidates {
         if scheduled_job_uses_remote_io(&candidate.job_type) {
-            if let Some(permit) = try_acquire_maintenance_remote_io_slot_for_state(state) {
+            if let Some(permit) = LegacySchedulerAdapter::for_state(state)
+                .try_acquire_remote_io_slot()
+            {
                 remote_io_permit = Some(permit);
                 selected = Some(candidate);
                 break;
@@ -444,7 +523,10 @@ async fn dequeue_next_scheduled_job(
     }
 }
 
-async fn run_queued_scheduled_job(state: Arc<AppState>, job: JobLog) {
+async fn run_queued_scheduled_job(
+    state: Arc<AppState>,
+    job: JobLog,
+) -> ScheduledJobCompletion {
     let job_type = job.job_type.clone();
     let key_id = job.key_id.clone();
     let trigger_source = job.trigger_source.clone();
@@ -499,6 +581,7 @@ async fn run_queued_scheduled_job(state: Arc<AppState>, job: JobLog) {
             ),
         }
     }
+    LegacySchedulerAdapter::completion_for(&job_type, completed)
 }
 
 fn spawn_dashboard_rollup_integrity_scheduler(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {
@@ -645,24 +728,46 @@ async fn run_dashboard_rollup_integrity_claimed_job(
     .await
 }
 
+#[cfg(test)]
 fn spawn_maintenance_worker(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {
+    spawn_maintenance_worker_with_cancellation(
+        state,
+        tokio_util::sync::CancellationToken::new(),
+    )
+}
+
+fn spawn_maintenance_worker_with_cancellation(
+    state: Arc<AppState>,
+    cancellation: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let wake = maintenance_worker_wake_for_state(state.as_ref());
-        let mut remote_jobs = tokio::task::JoinSet::new();
-        loop {
-            while remote_jobs.try_join_next().is_some() {}
-            match dequeue_next_scheduled_job(state.as_ref()).await {
+        let adapter = LegacySchedulerAdapter::for_state(state.as_ref());
+        let wake = state.ha.maintenance_runtime().wake();
+        'worker: loop {
+            adapter.reap_remote_tasks().await;
+            let next_job = tokio::select! {
+                _ = cancellation.cancelled() => break 'worker,
+                result = dequeue_next_scheduled_job(state.as_ref()) => result,
+            };
+            match next_job {
                 Ok(Some((job, remote_io_permit))) => {
                     if let Some(remote_io_permit) = remote_io_permit {
                         let run_state = state.clone();
                         let run_wake = wake.clone();
-                        remote_jobs.spawn(async move {
+                        let run_cancellation = cancellation.clone();
+                        adapter.spawn_remote_task(async move {
                             let _remote_io_permit = remote_io_permit;
-                            run_queued_scheduled_job(run_state, job).await;
+                            tokio::select! {
+                                _ = run_cancellation.cancelled() => {}
+                                _ = run_queued_scheduled_job(run_state, job) => {}
+                            }
                             run_wake.notify_one();
-                        });
+                        }).await;
                     } else {
-                        run_queued_scheduled_job(state.clone(), job).await;
+                        tokio::select! {
+                            _ = cancellation.cancelled() => break 'worker,
+                            _ = run_queued_scheduled_job(state.clone(), job) => {}
+                        }
                     }
                 }
                 Ok(None) => {
@@ -676,6 +781,7 @@ fn spawn_maintenance_worker(state: Arc<AppState>) -> tokio::task::JoinHandle<()>
                         .map(|available_at| available_at.saturating_sub(now).max(1) as u64)
                         .unwrap_or(60 * 60);
                     tokio::select! {
+                        _ = cancellation.cancelled() => break 'worker,
                         _ = wake.notified() => {}
                         _ = state.proxy.backend_time().sleep(Duration::from_secs(delay_secs)) => {}
                     }
@@ -686,10 +792,14 @@ fn spawn_maintenance_worker(state: Arc<AppState>) -> tokio::task::JoinHandle<()>
                         event = "maintenance_dequeue_failed",
                         err = %err,
                     );
-                    state.proxy.backend_time().sleep(Duration::from_secs(1)).await;
+                    tokio::select! {
+                        _ = cancellation.cancelled() => break 'worker,
+                        _ = state.proxy.backend_time().sleep(Duration::from_secs(1)) => {}
+                    }
                 }
             }
         }
+        adapter.abort_remote_tasks().await;
     })
 }
 
@@ -706,7 +816,7 @@ fn spawn_scheduled_job_stale_reaper(state: Arc<AppState>) -> tokio::task::JoinHa
                         recovered,
                         continuation_delay_secs = 30_i64,
                     );
-                    maintenance_worker_wake_for_state(state.as_ref()).notify_one();
+                    LegacySchedulerAdapter::for_state(state.as_ref()).notify_worker();
                 }
                 Err(err) => tracing::error!(
                     component = "scheduler",
@@ -1280,7 +1390,9 @@ async fn run_ha_outbox_gc_claimed_job(
     } = claimed_job;
     drop(_job_execution_gate);
 
-    let Some(_gc_lease) = try_acquire_online_ha_gc_lease() else {
+    let Some(_gc_lease) = LegacySchedulerAdapter::for_state(state.as_ref())
+        .try_acquire_maintenance_lease()
+    else {
         tracing::debug!(
             component = "ha_outbox_gc",
             event = "deferred",

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -21,27 +21,21 @@ fn random_delay_secs(max_inclusive: u64) -> u64 {
     let mut rng = rand::thread_rng();
     rng.gen_range(0..=max_inclusive)
 }
-
 fn twenty_four_hours_secs() -> i64 {
     24 * 60 * 60
 }
-
 fn two_hours_secs() -> i64 {
     2 * 60 * 60
 }
-
 fn fifteen_minutes_secs() -> i64 {
     15 * 60
 }
-
 fn forward_proxy_geo_refresh_recheck_secs() -> i64 {
     60
 }
-
 fn linuxdo_credit_recharge_lifecycle_recheck_secs() -> i64 {
     30
 }
-
 fn scheduled_request_logs_gc_options() -> RequestLogsGcOptions {
     RequestLogsGcOptions {
         batch_size: 100,
@@ -573,6 +567,9 @@ async fn run_queued_scheduled_job(
         claim_generation: job.claim_generation,
         _job_execution_gate: None,
     };
+    if job_type == "ha_outbox_gc" {
+        return run_ha_outbox_gc_claimed_job(state, claimed_job).await;
+    }
     let completed = run_manual_claimed_job(
         state.clone(),
         job_type.clone(),
@@ -1349,7 +1346,7 @@ async fn finish_ha_gc_with_continuation(
     claim_generation: i64,
     message: String,
     continuation_delay_secs: i64,
-) -> bool {
+) -> ScheduledJobCompletion {
     let available_at = state
         .proxy
         .backend_time()
@@ -1378,6 +1375,7 @@ async fn finish_ha_gc_with_continuation(
                 continuation_delay_secs,
                 available_at,
             );
+            ScheduledJobCompletion::Deferred
         }
         Err(err) if err.is_stale_claim() => {
             tracing::debug!(
@@ -1387,7 +1385,7 @@ async fn finish_ha_gc_with_continuation(
                 claim_generation,
                 "stale GC claim cannot finish or enqueue a continuation"
             );
-            return true;
+            ScheduledJobCompletion::Deferred
         }
         Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
             tracing::debug!(
@@ -1399,7 +1397,7 @@ async fn finish_ha_gc_with_continuation(
                 err = %err,
                 "HA outbox GC continuation hit a transient SQLite conflict; stale reaper will recover it"
             );
-            return false;
+            ScheduledJobCompletion::Deferred
         }
         Err(err) => {
             tracing::error!(
@@ -1426,17 +1424,18 @@ async fn finish_ha_gc_with_continuation(
                     err = %finish_err,
                     "HA outbox GC deferred job remains eligible for the outer continuation retry"
                 );
+                ScheduledJobCompletion::Deferred
+            } else {
+                ScheduledJobCompletion::Failed
             }
-            return false;
         }
     }
-    true
 }
 
 async fn run_ha_outbox_gc_claimed_job(
     state: Arc<AppState>,
     claimed_job: ClaimedScheduledJob,
-) -> bool {
+) -> ScheduledJobCompletion {
     let ClaimedScheduledJob {
         job_id,
         claim_generation,
@@ -1619,6 +1618,7 @@ async fn run_ha_outbox_gc_claimed_job(
                     .await;
                 }
             }
+            ScheduledJobCompletion::Completed
         }
         Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
             tracing::debug!(
@@ -1640,13 +1640,16 @@ async fn run_ha_outbox_gc_claimed_job(
         }
         Err(err) => {
             let message = err.to_string();
-            let _ = state
+            match state
                 .proxy
                 .scheduled_job_finish_claimed(job_id, claim_generation, "error", Some(&message))
-                .await;
+                .await
+            {
+                Ok(()) => ScheduledJobCompletion::Failed,
+                Err(_) => ScheduledJobCompletion::Deferred,
+            }
         }
     }
-    true
 }
 
 async fn record_linuxdo_user_sync_failure(
@@ -2617,9 +2620,6 @@ async fn run_manual_claimed_job(
     key_id: Option<String>,
     mut claimed_job: ClaimedScheduledJob,
 ) -> bool {
-    if job_type == "ha_outbox_gc" {
-        return run_ha_outbox_gc_claimed_job(state, claimed_job).await;
-    }
     if job_type == "request_logs_gc" {
         return run_request_logs_gc_catchup_claimed_job(state, claimed_job).await;
     }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1735,6 +1735,10 @@ async fn demote_writable_runtime(state: &Arc<AppState>) -> Result<(), ProxyError
     let maintenance = state.ha.maintenance_runtime().await;
     supervisor.quiesce_demotion().await;
     maintenance.abort_remote_tasks().await;
+    state
+        .proxy
+        .requeue_running_scheduled_jobs_for_demotion()
+        .await?;
     let authority = state
         .proxy
         .advance_writable_authority_epoch(tavily_hikari::WritableAuthorityPhase::Standby)

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1585,9 +1585,10 @@ async fn run_ha_sync_once_for_peer(
 
 fn spawn_business_background_tasks(
     state: Arc<AppState>,
-) -> Vec<tokio_util::task::AbortOnDropHandle<()>> {
+    cancellation: tokio_util::sync::CancellationToken,
+) -> Vec<tokio::task::JoinHandle<()>> {
     let mut tasks = vec![
-        spawn_maintenance_worker(state.clone()),
+        spawn_maintenance_worker_with_cancellation(state.clone(), cancellation),
         spawn_scheduled_job_stale_reaper(state.clone()),
         spawn_token_usage_rollup_scheduler(state.clone()),
         spawn_upstream_reconciliation_scheduler(state.clone()),
@@ -1610,9 +1611,6 @@ fn spawn_business_background_tasks(
     tasks.push(spawn_forward_proxy_maintenance_scheduler(state.clone()));
     tasks.push(spawn_db_compaction_scheduler(state));
     tasks
-        .into_iter()
-        .map(tokio_util::task::AbortOnDropHandle::new)
-        .collect()
 }
 
 fn background_tasks_disabled_via_env() -> bool {
@@ -1698,20 +1696,21 @@ async fn spawn_background_tasks_for_current_role(state: Arc<AppState>) -> bool {
         }
     }
     let runtime_state = state.clone();
+    let maintenance = state.ha.maintenance_runtime();
     supervisor
         .promote(authority.epoch, move |revision| async move {
+            let cancellation = revision.cancellation_token();
             let tasks = if background_tasks_disabled {
                 Vec::new()
             } else {
-                spawn_business_background_tasks(runtime_state)
+                spawn_business_background_tasks(runtime_state, cancellation.clone())
             };
-            revision.cancellation_token().cancelled().await;
-            for task in &tasks {
-                task.abort();
-            }
-            for task in tasks {
-                let _ = task.await;
-            }
+            let completion = maintenance.supervise(cancellation, tasks).await;
+            tracing::debug!(
+                component = "ha",
+                event = "maintenance_runtime_completed",
+                ?completion,
+            );
         })
         .await
         .is_ok()

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1696,7 +1696,11 @@ async fn spawn_background_tasks_for_current_role(state: Arc<AppState>) -> bool {
         }
     }
     let runtime_state = state.clone();
-    let maintenance = state.ha.maintenance_runtime();
+    let maintenance = if supervisor.current_revision().await.is_none() {
+        state.ha.start_maintenance_runtime().await
+    } else {
+        state.ha.maintenance_runtime().await
+    };
     supervisor
         .promote(authority.epoch, move |revision| async move {
             let cancellation = revision.cancellation_token();
@@ -1728,7 +1732,9 @@ async fn demote_writable_runtime(state: &Arc<AppState>) -> Result<(), ProxyError
         .proxy
         .persist_writable_authority_phase(tavily_hikari::WritableAuthorityPhase::Demoting)
         .await?;
+    let maintenance = state.ha.maintenance_runtime().await;
     supervisor.quiesce_demotion().await;
+    maintenance.abort_remote_tasks().await;
     let authority = state
         .proxy
         .advance_writable_authority_epoch(tavily_hikari::WritableAuthorityPhase::Standby)

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1642,6 +1642,19 @@ async fn spawn_background_tasks_for_current_role(state: Arc<AppState>) -> bool {
     };
     if authority.phase == tavily_hikari::WritableAuthorityPhase::Demoting {
         let _business_admission = state.ha.acquire_writable_demotion_admission().await;
+        if let Err(err) = state
+            .proxy
+            .requeue_running_scheduled_jobs_for_demotion()
+            .await
+        {
+            tracing::warn!(
+                component = "ha",
+                event = "writable_authority_demotion_resume_requeue_failed",
+                err = %err,
+                "persisted writable demotion remains fail closed until running claims are requeued"
+            );
+            return false;
+        }
         let authority = match state
             .proxy
             .advance_writable_authority_epoch(tavily_hikari::WritableAuthorityPhase::Standby)

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -83,7 +83,6 @@ fn new_dashboard_overview_cache() -> Arc<Mutex<DashboardOverviewCacheState>> {
 }
 
 static DB_MAINTENANCE_GATE: OnceLock<RwLock<()>> = OnceLock::new();
-static ONLINE_HA_GC_LEASE: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
 const FOREGROUND_ACTIVITY_BUCKETS: usize = 10;
 const FOREGROUND_ACTIVITY_BUCKET_MS: u64 = 100;
 
@@ -180,12 +179,6 @@ pub(crate) fn foreground_activity_low_pressure_since_floor() -> i64 {
 }
 static DB_JOB_EXECUTION_GATES: OnceLock<std::sync::Mutex<HashMap<usize, std::sync::Weak<Mutex<()>>>>> =
     OnceLock::new();
-static MAINTENANCE_WORKER_WAKES: OnceLock<
-    std::sync::Mutex<HashMap<usize, std::sync::Weak<tokio::sync::Notify>>>,
-> = OnceLock::new();
-static MAINTENANCE_REMOTE_IO_SLOTS: OnceLock<
-    std::sync::Mutex<HashMap<usize, std::sync::Weak<Semaphore>>>,
-> = OnceLock::new();
 
 fn db_maintenance_gate() -> &'static RwLock<()> {
     DB_MAINTENANCE_GATE.get_or_init(|| RwLock::new(()))
@@ -203,41 +196,8 @@ fn db_job_execution_gate_for_state(state: &AppState) -> Arc<Mutex<()>> {
     gate
 }
 
-fn maintenance_worker_wake_for_state(state: &AppState) -> Arc<tokio::sync::Notify> {
-    let key = state as *const AppState as usize;
-    let wakes = MAINTENANCE_WORKER_WAKES.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-    let mut wakes = wakes.lock().expect("maintenance worker wake map lock");
-    if let Some(wake) = wakes.get(&key).and_then(std::sync::Weak::upgrade) {
-        return wake;
-    }
-    let wake = Arc::new(tokio::sync::Notify::new());
-    wakes.insert(key, Arc::downgrade(&wake));
-    wake
-}
-
-fn maintenance_remote_io_slot_for_state(state: &AppState) -> Arc<Semaphore> {
-    let key = state as *const AppState as usize;
-    let slots =
-        MAINTENANCE_REMOTE_IO_SLOTS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-    let mut slots = slots.lock().expect("maintenance remote I/O slot map lock");
-    if let Some(slot) = slots.get(&key).and_then(std::sync::Weak::upgrade) {
-        return slot;
-    }
-    let slot = Arc::new(Semaphore::new(1));
-    slots.insert(key, Arc::downgrade(&slot));
-    slot
-}
-
 fn dashboard_overview_cache_for_state(state: &AppState) -> Arc<Mutex<DashboardOverviewCacheState>> {
     state.dashboard_overview_cache.clone()
-}
-
-fn try_acquire_maintenance_remote_io_slot_for_state(
-    state: &AppState,
-) -> Option<tokio::sync::OwnedSemaphorePermit> {
-    maintenance_remote_io_slot_for_state(state)
-        .try_acquire_owned()
-        .ok()
 }
 
 async fn acquire_db_maintenance_read_gate() -> tokio::sync::RwLockReadGuard<'static, ()> {
@@ -246,14 +206,6 @@ async fn acquire_db_maintenance_read_gate() -> tokio::sync::RwLockReadGuard<'sta
 
 async fn acquire_db_maintenance_write_gate() -> tokio::sync::RwLockWriteGuard<'static, ()> {
     db_maintenance_gate().write().await
-}
-
-pub(crate) fn try_acquire_online_ha_gc_lease() -> Option<OwnedMutexGuard<()>> {
-    ONLINE_HA_GC_LEASE
-        .get_or_init(|| Arc::new(Mutex::new(())))
-        .clone()
-        .try_lock_owned()
-        .ok()
 }
 
 async fn acquire_db_job_execution_gate_for_state(
@@ -347,11 +299,14 @@ mod db_maintenance_gate_tests {
 
     #[tokio::test]
     async fn online_gc_lease_is_independent_from_http_readers() {
+        let runtime = tavily_hikari::MaintenanceRuntime::new();
         let read_guard = super::acquire_db_maintenance_read_gate().await;
-        assert!(super::try_acquire_online_ha_gc_lease().is_some());
+        assert!(runtime.try_acquire_maintenance_lease().is_some());
         drop(read_guard);
-        let lease = super::try_acquire_online_ha_gc_lease().expect("GC lease available");
-        assert!(super::try_acquire_online_ha_gc_lease().is_none());
+        let lease = runtime
+            .try_acquire_maintenance_lease()
+            .expect("GC lease available");
+        assert!(runtime.try_acquire_maintenance_lease().is_none());
         drop(lease);
     }
 

--- a/src/server/tests/alerts_and_ha_startup_roles.rs
+++ b/src/server/tests/alerts_and_ha_startup_roles.rs
@@ -69,6 +69,78 @@ async fn standby_server_startup_does_not_spawn_business_scheduled_jobs() {
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
 }
 
+#[tokio::test]
+async fn demoting_startup_requeues_running_scheduled_jobs_before_standby() {
+    let db_path = temp_db_path("ha-demoting-startup-requeues-jobs");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-demoting-startup-requeues-jobs".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let job = proxy
+        .scheduled_job_enqueue("token_usage_rollup", "scheduler", None, 1)
+        .await
+        .expect("enqueue scheduled job");
+    let claim = proxy
+        .scheduled_job_mark_running(job.job_id)
+        .await
+        .expect("claim scheduled job")
+        .expect("scheduled job claim exists");
+    proxy
+        .persist_writable_authority_phase(tavily_hikari::WritableAuthorityPhase::Demoting)
+        .await
+        .expect("persist demoting authority");
+
+    let state = Arc::new(AppState {
+        proxy: proxy.clone(),
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        admin_passkey: AdminPasskeyOptions::disabled(),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig {
+            mode: tavily_hikari::HaMode::ActiveStandby,
+            node_id: "node-demoting-startup-requeues-jobs".to_string(),
+            database_path: Some(db_str.clone()),
+            sync_source_url: Some("http://127.0.0.1:59999".to_string()),
+            internal_token: Some("ha-test-token".to_string()),
+            sync_interval_secs: 5,
+            ..tavily_hikari::HaConfig::default()
+        }),
+        dev_open_admin: false,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    });
+
+    assert!(!spawn_background_tasks_for_current_role(state).await);
+    let recovered = proxy
+        .scheduled_job_by_id(job.job_id)
+        .await
+        .expect("read recovered scheduled job")
+        .expect("recovered scheduled job exists");
+    assert_eq!(recovered.status, "queued");
+    assert!(recovered.claim_generation > claim.claim_generation);
+    assert!(proxy
+        .scheduled_job_finish_claimed(
+            job.job_id,
+            claim.claim_generation,
+            "success",
+            Some("stale demoted claim"),
+        )
+        .await
+        .is_err());
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
 #[test]
 fn dual_active_peer_sync_runs_for_fenced_standby_until_leader_is_seeded() {
     let status = tavily_hikari::HaStatusView {

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -1195,6 +1195,26 @@ impl KeyStore {
         self.abandon_active_scheduled_jobs().await
     }
 
+    pub(crate) async fn requeue_running_scheduled_jobs_for_demotion(
+        &self,
+    ) -> Result<u64, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let result = sqlx::query(
+            r#"UPDATE scheduled_jobs
+               SET status = 'queued',
+                   started_at = NULL,
+                   finished_at = NULL,
+                   available_at = ?,
+                   claim_generation = claim_generation + 1,
+                   message = 'deferred=writable_demotion'
+               WHERE status = 'running' AND finished_at IS NULL"#,
+        )
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     pub(crate) async fn recover_stale_scheduled_jobs(&self) -> Result<u64, ProxyError> {
         let now = self.backend_time.now_ts();
         let result = sqlx::query(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -2218,6 +2218,12 @@ impl TavilyProxy {
         self.key_store.abandon_running_scheduled_jobs().await
     }
 
+    pub async fn requeue_running_scheduled_jobs_for_demotion(&self) -> Result<u64, ProxyError> {
+        self.key_store
+            .requeue_running_scheduled_jobs_for_demotion()
+            .await
+    }
+
     pub async fn abandon_active_scheduled_jobs(&self) -> Result<u64, ProxyError> {
         self.key_store.abandon_active_scheduled_jobs().await
     }

--- a/src/tests/maintenance_queue_performance.rs
+++ b/src/tests/maintenance_queue_performance.rs
@@ -377,6 +377,79 @@ async fn stale_claim_cannot_be_misreported_as_a_non_running_job_when_requeueing(
 }
 
 #[tokio::test]
+async fn writable_demotion_requeues_running_jobs_and_fences_old_claims() {
+    let db_path = temp_db_path("scheduled-job-demotion-requeue");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("proxy created");
+    let first = proxy
+        .scheduled_job_enqueue("token_usage_rollup", "scheduler", None, 1)
+        .await
+        .expect("enqueue first job");
+    let second = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "scheduler", None, 1)
+        .await
+        .expect("enqueue second job");
+    let first_claim = proxy
+        .scheduled_job_mark_running(first.job_id)
+        .await
+        .expect("claim first job")
+        .expect("first claim exists");
+    let second_claim = proxy
+        .scheduled_job_mark_running(second.job_id)
+        .await
+        .expect("claim second job")
+        .expect("second claim exists");
+
+    assert_eq!(
+        proxy
+            .requeue_running_scheduled_jobs_for_demotion()
+            .await
+            .expect("requeue running jobs"),
+        2
+    );
+    for (job_id, claim_generation) in [
+        (first.job_id, first_claim.claim_generation),
+        (second.job_id, second_claim.claim_generation),
+    ] {
+        let recovered = proxy
+            .scheduled_job_by_id(job_id)
+            .await
+            .expect("read requeued job")
+            .expect("requeued job exists");
+        assert_eq!(recovered.status, "queued");
+        assert!(recovered.started_at.is_none());
+        assert!(recovered.finished_at.is_none());
+        assert!(recovered.claim_generation > claim_generation);
+        assert!(
+            proxy
+                .scheduled_job_finish_claimed(
+                    job_id,
+                    claim_generation,
+                    "success",
+                    Some("stale demoted claim"),
+                )
+                .await
+                .is_err(),
+            "demotion must fence the old claim"
+        );
+    }
+    assert_eq!(
+        proxy
+            .requeue_running_scheduled_jobs_for_demotion()
+            .await
+            .expect("repeat demotion cleanup"),
+        0
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
 async fn stale_reaper_recovers_ha_gc_once_with_delay() {
     let db_path = temp_db_path("scheduled-job-stale-reaper");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/writable_authority.rs
+++ b/src/writable_authority.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
-use tokio::task::JoinSet;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 pub const WRITABLE_TENURE_CAPABILITY: &str = "writable_tenure_v1";
@@ -53,7 +53,7 @@ impl WritableRevision {
 
 struct ActiveRuntime {
     revision: WritableRevision,
-    tasks: JoinSet<()>,
+    task: JoinHandle<()>,
 }
 
 struct SupervisorState {
@@ -129,15 +129,14 @@ impl WritableTenureSupervisor {
             epoch,
             cancellation: CancellationToken::new(),
         };
-        let mut tasks = JoinSet::new();
-        tasks.spawn(start(revision.clone()));
+        let task = tokio::spawn(start(revision.clone()));
         state.authority = WritableAuthorityState {
             epoch,
             phase: WritableAuthorityPhase::Writable,
         };
         state.runtime = Some(ActiveRuntime {
             revision: revision.clone(),
-            tasks,
+            task,
         });
         Ok(revision)
     }
@@ -154,15 +153,12 @@ impl WritableTenureSupervisor {
     pub async fn quiesce_demotion(&self) {
         let runtime = self.state.lock().await.runtime.take();
         if let Some(mut runtime) = runtime
-            && tokio::time::timeout(
-                std::time::Duration::from_millis(250),
-                runtime.tasks.join_next(),
-            )
-            .await
-            .is_err()
+            && tokio::time::timeout(std::time::Duration::from_millis(250), &mut runtime.task)
+                .await
+                .is_err()
         {
-            runtime.tasks.abort_all();
-            while runtime.tasks.join_next().await.is_some() {}
+            runtime.task.abort();
+            let _ = runtime.task.await;
         }
     }
 


### PR DESCRIPTION
Refs #486

## Summary
- Add `MaintenanceRuntime` as the tenure-scoped owner for workers, stale reapers, JoinSet tasks, maintenance leases, and remote-I/O slots.
- Route scheduled-job enqueue, admission, remote task tracking, and typed completion through the compatibility adapter.
- Fence demotion races by requeueing running claims, incrementing claim generations, aborting in-flight remote work, and retrying persisted-demoting recovery before standby.
- Preserve scheduled-job behavior and public response shapes while keeping the existing SQLite/HA configuration unchanged.

## Validation
- `cargo test`: lib 608 passed; main 459 passed; all binary and integration targets passed; doc-tests 0 passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo fmt --all -- --check` passed.
- `cargo check --all-targets --all-features` passed.
- Rust source line-budget test and `git diff --check` passed.

## References
- Specs: `docs/specs/performance-architecture-hardening/SPEC.md`
- Solutions: -
- Project Docs: `docs/agents/issue-tracker.md`

## Review
- Fixed review baseline: `71cf979b8e780fadf01d645e1727638bf5f5f6cd`.
- Final standards review: no P1/P2 findings.
- Final specification review: acceptance-complete; no P1/P2 findings.

## Constraints
No deployment, server 101 access, production data changes, HA configuration changes, SQLite PRAGMA changes, or public response-shape changes.

Child PR for Ticket #486; base is `prd/performance-architecture-hardening`. Stop condition is merge-ready; this PR is intentionally not merged.
