### PR TITLE
fix(ci): cover HA GC work tests

### DIFF
--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -295,6 +295,7 @@
       ],
       "include_prefixes": [
         "ha_perf_sampling_tests::",
+        "tests::ha_gc_work::",
         "tests::jobs_and_request_log_retention::abandon_",
         "tests::jobs_and_request_log_retention::abandoned_",
         "tests::jobs_and_request_log_retention::auth_",


### PR DESCRIPTION
## Summary

- register the HA GC durable-work regression tests with the backend lib-misc shard
- restore exhaustive backend shard coverage for the current integration frontier

## Validation

- `python3 scripts/ci_backend_tests.py verify`

## Initiative

- Integration repair for #489 after PR #507
- Bound failed integration SHA: `126f4c72cb745bc5344a7a34ce410f5c2882f5d4`

## References

- Specs: `docs/specs/performance-architecture-hardening/`
- Solutions: -
- Project Docs: -

Spec Disposition: link
Spec Sync: done
Spec Drift: none
Solutions Sync: n/a
Project Docs Sync: n/a (project_doc_disposition=none)
PR Role: child
