### PR TITLE
feat(ha): isolate durable outbox gc work by channel

### DIFF
--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -209,6 +209,11 @@ month-tail public metrics scan.
   evidence that a write micro-batch exceeded budget. Keep an hourly baseline sweep for newly
   expired rows, and gate a low-frequency watchdog on durable pending-channel debt so it rediscovers
   a lost continuation without creating clean-state jobs.
+- Persist that per-channel controller as independent `ha_outbox_gc_work` rows with eligibility,
+  generation leases, adaptive batch size, and typed outcomes. Use the bounded `SqliteRuntime`
+  `BEGIN IMMEDIATE` contract for claim and finish: writer contention returns typed `Busy` within
+  250ms, while a continuation finish updates the work row, scheduled job, and next channel job in
+  one transaction. A stale generation or expired lease must not finish a newer claim.
 - Sequence high-watermark deltas are useful low-cost evidence of drainage versus ingress, but they
   are estimates, not exact row counts. If historical exact counts were not sampled, report the
   oldest retained age moving forward as proof of partial cleanup only; do not claim that total

--- a/docs/specs/performance-architecture-hardening/HISTORY.md
+++ b/docs/specs/performance-architecture-hardening/HISTORY.md
@@ -19,6 +19,11 @@
 - 外部业务 request 在 writable tenure admission 内运行；demotion 取得独占 admission、排空已进入的
   request 后再推进 SQLite epoch。authority 写使用独立短等待预算，writer contention 不会继承主 pool
   的 5 秒 busy timeout。
+- per-channel HA GC 使用独立 durable eligibility 与 generation lease；完成事务同时更新 typed
+  outcome、adaptive channel state、scheduled job 与 continuation，避免 control 延迟阻塞 billing 或
+  runtime，并让旧 claim 在接管后无法覆盖新状态。
+- HA outbox UPDATE trigger 以 wire JSON 比较 old/new payload；只有有效变化写入一条兼容事件，保持
+  旧 reader、retention、ACK 与 `410 -> baseline` 语义不变。
 
 ## Key Reasons / Replacements
 

--- a/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
+++ b/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
@@ -5,7 +5,7 @@
 ## Current Status
 
 - Implementation: Ticket #485 SqliteRuntime seam 已合入 integration branch；Ticket #484 已实现，等待
-  child PR integration
+  child PR integration；Ticket #489 per-channel HA GC 已实现，等待 child PR integration
 - Lifecycle: active
 - Delivery topology: aggregate-stack
 - Integration branch: `prd/performance-architecture-hardening`
@@ -20,7 +20,7 @@
 3. MaintenanceRuntime legacy adapter
 4. RequestStatsPipeline
 5. HaPeerObservationStore
-6. per-channel HA GC 与 no-op outbox suppression
+6. per-channel HA GC 与 no-op outbox suppression（Ticket #489 已实现，等待 child PR integration）
 7. reconciliation work projection
 8. AlertProjection expand/shadow
 9. ReconciliationEngine cutover
@@ -38,6 +38,9 @@
 - 将这些 legacy workers 封装为独立 `MaintenanceRuntime`、把 ingress fence 下沉为各业务写事务的细粒度
   authority epoch guard，以及其余 runtime ownership 收敛由后续 Ticket 完成。
 - aggregate 验证、架构 checker、30 分钟 RSS 基准及 rollout 文档尚待完成。
+- Ticket #489 已为 control、billing、runtime 建立独立 durable GC work、claim generation、eligibility、
+  adaptive continuation 与 typed outcome；channel scheduled job 完成和 continuation 在同一 SQLite
+  writer transaction 内提交，并为 wire-identical UPDATE 抑制 HA outbox 事件。
 
 ## Related Changes
 
@@ -47,6 +50,7 @@
   compatibility handles while expand-contract callers migrate; pool sizes, busy timeouts,
   PRAGMAs, and transaction SQL remain unchanged.
 - Ticket #484: revisioned writable-tenure supervisor and mixed-version capability gate.
