### PR TITLE
fix(tests): split HA coverage for source budget

### DIFF
--- a/src/server/tests/alerts_and_ha.rs
+++ b/src/server/tests/alerts_and_ha.rs
@@ -1822,55 +1822,6 @@ async fn ha_events_ack_records_peer_watermark() {
 }
 
 #[tokio::test]
-async fn ha_sync_watermark_reads_pending_overlay_before_flush() {
-    let db_path = temp_db_path("ha-sync-watermark-pending-overlay");
-    let db_str = db_path.to_string_lossy().to_string();
-    let proxy = TavilyProxy::with_endpoint(
-        vec!["tvly-ha-sync-watermark-pending-overlay".to_string()],
-        DEFAULT_UPSTREAM,
-        &db_str,
-    )
-    .await
-    .expect("proxy created");
-
-    proxy
-        .persist_ha_sync_watermark(
-            "standby_control_applied_seq",
-            Some("source-a"),
-            Some("target-a"),
-            42,
-            Some("pending overlay"),
-        )
-        .await
-        .expect("enqueue watermark");
-
-    assert_eq!(
-        proxy
-            .get_ha_sync_watermark("standby_control_applied_seq")
-            .await
-            .expect("read pending watermark"),
-        Some(42)
-    );
-
-    proxy
-        .flush_ha_state_writes()
-        .await
-        .expect("flush pending watermark");
-
-    assert_eq!(
-        proxy
-            .get_ha_sync_watermark("standby_control_applied_seq")
-            .await
-            .expect("read flushed watermark"),
-        Some(42)
-    );
-
-    let _ = std::fs::remove_file(&db_path);
-    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
-    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
-}
-
-#[tokio::test]
 async fn ha_event_apply_preserves_foreign_keys_and_composite_deletes() {
     let db_path = temp_db_path("ha-event-apply-keys");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/alerts_and_ha_sync_recovery.rs
+++ b/src/server/tests/alerts_and_ha_sync_recovery.rs
@@ -1244,3 +1244,52 @@ async fn dual_active_runtime_counter_exports_only_local_contribution() {
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
 }
+
+#[tokio::test]
+async fn ha_sync_watermark_reads_pending_overlay_before_flush() {
+    let db_path = temp_db_path("ha-sync-watermark-pending-overlay");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-sync-watermark-pending-overlay".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    proxy
+        .persist_ha_sync_watermark(
+            "standby_control_applied_seq",
+            Some("source-a"),
+            Some("target-a"),
+            42,
+            Some("pending overlay"),
+        )
+        .await
+        .expect("enqueue watermark");
+
+    assert_eq!(
+        proxy
+            .get_ha_sync_watermark("standby_control_applied_seq")
+            .await
+            .expect("read pending watermark"),
+        Some(42)
+    );
+
+    proxy
+        .flush_ha_state_writes()
+        .await
+        .expect("flush pending watermark");
+
+    assert_eq!(
+        proxy
+            .get_ha_sync_watermark("standby_control_applied_seq")
+            .await
+            .expect("read flushed watermark"),
+        Some(42)
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}


### PR DESCRIPTION
## Summary

- Repair the integration CI source-budget failure after PR #502 merged at `dc53f50e724009e72e6920598a80285e58248551`.
- Move the complete `ha_sync_watermark_reads_pending_overlay_before_flush` test from the consolidated HA test file into the established `alerts_and_ha_sync_recovery` module.
- Reduce `src/server/tests/alerts_and_ha.rs` from 3079 to 3030 lines without weakening the 3050-line verifier.
- No runtime, `MaintenanceRuntime`, HA protocol/configuration, public/admin response shape, or production behavior changes.

## Ticket Handover

- Initiative: `performance-architecture-hardening`
- Ticket: #488
- PR role: `child` repair
- Parent child PR: #502 (merged)
- Repair base branch: `prd/performance-architecture-hardening`
- Repair base SHA: `dc53f50e724009e72e6920598a80285e58248551`
- Repair head SHA: `3bd3f7adb9dd16891b2b9da457eabeb189036ada`
- Wave: 4, risk-gated
- Dependency: #484 closed
- Stop condition: merge-ready; owner approval is required before merge

## Validation

- `cargo test --test rust_source_line_budgets` passed.
- `cargo fmt --all -- --check` passed.
- `cargo clippy -- -D warnings` passed.
- Moved test passed in isolation.
- HA admin status cache tests passed: 2 tests.
- Dual-active live-probe tests passed: 14 tests.
- Full `cargo test --bin tavily-hikari -- --test-threads=1`: 459 passed, 1 existing timing-sensitive `admin_user_management_lists_details_and_updates_quota` failure; isolated rerun passed.
- Commit hooks passed fmt, clippy, and commitlint.

## Review

- Fresh Standards review: passed with no findings, bound to base `dc53f50e724009e72e6920598a80285e58248551` and head `3bd3f7adb9dd16891b2b9da457eabeb189036ada`.
- Fresh Spec review: passed with no findings, bound to the same exact base/head.
- Integration CI must rerun after this repair is merged into the integration branch.

## References

- Specs: `docs/specs/performance-architecture-hardening/SPEC.md` (at base `dc53f50e724009e72e6920598a80285e58248551`)
- Solutions: `-`
- Project Docs: `-`
- Issue: #488
- Source CI failure: run [31039064947](https://github.com/IvanLi-CN/tavily-hikari/actions/runs/31039064947)
