### PR TITLE
fix(ci): cover maintenance runtime shard tests

### DIFF
--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -87,6 +87,7 @@
         "analysis::tests::",
         "ha::tests::",
         "writable_authority::tests::",
+        "maintenance_runtime::tests::",
         "models::client_ip_tests::",
         "runtime_logging::tests::",
         "store::admin_passkey_store_tests::",
@@ -503,6 +504,7 @@
         "server::tests::alerts_and_ha_startup_roles::post_ready_",
         "server::tests::alerts_and_ha_startup_roles::persist_",
         "server::tests::alerts_and_ha_startup_roles::startup_",
+        "server::tests::alerts_and_ha_startup_roles::demoting_",
         "server::tests::alerts_and_ha_startup_roles::standby_",
         "server::tests::alerts_and_ha_startup_roles::dual_active_",
         "server::tests::alerts_and_ha_event_exports::ha_",
@@ -523,7 +525,8 @@
         "server::tests::log_catalog_and_dashboard_sse::key_",
         "server::tests::research_result_and_mcp_subpath::db_",
         "server::tests::mcp_rebalance_and_follow_up::observed_",
-        "server::tests::system_settings_and_forward_proxy::proxy_"
+        "server::tests::system_settings_and_forward_proxy::proxy_",
+        "server::legacy_scheduler_adapter_exposes_typed_completion"
       ]
     },
     {


### PR DESCRIPTION
Refs #486

## Summary

- Add the missing `maintenance_runtime::tests::` lib selector to the backend shard manifest.
- Add the missing `demoting_` startup selector and exact legacy scheduler test selector to `bin-ha-rest`; these two bin gaps were revealed after the verifier passed the initial lib repair.
- Keep the repair limited to `scripts/ci_backend_test_manifest.json`; no runner, runtime, production, server 101, SQLite PRAGMA, or public API changes.

## Integration context

- PR role: child repair
- Integration base: `prd/performance-architecture-hardening@881f5fd01e44c9db6f780a189c3ce0a9554beaa3`
- Original failed run: [31016356414](https://github.com/IvanLi-CN/tavily-hikari/actions/runs/31016356414)
- Repair head: `52eb10ac2ecb24cd56f21a7567e4c7662627b44c`

## Validation

- `CARGO_NET_OFFLINE=true python3 scripts/ci_backend_tests.py verify` passed: 608 lib tests, 459 bin-main tests, bin-support, and all five integration targets covered with no unmatched, overlap, or stale selectors.
- `CARGO_NET_OFFLINE=true cargo fmt --all -- --check` passed.
- `CARGO_NET_OFFLINE=true cargo check --locked --all-targets --all-features` passed.
- `git diff --check` and JSON parsing passed.
- `CARGO_NET_OFFLINE=true cargo test --locked --all-features`: 608 lib tests passed; bin-main had 457 passed and 2 host-load-sensitive failures. Both failures passed on serial exact reruns with `RUST_TEST_THREADS=1`; all five newly covered tests passed in the full run.

## Review

- Fixed-base standards review: PASS.
- Fixed-base specification review: PASS.
- Review range: `881f5fd01e44c9db6f780a189c3ce0a9554beaa3...52eb10ac2ecb24cd56f21a7567e4c7662627b44c`.

## References

- Specs: `docs/specs/3grrf-ci-backend-test-split/SPEC.md`; `docs/specs/performance-architecture-hardening/SPEC.md`
- Solutions: -
- Project Docs: `docs/agents/issue-tracker.md`

Stop condition: merge-ready. Do not merge this child repair PR; integration CI must rerun after the repair is merged into the exact integration branch.