+- Ticket #489: durable per-channel HA GC work and unchanged-wire UPDATE suppression.
 
 ## References
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,6 +797,71 @@ pub struct HaOutboxGcChannelReport {
     pub observed_at: i64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HaOutboxGcWorkClaim {
+    pub channel: HaSyncChannel,
+    pub claim_generation: i64,
+    pub batch_size: i64,
+    pub eligible_at: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HaOutboxGcWorkClaimResult {
+    Claimed(HaOutboxGcWorkClaim),
+    NotEligible {
+        eligible_at: i64,
+    },
+    AlreadyClaimed {
+        claim_generation: i64,
+        claim_expires_at: i64,
+    },
+    Busy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HaOutboxGcWorkDueResult {
+    Refreshed,
+    Busy,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HaOutboxGcWorkDueChannelsResult {
+    Ready(Vec<HaSyncChannel>),
+    Busy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HaOutboxGcWorkOutcome {
+    Pending,
+    Running,
+    Completed,
+    Deferred,
+    Busy,
+    Failed,
+    Stale,
+}
+
+impl HaOutboxGcWorkOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Deferred => "deferred",
+            Self::Busy => "busy",
+            Self::Failed => "failed",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HaOutboxGcWorkFinishResult {
+    Finished(HaOutboxGcWorkOutcome),
+    Stale,
+    Busy,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HaOutboxGcReport {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -88,6 +88,7 @@ use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 use tokio_util::io::{ReaderStream, StreamReader};
 include!("state.rs");
 include!("schedulers.rs");
+include!("schedulers_ha_gc.rs");
 include!("spa.rs");
 include!("handlers/tavily.rs");
 include!("handlers/public.rs");

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -6,6 +6,9 @@ use tavily_hikari::{
     LinuxDoCreditRefundExternalSuccessMarker as SharedLinuxDoCreditRefundExternalSuccessMarker,
     decode_linuxdo_credit_refund_external_success_marker,
     format_ha_outbox_gc_report_message, format_linuxdo_credit_money,
+    HaOutboxGcWorkClaim, HaOutboxGcWorkClaimResult, HaOutboxGcWorkDueChannelsResult,
+    HaOutboxGcWorkDueResult,
+    HaOutboxGcWorkFinishResult, HaOutboxGcWorkOutcome, HaSyncChannel,
     HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
     HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS,
     HA_OUTBOX_GC_LOW_PRESSURE_RPS,
@@ -53,7 +56,11 @@ const TRIGGER_SOURCE_MANUAL: &str = "manual";
 const TRIGGER_SOURCE_AUTO: &str = "auto";
 const REQUEST_LOGS_GC_CONTINUATION_DELAY_SECS: i64 = 5 * 60;
 const HA_OUTBOX_GC_RECHECK_SECS: u64 = 5 * 60;
+const HA_OUTBOX_GC_BUSY_RECHECK_SECS: u64 = 30;
 const HA_OUTBOX_GC_BASELINE_SECS: i64 = 60 * 60;
+const HA_OUTBOX_GC_CONTROL_JOB_TYPE: &str = "ha_outbox_gc/control";
+const HA_OUTBOX_GC_BILLING_JOB_TYPE: &str = "ha_outbox_gc/billing";
+const HA_OUTBOX_GC_RUNTIME_JOB_TYPE: &str = "ha_outbox_gc/runtime";
 const REQUEST_LOGS_BODY_GC_INDEX_ENSURE_JOB_TYPE: &str = "request_logs_body_gc_index_ensure";
 const AUTH_TOKEN_LOGS_ALERT_INDEX_ENSURE_JOB_TYPE: &str =
     "auth_token_logs_alert_index_ensure";
@@ -67,6 +74,23 @@ const SCHEDULED_JOB_WAIT_WARN_SAMPLE_SECS: u64 = 5 * 60;
 static REQUEST_LOGS_GC_ZERO_PROGRESS_STREAK: AtomicU64 = AtomicU64::new(0);
 static SCHEDULED_JOB_QUEUE_WAIT_WARN_WINDOWS: OnceLock<StdMutex<HashMap<String, Instant>>> =
     OnceLock::new();
+
+fn ha_outbox_gc_job_type(channel: HaSyncChannel) -> &'static str {
+    match channel {
+        HaSyncChannel::Control => HA_OUTBOX_GC_CONTROL_JOB_TYPE,
+        HaSyncChannel::Billing => HA_OUTBOX_GC_BILLING_JOB_TYPE,
+        HaSyncChannel::Runtime => HA_OUTBOX_GC_RUNTIME_JOB_TYPE,
+    }
+}
+
+fn ha_outbox_gc_channel_for_job_type(job_type: &str) -> Option<HaSyncChannel> {
+    match job_type {
+        HA_OUTBOX_GC_CONTROL_JOB_TYPE => Some(HaSyncChannel::Control),
+        HA_OUTBOX_GC_BILLING_JOB_TYPE => Some(HaSyncChannel::Billing),
+        HA_OUTBOX_GC_RUNTIME_JOB_TYPE => Some(HaSyncChannel::Runtime),
+        _ => None,
+    }
+}
 
 fn ha_gc_continuation_delay_secs(report_delay_secs: Option<i64>, foreground_rps: i64) -> i64 {
     let report_delay_secs =
@@ -134,9 +158,6 @@ impl LegacySchedulerAdapter {
     }
     fn try_acquire_remote_io_slot(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
         self.runtime.try_acquire_remote_io_slot()
-    }
-    fn try_acquire_maintenance_lease(&self) -> Option<OwnedMutexGuard<()>> {
-        self.runtime.try_acquire_maintenance_lease()
     }
     async fn spawn_remote_task<F>(&self, task: F)
     where
@@ -437,7 +458,7 @@ fn scheduled_job_uses_remote_io(job_type: &str) -> bool {
 }
 
 fn scheduled_job_uses_db_execution_gate(job_type: &str) -> bool {
-    job_type != "upstream_reconciliation"
+    job_type != "upstream_reconciliation" && ha_outbox_gc_channel_for_job_type(job_type).is_none()
 }
 
 #[cfg(test)]
@@ -448,6 +469,9 @@ fn upstream_reconciliation_does_not_wait_for_db_execution_gate() {
         "upstream_reconciliation"
     ));
     assert!(scheduled_job_uses_db_execution_gate("ha_outbox_gc"));
+    assert!(!scheduled_job_uses_db_execution_gate(
+        HA_OUTBOX_GC_CONTROL_JOB_TYPE
+    ));
 }
 
 #[cfg(test)]
@@ -567,6 +591,9 @@ async fn run_queued_scheduled_job(
         claim_generation: job.claim_generation,
         _job_execution_gate: None,
     };
+    if let Some(channel) = ha_outbox_gc_channel_for_job_type(&job_type) {
+        return run_ha_outbox_gc_channel_claimed_job(state, claimed_job, channel).await;
+    }
     if job_type == "ha_outbox_gc" {
         return run_ha_outbox_gc_claimed_job(state, claimed_job).await;
     }
@@ -787,7 +814,31 @@ fn spawn_maintenance_worker_with_cancellation(
             };
             match next_job {
                 Ok(Some((job, remote_io_permit))) => {
-                    if let Some(remote_io_permit) = remote_io_permit {
+                    if let Some(channel) = ha_outbox_gc_channel_for_job_type(&job.job_type) {
+                        let run_state = state.clone();
+                        let run_wake = wake.clone();
+                        let run_cancellation = cancellation.clone();
+                        let run_adapter = adapter.clone();
+                        let job_id = job.id;
+                        let job_type = job.job_type.clone();
+                        let claimed_job = ClaimedScheduledJob {
+                            job_id: job.id,
+                            claim_generation: job.claim_generation,
+                            _job_execution_gate: None,
+                        };
+                        adapter
+                            .spawn_remote_task(async move {
+                                tokio::select! {
+                                    biased;
+                                    _ = run_cancellation.cancelled() => {}
+                                    completion = run_ha_outbox_gc_channel_claimed_job(run_state, claimed_job, channel) => {
+                                        run_adapter.record_completion(job_id, &job_type, completion);
+                                    }
+                                }
+                                run_wake.notify_one();
+                            })
+                            .await;
+                    } else if let Some(remote_io_permit) = remote_io_permit {
                         let run_state = state.clone();
                         let run_wake = wake.clone();
                         let run_cancellation = cancellation.clone();
@@ -1052,44 +1103,94 @@ fn spawn_ha_outbox_gc_scheduler(state: Arc<AppState>) -> tokio::task::JoinHandle
         loop {
             let now = state.proxy.backend_time().now_ts();
             let baseline_due = now >= next_baseline_at;
-            let watchdog_needed = if baseline_due {
-                false
-            } else {
-                match state.proxy.ha_outbox_gc_watchdog_needed().await {
-                    Ok(needed) => needed,
+            let baseline_refreshed = if baseline_due {
+                match state.proxy.make_ha_outbox_gc_work_due().await {
+                    Ok(HaOutboxGcWorkDueResult::Refreshed) => true,
+                    Ok(HaOutboxGcWorkDueResult::Busy) => {
+                        tracing::debug!(
+                            component = "ha_outbox_gc",
+                            event = "baseline_eligibility_deferred",
+                            defer_reason = "sqlite_busy",
+                            "HA outbox GC baseline could not refresh durable channel eligibility"
+                        );
+                        false
+                    }
                     Err(err) => {
                         tracing::debug!(
                             component = "ha_outbox_gc",
-                            event = "watchdog_state_unavailable",
+                            event = "baseline_eligibility_deferred",
                             err = %err,
-                            "HA outbox GC watchdog could not read durable debt state"
+                            "HA outbox GC baseline could not refresh durable channel eligibility"
                         );
                         false
                     }
                 }
+            } else {
+                false
             };
 
-            if baseline_due || watchdog_needed {
-                let enqueued = enqueue_scheduled_job_logged(
+            let mut work_state_busy = false;
+            let channels = if baseline_due && baseline_refreshed {
+                vec![
+                    HaSyncChannel::Control,
+                    HaSyncChannel::Billing,
+                    HaSyncChannel::Runtime,
+                ]
+            } else {
+                match state.proxy.ha_outbox_gc_work_due_channels().await {
+                    Ok(HaOutboxGcWorkDueChannelsResult::Ready(channels)) => channels,
+                    Ok(HaOutboxGcWorkDueChannelsResult::Busy) => {
+                        work_state_busy = true;
+                        tracing::debug!(
+                            component = "ha_outbox_gc",
+                            event = "work_state_deferred",
+                            defer_reason = "sqlite_busy",
+                            "HA outbox GC scheduler could not read durable channel work"
+                        );
+                        Vec::new()
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            component = "ha_outbox_gc",
+                            event = "work_state_unavailable",
+                            err = %err,
+                            "HA outbox GC scheduler could not read durable channel work"
+                        );
+                        Vec::new()
+                    }
+                }
+            };
+
+            let mut enqueued_any = false;
+            for channel in channels {
+                if enqueue_scheduled_job_logged(
                     state.as_ref(),
-                    "ha_outbox_gc",
+                    ha_outbox_gc_job_type(channel),
                     None,
                     TRIGGER_SOURCE_SCHEDULER,
                     "ha-outbox-gc",
                 )
-                .await;
-                if baseline_due && enqueued.is_some() {
-                    next_baseline_at = now.saturating_add(HA_OUTBOX_GC_BASELINE_SECS);
+                .await
+                .is_some()
+                {
+                    enqueued_any = true;
                 }
+            }
+            if baseline_due && baseline_refreshed && enqueued_any {
+                next_baseline_at = now.saturating_add(HA_OUTBOX_GC_BASELINE_SECS);
             }
 
             // The hourly baseline discovers newly expired records. Between sweeps,
-            // this only restores a lost continuation when durable GC state still
-            // reports channel debt.
+            // each channel's durable eligibility independently restores its own
+            // continuation without making another channel wait.
             state
                 .proxy
                 .backend_time()
-                .sleep(Duration::from_secs(HA_OUTBOX_GC_RECHECK_SECS))
+                .sleep(Duration::from_secs(if work_state_busy {
+                    HA_OUTBOX_GC_BUSY_RECHECK_SECS
+                } else {
+                    HA_OUTBOX_GC_RECHECK_SECS
+                }))
                 .await;
         }
     })
@@ -1336,318 +1437,6 @@ async fn run_request_logs_body_gc_index_ensure_claimed_job(
                 ),
             }
             false
-        }
-    }
-}
-
-async fn finish_ha_gc_with_continuation(
-    state: &Arc<AppState>,
-    job_id: i64,
-    claim_generation: i64,
-    message: String,
-    continuation_delay_secs: i64,
-) -> ScheduledJobCompletion {
-    let available_at = state
-        .proxy
-        .backend_time()
-        .now_ts()
-        .saturating_add(continuation_delay_secs);
-    let result = state
-        .proxy
-        .scheduled_job_finish_and_enqueue_auto_at(
-            job_id,
-            claim_generation,
-            "ha_outbox_gc",
-            None,
-            1,
-            Some(&message),
-            available_at,
-        )
-        .await;
-    match result {
-        Ok(result) => {
-            tracing::debug!(
-                component = "ha_outbox_gc",
-                event = "continuation_queued",
-                job_id,
-                continuation_job_id = result.job_id,
-                continuation_created = result.created,
-                continuation_delay_secs,
-                available_at,
-            );
-            ScheduledJobCompletion::Deferred
-        }
-        Err(err) if err.is_stale_claim() => {
-            tracing::debug!(
-                component = "ha_outbox_gc",
-                event = "stale_claim_ignored",
-                job_id,
-                claim_generation,
-                "stale GC claim cannot finish or enqueue a continuation"
-            );
-            ScheduledJobCompletion::Deferred
-        }
-        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
-            tracing::debug!(
-                component = "ha_outbox_gc",
-                event = "continuation_persist_deferred",
-                job_id,
-                claim_generation,
-                continuation_delay_secs,
-                err = %err,
-                "HA outbox GC continuation hit a transient SQLite conflict; stale reaper will recover it"
-            );
-            ScheduledJobCompletion::Deferred
-        }
-        Err(err) => {
-            tracing::error!(
-                component = "ha_outbox_gc",
-                event = "continuation_transaction_failed",
-                job_id,
-                continuation_delay_secs,
-                err = %err,
-                "HA outbox GC could not persist its deferred continuation"
-            );
-            let _ = state
-                .proxy
-                .record_ha_outbox_gc_deferred("continuation_persist_failed")
-                .await;
-            if let Err(finish_err) = state
-                .proxy
-                .scheduled_job_finish_claimed(job_id, claim_generation, "error", Some(&message))
-                .await
-            {
-                tracing::error!(
-                    component = "ha_outbox_gc",
-                    event = "deferred_job_finish_failed",
-                    job_id,
-                    err = %finish_err,
-                    "HA outbox GC deferred job remains eligible for the outer continuation retry"
-                );
-                ScheduledJobCompletion::Deferred
-            } else {
-                ScheduledJobCompletion::Failed
-            }
-        }
-    }
-}
-
-async fn run_ha_outbox_gc_claimed_job(
-    state: Arc<AppState>,
-    claimed_job: ClaimedScheduledJob,
-) -> ScheduledJobCompletion {
-    let ClaimedScheduledJob {
-        job_id,
-        claim_generation,
-        _job_execution_gate,
-    } = claimed_job;
-    drop(_job_execution_gate);
-
-    let Some(_gc_lease) = LegacySchedulerAdapter::for_state(state.as_ref())
-        .await
-        .try_acquire_maintenance_lease()
-    else {
-        tracing::debug!(
-            component = "ha_outbox_gc",
-            event = "deferred",
-            job_id,
-            claim_generation,
-            defer_reason = "gc_lease_busy",
-            continuation_delay_secs = HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
-        );
-        return finish_ha_gc_with_continuation(
-            &state,
-            job_id,
-            claim_generation,
-            "deferred=gc_lease_busy".to_string(),
-            HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
-        )
-        .await;
-    };
-    let result = state
-        .proxy
-        .gc_ha_outbox_online_with_foreground_pressure(
-            foreground_activity_rps(),
-            foreground_activity_low_pressure_since_floor(),
-        )
-        .await;
-
-    match result {
-        Ok(report) => {
-            let needs_continuation = report.has_more || !report.completed;
-            let foreground_rps_after_slice = needs_continuation.then(foreground_activity_rps);
-            let effective_continuation_delay_secs = foreground_rps_after_slice.map_or(
-                report.continuation_delay_secs,
-                |foreground_rps| {
-                    Some(ha_gc_continuation_delay_secs(
-                        report.continuation_delay_secs,
-                        foreground_rps,
-                    ))
-                },
-            );
-            if report.max_batch_elapsed_ms > tavily_hikari::HA_OUTBOX_GC_ACTIVE_BUDGET_MS {
-                tracing::warn!(
-                    component = "ha_outbox_gc",
-                    event = "slow_slice",
-                    job_id,
-                    claim_generation,
-                    max_batch_elapsed_ms = report.max_batch_elapsed_ms as u64,
-                    active_elapsed_ms = report.active_elapsed_ms as u64,
-                    elapsed_ms = report.elapsed_ms as u64,
-                    "HA outbox GC slice exceeded its SQL budget"
-                );
-            }
-            for channel in &report.channels {
-                let sampling =
-                    tavily_hikari::sample_ha_perf_event_windowed("gc_aggregate", channel.channel);
-                if sampling.emit_info {
-                    tracing::info!(
-                        component = "ha_outbox_gc",
-                        event = "aggregate",
-                        job_id,
-                        claim_generation,
-                        channel = channel.channel.as_str(),
-                        deleted_rows = channel.deleted_rows,
-                        retention_deleted_rows = channel.retention_deleted_rows,
-                        invalid_legacy_deleted_rows = channel.invalid_legacy_deleted_rows,
-                        oldest_deletable_age_secs = channel.oldest_deletable_age_secs,
-                        deleted_rows_per_minute = channel.deleted_rows_per_minute,
-                        foreground_rps = channel.foreground_rps,
-                        debt_mode = channel.debt_mode.as_str(),
-                        slo_state = channel.slo_state.as_str(),
-                        has_more = channel.has_more,
-                        continuation_delay_secs = effective_continuation_delay_secs,
-                        next_retry_at = effective_continuation_delay_secs
-                            .map(|delay| channel.observed_at.saturating_add(delay)),
-                        elapsed_ms = report.elapsed_ms as u64,
-                    );
-                }
-                if let Some(transition) = channel.slo_state_transition.as_deref() {
-                    match transition {
-                        "breached" => tracing::warn!(
-                            component = "ha_outbox_gc",
-                            event = "slo_breached",
-                            job_id,
-                            channel = channel.channel.as_str(),
-                            oldest_deletable_age_secs = channel.oldest_deletable_age_secs,
-                            deleted_rows_per_minute = channel.deleted_rows_per_minute,
-                            recovery_deadline_at = channel.recovery_deadline_at,
-                            "HA outbox GC recovery SLO breached"
-                        ),
-                        "recovered" => tracing::info!(
-                            component = "ha_outbox_gc",
-                            event = "slo_recovered",
-                            job_id,
-                            channel = channel.channel.as_str(),
-                            oldest_deletable_age_secs = channel.oldest_deletable_age_secs,
-                            deleted_rows_per_minute = channel.deleted_rows_per_minute,
-                            "HA outbox GC recovery SLO recovered"
-                        ),
-                        _ => {}
-                    }
-                }
-            }
-            if needs_continuation {
-                // A request may arrive while the one-second slice is running.
-                // Finish that slice, but do not immediately start another one.
-                let foreground_rps_after_slice = foreground_rps_after_slice
-                    .expect("foreground RPS must be sampled when GC continuation is required");
-                let continuation_delay_secs = effective_continuation_delay_secs
-                    .expect("continuation delay must be set when GC continuation is required");
-                let defer_reason = if foreground_rps_after_slice > HA_OUTBOX_GC_LOW_PRESSURE_RPS {
-                    "foreground_pressure"
-                } else if continuation_delay_secs == HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS {
-                    "legacy_scan"
-                } else if continuation_delay_secs < HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS {
-                    "fast_progress"
-                } else {
-                    "slice_budget_exhausted"
-                };
-                tracing::debug!(
-                    component = "ha_outbox_gc",
-                    event = "deferred",
-                    job_id,
-                    claim_generation,
-                    defer_reason,
-                    deleted_rows = report.deleted_rows,
-                    active_elapsed_ms = report.active_elapsed_ms as u64,
-                    max_batch_elapsed_ms = report.max_batch_elapsed_ms as u64,
-                    elapsed_ms = report.elapsed_ms as u64,
-                    foreground_rps_after_slice,
-                    continuation_delay_secs,
-                );
-                return finish_ha_gc_with_continuation(
-                    &state,
-                    job_id,
-                    claim_generation,
-                    format!(
-                        "deferred={defer_reason} {}",
-                        format_ha_outbox_gc_report_message(&report, 1)
-                    ),
-                    continuation_delay_secs,
-                )
-                .await;
-            } else {
-                let message = format_ha_outbox_gc_report_message(&report, 1);
-                if let Err(err) = state
-                    .proxy
-                    .scheduled_job_finish_claimed(
-                        job_id,
-                        claim_generation,
-                        "success",
-                        Some(&message),
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        component = "ha_outbox_gc",
-                        event = "deferred",
-                        job_id,
-                        claim_generation,
-                        defer_reason = "job_finish_failed",
-                        err = %err,
-                        "HA outbox GC completion could not be persisted; retaining a durable continuation"
-                    );
-                    return finish_ha_gc_with_continuation(
-                        &state,
-                        job_id,
-                        claim_generation,
-                        format!("deferred=job_finish_failed error={err}"),
-                        HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
-                    )
-                    .await;
-                }
-            }
-            ScheduledJobCompletion::Completed
-        }
-        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
-            tracing::debug!(
-                component = "ha_outbox_gc",
-                event = "deferred",
-                job_id,
-                claim_generation,
-                defer_reason = "sqlite_busy",
-                err = %err,
-            );
-            return finish_ha_gc_with_continuation(
-                &state,
-                job_id,
-                claim_generation,
-                format!("deferred=sqlite_busy error={err}"),
-                HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
-            )
-            .await;
-        }
-        Err(err) => {
-            let message = err.to_string();
-            match state
-                .proxy
-                .scheduled_job_finish_claimed(job_id, claim_generation, "error", Some(&message))
-                .await
-            {
-                Ok(()) => ScheduledJobCompletion::Failed,
-                Err(_) => ScheduledJobCompletion::Deferred,
-            }
         }
     }
 }

--- a/src/server/schedulers_ha_gc.rs
+++ b/src/server/schedulers_ha_gc.rs
@@ -1,0 +1,541 @@
+async fn run_ha_outbox_gc_claimed_job(
+    state: Arc<AppState>,
+    claimed_job: ClaimedScheduledJob,
+) -> ScheduledJobCompletion {
+    let job_id = claimed_job.job_id;
+    let claim_generation = claimed_job.claim_generation;
+    let due_channels = match state.proxy.ha_outbox_gc_work_due_channels().await {
+        Ok(HaOutboxGcWorkDueChannelsResult::Ready(channels)) => channels,
+        Ok(HaOutboxGcWorkDueChannelsResult::Busy) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "compatibility_due_read_deferred",
+                job_id,
+                claim_generation,
+                defer_reason = "sqlite_busy",
+            );
+            return ScheduledJobCompletion::Deferred;
+        }
+        Err(err) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "compatibility_due_read_failed",
+                job_id,
+                claim_generation,
+                err = %err,
+            );
+            return ScheduledJobCompletion::Deferred;
+        }
+    };
+    if due_channels.is_empty() {
+        return match state
+            .proxy
+            .scheduled_job_finish_claimed(job_id, claim_generation, "success", Some("not_eligible"))
+            .await
+        {
+            Ok(()) => ScheduledJobCompletion::Completed,
+            Err(err) if err.is_stale_claim() => ScheduledJobCompletion::Deferred,
+            Err(err) => {
+                tracing::debug!(
+                    component = "ha_outbox_gc",
+                    event = "compatibility_finish_failed",
+                    job_id,
+                    claim_generation,
+                    err = %err,
+                );
+                ScheduledJobCompletion::Deferred
+            }
+        };
+    }
+
+    let mut enqueued = 0;
+    for channel in due_channels {
+        if enqueue_scheduled_job_logged(
+            state.as_ref(),
+            ha_outbox_gc_job_type(channel),
+            None,
+            TRIGGER_SOURCE_AUTO,
+            "ha-outbox-gc-compatibility",
+        )
+        .await
+        .is_some()
+        {
+            enqueued += 1;
+        }
+    }
+    let message = format!("compatibility_handoff=enqueued_{enqueued}");
+    match state
+        .proxy
+        .scheduled_job_finish_claimed(job_id, claim_generation, "success", Some(&message))
+        .await
+    {
+        Ok(()) => ScheduledJobCompletion::Completed,
+        Err(err) if err.is_stale_claim() => ScheduledJobCompletion::Deferred,
+        Err(err) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "compatibility_handoff_finish_failed",
+                job_id,
+                claim_generation,
+                err = %err,
+            );
+            ScheduledJobCompletion::Deferred
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finish_ha_outbox_gc_channel(
+    state: &Arc<AppState>,
+    claimed_job: &ClaimedScheduledJob,
+    claim: HaOutboxGcWorkClaim,
+    outcome: HaOutboxGcWorkOutcome,
+    eligible_at: i64,
+    status: &'static str,
+    message: String,
+    continuation_available_at: Option<i64>,
+    deleted_rows: i64,
+) -> ScheduledJobCompletion {
+    let continuation_job_type = continuation_available_at.map(|_| ha_outbox_gc_job_type(claim.channel));
+    let result = state
+        .proxy
+        .finish_ha_outbox_gc_work_and_enqueue(
+            claimed_job.job_id,
+            claimed_job.claim_generation,
+            claim,
+            outcome,
+            eligible_at,
+            status,
+            Some(&message),
+            continuation_job_type,
+            continuation_available_at,
+            deleted_rows,
+        )
+        .await;
+    let result = match result {
+        Ok((HaOutboxGcWorkFinishResult::Busy, _)) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "finish_retry",
+                job_id = claimed_job.job_id,
+                channel = claim.channel.as_str(),
+                defer_reason = "sqlite_busy",
+                "HA GC finish retry remains bounded by the second SQLite operation budget"
+            );
+            state
+                .proxy
+                .finish_ha_outbox_gc_work_and_enqueue(
+                    claimed_job.job_id,
+                    claimed_job.claim_generation,
+                    claim,
+                    outcome,
+                    eligible_at,
+                    status,
+                    Some(&message),
+                    continuation_job_type,
+                    continuation_available_at,
+                    deleted_rows,
+                )
+                .await
+        }
+        other => other,
+    };
+    match result {
+        Ok((HaOutboxGcWorkFinishResult::Finished(finished_outcome), continuation)) => {
+            if let Some(continuation) = continuation {
+                tracing::debug!(
+                    component = "ha_outbox_gc",
+                    event = "continuation_queued",
+                    job_id = claimed_job.job_id,
+                    channel = claim.channel.as_str(),
+                    continuation_job_id = continuation.job_id,
+                    continuation_created = continuation.created,
+                    continuation_available_at,
+                );
+            }
+            match finished_outcome {
+                HaOutboxGcWorkOutcome::Completed => ScheduledJobCompletion::Completed,
+                HaOutboxGcWorkOutcome::Failed => ScheduledJobCompletion::Failed,
+                HaOutboxGcWorkOutcome::Deferred
+                | HaOutboxGcWorkOutcome::Busy
+                | HaOutboxGcWorkOutcome::Pending
+                | HaOutboxGcWorkOutcome::Running
+                | HaOutboxGcWorkOutcome::Stale => ScheduledJobCompletion::Deferred,
+            }
+        }
+        Ok((HaOutboxGcWorkFinishResult::Stale, _)) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "stale_claim_ignored",
+                job_id = claimed_job.job_id,
+                claim_generation = claimed_job.claim_generation,
+                channel = claim.channel.as_str(),
+                "stale HA GC generation cannot finish or enqueue a continuation"
+            );
+            ScheduledJobCompletion::Deferred
+        }
+        Ok((HaOutboxGcWorkFinishResult::Busy, _)) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "finish_deferred",
+                job_id = claimed_job.job_id,
+                channel = claim.channel.as_str(),
+                defer_reason = "sqlite_busy",
+                "HA GC finish was busy; stale recovery will revisit the durable claim"
+            );
+            ScheduledJobCompletion::Deferred
+        }
+        Err(err) => {
+            tracing::warn!(
+                component = "ha_outbox_gc",
+                event = "finish_failed",
+                job_id = claimed_job.job_id,
+                channel = claim.channel.as_str(),
+                err = %err,
+                "HA GC work and scheduled job finish could not be committed"
+            );
+            let now = state.proxy.backend_time().now_ts();
+            let eligible_at = now.saturating_add(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
+            let handoff_message = format!("deferred=finish_error error={err}");
+            match state
+                .proxy
+                .defer_ha_outbox_gc_claim_and_enqueue(
+                    claimed_job.job_id,
+                    claimed_job.claim_generation,
+                    claim,
+                    eligible_at,
+                    &handoff_message,
+                    eligible_at,
+                )
+                .await
+            {
+                Ok((HaOutboxGcWorkFinishResult::Finished(_), continuation)) => {
+                    tracing::debug!(
+                        component = "ha_outbox_gc",
+                        event = "finish_failure_handoff_queued",
+                        job_id = claimed_job.job_id,
+                        channel = claim.channel.as_str(),
+                        continuation_job_id = continuation.map(|value| value.job_id),
+                        available_at = eligible_at,
+                    );
+                }
+                Ok((HaOutboxGcWorkFinishResult::Stale, _)) => {}
+                Ok((HaOutboxGcWorkFinishResult::Busy, _)) => {
+                    tracing::debug!(
+                        component = "ha_outbox_gc",
+                        event = "finish_failure_handoff_deferred",
+                        job_id = claimed_job.job_id,
+                        channel = claim.channel.as_str(),
+                        defer_reason = "sqlite_busy",
+                    );
+                }
+                Err(handoff_err) => tracing::warn!(
+                    component = "ha_outbox_gc",
+                    event = "finish_failure_handoff_failed",
+                    job_id = claimed_job.job_id,
+                    channel = claim.channel.as_str(),
+                    err = %handoff_err,
+                ),
+            }
+            ScheduledJobCompletion::Deferred
+        }
+    }
+}
+
+async fn defer_ha_outbox_gc_channel_job(
+    state: &Arc<AppState>,
+    claimed_job: &ClaimedScheduledJob,
+    channel: HaSyncChannel,
+    outcome: HaOutboxGcWorkOutcome,
+    eligible_at: i64,
+    message: String,
+) -> ScheduledJobCompletion {
+    let mut result = state
+        .proxy
+        .defer_ha_outbox_gc_job_and_enqueue(
+            claimed_job.job_id,
+            claimed_job.claim_generation,
+            channel,
+            outcome,
+            eligible_at,
+            &message,
+            eligible_at,
+        )
+        .await;
+    if matches!(
+        result,
+        Ok((HaOutboxGcWorkFinishResult::Busy, _))
+    ) {
+        result = state
+            .proxy
+            .defer_ha_outbox_gc_job_and_enqueue(
+                claimed_job.job_id,
+                claimed_job.claim_generation,
+                channel,
+                outcome,
+                eligible_at,
+                &message,
+                eligible_at,
+            )
+            .await;
+    }
+    match result {
+        Ok((HaOutboxGcWorkFinishResult::Finished(_), continuation)) => {
+            if let Some(continuation) = continuation {
+                tracing::debug!(
+                    component = "ha_outbox_gc",
+                    event = "handoff_continuation_queued",
+                    job_id = claimed_job.job_id,
+                    channel = channel.as_str(),
+                    continuation_job_id = continuation.job_id,
+                    continuation_created = continuation.created,
+                    available_at = eligible_at,
+                );
+            }
+            ScheduledJobCompletion::Deferred
+        }
+        Ok((HaOutboxGcWorkFinishResult::Stale, _)) => ScheduledJobCompletion::Deferred,
+        Ok((HaOutboxGcWorkFinishResult::Busy, _)) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "handoff_deferred",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                "HA GC handoff remained busy; lease recovery will revisit it"
+            );
+            ScheduledJobCompletion::Deferred
+        }
+        Err(err) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "handoff_failed",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                err = %err,
+            );
+            ScheduledJobCompletion::Deferred
+        }
+    }
+}
+
+async fn run_ha_outbox_gc_channel_claimed_job(
+    state: Arc<AppState>,
+    claimed_job: ClaimedScheduledJob,
+    channel: HaSyncChannel,
+) -> ScheduledJobCompletion {
+    let claim = match state.proxy.claim_ha_outbox_gc_work(channel).await {
+        Ok(HaOutboxGcWorkClaimResult::Claimed(claim)) => claim,
+        Ok(HaOutboxGcWorkClaimResult::NotEligible { eligible_at }) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "not_eligible",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                eligible_at,
+            );
+            return match state
+                .proxy
+                .scheduled_job_finish_claimed(
+                    claimed_job.job_id,
+                    claimed_job.claim_generation,
+                    "success",
+                    Some("not_eligible"),
+                )
+                .await
+            {
+                Ok(()) => ScheduledJobCompletion::Completed,
+                Err(err) if err.is_stale_claim() => ScheduledJobCompletion::Deferred,
+                Err(err) => {
+                    let now = state.proxy.backend_time().now_ts();
+                    defer_ha_outbox_gc_channel_job(
+                        &state,
+                        &claimed_job,
+                        channel,
+                        HaOutboxGcWorkOutcome::Busy,
+                        now.saturating_add(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS),
+                        format!("deferred=not_eligible_finish error={err}"),
+                    )
+                    .await
+                }
+            };
+        }
+        Ok(HaOutboxGcWorkClaimResult::AlreadyClaimed {
+            claim_generation,
+            claim_expires_at,
+        }) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "claim_already_owned",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                claim_generation,
+                claim_expires_at,
+            );
+            return ScheduledJobCompletion::Deferred;
+        }
+        Ok(HaOutboxGcWorkClaimResult::Busy) => {
+            tracing::debug!(
+                component = "ha_outbox_gc",
+                event = "claim_deferred",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                defer_reason = "sqlite_busy",
+                "HA GC claim hit the bounded SQLite write budget"
+            );
+            let now = state.proxy.backend_time().now_ts();
+            let eligible_at = now.saturating_add(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
+            return defer_ha_outbox_gc_channel_job(
+                &state,
+                &claimed_job,
+                channel,
+                HaOutboxGcWorkOutcome::Busy,
+                eligible_at,
+                "deferred=sqlite_busy".to_string(),
+            )
+            .await;
+        }
+        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
+            tracing::warn!(
+                component = "ha_outbox_gc",
+                event = "claim_failed",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                err = %err,
+            );
+            let now = state.proxy.backend_time().now_ts();
+            let eligible_at = now.saturating_add(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
+            return defer_ha_outbox_gc_channel_job(
+                &state,
+                &claimed_job,
+                channel,
+                HaOutboxGcWorkOutcome::Busy,
+                eligible_at,
+                format!("deferred=sqlite_busy error={err}"),
+            )
+            .await;
+        }
+        Err(err) => {
+            tracing::warn!(
+                component = "ha_outbox_gc",
+                event = "claim_failed",
+                job_id = claimed_job.job_id,
+                channel = channel.as_str(),
+                err = %err,
+            );
+            let now = state.proxy.backend_time().now_ts();
+            let eligible_at = now.saturating_add(HA_OUTBOX_GC_BASELINE_SECS);
+            return defer_ha_outbox_gc_channel_job(
+                &state,
+                &claimed_job,
+                channel,
+                HaOutboxGcWorkOutcome::Failed,
+                eligible_at,
+                format!("failed=claim error={err}"),
+            )
+            .await;
+        }
+    };
+
+    let result = state
+        .proxy
+        .gc_ha_outbox_online_for_channel_with_foreground_pressure(
+            channel,
+            foreground_activity_rps(),
+            foreground_activity_low_pressure_since_floor(),
+        )
+        .await;
+    match result {
+        Ok(report) => {
+            let needs_continuation = report.has_more || !report.completed;
+            let foreground_rps_after_slice = needs_continuation.then(foreground_activity_rps);
+            let continuation_delay_secs = foreground_rps_after_slice.map_or(
+                report.continuation_delay_secs,
+                |foreground_rps| {
+                    Some(ha_gc_continuation_delay_secs(
+                        report.continuation_delay_secs,
+                        foreground_rps,
+                    ))
+                },
+            );
+            let now = state.proxy.backend_time().now_ts();
+            if needs_continuation {
+                let continuation_delay_secs = continuation_delay_secs
+                    .unwrap_or(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
+                let foreground_rps_after_slice = foreground_rps_after_slice.unwrap_or_default();
+                let defer_reason = if foreground_rps_after_slice > HA_OUTBOX_GC_LOW_PRESSURE_RPS {
+                    "foreground_pressure"
+                } else if continuation_delay_secs
+                    == HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS
+                {
+                    "legacy_scan"
+                } else if continuation_delay_secs < HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS {
+                    "fast_progress"
+                } else {
+                    "slice_budget_exhausted"
+                };
+                let continuation_at = now.saturating_add(continuation_delay_secs);
+                let message = format!(
+                    "deferred={defer_reason} {}",
+                    format_ha_outbox_gc_report_message(&report, 1)
+                );
+                finish_ha_outbox_gc_channel(
+                    &state,
+                    &claimed_job,
+                    claim,
+                    HaOutboxGcWorkOutcome::Deferred,
+                    continuation_at,
+                    "success",
+                    message,
+                    Some(continuation_at),
+                    report.deleted_rows,
+                )
+                .await
+            } else {
+                let eligible_at = now.saturating_add(HA_OUTBOX_GC_BASELINE_SECS);
+                finish_ha_outbox_gc_channel(
+                    &state,
+                    &claimed_job,
+                    claim,
+                    HaOutboxGcWorkOutcome::Completed,
+                    eligible_at,
+                    "success",
+                    format_ha_outbox_gc_report_message(&report, 1),
+                    None,
+                    report.deleted_rows,
+                )
+                .await
+            }
+        }
+        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
+            let now = state.proxy.backend_time().now_ts();
+            let eligible_at = now.saturating_add(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
+            finish_ha_outbox_gc_channel(
+                &state,
+                &claimed_job,
+                claim,
+                HaOutboxGcWorkOutcome::Busy,
+                eligible_at,
+                "success",
+                format!("deferred=sqlite_busy error={err}"),
+                Some(eligible_at),
+                0,
+            )
+            .await
+        }
+        Err(err) => {
+            let now = state.proxy.backend_time().now_ts();
+            finish_ha_outbox_gc_channel(
+                &state,
+                &claimed_job,
+                claim,
+                HaOutboxGcWorkOutcome::Failed,
+                now.saturating_add(HA_OUTBOX_GC_BASELINE_SECS),
+                "error",
+                err.to_string(),
+                None,
+                0,
+            )
+            .await
+        }
+    }
+}

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -1318,6 +1318,8 @@ impl KeyStore {
             }
             let new_json = ha_trigger_json_object(channel, table, "NEW", &columns);
             let old_json = ha_trigger_json_object(channel, table, "OLD", &columns);
