### PR TITLE
fix(ha): isolate outbox GC channel scheduling

### DIFF
--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -7,8 +7,6 @@ use tavily_hikari::{
     decode_linuxdo_credit_refund_external_success_marker,
     format_ha_outbox_gc_report_message, format_linuxdo_credit_money,
     HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
-    HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS,
-    HA_OUTBOX_GC_LOW_PRESSURE_RPS,
     linuxdo_credit_recharge_system_refund_retry_delay_secs,
     linuxdo_credit_refund_params as shared_linuxdo_credit_refund_params,
     linuxdo_credit_refund_url as shared_linuxdo_credit_refund_url,
@@ -73,20 +71,6 @@ const SCHEDULED_JOB_WAIT_WARN_SAMPLE_SECS: u64 = 5 * 60;
 static REQUEST_LOGS_GC_ZERO_PROGRESS_STREAK: AtomicU64 = AtomicU64::new(0);
 static SCHEDULED_JOB_QUEUE_WAIT_WARN_WINDOWS: OnceLock<StdMutex<HashMap<String, Instant>>> =
     OnceLock::new();
-
-fn ha_gc_continuation_delay_secs(report_delay_secs: Option<i64>, foreground_rps: i64) -> i64 {
-    let report_delay_secs =
-        report_delay_secs.unwrap_or(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
-    if report_delay_secs == HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS {
-        // Legacy-only scans make no retention progress. Keep their deliberate
-        // five-minute yield even when foreground traffic arrives.
-        report_delay_secs
-    } else if foreground_rps > HA_OUTBOX_GC_LOW_PRESSURE_RPS {
-        HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS
-    } else {
-        report_delay_secs
-    }
-}
 
 fn should_warn_scheduled_job_queue_wait(job_type: &str) -> bool {
     let now = Instant::now();
@@ -1299,17 +1283,10 @@ async fn run_ha_outbox_gc_claimed_job(
 
     match result {
         Ok(report) => {
-            let needs_continuation = report.has_more || !report.completed;
-            let foreground_rps_after_slice = needs_continuation.then(foreground_activity_rps);
-            let effective_continuation_delay_secs = foreground_rps_after_slice.map_or(
-                report.continuation_delay_secs,
-                |foreground_rps| {
-                    Some(ha_gc_continuation_delay_secs(
-                        report.continuation_delay_secs,
-                        foreground_rps,
-                    ))
-                },
-            );
+            // The durable controller has already selected the next fair channel
+            // and its wake. The scheduler only persists that typed wake; it must
+            // not turn a defer for one channel into a global delay.
+            let continuation_delay_secs = report.continuation_delay_secs;
             if report.max_batch_elapsed_ms > tavily_hikari::HA_OUTBOX_GC_ACTIVE_BUDGET_MS {
                 tracing::warn!(
                     component = "ha_outbox_gc",
@@ -1341,9 +1318,7 @@ async fn run_ha_outbox_gc_claimed_job(
                         debt_mode = channel.debt_mode.as_str(),
                         slo_state = channel.slo_state.as_str(),
                         has_more = channel.has_more,
-                        continuation_delay_secs = effective_continuation_delay_secs,
-                        next_retry_at = effective_continuation_delay_secs
-                            .map(|delay| channel.observed_at.saturating_add(delay)),
+                        controller_wake_delay_secs = continuation_delay_secs,
                         elapsed_ms = report.elapsed_ms as u64,
                     );
                 }
@@ -1372,33 +1347,17 @@ async fn run_ha_outbox_gc_claimed_job(
                     }
                 }
             }
-            if needs_continuation {
-                // A request may arrive while the one-second slice is running.
-                // Finish that slice, but do not immediately start another one.
-                let foreground_rps_after_slice = foreground_rps_after_slice
-                    .expect("foreground RPS must be sampled when GC continuation is required");
-                let continuation_delay_secs = effective_continuation_delay_secs
-                    .expect("continuation delay must be set when GC continuation is required");
-                let defer_reason = if foreground_rps_after_slice > HA_OUTBOX_GC_LOW_PRESSURE_RPS {
-                    "foreground_pressure"
-                } else if continuation_delay_secs == HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS {
-                    "legacy_scan"
-                } else if continuation_delay_secs < HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS {
-                    "fast_progress"
-                } else {
-                    "slice_budget_exhausted"
-                };
+            if let Some(continuation_delay_secs) = continuation_delay_secs {
                 tracing::debug!(
                     component = "ha_outbox_gc",
                     event = "deferred",
                     job_id,
                     claim_generation,
-                    defer_reason,
+                    defer_reason = "controller_wake",
                     deleted_rows = report.deleted_rows,
                     active_elapsed_ms = report.active_elapsed_ms as u64,
                     max_batch_elapsed_ms = report.max_batch_elapsed_ms as u64,
                     elapsed_ms = report.elapsed_ms as u64,
-                    foreground_rps_after_slice,
                     continuation_delay_secs,
                 );
                 return finish_ha_gc_with_continuation(
@@ -1406,7 +1365,7 @@ async fn run_ha_outbox_gc_claimed_job(
                     job_id,
                     claim_generation,
                     format!(
-                        "deferred={defer_reason} {}",
+                        "controller_wake_delay_secs={continuation_delay_secs} {}",
                         format_ha_outbox_gc_report_message(&report, 1)
                     ),
                     continuation_delay_secs,

--- a/src/server/tests/alerts_and_ha_source_and_recovery.rs
+++ b/src/server/tests/alerts_and_ha_source_and_recovery.rs
@@ -2,19 +2,159 @@ use super::core_support_and_parsing::*;
 use super::upstream_support_and_manual_jobs::*;
 use super::*;
 
-#[test]
-fn ha_gc_keeps_legacy_scan_yield_under_foreground_load() {
-    assert_eq!(
-        ha_gc_continuation_delay_secs(
-            Some(HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS),
-            HA_OUTBOX_GC_LOW_PRESSURE_RPS + 1,
-        ),
-        HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS,
+#[tokio::test]
+async fn ha_gc_real_worker_wakes_an_eligible_channel_before_a_legacy_defer() {
+    let db_path = temp_db_path("ha-gc-worker-fair-wake");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("create proxy");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = Utc::now().timestamp();
+    let mut tx = pool.begin().await.expect("begin outbox seed transaction");
+    for index in 0..250 {
+        sqlx::query(
+            r#"
+            INSERT INTO ha_outbox
+                (kind, resource, resource_id, op, payload_json, created_at, checksum)
+            VALUES ('state', 'users', ?, 'upsert', '{}', ?, NULL)
+            "#,
+        )
+        .bind(format!("legacy-scan-{index}"))
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .expect("seed retained control event");
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO ha_outbox
+            (kind, resource, resource_id, op, payload_json, created_at, checksum)
+        VALUES ('state', 'scheduled_jobs', 'legacy-after-page', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .expect("seed deferred legacy control event");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_billing_outbox
+            (kind, resource, resource_id, op, payload_json, created_at, checksum)
+        VALUES ('state', 'billing_ledger', 'billing-ready', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(now - 15 * 24 * 60 * 60)
+    .execute(&mut *tx)
+    .await
+    .expect("seed eligible billing event");
+    tx.commit().await.expect("commit outbox seed transaction");
+    sqlx::query(
+        "UPDATE ha_outbox_gc_state SET next_channel = 'control', pending_channel_mask = 7 WHERE id = 'local'",
+    )
+    .execute(&pool)
+    .await
+    .expect("select control first");
+
+    let state = Arc::new(AppState {
+        proxy,
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        admin_passkey: AdminPasskeyOptions::disabled(),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+        dev_open_admin: false,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    });
+
+    let initial = state
+        .proxy
+        .scheduled_job_enqueue("ha_outbox_gc", "test", None, 1)
+        .await
+        .expect("enqueue control worker job");
+    let initial_claim = state
+        .proxy
+        .scheduled_job_mark_running(initial.job_id)
+        .await
+        .expect("claim control worker job")
+        .expect("initial job is due");
+    assert!(
+        run_ha_outbox_gc_claimed_job(
+            state.clone(),
+            ClaimedScheduledJob {
+                job_id: initial_claim.id,
+                claim_generation: initial_claim.claim_generation,
+                _job_execution_gate: None,
+            },
+        )
+        .await
     );
+
+    let continuation: (i64, i64, i64) = sqlx::query_as(
+        "SELECT id, queued_at, available_at FROM scheduled_jobs WHERE job_type = 'ha_outbox_gc' AND status = 'queued'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read controller continuation");
     assert_eq!(
-        ha_gc_continuation_delay_secs(Some(1), HA_OUTBOX_GC_LOW_PRESSURE_RPS + 1),
-        HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS,
+        continuation.2.saturating_sub(continuation.1),
+        1,
+        "the scheduler must persist the controller's one-second fair wake, not the control channel's 300-second legacy defer"
     );
+    let (control_delay, control_cursor): (i64, i64) = sqlx::query_as(
+        "SELECT next_retry_at - last_attempt_at, legacy_cursor_seq FROM ha_outbox_gc_channel_state WHERE channel = 'control'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read durable control defer");
+    assert_eq!(control_delay, 300);
+    assert_eq!(control_cursor, 250);
+
+    // Contract split: the library's manual-clock regression proves the
+    // controller calculates this one-second fair wake. This binary test proves
+    // the scheduler persists that exact typed wake and the next real worker
+    // advances billing when the durable job becomes due.
+    sqlx::query("UPDATE scheduled_jobs SET available_at = ? WHERE id = ?")
+        .bind(Utc::now().timestamp())
+        .bind(continuation.0)
+        .execute(&pool)
+        .await
+        .expect("advance continuation to its fair wake");
+    let billing_claim = state
+        .proxy
+        .scheduled_job_mark_running(continuation.0)
+        .await
+        .expect("claim billing worker job")
+        .expect("fair continuation is due");
+    assert!(
+        run_ha_outbox_gc_claimed_job(
+            state.clone(),
+            ClaimedScheduledJob {
+                job_id: billing_claim.id,
+                claim_generation: billing_claim.claim_generation,
+                _job_execution_gate: None,
+            },
+        )
+        .await
+    );
+    let billing_remaining: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM ha_billing_outbox WHERE resource_id = 'billing-ready' LIMIT 1)",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read billing progress");
+    assert!(!billing_remaining, "billing must advance on the fair wake");
+
+    drop(state);
+    pool.close().await;
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
 }
 
 #[tokio::test]

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -3175,14 +3175,6 @@ impl KeyStore {
         Ok((deleted_seqs.len() as i64, max_deleted_seq))
     }
 
-    fn ha_outbox_gc_legacy_cursor_column(channel: HaSyncChannel) -> &'static str {
-        match channel {
-            HaSyncChannel::Control => "last_legacy_control_seq",
-            HaSyncChannel::Billing => "last_legacy_billing_seq",
-            HaSyncChannel::Runtime => "last_legacy_runtime_seq",
-        }
-    }
-
     async fn delete_ha_invalid_legacy_events_bounded_on_conn(
         conn: &mut sqlx::SqliteConnection,
         channel: HaSyncChannel,
@@ -3190,10 +3182,10 @@ impl KeyStore {
         updated_at: i64,
     ) -> Result<(i64, bool, bool), ProxyError> {
         let table = quote_sqlite_identifier(ha_channel_event_table(channel));
-        let cursor_column = Self::ha_outbox_gc_legacy_cursor_column(channel);
-        let last_seq: i64 = sqlx::query_scalar(&format!(
-            "SELECT {cursor_column} FROM ha_outbox_gc_state WHERE id = 'local'"
-        ))
+        let last_seq: i64 = sqlx::query_scalar(
+            "SELECT legacy_cursor_seq FROM ha_outbox_gc_channel_state WHERE channel = ?",
+        )
+        .bind(channel.as_str())
         .fetch_one(&mut *conn)
         .await?;
         let scanned: Vec<(i64, String)> = sqlx::query_as(&format!(
@@ -3234,10 +3226,11 @@ impl KeyStore {
         // Keep the range cursor at the last scanned primary key even at the
         // end of the table. Resetting it to zero makes every online slice
         // rescan the entire outbox and defeats the bounded legacy pass.
-        sqlx::query(&format!(
-            "UPDATE ha_outbox_gc_state SET {cursor_column} = ? WHERE id = 'local'"
-        ))
+        sqlx::query(
+            "UPDATE ha_outbox_gc_channel_state SET legacy_cursor_seq = ? WHERE channel = ?",
+        )
         .bind(next_seq)
+        .bind(channel.as_str())
         .execute(&mut *conn)
         .await?;
         if let Some(max_deleted_seq) = invalid_seqs.iter().copied().max() {

--- a/src/store/key_store_ha_gc_online.rs
+++ b/src/store/key_store_ha_gc_online.rs
@@ -10,6 +10,7 @@ type HaOutboxGcChannelStateRow = (
     String,
 );
 const HA_GC_CHANNEL_CLAIM_STALE_SECS: i64 = 120;
+type HaGcChannelEligibility = (String, Option<i64>, i64, Option<i64>);
 
 #[derive(Debug, Clone, Copy)]
 struct HaGcChannelClaim {
@@ -21,23 +22,24 @@ struct HaGcChannelClaim {
 struct HaGcController;
 
 impl HaGcController {
+    const CHANNELS: [HaSyncChannel; 3] = [
+        HaSyncChannel::Control,
+        HaSyncChannel::Billing,
+        HaSyncChannel::Runtime,
+    ];
+
     fn claim_eligible_channel(
         preferred: HaSyncChannel,
         pending_channel_mask: i64,
         now: i64,
-        eligibility: &[(String, Option<i64>, i64, Option<i64>)],
+        eligibility: &[HaGcChannelEligibility],
     ) -> Option<HaGcChannelClaim> {
-        let channel_order = [
-            HaSyncChannel::Control,
-            HaSyncChannel::Billing,
-            HaSyncChannel::Runtime,
-        ];
-        let preferred_index = channel_order
+        let preferred_index = Self::CHANNELS
             .iter()
             .position(|candidate| *candidate == preferred)
             .unwrap_or(0);
-        (0..channel_order.len()).find_map(|offset| {
-            let candidate = channel_order[(preferred_index + offset) % channel_order.len()];
+        (0..Self::CHANNELS.len()).find_map(|offset| {
+            let candidate = Self::CHANNELS[(preferred_index + offset) % Self::CHANNELS.len()];
             let mask = KeyStore::ha_outbox_gc_channel_mask(candidate);
             if pending_channel_mask & mask == 0 {
                 return None;
@@ -58,9 +60,154 @@ impl HaGcController {
                 })
         })
     }
+
+    fn next_wake_delay_secs(
+        preferred: HaSyncChannel,
+        pending_channel_mask: i64,
+        now: i64,
+        eligibility: &[HaGcChannelEligibility],
+        ready_delay_secs: i64,
+    ) -> Option<i64> {
+        let preferred_index = Self::CHANNELS
+            .iter()
+            .position(|candidate| *candidate == preferred)
+            .unwrap_or(0);
+        let mut earliest_retry_at: Option<i64> = None;
+        for offset in 0..Self::CHANNELS.len() {
+            let candidate = Self::CHANNELS[(preferred_index + offset) % Self::CHANNELS.len()];
+            if pending_channel_mask & KeyStore::ha_outbox_gc_channel_mask(candidate) == 0 {
+                continue;
+            }
+            let Some((_, next_retry_at, _, claim_started_at)) = eligibility
+                .iter()
+                .find(|(name, _, _, _)| name == candidate.as_str())
+            else {
+                continue;
+            };
+            let eligible_at = next_retry_at.unwrap_or(now).max(
+                claim_started_at.map_or(now, |started_at| {
+                    started_at.saturating_add(HA_GC_CHANNEL_CLAIM_STALE_SECS)
+                }),
+            );
+            if eligible_at <= now {
+                return Some(ready_delay_secs.max(1));
+            }
+            earliest_retry_at = Some(
+                earliest_retry_at
+                    .map_or(eligible_at, |earliest| earliest.min(eligible_at)),
+            );
+        }
+        earliest_retry_at.map(|retry_at| retry_at.saturating_sub(now).max(1))
+    }
 }
 
 impl KeyStore {
+    pub(crate) async fn defer_claimed_ha_gc_channel_for_busy(
+        &self,
+        channel: HaSyncChannel,
+        claim_generation: i64,
+        pending_channel_mask: i64,
+        options: HaOutboxGcOptions,
+        foreground_rps: i64,
+        started: Instant,
+    ) -> Result<HaOutboxGcReport, ProxyError> {
+        let mut raw_conn = tokio::time::timeout(Duration::from_millis(100), self.pool.acquire())
+            .await
+            .map_err(|_| ProxyError::Database(sqlx::Error::PoolTimedOut))??;
+        sqlx::query("PRAGMA busy_timeout = 100")
+            .execute(&mut *raw_conn)
+            .await?;
+        let mut conn = ImmediateSqliteTransaction::begin(raw_conn).await?;
+        let result = async {
+            let now = self.backend_time.now_ts();
+            let channel_delay_secs = crate::HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS;
+            let channel_next_retry_at = now.saturating_add(channel_delay_secs);
+            let completed_claim = sqlx::query(
+                r#"UPDATE ha_outbox_gc_channel_state
+                   SET last_attempt_at = ?,
+                       last_deleted_rows = 0,
+                       last_defer_reason = 'sqlite_busy',
+                       next_retry_at = ?,
+                       consecutive_no_progress = consecutive_no_progress + 1,
+                       last_continuation_delay_secs = ?,
+                       debt_mode = 'sqlite_busy',
+                       foreground_rps = ?,
+                       claim_started_at = NULL
+                   WHERE channel = ? AND claim_generation = ?"#,
+            )
+            .bind(now)
+            .bind(channel_next_retry_at)
+            .bind(channel_delay_secs)
+            .bind(foreground_rps)
+            .bind(channel.as_str())
+            .bind(claim_generation)
+            .execute(&mut *conn)
+            .await?;
+            if completed_claim.rows_affected() == 0 {
+                return Err(ProxyError::Other(format!(
+                    "stale HA GC busy defer for {} generation {claim_generation}",
+                    channel.as_str(),
+                )));
+            }
+            let next_channel = Self::next_ha_outbox_gc_channel(channel);
+            let next_pending_channel_mask =
+                pending_channel_mask | Self::ha_outbox_gc_channel_mask(channel);
+            sqlx::query(
+                "UPDATE ha_outbox_gc_state SET next_channel = ?, pending_channel_mask = ?, updated_at = ? WHERE id = 'local'",
+            )
+            .bind(next_channel.as_str())
+            .bind(next_pending_channel_mask)
+            .bind(now)
+            .execute(&mut *conn)
+            .await?;
+            let eligibility = sqlx::query_as::<_, HaGcChannelEligibility>(
+                "SELECT channel, next_retry_at, claim_generation, claim_started_at FROM ha_outbox_gc_channel_state",
+            )
+            .fetch_all(&mut *conn)
+            .await?;
+            let continuation_delay_secs = HaGcController::next_wake_delay_secs(
+                next_channel,
+                next_pending_channel_mask,
+                now,
+                &eligibility,
+                crate::HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS,
+            );
+            Ok::<_, ProxyError>(HaOutboxGcReport {
+                batch_size: options.batch_size,
+                max_batches: options.max_batches,
+                deleted_rows: 0,
+                batches: 0,
+                completed: false,
+                has_more: true,
+                channels: Vec::new(),
+                wal_checkpoint_busy: false,
+                wal_checkpoint_log_frames: 0,
+                wal_checkpoint_checkpointed_frames: 0,
+                active_elapsed_ms: 0,
+                max_batch_elapsed_ms: 0,
+                elapsed_ms: started.elapsed().as_millis(),
+                continuation_delay_secs,
+            })
+        }
+        .await;
+        match result {
+            Ok(report) => {
+                sqlx::query(&format!(
+                    "PRAGMA busy_timeout = {}",
+                    crate::store::SQLITE_BUSY_TIMEOUT_DEFAULT.as_millis()
+                ))
+                .execute(&mut *conn)
+                .await?;
+                conn.commit().await?;
+                Ok(report)
+            }
+            Err(err) => {
+                let _ = conn.rollback().await;
+                Err(err)
+            }
+        }
+    }
+
     pub(crate) async fn ha_outbox_gc_watchdog_needed(&self) -> Result<bool, ProxyError> {
         let pending_channel_mask: Option<i64> = sqlx::query_scalar(
             "SELECT pending_channel_mask FROM ha_outbox_gc_state WHERE id = 'local'",
@@ -164,7 +311,7 @@ impl KeyStore {
                 pending_channel_mask & 7
             };
             let preferred = Self::ha_outbox_gc_channel_from_name(&next_channel);
-            let eligibility = sqlx::query_as::<_, (String, Option<i64>, i64, Option<i64>)>(
+            let mut eligibility = sqlx::query_as::<_, HaGcChannelEligibility>(
                 "SELECT channel, next_retry_at, claim_generation, claim_started_at FROM ha_outbox_gc_channel_state",
             )
             .fetch_all(&mut **conn)
@@ -431,25 +578,40 @@ impl KeyStore {
             } else {
                 None
             };
-            let continuation_delay_secs = if completed {
-                None
-            } else if let Some(delay) = channel_continuation_delay_secs {
-                Some(delay)
-            } else {
-                crate::ha_outbox_gc_continuation_delay_secs_for_pressure(
-                    true,
-                    max_batch_elapsed_ms,
-                    recovery_mode,
-                    foreground_rps,
+            let channel_next_retry_at =
+                channel_continuation_delay_secs.map(|delay| now.saturating_add(delay));
+            if let Some((_, next_retry_at, generation, claim_started_at)) = eligibility
+                .iter_mut()
+                .find(|(name, _, _, _)| name == channel.as_str())
+            {
+                *next_retry_at = channel_next_retry_at;
+                *generation = claim.generation;
+                *claim_started_at = None;
+            }
+            let continuation_delay_secs = (!completed).then(|| {
+                HaGcController::next_wake_delay_secs(
+                    next_channel,
+                    next_pending_channel_mask,
+                    now,
+                    &eligibility,
+                    // A fair handoff is intentionally faster than the normal
+                    // same-channel cadence: another ready channel must not sit
+                    // behind this channel's defer or five-second progression.
+                    crate::HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS,
                 )
-            };
+            })
+            .flatten();
             let defer_reason = channel_continuation_delay_secs.map(|delay| {
-                if delay == crate::HA_OUTBOX_GC_FAST_CONTINUATION_DELAY_SECS {
-                    "fast_progress"
-                } else if delay == crate::HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS {
+                if delay == crate::HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS {
                     "legacy_scan"
+                } else if foreground_rps > crate::HA_OUTBOX_GC_LOW_PRESSURE_RPS {
+                    "foreground_pressure"
+                } else if max_batch_elapsed_ms > crate::HA_OUTBOX_GC_ACTIVE_BUDGET_MS {
+                    "slow_slice"
+                } else if delay == crate::HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS {
+                    "recovery"
                 } else {
-                    "slice_budget"
+                    "fast_progress"
                 }
             });
             let ingress_seq_delta = last_observed_at.map(|_| {
@@ -532,7 +694,7 @@ impl KeyStore {
             .bind(now)
             .bind(deleted_rows)
             .bind(defer_reason)
-            .bind(channel_continuation_delay_secs.map(|delay| now.saturating_add(delay)))
+            .bind(channel_next_retry_at)
             .bind(deleted_rows)
             .bind(legacy_cursor_advanced)
             .bind(i64::from(channel_has_more))
@@ -596,7 +758,24 @@ impl KeyStore {
             }
             .await;
             pooled_conn = batch_conn;
-            gc_result
+            match gc_result {
+                Err(err) if crate::is_transient_sqlite_write_error(&err) => {
+                    // This claim already identifies the affected channel. Persist
+                    // its defer before returning so a busy control slice cannot
+                    // turn into a global scheduler delay for billing or runtime.
+                    drop(pooled_conn.take());
+                    self.defer_claimed_ha_gc_channel_for_busy(
+                        channel,
+                        claim.generation,
+                        pending_channel_mask,
+                        options,
+                        foreground_rps,
+                        started,
+                    )
+                    .await
+                }
+                other => other,
+            }
         }
         .await;
         if let Some(mut conn) = pooled_conn.take() {

--- a/src/store/key_store_ha_schema.rs
+++ b/src/store/key_store_ha_schema.rs
@@ -65,7 +65,8 @@ impl KeyStore {
                 slo_state TEXT NOT NULL DEFAULT 'unknown',
                 foreground_rps INTEGER NOT NULL DEFAULT 0,
                 claim_generation INTEGER NOT NULL DEFAULT 0,
-                claim_started_at INTEGER
+                claim_started_at INTEGER,
+                legacy_cursor_seq INTEGER NOT NULL DEFAULT 0
             )"#,
         )
         .execute(&self.pool)
@@ -85,6 +86,7 @@ impl KeyStore {
             ("foreground_rps", "INTEGER NOT NULL DEFAULT 0"),
             ("claim_generation", "INTEGER NOT NULL DEFAULT 0"),
             ("claim_started_at", "INTEGER"),
+            ("legacy_cursor_seq", "INTEGER NOT NULL DEFAULT 0"),
         ] {
             if !self
                 .table_column_exists("ha_outbox_gc_channel_state", column)
@@ -105,6 +107,23 @@ impl KeyStore {
             .execute(&self.pool)
             .await?;
         }
+        // New workers keep each bounded legacy scan with the channel that owns
+        // its claim. Retain the former shared columns for rolling-upgrade
+        // compatibility, but only seed an untouched per-channel cursor from them.
+        sqlx::query(
+            r#"
+            UPDATE ha_outbox_gc_channel_state
+               SET legacy_cursor_seq = CASE channel
+                   WHEN 'control' THEN (SELECT last_legacy_control_seq FROM ha_outbox_gc_state WHERE id = 'local')
+                   WHEN 'billing' THEN (SELECT last_legacy_billing_seq FROM ha_outbox_gc_state WHERE id = 'local')
+                   WHEN 'runtime' THEN (SELECT last_legacy_runtime_seq FROM ha_outbox_gc_state WHERE id = 'local')
+                   ELSE legacy_cursor_seq
+               END
+             WHERE legacy_cursor_seq = 0
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 }

--- a/src/tests/ha_outbox_and_compaction.rs
+++ b/src/tests/ha_outbox_and_compaction.rs
@@ -167,6 +167,197 @@ async fn online_ha_gc_skips_a_deferred_channel_without_freezing_other_debt() {
 }
 
 #[tokio::test]
+async fn online_ha_gc_manual_clock_advances_fair_scheduled_wakes() {
+    let db_path = temp_db_path("ha-outbox-gc-manual-clock-fair-wake");
+    let db_str = db_path.to_string_lossy().to_string();
+    let now = 1_700_010_000_i64;
+    let (backend_time, clock) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-ha-gc-manual-clock".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time,
+    )
+    .await
+    .expect("proxy created");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query(
+        "UPDATE ha_outbox_gc_state SET next_channel = 'control', pending_channel_mask = 7 WHERE id = 'local'",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed channel debt");
+    sqlx::query(
+        "UPDATE ha_outbox_gc_channel_state SET next_retry_at = ? WHERE channel = 'control'",
+    )
+    .bind(now + 300)
+    .execute(&pool)
+    .await
+    .expect("defer control channel");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_billing_outbox
+            (kind, resource, resource_id, op, payload_json, created_at, checksum)
+        VALUES ('state', 'billing_ledger', 'manual-clock-billing', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(now - 15 * SECS_PER_DAY)
+    .execute(&pool)
+    .await
+    .expect("seed eligible billing event");
+
+    let initial = proxy
+        .scheduled_job_enqueue("ha_outbox_gc", "test", None, 1)
+        .await
+        .expect("enqueue initial GC worker");
+    let initial_claim = proxy
+        .scheduled_job_mark_running(initial.job_id)
+        .await
+        .expect("claim initial GC worker")
+        .expect("initial GC worker is due");
+    let first = proxy
+        .gc_ha_outbox_online()
+        .await
+        .expect("billing fair wake");
+    assert_eq!(first.channels[0].channel, HaSyncChannel::Billing);
+    assert_eq!(first.channels[0].deleted_rows, 1);
+    assert_eq!(
+        first.continuation_delay_secs,
+        Some(HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS),
+        "an eligible runtime channel must be woken in one second while control is deferred"
+    );
+    let continuation = proxy
+        .scheduled_job_finish_and_enqueue_auto_at(
+            initial.job_id,
+            initial_claim.claim_generation,
+            "ha_outbox_gc",
+            None,
+            1,
+            Some("controller_wake_delay_secs=1"),
+            proxy.backend_time().now_ts()
+                + first
+                    .continuation_delay_secs
+                    .expect("controller produces the fair wake"),
+        )
+        .await
+        .expect("atomically queue the controller wake");
+    let (queued_at, available_at): (i64, i64) =
+        sqlx::query_as("SELECT queued_at, available_at FROM scheduled_jobs WHERE id = ?")
+            .bind(continuation.job_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read durable fair wake");
+    assert_eq!(available_at.saturating_sub(queued_at), 1);
+    clock.advance_wall(Duration::from_secs(1));
+    let second_claim = proxy
+        .scheduled_job_mark_running(continuation.job_id)
+        .await
+        .expect("claim fair continuation")
+        .expect("manual clock makes the one-second continuation due");
+    let second = proxy
+        .gc_ha_outbox_online()
+        .await
+        .expect("runtime fair wake");
+    assert_eq!(second.channels[0].channel, HaSyncChannel::Runtime);
+    assert!(second.continuation_delay_secs.is_some());
+    proxy
+        .scheduled_job_finish_claimed(
+            continuation.job_id,
+            second_claim.claim_generation,
+            "success",
+            Some("test completed"),
+        )
+        .await
+        .expect("finish fair continuation");
+
+    pool.close().await;
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn online_ha_gc_busy_defer_keeps_other_channels_eligible() {
+    let db_path = temp_db_path("ha-outbox-gc-busy-channel-local");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-gc-busy-channel-local".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = proxy.backend_time().now_ts();
+    sqlx::query(
+        "UPDATE ha_outbox_gc_state SET next_channel = 'control', pending_channel_mask = 7 WHERE id = 'local'",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed channel debt");
+    sqlx::query(
+        "UPDATE ha_outbox_gc_channel_state SET claim_generation = 11, claim_started_at = ? WHERE channel = 'control'",
+    )
+    .bind(now)
+    .execute(&pool)
+    .await
+    .expect("seed control claim");
+    sqlx::query(
+        r#"
+        INSERT INTO ha_billing_outbox
+            (kind, resource, resource_id, op, payload_json, created_at, checksum)
+        VALUES ('state', 'billing_ledger', 'busy-defer-billing', 'upsert', '{}', ?, NULL)
+        "#,
+    )
+    .bind(now - 15 * SECS_PER_DAY)
+    .execute(&pool)
+    .await
+    .expect("seed eligible billing event");
+
+    let report = proxy
+        .key_store
+        .defer_claimed_ha_gc_channel_for_busy(
+            HaSyncChannel::Control,
+            11,
+            7,
+            HaOutboxGcOptions::online(),
+            0,
+            Instant::now(),
+        )
+        .await
+        .expect("persist channel-local busy defer");
+    assert_eq!(
+        report.continuation_delay_secs,
+        Some(HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS),
+        "the controller must wake billing instead of waiting for control's busy backoff"
+    );
+    let (busy_delay, defer_reason, claim_started_at): (i64, String, Option<i64>) = sqlx::query_as(
+        "SELECT next_retry_at - last_attempt_at, last_defer_reason, claim_started_at FROM ha_outbox_gc_channel_state WHERE channel = 'control'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read persisted busy defer");
+    assert_eq!(busy_delay, HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS);
+    assert_eq!(defer_reason, "sqlite_busy");
+    assert_eq!(claim_started_at, None);
+
+    let billing = proxy
+        .gc_ha_outbox_online()
+        .await
+        .expect("billing fair wake");
+    assert_eq!(billing.channels[0].channel, HaSyncChannel::Billing);
+    assert_eq!(billing.channels[0].deleted_rows, 1);
+
+    pool.close().await;
+    drop(proxy);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
 async fn online_ha_gc_does_not_steal_an_active_channel_claim() {
     let db_path = temp_db_path("ha-outbox-gc-active-channel-claim");
     let db_str = db_path.to_string_lossy().to_string();
@@ -504,24 +695,27 @@ async fn online_ha_gc_uses_a_short_continuation_while_a_large_debt_is_draining()
     assert!(
         matches!(
             report.continuation_delay_secs,
-            Some(HA_OUTBOX_GC_FAST_CONTINUATION_DELAY_SECS)
+            Some(HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS)
+                | Some(HA_OUTBOX_GC_FAST_CONTINUATION_DELAY_SECS)
                 | Some(HA_OUTBOX_GC_DEFERRED_CONTINUATION_DELAY_SECS)
         ),
-        "a productive slice must continue quickly unless an individual SQL batch exceeded its budget"
+        "a productive slice must either hand off fairly or continue quickly unless an individual SQL batch exceeded its budget"
     );
 
-    let (last_attempt_at, next_retry_at, total_deleted_rows, last_high_watermark):
-        (i64, i64, i64, i64) = sqlx::query_as(
-        "SELECT last_attempt_at, next_retry_at, total_deleted_rows, last_high_watermark FROM ha_outbox_gc_channel_state WHERE channel = 'control'",
+    let (last_attempt_at, next_retry_at, total_deleted_rows, last_high_watermark,
+        channel_delay_secs): (i64, i64, i64, i64, Option<i64>) = sqlx::query_as(
+        "SELECT last_attempt_at, next_retry_at, total_deleted_rows, last_high_watermark, last_continuation_delay_secs FROM ha_outbox_gc_channel_state WHERE channel = 'control'",
     )
     .fetch_one(&pool)
     .await
     .expect("read GC continuation state");
     assert_eq!(
         next_retry_at.saturating_sub(last_attempt_at),
-        report
-            .continuation_delay_secs
-            .expect("continuation is scheduled")
+        channel_delay_secs.expect("control continuation is persisted")
+    );
+    assert_ne!(
+        channel_delay_secs, report.continuation_delay_secs,
+        "the next global wake may be shorter than the deferred channel's own continuation"
     );
     assert_eq!(total_deleted_rows, 1_000);
     assert_eq!(last_high_watermark, 1_250);
@@ -652,13 +846,22 @@ async fn online_ha_gc_does_not_fast_loop_while_only_legacy_scanning_remains() {
     .expect("insert old invalid legacy event beyond the first cursor window");
     tx.commit().await.expect("commit seed transaction");
 
-    let report = proxy.gc_ha_outbox_online().await.expect("online GC");
-    assert_eq!(report.deleted_rows, 0);
-    assert!(report.has_more);
+    let control = proxy.gc_ha_outbox_online().await.expect("control GC");
+    assert_eq!(control.deleted_rows, 0);
+    assert!(control.has_more);
     assert_eq!(
-        report.continuation_delay_secs,
+        control.continuation_delay_secs,
+        Some(HA_OUTBOX_GC_RECOVERY_CONTINUATION_DELAY_SECS),
+        "the controller must promptly discover other channels before honoring one channel's legacy defer"
+    );
+    let billing = proxy.gc_ha_outbox_online().await.expect("billing GC");
+    assert_eq!(billing.channels[0].channel, HaSyncChannel::Billing);
+    let runtime = proxy.gc_ha_outbox_online().await.expect("runtime GC");
+    assert_eq!(runtime.channels[0].channel, HaSyncChannel::Runtime);
+    assert_eq!(
+        runtime.continuation_delay_secs,
         Some(HA_OUTBOX_GC_LEGACY_SCAN_CONTINUATION_DELAY_SECS),
-        "legacy cursor progress must not form a fast maintenance loop"
+        "once the other channels are clear, the legacy cursor keeps its own five-minute defer"
     );
 
     pool.close().await;
@@ -714,7 +917,7 @@ async fn online_ha_gc_scans_legacy_rows_by_persisted_sequence_cursor() {
             .await
             .expect("read remaining resources");
     let cursor: i64 = sqlx::query_scalar(
-        "SELECT last_legacy_control_seq FROM ha_outbox_gc_state WHERE id = 'local'",
+        "SELECT legacy_cursor_seq FROM ha_outbox_gc_channel_state WHERE channel = 'control'",
     )
     .fetch_one(&pool)
     .await
@@ -1059,6 +1262,43 @@ async fn ha_outbox_cursor_validation_query_prefers_resource_created_seq_index() 
     assert!(
         joined.contains("idx_ha_outbox_resource_created_seq"),
         "expected resource/time/seq index in query plan, got:\n{joined}"
+    );
+
+    let retention_plan = explain_query_plan_details(
+        &pool,
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT seq
+        FROM ha_outbox
+        WHERE created_at < 1
+          AND resource IN ('meta', 'users', 'api_keys', 'api_key_quarantines', 'api_key_maintenance_records', 'system_settings')
+        ORDER BY created_at ASC, seq ASC
+        LIMIT 250
+        "#,
+    )
+    .await;
+    let retention_joined = retention_plan.join("\n");
+    assert!(
+        retention_joined.contains("idx_ha_outbox_resource_created_seq"),
+        "the bounded online retention page must use the resource/time index, got:\n{retention_joined}"
+    );
+
+    let legacy_plan = explain_query_plan_details(
+        &pool,
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT seq, resource
+        FROM ha_outbox
+        WHERE seq > 0
+        ORDER BY seq ASC
+        LIMIT 250
+        "#,
+    )
+    .await;
+    let legacy_joined = legacy_plan.join("\n");
+    assert!(
+        legacy_joined.contains("INTEGER PRIMARY KEY"),
+        "the legacy cursor page must use its primary-key range, got:\n{legacy_joined}"
     );
 
     let _ = std::fs::remove_file(db_path);


### PR DESCRIPTION
## Delivery

- Delivery role: child
- Parent issue: #517
- Initiative: performance-debt-recovery
- Wave: 1
- Integration base: `prd/performance-debt-recovery`
- Spec: `docs/specs/performance-architecture-hardening/SPEC.md@77f4e8bfc281aa1ed1fc47486401d7077a85f0b8`
- Spec Disposition: linked; no canonical spec change
- Solutions: -
- Project Docs: -
- Visual evidence: not applicable (backend durable scheduling)
- Risk: HA state migration and channel-local scheduler ownership
- Blocker: none

## Changes

- Make `HaGcController` the durable owner of per-channel eligibility, cursors, defer/progress state, batches, and fair continuation timing.
- Keep scheduler wake persistence typed and channel-neutral so a deferred control channel cannot delay eligible billing/runtime work.
- Cover fair wakes with deterministic manual clock scheduling, real scheduler dispatch, busy/defer behavior, bounded query plans, retention, ACK, and 410 baseline behavior.

## Validation

- `cargo test --lib` (636 passed)
- `cargo test --bin tavily-hikari` (456 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `bun test` (523 passed)
- `bun run test:source-budgets`
- `bun run build`

## Review

- `$code-review` standards: no findings
- `$code-review` spec: no findings

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->