+            let new_wire_json = ha_trigger_wire_json_object(channel, table, "NEW", &columns);
+            let old_wire_json = ha_trigger_wire_json_object(channel, table, "OLD", &columns);
             let new_resource_id = ha_trigger_resource_id("NEW", &columns);
             let old_resource_id = ha_trigger_resource_id("OLD", &columns);
             let table_ident = sqlite_qualified_table_name(table);
@@ -1340,11 +1342,16 @@ impl KeyStore {
                     }
                     _ => String::new(),
                 };
+                let wire_payload_filter = if suffix == "update" {
+                    format!(" AND json({old_wire_json}) IS NOT json({new_wire_json})")
+                } else {
+                    String::new()
+                };
                 let sql = format!(
                     r#"
                     CREATE TRIGGER IF NOT EXISTS {trigger}
                     {timing} ON {table_ident}
-                    WHEN NOT EXISTS (SELECT 1 FROM ha_outbox_suppression WHERE id = 'local'){row_filter}
+                    WHEN NOT EXISTS (SELECT 1 FROM ha_outbox_suppression WHERE id = 'local'){row_filter}{wire_payload_filter}
                     BEGIN
                         INSERT INTO {} (
                             kind, resource, resource_id, op, payload_json, created_at, checksum
@@ -1893,6 +1900,33 @@ fn ha_trigger_json_object(
     let args = columns
         .iter()
         .map(|column| ha_export_json_arg(channel, table, Some(alias), column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("json_object({args})")
+}
+
+fn ha_trigger_wire_json_object(
+    channel: HaSyncChannel,
+    table: &str,
+    alias: &str,
+    columns: &[String],
+) -> String {
+    let args = columns
+        .iter()
+        .map(|column| {
+            let sanitized = match table {
+                "api_key_maintenance_records" => {
+                    matches!(column.as_str(), "request_log_id" | "auth_token_log_id")
+                }
+                "api_key_transient_backoffs" => column == "source_request_log_id",
+                _ => false,
+            };
+            if sanitized {
+                format!("{}, NULL", quote_sqlite_string(column))
+            } else {
+                ha_export_json_arg(channel, table, Some(alias), column)
+            }
+        })
         .collect::<Vec<_>>()
         .join(", ");
     format!("json_object({args})")

--- a/src/store/key_store_ha_gc_online.rs
+++ b/src/store/key_store_ha_gc_online.rs
@@ -12,12 +12,30 @@ type HaOutboxGcChannelStateRow = (
 
 impl KeyStore {
     pub(crate) async fn ha_outbox_gc_watchdog_needed(&self) -> Result<bool, ProxyError> {
+        let now = self.backend_time.now_ts();
         let pending_channel_mask: Option<i64> = sqlx::query_scalar(
             "SELECT pending_channel_mask FROM ha_outbox_gc_state WHERE id = 'local'",
         )
         .fetch_optional(&self.pool)
         .await?;
-        Ok(pending_channel_mask.is_none_or(|mask| mask & 7 != 0))
+        let work_due: bool = sqlx::query_scalar(
+            r#"SELECT EXISTS(
+                   SELECT 1
+                   FROM ha_outbox_gc_work
+                   WHERE last_outcome <> 'pending'
+                     AND eligible_at <= ?
+                     AND (
+                         claim_started_at IS NULL
+                         OR claim_expires_at IS NULL
+                         OR claim_expires_at <= ?
+                     )
+               )"#,
+        )
+        .bind(now)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(pending_channel_mask.is_none_or(|mask| mask & 7 != 0) || work_due)
     }
 
     pub(crate) async fn gc_ha_outbox_online(&self) -> Result<HaOutboxGcReport, ProxyError> {
@@ -41,8 +59,24 @@ impl KeyStore {
             HaOutboxGcOptions::online(),
             foreground_rps,
             low_pressure_since_floor,
+            None,
         )
-            .await
+        .await
+    }
+
+    pub(crate) async fn gc_ha_outbox_online_for_channel_with_foreground_pressure(
+        &self,
+        channel: HaSyncChannel,
+        foreground_rps: i64,
+        low_pressure_since_floor: i64,
+    ) -> Result<HaOutboxGcReport, ProxyError> {
+        self.gc_ha_outbox_online_with_options(
+            HaOutboxGcOptions::online(),
+            foreground_rps,
+            low_pressure_since_floor,
+            Some(channel),
+        )
+        .await
     }
 
     pub(crate) async fn record_ha_outbox_gc_deferred(
@@ -115,6 +149,7 @@ impl KeyStore {
         options: HaOutboxGcOptions,
         foreground_rps: i64,
         low_pressure_since_floor: i64,
+        requested_channel: Option<HaSyncChannel>,
     ) -> Result<HaOutboxGcReport, ProxyError> {
         let started = Instant::now();
         let deadline = started + Duration::from_secs(options.max_runtime_secs.max(1));
@@ -168,20 +203,28 @@ impl KeyStore {
                 crate::HA_OUTBOX_GC_MAX_ONLINE_BATCH_SIZE,
             );
             let max_batches = options.max_batches.max(1);
-            let (next_channel, pending_channel_mask): (String, i64) = sqlx::query_as(
-                "SELECT next_channel, pending_channel_mask FROM ha_outbox_gc_state WHERE id = 'local'",
-            )
-            .fetch_one(&mut **conn)
-            .await?;
-            let pending_channel_mask = if pending_channel_mask == 0 {
-                7
+            let (channel, pending_channel_mask) = if let Some(channel) = requested_channel {
+                (channel, Self::ha_outbox_gc_channel_mask(channel))
             } else {
-                pending_channel_mask & 7
+                let (next_channel, persisted_pending_channel_mask): (String, i64) =
+                    sqlx::query_as(
+                        "SELECT next_channel, pending_channel_mask FROM ha_outbox_gc_state WHERE id = 'local'",
+                    )
+                    .fetch_one(&mut **conn)
+                    .await?;
+                let pending_channel_mask = if persisted_pending_channel_mask == 0 {
+                    7
+                } else {
+                    persisted_pending_channel_mask & 7
+                };
+                (
+                    Self::select_ha_outbox_gc_channel(
+                        Self::ha_outbox_gc_channel_from_name(&next_channel),
+                        pending_channel_mask,
+                    ),
+                    pending_channel_mask,
+                )
             };
-            let channel = Self::select_ha_outbox_gc_channel(
-                Self::ha_outbox_gc_channel_from_name(&next_channel),
-                pending_channel_mask,
-            );
             let (persisted_batch_size, last_attempt_at, last_observed_at, last_high_watermark,
                 _total_deleted_rows, _persisted_debt_mode, _persisted_oldest_age_secs,
                 persisted_deleted_rows_per_minute, persisted_slo_state): HaOutboxGcChannelStateRow = sqlx::query_as(
@@ -335,26 +378,30 @@ impl KeyStore {
             .fetch_one(&mut **conn)
             .await?;
             let high_watermark = Self::ha_channel_high_watermark_on_conn(conn, channel).await?;
-            let channel_mask = Self::ha_outbox_gc_channel_mask(channel);
-            let next_pending_channel_mask = if channel_has_more {
-                pending_channel_mask | channel_mask
+            let completed = if requested_channel.is_some() {
+                !channel_has_more
             } else {
-                pending_channel_mask & !channel_mask
+                let channel_mask = Self::ha_outbox_gc_channel_mask(channel);
+                let next_pending_channel_mask = if channel_has_more {
+                    pending_channel_mask | channel_mask
+                } else {
+                    pending_channel_mask & !channel_mask
+                };
+                let next_channel = Self::next_ha_outbox_gc_channel(channel);
+                sqlx::query(
+                    r#"
+                    UPDATE ha_outbox_gc_state
+                       SET next_channel = ?, pending_channel_mask = ?, updated_at = ?
+                     WHERE id = 'local'
+                    "#,
+                )
+                .bind(next_channel.as_str())
+                .bind(next_pending_channel_mask)
+                .bind(self.backend_time.now_ts())
+                .execute(&mut **conn)
+                .await?;
+                next_pending_channel_mask == 0
             };
-            let next_channel = Self::next_ha_outbox_gc_channel(channel);
-            sqlx::query(
-                r#"
-                UPDATE ha_outbox_gc_state
-                   SET next_channel = ?, pending_channel_mask = ?, updated_at = ?
-                 WHERE id = 'local'
-                "#,
-            )
-            .bind(next_channel.as_str())
-            .bind(next_pending_channel_mask)
-            .bind(self.backend_time.now_ts())
-            .execute(&mut **conn)
-            .await?;
-            let completed = next_pending_channel_mask == 0;
             let now = self.backend_time.now_ts();
             let channel_continuation_delay_secs = if has_more_retention {
                 crate::ha_outbox_gc_continuation_delay_secs_for_pressure(

--- a/src/store/key_store_ha_gc_work.rs
+++ b/src/store/key_store_ha_gc_work.rs
@@ -1,0 +1,704 @@
+const HA_OUTBOX_GC_WORK_CLAIM_LEASE_SECS: i64 = 120;
+
+fn ha_outbox_gc_work_job_type(channel: HaSyncChannel) -> &'static str {
+    match channel {
+        HaSyncChannel::Control => "ha_outbox_gc/control",
+        HaSyncChannel::Billing => "ha_outbox_gc/billing",
+        HaSyncChannel::Runtime => "ha_outbox_gc/runtime",
+    }
+}
+
+impl KeyStore {
+    async fn ensure_ha_outbox_gc_work_schema(&self) -> Result<(), ProxyError> {
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS ha_outbox_gc_work (
+                channel TEXT PRIMARY KEY CHECK (channel IN ('control', 'billing', 'runtime')),
+                eligible_at INTEGER NOT NULL DEFAULT 0,
+                claim_generation INTEGER NOT NULL DEFAULT 0,
+                claim_started_at INTEGER,
+                claim_expires_at INTEGER,
+                batch_size INTEGER NOT NULL DEFAULT 250,
+                last_outcome TEXT NOT NULL DEFAULT 'pending',
+                last_outcome_detail TEXT,
+                last_attempt_at INTEGER,
+                last_progress_at INTEGER,
+                last_deleted_rows INTEGER NOT NULL DEFAULT 0,
+                last_continuation_delay_secs INTEGER
+            )"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        for channel in ["control", "billing", "runtime"] {
+            sqlx::query(
+                "INSERT OR IGNORE INTO ha_outbox_gc_work (channel) VALUES (?)",
+            )
+            .bind(channel)
+            .execute(&self.pool)
+            .await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn ha_outbox_gc_work_due_channels(
+        &self,
+    ) -> Result<HaOutboxGcWorkDueChannelsResult, ProxyError> {
+        let mut connection = match self
+            .sqlite_runtime
+            .read(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(connection) => connection,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok(HaOutboxGcWorkDueChannelsResult::Busy);
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+        let now = self.backend_time.now_ts();
+        let rows = sqlx::query(
+            r#"SELECT channel
+               FROM ha_outbox_gc_work
+               WHERE eligible_at <= ?
+                 AND (
+                     claim_started_at IS NULL
+                     OR claim_expires_at IS NULL
+                     OR claim_expires_at <= ?
+                 )
+               ORDER BY CASE channel
+                   WHEN 'control' THEN 0
+                   WHEN 'billing' THEN 1
+                   WHEN 'runtime' THEN 2
+               END"#,
+        )
+        .bind(now)
+        .bind(now)
+        .fetch_all(&mut *connection)
+        .await?;
+        let channels = rows
+            .into_iter()
+            .map(|row| {
+                let channel = row.try_get::<String, _>("channel")?;
+                HaSyncChannel::parse(&channel).ok_or_else(|| {
+                    ProxyError::Other(format!("invalid HA GC work channel {channel}"))
+                })
+            })
+            .collect::<Result<Vec<_>, ProxyError>>()?;
+        Ok(HaOutboxGcWorkDueChannelsResult::Ready(channels))
+    }
+
+    pub(crate) async fn make_ha_outbox_gc_work_due(
+        &self,
+    ) -> Result<HaOutboxGcWorkDueResult, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let mut transaction = match self
+            .sqlite_runtime
+            .begin_immediate(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(transaction) => transaction,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok(HaOutboxGcWorkDueResult::Busy);
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+        sqlx::query(
+            r#"UPDATE ha_outbox_gc_work
+               SET eligible_at = MIN(eligible_at, ?),
+                   last_outcome_detail = 'baseline'
+               WHERE claim_started_at IS NULL"#,
+        )
+        .bind(now)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(HaOutboxGcWorkDueResult::Refreshed)
+    }
+
+    pub(crate) async fn claim_ha_outbox_gc_work(
+        &self,
+        channel: HaSyncChannel,
+    ) -> Result<HaOutboxGcWorkClaimResult, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let mut transaction = match self
+            .sqlite_runtime
+            .begin_immediate(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(transaction) => transaction,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok(HaOutboxGcWorkClaimResult::Busy);
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+
+        let row = sqlx::query(
+            r#"SELECT eligible_at, claim_generation, claim_started_at,
+                      claim_expires_at, batch_size
+               FROM ha_outbox_gc_work
+               WHERE channel = ?"#,
+        )
+        .bind(channel.as_str())
+        .fetch_one(&mut *transaction)
+        .await?;
+        let eligible_at = row.try_get::<i64, _>("eligible_at")?;
+        let claim_generation = row.try_get::<i64, _>("claim_generation")?;
+        let claim_started_at = row.try_get::<Option<i64>, _>("claim_started_at")?;
+        let claim_expires_at = row.try_get::<Option<i64>, _>("claim_expires_at")?;
+        let batch_size = row.try_get::<i64, _>("batch_size")?;
+
+        if eligible_at > now {
+            transaction.commit().await?;
+            return Ok(HaOutboxGcWorkClaimResult::NotEligible { eligible_at });
+        }
+        if claim_started_at.is_some()
+            && let Some(claim_expires_at) = claim_expires_at.filter(|expires| *expires > now)
+        {
+            transaction.commit().await?;
+            return Ok(HaOutboxGcWorkClaimResult::AlreadyClaimed {
+                claim_generation,
+                claim_expires_at,
+            });
+        }
+
+        let claim_generation = claim_generation.saturating_add(1);
+        let claim_expires_at = now.saturating_add(HA_OUTBOX_GC_WORK_CLAIM_LEASE_SECS);
+        sqlx::query(
+            r#"UPDATE ha_outbox_gc_work
+               SET claim_generation = ?,
+                   claim_started_at = ?,
+                   claim_expires_at = ?,
+                   last_attempt_at = ?,
+                   last_outcome = 'running',
+                   last_outcome_detail = NULL
+               WHERE channel = ?"#,
+        )
+        .bind(claim_generation)
+        .bind(now)
+        .bind(claim_expires_at)
+        .bind(now)
+        .bind(channel.as_str())
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+
+        Ok(HaOutboxGcWorkClaimResult::Claimed(HaOutboxGcWorkClaim {
+            channel,
+            claim_generation,
+            batch_size,
+            eligible_at,
+        }))
+    }
+
+    pub(crate) async fn finish_ha_outbox_gc_work(
+        &self,
+        claim: HaOutboxGcWorkClaim,
+        outcome: HaOutboxGcWorkOutcome,
+        eligible_at: i64,
+    ) -> Result<HaOutboxGcWorkFinishResult, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let mut transaction = match self
+            .sqlite_runtime
+            .begin_immediate(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(transaction) => transaction,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok(HaOutboxGcWorkFinishResult::Busy);
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+
+        let updated = sqlx::query(
+            r#"UPDATE ha_outbox_gc_work
+               SET eligible_at = ?,
+                   claim_started_at = NULL,
+                   claim_expires_at = NULL,
+                   last_outcome = ?,
+                   last_progress_at = ?,
+                   last_continuation_delay_secs = MAX(0, ? - ?)
+               WHERE channel = ?
+                 AND claim_generation = ?
+                 AND claim_started_at IS NOT NULL
+                 AND claim_expires_at > ?"#,
+        )
+        .bind(eligible_at)
+        .bind(outcome.as_str())
+        .bind(now)
+        .bind(eligible_at)
+        .bind(now)
+        .bind(claim.channel.as_str())
+        .bind(claim.claim_generation)
+        .bind(now)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        transaction.commit().await?;
+
+        if updated == 0 {
+            Ok(HaOutboxGcWorkFinishResult::Stale)
+        } else {
+            Ok(HaOutboxGcWorkFinishResult::Finished(outcome))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn finish_ha_outbox_gc_work_and_enqueue(
+        &self,
+        scheduled_job_id: i64,
+        scheduled_claim_generation: i64,
+        claim: HaOutboxGcWorkClaim,
+        outcome: HaOutboxGcWorkOutcome,
+        eligible_at: i64,
+        status: &str,
+        message: Option<&str>,
+        continuation_job_type: Option<&str>,
+        continuation_available_at: Option<i64>,
+        deleted_rows: i64,
+    ) -> Result<
+        (
+            HaOutboxGcWorkFinishResult,
+            Option<ScheduledJobEnqueueResult>,
+        ),
+        ProxyError,
+    > {
+        let finished_at = self.backend_time.now_ts();
+        let mut transaction = match self
+            .sqlite_runtime
+            .begin_immediate(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(transaction) => transaction,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok((HaOutboxGcWorkFinishResult::Busy, None));
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+
+        let updated_work = sqlx::query(
+            r#"UPDATE ha_outbox_gc_work
+               SET eligible_at = ?,
+                   claim_started_at = NULL,
+                   claim_expires_at = NULL,
+                   last_outcome = ?,
+                   last_outcome_detail = ?,
+                   last_progress_at = ?,
+                   last_deleted_rows = ?,
+                   last_continuation_delay_secs = MAX(0, ? - ?),
+                   batch_size = COALESCE(
+                       (SELECT batch_size FROM ha_outbox_gc_channel_state WHERE channel = ?),
+                       batch_size
+                   )
+               WHERE channel = ?
+                 AND claim_generation = ?
+                 AND claim_started_at IS NOT NULL
+                 AND claim_expires_at > ?"#,
+        )
+        .bind(eligible_at)
+        .bind(outcome.as_str())
+        .bind(message)
+        .bind(finished_at)
+        .bind(deleted_rows)
+        .bind(eligible_at)
+        .bind(finished_at)
+        .bind(claim.channel.as_str())
+        .bind(claim.channel.as_str())
+        .bind(claim.claim_generation)
+        .bind(finished_at)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated_work == 0 {
+            let _ = transaction.rollback().await;
+            return Ok((HaOutboxGcWorkFinishResult::Stale, None));
+        }
+
+        let updated_job = sqlx::query(
+            r#"UPDATE scheduled_jobs
+               SET status = ?, message = ?, finished_at = ?
+               WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+        )
+        .bind(status)
+        .bind(message)
+        .bind(finished_at)
+        .bind(scheduled_job_id)
+        .bind(scheduled_claim_generation)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated_job == 0 {
+            let _ = transaction.rollback().await;
+            return Ok((HaOutboxGcWorkFinishResult::Stale, None));
+        }
+
+        let continuation = match (continuation_job_type, continuation_available_at) {
+            (Some(job_type), Some(available_at)) => {
+                if let Some((continuation_id, continuation_status, trigger_source)) =
+                    Self::scheduled_job_lookup_active_locked(&mut transaction, job_type, None)
+                        .await?
+                {
+                    if continuation_status == "queued" {
+                        sqlx::query(
+                            "UPDATE scheduled_jobs
+                             SET available_at = MIN(available_at, ?), ha_gc_work_generation = ?
+                             WHERE id = ?",
+                        )
+                        .bind(available_at)
+                        .bind(claim.claim_generation)
+                        .bind(continuation_id)
+                        .execute(&mut *transaction)
+                        .await?;
+                    }
+                    Some(ScheduledJobEnqueueResult {
+                        job_id: continuation_id,
+                        created: false,
+                        promoted: false,
+                        status: continuation_status,
+                        trigger_source,
+                    })
+                } else {
+                    let inserted = sqlx::query(
+                        r#"INSERT INTO scheduled_jobs (
+                               job_type,
+                               trigger_source,
+                               key_id,
+                               status,
+                               attempt,
+                               queued_at,
+                               available_at,
+                               ha_gc_work_generation,
+                               started_at,
+                               finished_at
+                           ) VALUES (?, 'auto', NULL, 'queued', 1, ?, ?, ?, NULL, NULL)"#,
+                    )
+                    .bind(job_type)
+                    .bind(finished_at)
+                    .bind(available_at)
+                    .bind(claim.claim_generation)
+                    .execute(&mut *transaction)
+                    .await?;
+                    Some(ScheduledJobEnqueueResult {
+                        job_id: inserted.last_insert_rowid(),
+                        created: true,
+                        promoted: false,
+                        status: "queued".to_string(),
+                        trigger_source: "auto".to_string(),
+                    })
+                }
+            }
+            _ => None,
+        };
+        transaction.commit().await?;
+        Ok((
+            HaOutboxGcWorkFinishResult::Finished(outcome),
+            continuation,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn defer_ha_outbox_gc_job_and_enqueue(
+        &self,
+        scheduled_job_id: i64,
+        scheduled_claim_generation: i64,
+        channel: HaSyncChannel,
+        outcome: HaOutboxGcWorkOutcome,
+        eligible_at: i64,
+        message: &str,
+        continuation_available_at: i64,
+    ) -> Result<
+        (
+            HaOutboxGcWorkFinishResult,
+            Option<ScheduledJobEnqueueResult>,
+        ),
+        ProxyError,
+    > {
+        let finished_at = self.backend_time.now_ts();
+        let mut transaction = match self
+            .sqlite_runtime
+            .begin_immediate(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(transaction) => transaction,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok((HaOutboxGcWorkFinishResult::Busy, None));
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+
+        let Some((Some(expected_work_generation),)) = sqlx::query_as::<_, (Option<i64>,)>(
+            r#"SELECT ha_gc_work_generation
+               FROM scheduled_jobs
+               WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+        )
+        .bind(scheduled_job_id)
+        .bind(scheduled_claim_generation)
+        .fetch_optional(&mut *transaction)
+        .await?
+        else {
+            let _ = transaction.rollback().await;
+            return Ok((HaOutboxGcWorkFinishResult::Stale, None));
+        };
+
+        let updated_work = sqlx::query(
+            r#"UPDATE ha_outbox_gc_work
+               SET eligible_at = ?,
+                   claim_started_at = CASE
+                       WHEN claim_expires_at IS NULL OR claim_expires_at <= ? THEN NULL
+                       ELSE claim_started_at
+                   END,
+                   claim_expires_at = CASE
+                       WHEN claim_expires_at IS NULL OR claim_expires_at <= ? THEN NULL
+                       ELSE claim_expires_at
+                   END,
+                   last_outcome = ?,
+                   last_outcome_detail = ?,
+                   last_attempt_at = ?,
+                   last_continuation_delay_secs = MAX(0, ? - ?)
+               WHERE channel = ?
+                 AND claim_generation = ?
+                 AND (
+                     claim_started_at IS NULL
+                     OR claim_expires_at IS NULL
+                     OR claim_expires_at <= ?
+                 )
+                 AND last_outcome IN ('pending', 'busy', 'deferred')"#,
+        )
+        .bind(eligible_at)
+        .bind(finished_at)
+        .bind(finished_at)
+        .bind(outcome.as_str())
+        .bind(message)
+        .bind(finished_at)
+        .bind(eligible_at)
+        .bind(finished_at)
+        .bind(channel.as_str())
+        .bind(expected_work_generation)
+        .bind(finished_at)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+
+        let updated_job = sqlx::query(
+            r#"UPDATE scheduled_jobs
+               SET status = 'success', message = ?, finished_at = ?
+               WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+        )
+        .bind(message)
+        .bind(finished_at)
+        .bind(scheduled_job_id)
+        .bind(scheduled_claim_generation)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated_job == 0 {
+            let _ = transaction.rollback().await;
+            return Ok((HaOutboxGcWorkFinishResult::Stale, None));
+        }
+
+        let job_type = ha_outbox_gc_work_job_type(channel);
+        let continuation = if updated_work == 0 {
+            None
+        } else if let Some((continuation_id, status, trigger_source)) =
+            Self::scheduled_job_lookup_active_locked(&mut transaction, job_type, None).await?
+        {
+            if status == "queued" {
+                sqlx::query(
+                    "UPDATE scheduled_jobs
+                     SET available_at = MIN(available_at, ?), ha_gc_work_generation = ?
+                     WHERE id = ?",
+                )
+                .bind(continuation_available_at)
+                .bind(expected_work_generation)
+                .bind(continuation_id)
+                .execute(&mut *transaction)
+                .await?;
+            }
+            Some(ScheduledJobEnqueueResult {
+                job_id: continuation_id,
+                created: false,
+                promoted: false,
+                status,
+                trigger_source,
+            })
+        } else {
+            let inserted = sqlx::query(
+                r#"INSERT INTO scheduled_jobs (
+                       job_type,
+                       trigger_source,
+                       key_id,
+                       status,
+                       attempt,
+                       queued_at,
+                       available_at,
+                       ha_gc_work_generation,
+                       started_at,
+                       finished_at
+                   ) VALUES (?, 'auto', NULL, 'queued', 1, ?, ?, ?, NULL, NULL)"#,
+            )
+            .bind(job_type)
+            .bind(finished_at)
+            .bind(continuation_available_at)
+            .bind(expected_work_generation)
+            .execute(&mut *transaction)
+            .await?;
+            Some(ScheduledJobEnqueueResult {
+                job_id: inserted.last_insert_rowid(),
+                created: true,
+                promoted: false,
+                status: "queued".to_string(),
+                trigger_source: "auto".to_string(),
+            })
+        };
+
+        transaction.commit().await?;
+        Ok((
+            if updated_work == 0 {
+                HaOutboxGcWorkFinishResult::Stale
+            } else {
+                HaOutboxGcWorkFinishResult::Finished(outcome)
+            },
+            continuation,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn defer_ha_outbox_gc_claim_and_enqueue(
+        &self,
+        scheduled_job_id: i64,
+        scheduled_claim_generation: i64,
+        claim: HaOutboxGcWorkClaim,
+        eligible_at: i64,
+        message: &str,
+        continuation_available_at: i64,
+    ) -> Result<
+        (
+            HaOutboxGcWorkFinishResult,
+            Option<ScheduledJobEnqueueResult>,
+        ),
+        ProxyError,
+    > {
+        let finished_at = self.backend_time.now_ts();
+        let mut transaction = match self
+            .sqlite_runtime
+            .begin_immediate(&CancellationToken::new())
+            .await
+        {
+            SqliteOperationOutcome::Completed(transaction) => transaction,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+            | SqliteOperationOutcome::Deferred(SqliteDeferredReason::Cancelled) => {
+                return Ok((HaOutboxGcWorkFinishResult::Busy, None));
+            }
+            SqliteOperationOutcome::Failed(err) => return Err(err),
+        };
+
+        let updated_work = sqlx::query(
+            r#"UPDATE ha_outbox_gc_work
+               SET eligible_at = ?,
+                   claim_started_at = NULL,
+                   claim_expires_at = NULL,
+                   last_outcome = 'busy',
+                   last_outcome_detail = ?,
+                   last_progress_at = ?,
+                   last_continuation_delay_secs = MAX(0, ? - ?)
+               WHERE channel = ?
+                 AND claim_generation = ?
+                 AND claim_started_at IS NOT NULL
+                 AND claim_expires_at > ?"#,
+        )
+        .bind(eligible_at)
+        .bind(message)
+        .bind(finished_at)
+        .bind(eligible_at)
+        .bind(finished_at)
+        .bind(claim.channel.as_str())
+        .bind(claim.claim_generation)
+        .bind(finished_at)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated_work == 0 {
+            let _ = transaction.rollback().await;
+            return Ok((HaOutboxGcWorkFinishResult::Stale, None));
+        }
+
+        let updated_job = sqlx::query(
+            r#"UPDATE scheduled_jobs
+               SET status = 'success', message = ?, finished_at = ?
+               WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+        )
+        .bind(message)
+        .bind(finished_at)
+        .bind(scheduled_job_id)
+        .bind(scheduled_claim_generation)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+        if updated_job == 0 {
+            let _ = transaction.rollback().await;
+            return Ok((HaOutboxGcWorkFinishResult::Stale, None));
+        }
+
+        let job_type = ha_outbox_gc_work_job_type(claim.channel);
+        let continuation = if let Some((continuation_id, status, trigger_source)) =
+            Self::scheduled_job_lookup_active_locked(&mut transaction, job_type, None).await?
+        {
+            if status == "queued" {
+                sqlx::query(
+                    "UPDATE scheduled_jobs
+                     SET available_at = MIN(available_at, ?), ha_gc_work_generation = ?
+                     WHERE id = ?",
+                )
+                .bind(continuation_available_at)
+                .bind(claim.claim_generation)
+                .bind(continuation_id)
+                .execute(&mut *transaction)
+                .await?;
+            }
+            Some(ScheduledJobEnqueueResult {
+                job_id: continuation_id,
+                created: false,
+                promoted: false,
+                status,
+                trigger_source,
+            })
+        } else {
+            let inserted = sqlx::query(
+                r#"INSERT INTO scheduled_jobs (
+                       job_type,
+                       trigger_source,
+                       key_id,
+                       status,
+                       attempt,
+                       queued_at,
+                       available_at,
+                       ha_gc_work_generation,
+                       started_at,
+                       finished_at
+                   ) VALUES (?, 'auto', NULL, 'queued', 1, ?, ?, ?, NULL, NULL)"#,
+            )
+            .bind(job_type)
+            .bind(finished_at)
+            .bind(continuation_available_at)
+            .bind(claim.claim_generation)
+            .execute(&mut *transaction)
+            .await?;
+            Some(ScheduledJobEnqueueResult {
+                job_id: inserted.last_insert_rowid(),
+                created: true,
+                promoted: false,
+                status: "queued".to_string(),
+                trigger_source: "auto".to_string(),
+            })
+        };
+
+        transaction.commit().await?;
+        Ok((
+            HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Busy),
+            continuation,
+        ))
+    }
+}

--- a/src/store/key_store_ha_schema.rs
+++ b/src/store/key_store_ha_schema.rs
@@ -38,7 +38,8 @@ impl KeyStore {
         )
         .execute(&self.pool)
         .await?;
-        self.ensure_ha_outbox_gc_channel_state().await
+        self.ensure_ha_outbox_gc_channel_state().await?;
+        self.ensure_ha_outbox_gc_work_schema().await
     }
 
     async fn ensure_ha_outbox_gc_channel_state(&self) -> Result<(), ProxyError> {

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -19,6 +19,12 @@ impl KeyStore {
     }
 
     fn scheduled_job_priority(job_type: &str, trigger_source: &str) -> i64 {
+        if matches!(
+            job_type,
+            "ha_outbox_gc/control" | "ha_outbox_gc/billing" | "ha_outbox_gc/runtime"
+        ) {
+            return if trigger_source == "manual" { 1 } else { 3 };
+        }
         match (trigger_source, job_type) {
             ("manual", "request_logs_gc" | "db_compaction") => 0,
             ("manual", _) => 1,
@@ -60,7 +66,7 @@ impl KeyStore {
                 WHEN {trigger_source_column} = 'manual' AND ({job_type_column} = 'request_logs_gc' OR {job_type_column} = 'db_compaction') THEN 0 \
                 WHEN {trigger_source_column} = 'manual' THEN 1 \
                 WHEN {job_type_column} = 'request_logs_gc' OR {job_type_column} = 'db_compaction' THEN 2 \
-                WHEN {job_type_column} = 'auth_token_logs_gc' OR {job_type_column} = 'ha_outbox_gc' OR {job_type_column} = 'mcp_sessions_gc' OR {job_type_column} = 'mcp_session_init_backoffs_gc' OR {job_type_column} = 'token_usage_rollup' OR {job_type_column} = 'upstream_reconciliation' OR {job_type_column} = 'usage_aggregation' THEN 3 \
+                WHEN {job_type_column} = 'auth_token_logs_gc' OR {job_type_column} = 'ha_outbox_gc' OR {job_type_column} LIKE 'ha_outbox_gc/%' OR {job_type_column} = 'mcp_sessions_gc' OR {job_type_column} = 'mcp_session_init_backoffs_gc' OR {job_type_column} = 'token_usage_rollup' OR {job_type_column} = 'upstream_reconciliation' OR {job_type_column} = 'usage_aggregation' THEN 3 \
                 WHEN {job_type_column} = 'linuxdo_user_tag_binding_refresh' OR {job_type_column} = 'forward_proxy_geo_refresh' OR {job_type_column} = 'linuxdo_credit_recharge_lifecycle' OR {job_type_column} = 'linuxdo_user_status_sync' THEN 4 \
                 WHEN {job_type_column} = 'quota_sync' OR {job_type_column} = 'quota_sync/manual' OR {job_type_column} = 'quota_sync/hot' THEN 5 \
                 ELSE 6 \
@@ -160,6 +166,16 @@ impl KeyStore {
             .execute(&self.pool)
             .await?;
         }
+        if !self
+            .table_column_exists("scheduled_jobs", "ha_gc_work_generation")
+            .await?
+        {
+            sqlx::query(
+                "ALTER TABLE scheduled_jobs ADD COLUMN ha_gc_work_generation INTEGER",
+            )
+            .execute(&self.pool)
+            .await?;
+        }
         self.create_scheduled_jobs_indexes().await
     }
 
@@ -187,6 +203,7 @@ impl KeyStore {
                     queued_at INTEGER NOT NULL,
                     available_at INTEGER NOT NULL DEFAULT 0,
                     claim_generation INTEGER NOT NULL DEFAULT 0,
+                    ha_gc_work_generation INTEGER,
                     started_at INTEGER,
                     finished_at INTEGER,
                     FOREIGN KEY (key_id) REFERENCES api_keys(id)
@@ -208,6 +225,7 @@ impl KeyStore {
                     queued_at,
                     available_at,
                     claim_generation,
+                    ha_gc_work_generation,
                     started_at,
                     finished_at
                 )
@@ -222,6 +240,7 @@ impl KeyStore {
                     started_at,
                     0,
                     0,
+                    NULL,
                     started_at,
                     finished_at
                 FROM scheduled_jobs
@@ -858,7 +877,25 @@ impl KeyStore {
                     UPDATE scheduled_jobs
                     SET status = 'running',
                         started_at = ?,
-                        claim_generation = claim_generation + 1
+                        claim_generation = claim_generation + 1,
+                        ha_gc_work_generation = CASE job_type
+                            WHEN 'ha_outbox_gc/control' THEN (
+                                SELECT claim_generation
+                                FROM ha_outbox_gc_work
+                                WHERE channel = 'control'
+                            )
+                            WHEN 'ha_outbox_gc/billing' THEN (
+                                SELECT claim_generation
+                                FROM ha_outbox_gc_work
+                                WHERE channel = 'billing'
+                            )
+                            WHEN 'ha_outbox_gc/runtime' THEN (
+                                SELECT claim_generation
+                                FROM ha_outbox_gc_work
+                                WHERE channel = 'runtime'
+                            )
+                            ELSE ha_gc_work_generation
+                        END
                     WHERE id = ?
                       AND status = 'queued'
                       AND available_at <= ?
@@ -1127,24 +1164,24 @@ impl KeyStore {
                 r#"
                 UPDATE scheduled_jobs
                 SET status = CASE
-                        WHEN status = 'running' AND job_type = 'ha_outbox_gc' THEN 'queued'
+                        WHEN status = 'running' AND (job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%') THEN 'queued'
                         ELSE 'abandoned'
                     END,
                     message = CASE
-                        WHEN status = 'running' AND job_type = 'ha_outbox_gc'
+                        WHEN status = 'running' AND (job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%')
                             THEN COALESCE(message, 'deferred=process_restart')
                         ELSE COALESCE(message, 'abandoned after process restart')
                     END,
                     started_at = CASE
-                        WHEN status = 'running' AND job_type = 'ha_outbox_gc' THEN NULL
+                        WHEN status = 'running' AND (job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%') THEN NULL
                         ELSE started_at
                     END,
                     finished_at = CASE
-                        WHEN status = 'running' AND job_type = 'ha_outbox_gc' THEN NULL
+                        WHEN status = 'running' AND (job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%') THEN NULL
                         ELSE ?
                     END,
                     available_at = CASE
-                        WHEN status = 'running' AND job_type = 'ha_outbox_gc' THEN MAX(available_at, ?)
+                        WHEN status = 'running' AND (job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%') THEN MAX(available_at, ?)
                         ELSE available_at
                     END
                 WHERE (
@@ -1158,6 +1195,7 @@ impl KeyStore {
                                 AND (
                                     job_type = 'request_logs_gc'
                                     OR job_type = 'ha_outbox_gc'
+                                    OR job_type LIKE 'ha_outbox_gc/%'
                                 )
                             )
                         )
@@ -1225,13 +1263,13 @@ impl KeyStore {
                    available_at = ?,
                    claim_generation = claim_generation + 1,
                    message = CASE
-                       WHEN job_type = 'ha_outbox_gc' THEN 'deferred=stale_recovery'
+                       WHEN job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%' THEN 'deferred=stale_recovery'
                        ELSE 'deferred=stale_reconciliation_recovery'
                    END
                WHERE status = 'running'
                  AND started_at IS NOT NULL
                  AND (
-                     (job_type = 'ha_outbox_gc' AND started_at <= ?)
+                     ((job_type = 'ha_outbox_gc' OR job_type LIKE 'ha_outbox_gc/%') AND started_at <= ?)
                      OR (job_type = 'upstream_reconciliation' AND started_at <= ?)
                  )"#,
         )

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -11,13 +11,14 @@ use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
 use std::sync::{Mutex as StdMutex, OnceLock as StdOnceLock};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
 use tracing::log::LevelFilter;
 use tracing::{error, info, warn};
 
 mod immediate_transaction;
 pub(crate) use immediate_transaction::ImmediateSqliteTransaction;
 pub(crate) mod sqlite_runtime;
-pub(crate) use sqlite_runtime::SqliteRuntime;
+pub(crate) use sqlite_runtime::{SqliteDeferredReason, SqliteOperationOutcome, SqliteRuntime};
 
 pub(crate) struct ObservabilityOfflineGuard {
     _lock_file: File,
@@ -2608,6 +2609,7 @@ include!("key_store_ha_defs.rs");
 include!("key_store_ha_watermarks.rs");
 include!("key_store_writable_authority.rs");
 include!("key_store_ha.rs");
+include!("key_store_ha_gc_work.rs");
 #[cfg(test)]
 include!("key_store_request_logs_and_dashboard_test_support.rs");
 

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -223,4 +223,22 @@ mod tests {
             .await
             .expect("release writer lock");
     }
+
+    #[tokio::test]
+    async fn exhausted_primary_pool_read_is_deferred_within_operation_budget() {
+        let (runtime, _lock_pool, _temp_dir) = test_runtime().await;
+        let primary = runtime.compatibility_primary_pool();
+        let first = primary.acquire().await.expect("first primary connection");
+        let second = primary.acquire().await.expect("second primary connection");
+        let started = std::time::Instant::now();
+
+        let outcome = runtime.read(&CancellationToken::new()).await;
+
+        assert!(matches!(
+            outcome,
+            SqliteOperationOutcome::Deferred(SqliteDeferredReason::Busy)
+        ));
+        assert!(started.elapsed() < std::time::Duration::from_millis(750));
+        drop((first, second));
+    }
 }

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -1,4 +1,128 @@
 impl TavilyProxy {
+    pub async fn claim_ha_outbox_gc_work(
+        &self,
+        channel: HaSyncChannel,
+    ) -> Result<HaOutboxGcWorkClaimResult, ProxyError> {
+        self.key_store.claim_ha_outbox_gc_work(channel).await
+    }
+
+    pub async fn ha_outbox_gc_work_due_channels(
+        &self,
+    ) -> Result<HaOutboxGcWorkDueChannelsResult, ProxyError> {
+        self.key_store.ha_outbox_gc_work_due_channels().await
+    }
+
+    pub async fn make_ha_outbox_gc_work_due(
+        &self,
+    ) -> Result<HaOutboxGcWorkDueResult, ProxyError> {
+        self.key_store.make_ha_outbox_gc_work_due().await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn finish_ha_outbox_gc_work_and_enqueue(
+        &self,
+        scheduled_job_id: i64,
+        scheduled_claim_generation: i64,
+        claim: HaOutboxGcWorkClaim,
+        outcome: HaOutboxGcWorkOutcome,
+        eligible_at: i64,
+        status: &str,
+        message: Option<&str>,
+        continuation_job_type: Option<&str>,
+        continuation_available_at: Option<i64>,
+        deleted_rows: i64,
+    ) -> Result<
+        (
+            HaOutboxGcWorkFinishResult,
+            Option<ScheduledJobEnqueueResult>,
+        ),
+        ProxyError,
+    > {
+        self.key_store
+            .finish_ha_outbox_gc_work_and_enqueue(
+                scheduled_job_id,
+                scheduled_claim_generation,
+                claim,
+                outcome,
+                eligible_at,
+                status,
+                message,
+                continuation_job_type,
+                continuation_available_at,
+                deleted_rows,
+            )
+            .await
+    }
+
+    pub async fn finish_ha_outbox_gc_work(
+        &self,
+        claim: HaOutboxGcWorkClaim,
+        outcome: HaOutboxGcWorkOutcome,
+        eligible_at: i64,
+    ) -> Result<HaOutboxGcWorkFinishResult, ProxyError> {
+        self.key_store
+            .finish_ha_outbox_gc_work(claim, outcome, eligible_at)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn defer_ha_outbox_gc_job_and_enqueue(
+        &self,
+        scheduled_job_id: i64,
+        scheduled_claim_generation: i64,
+        channel: HaSyncChannel,
+        outcome: HaOutboxGcWorkOutcome,
+        eligible_at: i64,
+        message: &str,
+        continuation_available_at: i64,
+    ) -> Result<
+        (
+            HaOutboxGcWorkFinishResult,
+            Option<ScheduledJobEnqueueResult>,
+        ),
+        ProxyError,
+    > {
+        self.key_store
+            .defer_ha_outbox_gc_job_and_enqueue(
+                scheduled_job_id,
+                scheduled_claim_generation,
+                channel,
+                outcome,
+                eligible_at,
+                message,
+                continuation_available_at,
+            )
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn defer_ha_outbox_gc_claim_and_enqueue(
+        &self,
+        scheduled_job_id: i64,
+        scheduled_claim_generation: i64,
+        claim: HaOutboxGcWorkClaim,
+        eligible_at: i64,
+        message: &str,
+        continuation_available_at: i64,
+    ) -> Result<
+        (
+            HaOutboxGcWorkFinishResult,
+            Option<ScheduledJobEnqueueResult>,
+        ),
+        ProxyError,
+    > {
+        self.key_store
+            .defer_ha_outbox_gc_claim_and_enqueue(
+                scheduled_job_id,
+                scheduled_claim_generation,
+                claim,
+                eligible_at,
+                message,
+                continuation_available_at,
+            )
+            .await
+    }
+
     fn spawn_request_stats_coalescer(&self) {
         let store = self.key_store.clone();
         let coalescer = self.key_store.request_stats_coalescer.clone();
@@ -381,6 +505,21 @@ impl TavilyProxy {
     ) -> Result<HaOutboxGcReport, ProxyError> {
         self.key_store
             .gc_ha_outbox_online_with_foreground_pressure(foreground_rps, low_pressure_since_floor)
+            .await
+    }
+
+    pub async fn gc_ha_outbox_online_for_channel_with_foreground_pressure(
+        &self,
+        channel: HaSyncChannel,
+        foreground_rps: i64,
+        low_pressure_since_floor: i64,
+    ) -> Result<HaOutboxGcReport, ProxyError> {
+        self.key_store
+            .gc_ha_outbox_online_for_channel_with_foreground_pressure(
+                channel,
+                foreground_rps,
+                low_pressure_since_floor,
+            )
             .await
     }
 

--- a/src/tests/ha_gc_work.rs
+++ b/src/tests/ha_gc_work.rs
@@ -1,0 +1,650 @@
+use super::*;
+
+#[tokio::test]
+async fn ha_gc_work_fences_stale_generations_without_cross_channel_blocking() {
+    let db_path = temp_db_path("ha-gc-work-generation-fence");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-generation-fence".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let now = Utc::now().timestamp();
+
+    let control_claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Control)
+        .await
+        .expect("claim control work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected control claim, got {other:?}"),
+    };
+    let billing_claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Billing)
+        .await
+        .expect("claim billing work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected billing claim, got {other:?}"),
+    };
+
+    assert_eq!(
+        control_claim.claim_generation,
+        billing_claim.claim_generation
+    );
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query("UPDATE ha_outbox_gc_work SET claim_expires_at = ? WHERE channel = 'control'")
+        .bind(now - 1)
+        .execute(&pool)
+        .await
+        .expect("expire control claim");
+    let replacement_control_claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Control)
+        .await
+        .expect("take over expired control work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected replacement control claim, got {other:?}"),
+    };
+    assert_eq!(
+        replacement_control_claim.claim_generation,
+        control_claim.claim_generation + 1
+    );
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(control_claim, HaOutboxGcWorkOutcome::Completed, now + 3600,)
+            .await
+            .expect("reject expired control claim"),
+        HaOutboxGcWorkFinishResult::Stale
+    ));
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(
+                replacement_control_claim,
+                HaOutboxGcWorkOutcome::Deferred,
+                now + 300,
+            )
+            .await
+            .expect("finish control work"),
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Deferred)
+    ));
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(control_claim, HaOutboxGcWorkOutcome::Completed, now + 3600,)
+            .await
+            .expect("fence stale control completion"),
+        HaOutboxGcWorkFinishResult::Stale
+    ));
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(billing_claim, HaOutboxGcWorkOutcome::Completed, now + 3600,)
+            .await
+            .expect("finish billing work"),
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Completed)
+    ));
+
+    let control_row = sqlx::query(
+        "SELECT last_outcome, eligible_at, claim_generation, claim_started_at FROM ha_outbox_gc_work WHERE channel = 'control'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read control work");
+    assert_eq!(
+        control_row
+            .try_get::<String, _>("last_outcome")
+            .expect("control outcome"),
+        "deferred"
+    );
+    assert_eq!(
+        control_row
+            .try_get::<i64, _>("eligible_at")
+            .expect("control eligibility"),
+        now + 300
+    );
+    assert_eq!(
+        control_row
+            .try_get::<i64, _>("claim_generation")
+            .expect("control generation"),
+        replacement_control_claim.claim_generation
+    );
+    assert!(
+        control_row
+            .try_get::<Option<i64>, _>("claim_started_at")
+            .expect("control claim state")
+            .is_none()
+    );
+
+    pool.close().await;
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_gc_work_claim_maps_writer_contention_to_typed_busy() {
+    let db_path = temp_db_path("ha-gc-work-busy");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-busy".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let lock = begin_immediate_sqlite_connection(&proxy.key_store.pool)
+        .await
+        .expect("hold HA work writer lock");
+    let started = std::time::Instant::now();
+
+    assert_eq!(
+        proxy
+            .claim_ha_outbox_gc_work(HaSyncChannel::Runtime)
+            .await
+            .expect("claim under writer contention"),
+        HaOutboxGcWorkClaimResult::Busy
+    );
+    assert!(started.elapsed() < std::time::Duration::from_millis(750));
+    lock.rollback().await.expect("release HA work writer lock");
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_gc_work_busy_handoff_does_not_overwrite_completed_generation() {
+    let db_path = temp_db_path("ha-gc-work-stale-busy-handoff");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-stale-busy-handoff".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let now = Utc::now().timestamp();
+    let claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Runtime)
+        .await
+        .expect("claim runtime work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected runtime work claim, got {other:?}"),
+    };
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(claim, HaOutboxGcWorkOutcome::Completed, now + 3600)
+            .await
+            .expect("finish runtime work"),
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Completed)
+    ));
+    let job = proxy
+        .scheduled_job_enqueue("ha_outbox_gc/runtime", "scheduler", None, 1)
+        .await
+        .expect("enqueue stale handoff job");
+    let running_job = proxy
+        .scheduled_job_mark_running(job.job_id)
+        .await
+        .expect("claim stale handoff job")
+        .expect("stale handoff job is queued");
+
+    let (result, continuation) = proxy
+        .defer_ha_outbox_gc_job_and_enqueue(
+            running_job.id,
+            running_job.claim_generation,
+            HaSyncChannel::Runtime,
+            HaOutboxGcWorkOutcome::Busy,
+            now + 30,
+            "deferred=stale_busy",
+            now + 30,
+        )
+        .await
+        .expect("persist stale handoff");
+    assert_eq!(result, HaOutboxGcWorkFinishResult::Stale);
+    assert!(continuation.is_none());
+
+    let row = sqlx::query(
+        "SELECT last_outcome, eligible_at FROM ha_outbox_gc_work WHERE channel = 'runtime'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read fenced work");
+    assert_eq!(
+        row.try_get::<String, _>("last_outcome").expect("outcome"),
+        "completed"
+    );
+    assert_eq!(
+        row.try_get::<i64, _>("eligible_at").expect("eligibility"),
+        now + 3600
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_gc_work_busy_handoff_does_not_overwrite_newer_deferred_generation() {
+    let db_path = temp_db_path("ha-gc-work-stale-deferred-handoff");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-stale-deferred-handoff".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let job = proxy
+        .scheduled_job_enqueue("ha_outbox_gc/runtime", "scheduler", None, 1)
+        .await
+        .expect("enqueue runtime GC job");
+    let running_job = proxy
+        .scheduled_job_mark_running(job.job_id)
+        .await
+        .expect("claim scheduled job")
+        .expect("scheduled job is queued");
+    let claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Runtime)
+        .await
+        .expect("claim runtime work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected runtime work claim, got {other:?}"),
+    };
+    let deferred_at = Utc::now().timestamp() + 300;
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(claim, HaOutboxGcWorkOutcome::Deferred, deferred_at)
+            .await
+            .expect("finish newer runtime work"),
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Deferred)
+    ));
+
+    let (finish, continuation) = proxy
+        .defer_ha_outbox_gc_job_and_enqueue(
+            running_job.id,
+            running_job.claim_generation,
+            HaSyncChannel::Runtime,
+            HaOutboxGcWorkOutcome::Busy,
+            Utc::now().timestamp() + 30,
+            "deferred=sqlite_busy",
+            Utc::now().timestamp() + 30,
+        )
+        .await
+        .expect("persist stale busy handoff");
+    assert_eq!(finish, HaOutboxGcWorkFinishResult::Stale);
+    assert!(continuation.is_none());
+
+    let work_row = sqlx::query(
+        "SELECT last_outcome, eligible_at FROM ha_outbox_gc_work WHERE channel = 'runtime'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read fenced runtime work");
+    assert_eq!(
+        work_row
+            .try_get::<String, _>("last_outcome")
+            .expect("runtime outcome"),
+        "deferred"
+    );
+    assert_eq!(
+        work_row
+            .try_get::<i64, _>("eligible_at")
+            .expect("runtime eligibility"),
+        deferred_at
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_gc_work_due_channels_survive_restart_independently() {
+    let db_path = temp_db_path("ha-gc-work-restart-independence");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-restart-independence".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let now = Utc::now().timestamp();
+    let control_claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Control)
+        .await
+        .expect("claim delayed control work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected control claim, got {other:?}"),
+    };
+    assert!(matches!(
+        proxy
+            .finish_ha_outbox_gc_work(control_claim, HaOutboxGcWorkOutcome::Deferred, now + 300)
+            .await
+            .expect("persist delayed control work"),
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Deferred)
+    ));
+    drop(proxy);
+
+    let restarted = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-restart-independence".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("restarted proxy created");
+    let due_channels = match restarted
+        .ha_outbox_gc_work_due_channels()
+        .await
+        .expect("read due channels after restart")
+    {
+        HaOutboxGcWorkDueChannelsResult::Ready(channels) => channels,
+        HaOutboxGcWorkDueChannelsResult::Busy => panic!("restart due read was busy"),
+    };
+    assert!(!due_channels.contains(&HaSyncChannel::Control));
+    assert!(due_channels.contains(&HaSyncChannel::Billing));
+    assert!(due_channels.contains(&HaSyncChannel::Runtime));
+
+    drop(restarted);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_outbox_update_triggers_only_emit_when_wire_payload_changes() {
+    let db_path = temp_db_path("ha-outbox-update-wire-noop");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-outbox-update-wire-noop".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    repair_ha_triggers_once(&db_str, HaMode::ActiveStandby)
+        .await
+        .expect("HA triggers repaired");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query("DELETE FROM ha_outbox_suppression WHERE id = 'local'")
+        .execute(&pool)
+        .await
+        .expect("enable HA outbox writes");
+    sqlx::query("INSERT OR REPLACE INTO meta (key, value) VALUES ('request_rate_limit_v1', '{}')")
+        .execute(&pool)
+        .await
+        .expect("seed meta row");
+    let before_noop: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'meta'")
+            .fetch_one(&pool)
+            .await
+            .expect("count initial meta events");
+
+    sqlx::query("UPDATE meta SET value = '{}' WHERE key = 'request_rate_limit_v1'")
+        .execute(&pool)
+        .await
+        .expect("apply wire-identical update");
+    let after_noop: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'meta'")
+            .fetch_one(&pool)
+            .await
+            .expect("count wire-identical update events");
+    assert_eq!(after_noop, before_noop);
+
+    sqlx::query("UPDATE meta SET value = '{\"limit\":1}' WHERE key = 'request_rate_limit_v1'")
+        .execute(&pool)
+        .await
+        .expect("apply effective update");
+    let after_change: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ha_outbox WHERE resource = 'meta'")
+            .fetch_one(&pool)
+            .await
+            .expect("count effective update events");
+    assert_eq!(after_change, after_noop + 1);
+
+    sqlx::query(
+        "INSERT OR IGNORE INTO api_keys (id, api_key, status, created_at) VALUES ('ha-wire-key', 'tvly-ha-wire-key', 'active', 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed maintenance record key");
+    let before_maintenance: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ha_outbox WHERE resource = 'api_key_maintenance_records'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count maintenance events");
+    sqlx::query(
+        "INSERT INTO api_key_maintenance_records (id, key_id, source, operation_code, operation_summary, request_log_id, created_at) VALUES ('ha-wire-maintenance', 'ha-wire-key', 'test', 'unlink', 'unlink request log', 41, 1)",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed maintenance record");
+    let after_maintenance_insert: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ha_outbox WHERE resource = 'api_key_maintenance_records'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count inserted maintenance event");
+    assert_eq!(after_maintenance_insert, before_maintenance + 1);
+    sqlx::query(
+        "UPDATE api_key_maintenance_records SET request_log_id = NULL WHERE id = 'ha-wire-maintenance'",
+    )
+    .execute(&pool)
+    .await
+    .expect("unlink request log");
+    let after_maintenance_noop: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ha_outbox WHERE resource = 'api_key_maintenance_records'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count wire-identical maintenance update");
+    assert_eq!(after_maintenance_noop, after_maintenance_insert);
+    sqlx::query(
+        "UPDATE api_key_maintenance_records SET operation_summary = 'effective change' WHERE id = 'ha-wire-maintenance'",
+    )
+    .execute(&pool)
+    .await
+    .expect("apply effective maintenance update");
+    let after_maintenance_change: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ha_outbox WHERE resource = 'api_key_maintenance_records'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count effective maintenance update");
+    assert_eq!(after_maintenance_change, after_maintenance_noop + 1);
+
+    pool.close().await;
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_gc_work_finish_commits_job_and_channel_continuation_atomically() {
+    let db_path = temp_db_path("ha-gc-work-atomic-finish");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-atomic-finish".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let job = proxy
+        .scheduled_job_enqueue("ha_outbox_gc/control", "scheduler", None, 1)
+        .await
+        .expect("enqueue channel GC job");
+    let running_job = proxy
+        .scheduled_job_mark_running(job.job_id)
+        .await
+        .expect("claim scheduled job")
+        .expect("scheduled job is queued");
+    let claim = match proxy
+        .claim_ha_outbox_gc_work(HaSyncChannel::Control)
+        .await
+        .expect("claim channel work")
+    {
+        HaOutboxGcWorkClaimResult::Claimed(claim) => claim,
+        other => panic!("expected channel work claim, got {other:?}"),
+    };
+    let continuation_at = Utc::now().timestamp() + 30;
+    let (finish, continuation) = proxy
+        .finish_ha_outbox_gc_work_and_enqueue(
+            running_job.id,
+            running_job.claim_generation,
+            claim,
+            HaOutboxGcWorkOutcome::Deferred,
+            continuation_at,
+            "success",
+            Some("deferred=slice_budget_exhausted"),
+            Some("ha_outbox_gc/control"),
+            Some(continuation_at),
+            3,
+        )
+        .await
+        .expect("finish channel work atomically");
+    assert_eq!(
+        finish,
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Deferred)
+    );
+    let continuation = continuation.expect("continuation enqueued");
+    assert!(continuation.created);
+    assert_eq!(continuation.status, "queued");
+
+    let finished_job = proxy
+        .scheduled_job_by_id(running_job.id)
+        .await
+        .expect("read finished job")
+        .expect("finished job exists");
+    assert_eq!(finished_job.status, "success");
+    let continuation_job = proxy
+        .scheduled_job_by_id(continuation.job_id)
+        .await
+        .expect("read continuation job")
+        .expect("continuation job exists");
+    assert_eq!(continuation_job.status, "queued");
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let persisted_continuation_at: i64 =
+        sqlx::query_scalar("SELECT available_at FROM scheduled_jobs WHERE id = ?")
+            .bind(continuation.job_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read continuation availability");
+    assert_eq!(persisted_continuation_at, continuation_at);
+    let work_row = sqlx::query(
+        "SELECT last_outcome, last_deleted_rows, claim_started_at FROM ha_outbox_gc_work WHERE channel = 'control'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read finished channel work");
+    assert_eq!(
+        work_row
+            .try_get::<String, _>("last_outcome")
+            .expect("work outcome"),
+        "deferred"
+    );
+    assert_eq!(
+        work_row
+            .try_get::<i64, _>("last_deleted_rows")
+            .expect("work deleted rows"),
+        3
+    );
+    assert!(
+        work_row
+            .try_get::<Option<i64>, _>("claim_started_at")
+            .expect("work claim state")
+            .is_none()
+    );
+
+    pool.close().await;
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn ha_gc_work_busy_handoff_requeues_channel_job_atomically() {
+    let db_path = temp_db_path("ha-gc-work-busy-handoff");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-work-busy-handoff".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let job = proxy
+        .scheduled_job_enqueue("ha_outbox_gc/runtime", "scheduler", None, 1)
+        .await
+        .expect("enqueue runtime GC job");
+    let running_job = proxy
+        .scheduled_job_mark_running(job.job_id)
+        .await
+        .expect("claim scheduled job")
+        .expect("scheduled job is queued");
+    let continuation_at = Utc::now().timestamp() + 30;
+    let (finish, continuation) = proxy
+        .defer_ha_outbox_gc_job_and_enqueue(
+            running_job.id,
+            running_job.claim_generation,
+            HaSyncChannel::Runtime,
+            HaOutboxGcWorkOutcome::Busy,
+            continuation_at,
+            "deferred=sqlite_busy",
+            continuation_at,
+        )
+        .await
+        .expect("persist busy handoff");
+    assert_eq!(
+        finish,
+        HaOutboxGcWorkFinishResult::Finished(HaOutboxGcWorkOutcome::Busy)
+    );
+    let continuation = continuation.expect("continuation enqueued");
+    assert!(continuation.created);
+
+    let finished_job = proxy
+        .scheduled_job_by_id(running_job.id)
+        .await
+        .expect("read finished job")
+        .expect("finished job exists");
+    assert_eq!(finished_job.status, "success");
+    let work_row = sqlx::query(
+        "SELECT last_outcome, eligible_at, claim_started_at FROM ha_outbox_gc_work WHERE channel = 'runtime'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read busy work state");
+    assert_eq!(
+        work_row
+            .try_get::<String, _>("last_outcome")
+            .expect("busy outcome"),
+        "busy"
+    );
+    assert_eq!(
+        work_row
+            .try_get::<i64, _>("eligible_at")
+            .expect("busy eligibility"),
+        continuation_at
+    );
+    assert!(
+        work_row
+            .try_get::<Option<i64>, _>("claim_started_at")
+            .expect("busy claim state")
+            .is_none()
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod dashboard_hourly_credits;
 mod dashboard_month_series;
 mod dashboard_rollup_integrity;
 mod ha_baseline_streaming_and_sessions;
+mod ha_gc_work;
 mod ha_outbox_and_compaction;
 mod jobs_and_request_log_retention;
 mod linuxdo_credit_recharge;


### PR DESCRIPTION
## Summary

- Add durable per-channel control, billing, and runtime HA outbox GC work with persisted eligibility, generation fencing, adaptive continuation, typed Busy/Stale outcomes, and atomic work/job handoff.
- Run channel GC independently so delayed control work does not block billing/runtime across restart.
- Suppress unchanged wire-payload UPDATE outbox events while preserving effective changes and compatibility paths.

## Acceptance

- Delayed control eligibility leaves billing/runtime due and recoverable after restart.
- Stale generations cannot finish or requeue over newer completions; writer and pool contention returns bounded typed Busy.
- Identical UPDATE emits zero HA events; an effective UPDATE emits exactly one compatible event.

## Verification

- cargo fmt -- --check
- cargo check --all-targets
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -- --test-threads=1
- cargo test --test rust_source_line_budgets
- bun --cwd web test
- bun --cwd web run test:source-budgets
- bun --cwd web run build
- Two-axis standards/spec review: no P0/P1/P2 findings at the final fixed point.

## References

- Refs #489
- Approved plan: #483
- Specs: docs/specs/performance-architecture-hardening/SPEC.md
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions: docs/solutions/operations/sqlite-write-lock-contention.md
- Solutions Sync: done
- Project Docs: -
- Project Docs Sync: n/a(project_doc_disposition=none)

Child PR for integration branch prd/performance-architecture-hardening. No merge or deploy performed.
