### PR TITLE
fix(reconciliation): harden durable reconciliation

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1042,6 +1042,7 @@ pub struct UpstreamReconciliationResearchCandidate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpstreamReconciliationCandidateBatch {
     pub candidates: Vec<UpstreamReconciliationCandidate>,
+    pub(crate) work_generation_by_candidate: std::collections::HashMap<(String, String), i64>,
     pub recent_lane_budget: i64,
     pub backlog_lane_budget: i64,
     pub recent_candidate_count: i64,

--- a/src/server/handlers/tavily.rs
+++ b/src/server/handlers/tavily.rs
@@ -150,6 +150,8 @@ async fn record_rebalance_period_usage(
         .await
     {
         eprintln!("record upstream reconciliation usage failed: {err}");
+    } else {
+        maintenance_worker_wake_for_state(state.as_ref()).notify_one();
     }
 }
 

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -842,22 +842,6 @@ fn spawn_token_usage_rollup_scheduler(state: Arc<AppState>) {
     });
 }
 
-fn spawn_upstream_reconciliation_scheduler(state: Arc<AppState>) {
-    tokio::spawn(async move {
-        loop {
-            let _ = enqueue_scheduled_job_logged(
-                state.as_ref(),
-                "upstream_reconciliation",
-                None,
-                TRIGGER_SOURCE_SCHEDULER,
-                "upstream-reconciliation",
-            )
-            .await;
-            state.proxy.backend_time().sleep(Duration::from_secs(60)).await;
-        }
-    });
-}
-
 fn spawn_auth_token_logs_gc_scheduler(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
@@ -2597,11 +2581,9 @@ async fn run_manual_claimed_job(
             )
             .await
             {
-                Ok(Ok((_settled, true))) => true,
-                Ok(Ok((settled, false))) => {
-                    let now = state.proxy.backend_time().now_ts();
-                    match state.proxy.upstream_reconciliation_backoff_until().await {
-                        Ok(available_at) if available_at > now => state
+                Ok(Ok((settled, _))) => {
+                    match state.proxy.upstream_reconciliation_continuation_at().await {
+                        Ok(Some(available_at)) => state
                             .proxy
                             .scheduled_job_finish_and_enqueue_auto_at(
                                 job_id,
@@ -2609,12 +2591,12 @@ async fn run_manual_claimed_job(
                                 "upstream_reconciliation",
                                 None,
                                 1,
-                                Some(&format!("settled={settled} backoff_until={available_at}")),
+                                Some(&format!("settled={settled} continuation_at={available_at}")),
                                 available_at,
                             )
                             .await
                             .is_ok(),
-                        Ok(_) => finish(state, "success", format!("settled={settled}")).await,
+                        Ok(None) => finish(state, "success", format!("settled={settled}")).await,
                         Err(err) => finish(state, "error", err.to_string()).await,
                     }
                 }
@@ -2637,8 +2619,20 @@ async fn run_manual_claimed_job(
                             err = %err,
                         );
                     }
-                    finish(state, "success", "settled=unknown budget_exhausted=true".to_string())
+                    let available_at = state.proxy.backend_time().now_ts().saturating_add(300);
+                    state
+                        .proxy
+                        .scheduled_job_finish_and_enqueue_auto_at(
+                            job_id,
+                            claim_generation,
+                            "upstream_reconciliation",
+                            None,
+                            1,
+                            Some("settled=unknown budget_exhausted=true"),
+                            available_at,
+                        )
                         .await
+                        .is_ok()
                 }
             }
         }

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -691,6 +691,23 @@ fn spawn_maintenance_worker(state: Arc<AppState>) {
     });
 }
 
+fn spawn_upstream_reconciliation_startup_resume(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        match state
+            .proxy
+            .ensure_upstream_reconciliation_representative_job()
+            .await
+        {
+            Ok(()) => maintenance_worker_wake_for_state(state.as_ref()).notify_one(),
+            Err(err) => tracing::error!(
+                component = "reconciliation",
+                event = "startup_resume_enqueue_failed",
+                err = %err,
+            ),
+        }
+    });
+}
+
 fn spawn_scheduled_job_stale_reaper(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -729,6 +729,18 @@ fn spawn_scheduled_job_stale_reaper(state: Arc<AppState>) {
                     err = %err,
                 ),
             }
+            match state
+                .proxy
+                .ensure_upstream_reconciliation_representative_job()
+                .await
+            {
+                Ok(()) => maintenance_worker_wake_for_state(state.as_ref()).notify_one(),
+                Err(err) => tracing::debug!(
+                    component = "reconciliation",
+                    event = "resume_watcher_enqueue_failed",
+                    err = %err,
+                ),
+            }
         }
     });
 }
@@ -2598,7 +2610,7 @@ async fn run_manual_claimed_job(
             )
             .await
             {
-                Ok(Ok((settled, _))) => {
+                Ok(Ok(settled)) => {
                     match state.proxy.upstream_reconciliation_continuation_at().await {
                         Ok(Some(available_at)) => state
                             .proxy

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1534,7 +1534,6 @@ fn spawn_business_background_tasks(state: Arc<AppState>) {
     spawn_scheduled_job_stale_reaper(state.clone());
     spawn_quota_sync_scheduler(state.clone());
     spawn_token_usage_rollup_scheduler(state.clone());
-    spawn_upstream_reconciliation_scheduler(state.clone());
     spawn_auth_token_logs_gc_scheduler(state.clone());
     spawn_ha_outbox_gc_scheduler(state.clone());
     spawn_mcp_sessions_gc_scheduler(state.clone());

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1531,6 +1531,7 @@ async fn run_ha_sync_once_for_peer(
 
 fn spawn_business_background_tasks(state: Arc<AppState>) {
     spawn_maintenance_worker(state.clone());
+    spawn_upstream_reconciliation_startup_resume(state.clone());
     spawn_scheduled_job_stale_reaper(state.clone());
     spawn_quota_sync_scheduler(state.clone());
     spawn_token_usage_rollup_scheduler(state.clone());

--- a/src/server/tests/token_log_details.rs
+++ b/src/server/tests/token_log_details.rs
@@ -98,7 +98,7 @@ use super::upstream_support_and_manual_jobs::*;
         .bind(&token.id)
         .bind(&key_id)
         .bind(request_log_id)
-        .bind(created_at + 1)
+        .bind(created_at)
         .fetch_one(&pool)
         .await
         .expect("insert token log");

--- a/src/store/key_store_ha_defs.rs
+++ b/src/store/key_store_ha_defs.rs
@@ -156,6 +156,7 @@ const HA_RUNTIME_BASELINE_TABLES: &[&str] = &[
     "upstream_reconciliation_research",
     "upstream_reconciliation_settlements",
     "upstream_reconciliation_usage",
+    "upstream_reconciliation_work",
     "upstream_usage_rate_attempts",
     "user_primary_api_key_affinity",
 ];
@@ -175,6 +176,7 @@ const HA_RUNTIME_EVENT_TABLES: &[&str] = &[
     "upstream_reconciliation_research",
     "upstream_reconciliation_settlements",
     "upstream_reconciliation_usage",
+    "upstream_reconciliation_work",
     "upstream_usage_rate_attempts",
     "user_primary_api_key_affinity",
 ];

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -1006,6 +1006,27 @@ impl KeyStore {
         .map_err(ProxyError::from)
     }
 
+    pub(crate) async fn scheduled_job_claim_is_current(
+        &self,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<bool, ProxyError> {
+        let current: i64 = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM scheduled_jobs
+                WHERE id = ? AND status = 'running' AND claim_generation = ?
+            )
+            "#,
+        )
+        .bind(job_id)
+        .bind(claim_generation)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(current != 0)
+    }
+
     pub(crate) async fn scheduled_job_claim(
         &self,
         job_type: &str,

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -7,6 +7,9 @@ const GC_WORK_CHECKSUM: &str = "sha256:40e1bc657936ad891830471519d680e2";
 const RECONCILIATION_WORK_VERSION: i64 = 3;
 const RECONCILIATION_WORK_NAME: &str = "reconciliation-durable-work-projection-v1";
 const RECONCILIATION_WORK_CHECKSUM: &str = "sha256:7e94d5620f3e49a0a17587fb4e019a51";
+const RECONCILIATION_OUTCOME_VERSION: i64 = 4;
+const RECONCILIATION_OUTCOME_NAME: &str = "reconciliation-terminal-outcomes-v1";
+const RECONCILIATION_OUTCOME_CHECKSUM: &str = "sha256:4d6fd3e8c7a3a806a5d420ef07fa4f3c";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -618,6 +621,11 @@ impl KeyStore {
                 RECONCILIATION_WORK_NAME,
                 RECONCILIATION_WORK_CHECKSUM,
             ),
+            (
+                RECONCILIATION_OUTCOME_VERSION,
+                RECONCILIATION_OUTCOME_NAME,
+                RECONCILIATION_OUTCOME_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -678,6 +686,33 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 3".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_OUTCOME_VERSION)
+            .await?
+            && (!self
+                .table_column_exists("upstream_reconciliation_work", "work_generation")
+                .await?
+                || !self
+                    .table_column_exists("upstream_reconciliation_work", "completed_generation")
+                    .await?
+                || !self
+                    .table_column_exists("upstream_reconciliation_work", "next_attempt_at")
+                    .await?
+                || !self
+                    .table_column_exists("upstream_reconciliation_work", "last_outcome")
+                    .await?
+                || !self
+                    .schema_named_object_exists(
+                        "main",
+                        "trigger",
+                        "trg_upstream_reconciliation_usage_work_update",
+                    )
+                    .await?)
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 4".to_string(),
             ));
         }
         Ok(())
@@ -789,6 +824,118 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_outcome_migration(&self) -> Result<(), ProxyError> {
+        for (column, definition) in [
+            ("work_generation", "INTEGER NOT NULL DEFAULT 1"),
+            ("completed_generation", "INTEGER NOT NULL DEFAULT 0"),
+            ("next_attempt_at", "INTEGER NOT NULL DEFAULT 0"),
+            ("last_outcome", "TEXT"),
+        ] {
+            if !self
+                .table_column_exists("upstream_reconciliation_work", column)
+                .await?
+            {
+                sqlx::query(&format!(
+                    "ALTER TABLE upstream_reconciliation_work ADD COLUMN {column} {definition}",
+                ))
+                .execute(&self.pool)
+                .await?;
+            }
+        }
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_upstream_reconciliation_work_pending ON upstream_reconciliation_work(next_attempt_at, period_end, scheduling_key_id, token_id, period_code)",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query("DROP TRIGGER IF EXISTS trg_upstream_reconciliation_usage_work_insert")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DROP TRIGGER IF EXISTS trg_upstream_reconciliation_usage_work_update")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query(
+            r#"CREATE TRIGGER IF NOT EXISTS trg_upstream_reconciliation_usage_work_insert
+               AFTER INSERT ON upstream_reconciliation_usage
+               BEGIN
+                 INSERT INTO upstream_reconciliation_work (
+                   token_id, period_code, project_id, billing_subject, settlement_mode,
+                   period_start, period_end, scheduling_key_id, updated_at,
+                   work_generation, completed_generation, next_attempt_at, last_outcome
+                 ) VALUES (
+                   NEW.token_id, NEW.period_code, NEW.project_id, NEW.billing_subject,
+                   NEW.settlement_mode, NEW.period_start, NEW.period_end, NEW.key_id, NEW.updated_at,
+                   1, 0, 0, NULL
+                 )
+                 ON CONFLICT(token_id, period_code) DO UPDATE SET
+                   project_id = MIN(upstream_reconciliation_work.project_id, excluded.project_id),
+                   billing_subject = MIN(upstream_reconciliation_work.billing_subject, excluded.billing_subject),
+                   settlement_mode = MIN(upstream_reconciliation_work.settlement_mode, excluded.settlement_mode),
+                   period_start = MIN(upstream_reconciliation_work.period_start, excluded.period_start),
+                   period_end = MAX(upstream_reconciliation_work.period_end, excluded.period_end),
+                   scheduling_key_id = MIN(upstream_reconciliation_work.scheduling_key_id, excluded.scheduling_key_id),
+                   updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+                   work_generation = upstream_reconciliation_work.work_generation + 1,
+                   next_attempt_at = 0,
+                   last_outcome = NULL;
+               END"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"CREATE TRIGGER IF NOT EXISTS trg_upstream_reconciliation_usage_work_update
+               AFTER UPDATE ON upstream_reconciliation_usage
+               BEGIN
+                 INSERT INTO upstream_reconciliation_work (
+                   token_id, period_code, project_id, billing_subject, settlement_mode,
+                   period_start, period_end, scheduling_key_id, updated_at,
+                   work_generation, completed_generation, next_attempt_at, last_outcome
+                 ) VALUES (
+                   NEW.token_id, NEW.period_code, NEW.project_id, NEW.billing_subject,
+                   NEW.settlement_mode, NEW.period_start, NEW.period_end, NEW.key_id, NEW.updated_at,
+                   1, 0, 0, NULL
+                 )
+                 ON CONFLICT(token_id, period_code) DO UPDATE SET
+                   project_id = MIN(upstream_reconciliation_work.project_id, excluded.project_id),
+                   billing_subject = MIN(upstream_reconciliation_work.billing_subject, excluded.billing_subject),
+                   settlement_mode = MIN(upstream_reconciliation_work.settlement_mode, excluded.settlement_mode),
+                   period_start = MIN(upstream_reconciliation_work.period_start, excluded.period_start),
+                   period_end = MAX(upstream_reconciliation_work.period_end, excluded.period_end),
+                   scheduling_key_id = MIN(upstream_reconciliation_work.scheduling_key_id, excluded.scheduling_key_id),
+                   updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+                   work_generation = upstream_reconciliation_work.work_generation + 1,
+                   next_attempt_at = 0,
+                   last_outcome = NULL;
+               END"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"UPDATE upstream_reconciliation_work
+               SET completed_generation = work_generation,
+                   last_outcome = CASE
+                       WHEN EXISTS (
+                           SELECT 1 FROM upstream_reconciliation_settlements s
+                           WHERE s.settlement_key = 'v1:' || upstream_reconciliation_work.token_id || ':' || upstream_reconciliation_work.period_code
+                             AND s.status IN ('settled', 'degraded', 'shadow_settled', 'shadow_degraded')
+                       ) THEN 'settled'
+                       ELSE last_outcome
+                   END
+               WHERE EXISTS (
+                   SELECT 1 FROM upstream_reconciliation_settlements s
+                   WHERE s.settlement_key = 'v1:' || upstream_reconciliation_work.token_id || ':' || upstream_reconciliation_work.period_code
+                     AND s.status IN ('settled', 'degraded', 'shadow_settled', 'shadow_degraded')
+               )"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_OUTCOME_VERSION,
+            RECONCILIATION_OUTCOME_NAME,
+            RECONCILIATION_OUTCOME_CHECKSUM,
+        )
+        .await
+    }
+
     pub(crate) async fn prepare_versioned_schema(&self) -> Result<bool, ProxyError> {
         let started = std::time::Instant::now();
         let existing_database = self.schema_object_exists("main", "meta").await?;
@@ -850,6 +997,12 @@ impl KeyStore {
         {
             self.apply_reconciliation_work_migration().await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_OUTCOME_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_outcome_migration().await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -873,6 +1026,7 @@ impl KeyStore {
         .await?;
         self.apply_gc_work_migration().await?;
         self.apply_reconciliation_work_migration().await?;
+        self.apply_reconciliation_outcome_migration().await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -880,7 +1034,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 3_i64,
+            migration_count = 4_i64,
         );
         Ok(())
     }

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -9,6 +9,12 @@ pub(crate) const RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT: &str =
     "local_usage_rate_limit";
 pub(crate) const RECONCILIATION_RETRY_REASON_UPSTREAM_429: &str = "upstream429";
 pub(crate) const RECONCILIATION_RETRY_REASON_OTHER: &str = "other";
+pub(crate) const RECONCILIATION_OUTCOME_SETTLED: &str = "settled";
+pub(crate) const RECONCILIATION_OUTCOME_NO_ADJUSTMENT: &str = "no_adjustment";
+pub(crate) const RECONCILIATION_OUTCOME_UPSTREAM_429: &str = "upstream_429";
+pub(crate) const RECONCILIATION_OUTCOME_TRANSPORT_FAILURE: &str = "transport_failure";
+pub(crate) const RECONCILIATION_OUTCOME_SEMANTIC_FAILURE: &str = "semantic_failure";
+pub(crate) const RECONCILIATION_OUTCOME_LOCAL_PRESSURE: &str = "local_pressure";
 const RECONCILIATION_RECENT_LANE_BUDGET: i64 = 12;
 const RECONCILIATION_BACKLOG_LANE_BUDGET: i64 = 8;
 const RECONCILIATION_QUEUE_ESTIMATE_LIMIT: i64 = 64;
@@ -190,10 +196,12 @@ impl KeyStore {
                 LEFT JOIN upstream_reconciliation_settlements s
                   ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
                 WHERE w.period_end + 600 <= ?
-                  AND (s.settlement_key IS NULL OR (
-                      s.status IN ('pending', 'waiting', 'rate_limited')
-                      AND COALESCE(s.next_attempt_at, 0) <= ?
-                  ))
+                  AND w.work_generation > w.completed_generation
+                  AND MAX(
+                      w.next_attempt_at,
+                      CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                           THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+                  ) <= ?
                   AND (
                       w.period_end + 86400 <= ?
                       OR NOT EXISTS (
@@ -220,10 +228,12 @@ impl KeyStore {
             LEFT JOIN upstream_reconciliation_settlements s
               ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
             WHERE w.period_end + 600 <= ?
-              AND (s.settlement_key IS NULL OR (
-                  s.status IN ('pending', 'waiting', 'rate_limited')
-                  AND COALESCE(s.next_attempt_at, 0) <= ?
-              ))
+              AND w.work_generation > w.completed_generation
+              AND MAX(
+                  w.next_attempt_at,
+                  CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                       THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+              ) <= ?
               AND (
                   w.period_end + 86400 <= ?
                   OR NOT EXISTS (
@@ -254,10 +264,12 @@ impl KeyStore {
                         LEFT JOIN upstream_reconciliation_settlements s
                           ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
                         WHERE w.period_end + 600 <= ?
-                          AND (s.settlement_key IS NULL OR (
-                              s.status IN ('pending', 'waiting', 'rate_limited')
-                              AND COALESCE(s.next_attempt_at, 0) <= ?
-                          ))
+                          AND w.work_generation > w.completed_generation
+                          AND MAX(
+                              w.next_attempt_at,
+                              CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                                   THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+                          ) <= ?
                           AND (
                               w.period_end + 86400 <= ?
                               OR NOT EXISTS (
@@ -352,6 +364,71 @@ impl KeyStore {
         &self,
     ) -> Result<Option<i64>, ProxyError> {
         self.get_meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_LAST_RECOVERED_AT_V1).await
+    }
+
+    pub(crate) async fn upstream_reconciliation_continuation_at(
+        &self,
+    ) -> Result<Option<i64>, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let work_at: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT MIN(MAX(
+                w.next_attempt_at,
+                w.period_end + 600,
+                CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                     THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+            ))
+            FROM upstream_reconciliation_work w
+            LEFT JOIN upstream_reconciliation_settlements s
+              ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
+            WHERE w.work_generation > w.completed_generation
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let research_at: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT MIN(next_poll_at)
+            FROM upstream_reconciliation_research
+            WHERE terminal_at IS NULL AND next_poll_at > 0
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let Some(pending_at) = (match (work_at, research_at) {
+            (Some(work_at), Some(research_at)) => Some(work_at.min(research_at)),
+            (Some(work_at), None) => Some(work_at),
+            (None, Some(research_at)) => Some(research_at),
+            (None, None) => None,
+        }) else {
+            return Ok(None);
+        };
+        let global_until = self
+            .get_meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1)
+            .await?
+            .unwrap_or(0);
+        let local_until = self
+            .get_meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
+            .await?
+            .unwrap_or(0);
+        Ok(Some(pending_at.max(global_until).max(local_until).max(now)))
+    }
+
+    pub(crate) async fn ensure_upstream_reconciliation_representative_job(
+        &self,
+    ) -> Result<(), ProxyError> {
+        let Some(available_at) = self.upstream_reconciliation_continuation_at().await? else {
+            return Ok(());
+        };
+        self.scheduled_job_enqueue_at(
+            "upstream_reconciliation",
+            "auto",
+            None,
+            1,
+            available_at,
+        )
+        .await?;
+        Ok(())
     }
 
     async fn sync_upstream_reconciliation_representative_locked(
@@ -505,6 +582,7 @@ impl KeyStore {
             .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn update_upstream_reconciliation_local_backoff_claimed(
         &self,
         pressure: bool,
@@ -581,11 +659,7 @@ impl KeyStore {
             self.upstream_reconciliation_global_backoff_state().await?;
         let (streak, level, until) = if pressure {
             let streak = previous_streak.saturating_add(1);
-            let level = if streak < 3 {
-                0
-            } else {
-                previous_level.saturating_add(1).clamp(1, 4)
-            };
+            let level = previous_level.saturating_add(1).clamp(1, 4);
             let delay_secs = match level {
                 1 => 2 * 60,
                 2 => 5 * 60,
@@ -642,23 +716,6 @@ impl KeyStore {
             now,
             retry_after_until,
             None,
-        )
-        .await
-    }
-
-    pub(crate) async fn update_upstream_reconciliation_global_backoff_claimed(
-        &self,
-        pressure: bool,
-        now: i64,
-        retry_after_until: Option<i64>,
-        job_id: i64,
-        claim_generation: i64,
-    ) -> Result<(i64, i64, i64), ProxyError> {
-        self.update_upstream_reconciliation_global_backoff_inner(
-            pressure,
-            now,
-            retry_after_until,
-            Some((job_id, claim_generation)),
         )
         .await
     }
@@ -755,6 +812,7 @@ impl KeyStore {
             .await?;
         }
         tx.commit().await?;
+        self.ensure_upstream_reconciliation_representative_job().await?;
         Ok(Some(period))
     }
 
@@ -1017,14 +1075,15 @@ impl KeyStore {
         );
         query
             .push_bind(now)
-            .push(
-                r#"
-              AND (s.settlement_key IS NULL OR (
-                    s.status IN ('pending', 'waiting', 'rate_limited')
-                    AND COALESCE(s.next_attempt_at, 0) <= "#,
-            )
+            .push(r#"
+              AND w.work_generation > w.completed_generation
+              AND MAX(
+                  w.next_attempt_at,
+                  CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                       THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+              ) <= "#)
             .push_bind(now)
-            .push(" ))");
+            .push(" ");
         match scope {
             ReconciliationCandidateScope::Recent { start, end } => {
                 query
@@ -1303,10 +1362,12 @@ impl KeyStore {
         status: &str,
         next_attempt_at: i64,
         reason: Option<&str>,
+        outcome: &str,
     ) -> Result<(), ProxyError> {
         let now = self.backend_time.now_ts();
         let settlement_key = format!("v1:{}:{}", candidate.token_id, candidate.period_code);
         let normalized_reason = reason.map(|value| classify_reconciliation_retry_reason(Some(value)));
+        let mut tx = self.pool.begin().await?;
         sqlx::query(
             r#"
             INSERT INTO upstream_reconciliation_settlements (
@@ -1334,8 +1395,25 @@ impl KeyStore {
         .bind(next_attempt_at)
         .bind(now)
         .bind(now)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
+        sqlx::query(
+            r#"
+            UPDATE upstream_reconciliation_work
+            SET next_attempt_at = ?, last_outcome = ?, updated_at = ?
+            WHERE token_id = ? AND period_code = ?
+              AND completed_generation < work_generation
+            "#,
+        )
+        .bind(next_attempt_at)
+        .bind(outcome)
+        .bind(now)
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        self.ensure_upstream_reconciliation_representative_job().await?;
         Ok(())
     }
 
@@ -1359,6 +1437,66 @@ impl KeyStore {
         let day_bucket = start_of_local_day_utc_ts(attributed_utc.with_timezone(&Local));
         let month_start = start_of_month(attributed_utc).timestamp();
         let mut tx = self.pool.begin().await?;
+        if delta == 0 {
+            sqlx::query(
+                r#"
+                INSERT INTO upstream_reconciliation_settlements (
+                    settlement_key, token_id, period_code, project_id, billing_subject,
+                    period_start, period_end, status, upstream_usage, local_billed_credits,
+                    delta_credits, degraded_reason, next_attempt_at, attempt_count,
+                    created_at, updated_at, settled_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL, 1, ?, ?, ?)
+                ON CONFLICT(settlement_key) DO UPDATE SET
+                    status = excluded.status,
+                    upstream_usage = excluded.upstream_usage,
+                    local_billed_credits = excluded.local_billed_credits,
+                    delta_credits = excluded.delta_credits,
+                    degraded_reason = excluded.degraded_reason,
+                    next_attempt_at = NULL,
+                    attempt_count = upstream_reconciliation_settlements.attempt_count + 1,
+                    updated_at = excluded.updated_at,
+                    settled_at = excluded.settled_at
+                "#,
+            )
+            .bind(&settlement_key)
+            .bind(&candidate.token_id)
+            .bind(&candidate.period_code)
+            .bind(&candidate.project_id)
+            .bind(&candidate.billing_subject)
+            .bind(candidate.period_start)
+            .bind(candidate.period_end)
+            .bind(if candidate.degraded {
+                RECONCILIATION_STATUS_DEGRADED
+            } else {
+                RECONCILIATION_STATUS_SETTLED
+            })
+            .bind(upstream_usage)
+            .bind(local_billed_credits)
+            .bind(candidate.degraded.then_some("research_timeout_24h"))
+            .bind(now)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                r#"
+                UPDATE upstream_reconciliation_work
+                SET completed_generation = work_generation,
+                    next_attempt_at = 0,
+                    last_outcome = ?,
+                    updated_at = ?
+                WHERE token_id = ? AND period_code = ?
+                "#,
+            )
+            .bind(RECONCILIATION_OUTCOME_NO_ADJUSTMENT)
+            .bind(now)
+            .bind(&candidate.token_id)
+            .bind(&candidate.period_code)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(true);
+        }
         let inserted = sqlx::query(
             r#"
             INSERT OR IGNORE INTO billing_reconciliation_adjustments (
@@ -1380,7 +1518,23 @@ impl KeyStore {
         .await?
         .rows_affected();
         if inserted == 0 {
-            tx.rollback().await?;
+            sqlx::query(
+                r#"
+                UPDATE upstream_reconciliation_work
+                SET completed_generation = work_generation,
+                    next_attempt_at = 0,
+                    last_outcome = ?,
+                    updated_at = ?
+                WHERE token_id = ? AND period_code = ?
+                "#,
+            )
+            .bind(RECONCILIATION_OUTCOME_SETTLED)
+            .bind(now)
+            .bind(&candidate.token_id)
+            .bind(&candidate.period_code)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
             return Ok(false);
         }
         let (subject_kind, subject_id) = candidate
@@ -1485,6 +1639,22 @@ impl KeyStore {
         .bind(now)
         .execute(&mut *tx)
         .await?;
+        sqlx::query(
+            r#"
+            UPDATE upstream_reconciliation_work
+            SET completed_generation = work_generation,
+                next_attempt_at = 0,
+                last_outcome = ?,
+                updated_at = ?
+            WHERE token_id = ? AND period_code = ?
+            "#,
+        )
+        .bind(RECONCILIATION_OUTCOME_SETTLED)
+        .bind(now)
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .execute(&mut *tx)
+        .await?;
         tx.commit().await?;
         Ok(true)
     }
@@ -1501,6 +1671,90 @@ impl KeyStore {
         let delta = upstream_usage.saturating_sub(local_billed_credits);
         let attributed_at = candidate.period_end.saturating_sub(60);
         let mut tx = self.pool.begin().await?;
+        if delta == 0 {
+            sqlx::query(
+                r#"
+                INSERT INTO upstream_reconciliation_settlements (
+                    settlement_key, token_id, period_code, project_id, billing_subject,
+                    period_start, period_end, status, upstream_usage, local_billed_credits,
+                    delta_credits, degraded_reason, next_attempt_at, attempt_count,
+                    created_at, updated_at, settled_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL, 1, ?, ?, ?)
+                ON CONFLICT(settlement_key) DO UPDATE SET
+                    status = excluded.status,
+                    upstream_usage = excluded.upstream_usage,
+                    local_billed_credits = excluded.local_billed_credits,
+                    delta_credits = excluded.delta_credits,
+                    degraded_reason = excluded.degraded_reason,
+                    next_attempt_at = NULL,
+                    attempt_count = upstream_reconciliation_settlements.attempt_count + 1,
+                    updated_at = excluded.updated_at,
+                    settled_at = excluded.settled_at
+                "#,
+            )
+            .bind(&settlement_key)
+            .bind(&candidate.token_id)
+            .bind(&candidate.period_code)
+            .bind(&candidate.project_id)
+            .bind(&candidate.billing_subject)
+            .bind(candidate.period_start)
+            .bind(candidate.period_end)
+            .bind(if candidate.degraded {
+                RECONCILIATION_STATUS_SHADOW_DEGRADED
+            } else {
+                RECONCILIATION_STATUS_SHADOW_SETTLED
+            })
+            .bind(upstream_usage)
+            .bind(local_billed_credits)
+            .bind(candidate.degraded.then_some("research_timeout_24h"))
+            .bind(now)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                r#"
+                INSERT OR IGNORE INTO billing_reconciliation_shadow_adjustments (
+                    settlement_key, token_id, billing_subject, period_code, delta_credits,
+                    attributed_at, degraded_reason, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&settlement_key)
+            .bind(&candidate.token_id)
+            .bind(&candidate.billing_subject)
+            .bind(&candidate.period_code)
+            .bind(attributed_at)
+            .bind(candidate.degraded.then_some("research_timeout_24h"))
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+            set_meta_i64_executor(
+                &mut *tx,
+                META_KEY_UPSTREAM_RECONCILIATION_LAST_SHADOW_ADJUSTMENT_AT_V1,
+                now,
+            )
+            .await?;
+            sqlx::query(
+                r#"
+                UPDATE upstream_reconciliation_work
+                SET completed_generation = work_generation,
+                    next_attempt_at = 0,
+                    last_outcome = ?,
+                    updated_at = ?
+                WHERE token_id = ? AND period_code = ?
+                "#,
+            )
+            .bind(RECONCILIATION_OUTCOME_NO_ADJUSTMENT)
+            .bind(now)
+            .bind(&candidate.token_id)
+            .bind(&candidate.period_code)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(true);
+        }
         let inserted = sqlx::query(
             r#"
             INSERT OR IGNORE INTO billing_reconciliation_shadow_adjustments (
@@ -1522,7 +1776,23 @@ impl KeyStore {
         .await?
         .rows_affected();
         if inserted == 0 {
-            tx.rollback().await?;
+            sqlx::query(
+                r#"
+                UPDATE upstream_reconciliation_work
+                SET completed_generation = work_generation,
+                    next_attempt_at = 0,
+                    last_outcome = ?,
+                    updated_at = ?
+                WHERE token_id = ? AND period_code = ?
+                "#,
+            )
+            .bind(RECONCILIATION_OUTCOME_SETTLED)
+            .bind(now)
+            .bind(&candidate.token_id)
+            .bind(&candidate.period_code)
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
             return Ok(false);
         }
         sqlx::query(
@@ -1571,6 +1841,22 @@ impl KeyStore {
             META_KEY_UPSTREAM_RECONCILIATION_LAST_SHADOW_ADJUSTMENT_AT_V1,
             now,
         )
+        .await?;
+        sqlx::query(
+            r#"
+            UPDATE upstream_reconciliation_work
+            SET completed_generation = work_generation,
+                next_attempt_at = 0,
+                last_outcome = ?,
+                updated_at = ?
+            WHERE token_id = ? AND period_code = ?
+            "#,
+        )
+        .bind(RECONCILIATION_OUTCOME_SETTLED)
+        .bind(now)
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .execute(&mut *tx)
         .await?;
         tx.commit().await?;
         tracing::info!(

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -504,11 +504,12 @@ impl KeyStore {
         .await?;
         let research_at: Option<i64> = sqlx::query_scalar(
             r#"
-            SELECT MIN(next_poll_at)
+            SELECT MIN(CASE WHEN next_poll_at > 0 THEN next_poll_at ELSE ? END)
             FROM upstream_reconciliation_research
-            WHERE terminal_at IS NULL AND next_poll_at > 0
+            WHERE terminal_at IS NULL
             "#,
         )
+        .bind(now)
         .fetch_one(&self.pool)
         .await?;
         let Some(pending_at) = (match (work_at, research_at) {

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -584,30 +584,31 @@ impl KeyStore {
         .await?
         .unwrap_or(0);
         if let Some((job_id, claim_generation)) = claimed_job {
-            let updated = if available_at > now {
-                sqlx::query(
-                    r#"UPDATE scheduled_jobs
-                       SET status = 'queued', available_at = ?, started_at = NULL,
-                           finished_at = NULL, message = 'reconciliation backoff active'
-                       WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+            if available_at <= now {
+                if !Self::reconciliation_claim_is_current_locked(
+                    transaction,
+                    Some((job_id, claim_generation)),
                 )
-                .bind(available_at)
-                .bind(job_id)
-                .bind(claim_generation)
-                .execute(&mut **transaction)
                 .await?
-            } else {
-                sqlx::query(
-                    r#"UPDATE scheduled_jobs
-                       SET status = 'success', finished_at = ?, message = 'reconciliation completed'
-                       WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
-                )
-                .bind(now)
-                .bind(job_id)
-                .bind(claim_generation)
-                .execute(&mut **transaction)
-                .await?
-            };
+                {
+                    return Err(ProxyError::StaleClaim {
+                        job_id,
+                        claim_generation,
+                    });
+                }
+                return Ok(());
+            }
+            let updated = sqlx::query(
+                r#"UPDATE scheduled_jobs
+                   SET status = 'queued', available_at = ?, started_at = NULL,
+                       finished_at = NULL, message = 'reconciliation backoff active'
+                   WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+            )
+            .bind(available_at)
+            .bind(job_id)
+            .bind(claim_generation)
+            .execute(&mut **transaction)
+            .await?;
             if updated.rows_affected() == 0 {
                 return Err(ProxyError::StaleClaim {
                     job_id,

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -33,8 +33,21 @@ type UpstreamReconciliationCandidateRow = (
     i64,
     i64,
     i64,
+    i64,
     String,
 );
+
+#[derive(Clone)]
+struct UpstreamReconciliationCandidateWork {
+    candidate: UpstreamReconciliationCandidate,
+    work_generation: i64,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ReconciliationWorkFence {
+    pub(crate) work_generation: i64,
+    pub(crate) claimed_job: Option<(i64, i64)>,
+}
 
 fn upstream_reconciliation_shadow_ready(settings: &SystemSettings) -> bool {
     settings.upstream_project_id_mode == UpstreamProjectIdMode::AccessToken
@@ -968,7 +981,7 @@ impl KeyStore {
         &self,
         rows: Vec<UpstreamReconciliationCandidateRow>,
         now: i64,
-    ) -> Vec<UpstreamReconciliationCandidate> {
+    ) -> Vec<UpstreamReconciliationCandidateWork> {
         rows.into_iter()
             .filter_map(
                 |(
@@ -980,6 +993,7 @@ impl KeyStore {
                     period_start,
                     period_end,
                     pending_research,
+                    work_generation,
                     _scheduling_key_id,
                 )| {
                     let degraded = pending_research > 0
@@ -987,16 +1001,19 @@ impl KeyStore {
                     if pending_research > 0 && !degraded {
                         return None;
                     }
-                    Some(UpstreamReconciliationCandidate {
-                        token_id,
-                        period_code,
-                        project_id,
-                        billing_subject,
-                        settlement_mode,
-                        period_start,
-                        period_end,
-                        pending_research,
-                        degraded,
+                    Some(UpstreamReconciliationCandidateWork {
+                        candidate: UpstreamReconciliationCandidate {
+                            token_id,
+                            period_code,
+                            project_id,
+                            billing_subject,
+                            settlement_mode,
+                            period_start,
+                            period_end,
+                            pending_research,
+                            degraded,
+                        },
+                        work_generation,
                     })
                 },
             )
@@ -1048,7 +1065,7 @@ impl KeyStore {
         limit: i64,
         newest_first: bool,
         scope: ReconciliationCandidateScope,
-    ) -> Result<Vec<UpstreamReconciliationCandidate>, ProxyError> {
+    ) -> Result<Vec<UpstreamReconciliationCandidateWork>, ProxyError> {
         let mut query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
             r#"
             WITH eligible AS (
@@ -1061,6 +1078,7 @@ impl KeyStore {
                 w.period_start,
                 w.period_end,
                 w.scheduling_key_id,
+                w.work_generation,
                 CASE WHEN EXISTS (
                     SELECT 1
                     FROM upstream_reconciliation_research r
@@ -1134,6 +1152,7 @@ impl KeyStore {
                 period_start,
                 period_end,
                 pending_research,
+                work_generation,
                 scheduling_key_id
             FROM ranked
             ORDER BY key_slot ASC, period_end "#,
@@ -1207,22 +1226,39 @@ impl KeyStore {
         let extra_backlog = std::cmp::min(extra_backlog_available, remaining_capacity);
         backlog_candidate_count += extra_backlog;
 
-        let mut candidates =
+        let mut selected =
             Vec::with_capacity((recent_candidate_count + backlog_candidate_count) as usize);
-        candidates.extend(
+        selected.extend(
             recent_candidates
                 .iter()
                 .take(recent_candidate_count as usize)
                 .cloned(),
         );
-        candidates.extend(
+        selected.extend(
             backlog_candidates
                 .iter()
                 .take(backlog_candidate_count as usize)
                 .cloned(),
         );
+        let work_generation_by_candidate = selected
+            .iter()
+            .map(|work| {
+                (
+                    (
+                        work.candidate.token_id.clone(),
+                        work.candidate.period_code.clone(),
+                    ),
+                    work.work_generation,
+                )
+            })
+            .collect();
+        let candidates = selected
+            .into_iter()
+            .map(|work| work.candidate)
+            .collect();
         Ok(UpstreamReconciliationCandidateBatch {
             candidates,
+            work_generation_by_candidate,
             recent_lane_budget,
             backlog_lane_budget,
             recent_candidate_count,
@@ -1356,6 +1392,96 @@ impl KeyStore {
         Ok(Ok(()))
     }
 
+    async fn lock_reconciliation_work_generation(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        candidate: &UpstreamReconciliationCandidate,
+        expected_generation: Option<i64>,
+        expected_claim: Option<(i64, i64)>,
+    ) -> Result<bool, ProxyError> {
+        let Some(expected_generation) = expected_generation else {
+            return Ok(true);
+        };
+        let (claim_job_id, claim_generation) = expected_claim
+            .map(|(job_id, generation)| (Some(job_id), Some(generation)))
+            .unwrap_or((None, None));
+        let locked = sqlx::query(
+            r#"
+            UPDATE upstream_reconciliation_work
+            SET updated_at = updated_at
+            WHERE token_id = ? AND period_code = ?
+              AND work_generation = ?
+              AND completed_generation < work_generation
+              AND (
+                  ? IS NULL
+                  OR EXISTS (
+                      SELECT 1 FROM scheduled_jobs
+                      WHERE id = ? AND status = 'running' AND claim_generation = ?
+                  )
+              )
+            "#,
+        )
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .bind(expected_generation)
+        .bind(claim_job_id)
+        .bind(claim_job_id)
+        .bind(claim_generation)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
+        Ok(locked > 0)
+    }
+
+    async fn claim_reconciliation_work_completion(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        candidate: &UpstreamReconciliationCandidate,
+        expected_generation: Option<i64>,
+        expected_claim: Option<(i64, i64)>,
+        outcome: &str,
+        now: i64,
+    ) -> Result<bool, ProxyError> {
+        let Some(expected_generation) = expected_generation else {
+            return Ok(true);
+        };
+        let (claim_job_id, claim_generation) = expected_claim
+            .map(|(job_id, generation)| (Some(job_id), Some(generation)))
+            .unwrap_or((None, None));
+        let claimed = sqlx::query(
+            r#"
+            UPDATE upstream_reconciliation_work
+            SET completed_generation = ?,
+                next_attempt_at = 0,
+                last_outcome = ?,
+                updated_at = ?
+            WHERE token_id = ? AND period_code = ?
+              AND work_generation = ?
+              AND completed_generation < work_generation
+              AND (
+                  ? IS NULL
+                  OR EXISTS (
+                      SELECT 1 FROM scheduled_jobs
+                      WHERE id = ? AND status = 'running' AND claim_generation = ?
+                  )
+              )
+            "#,
+        )
+        .bind(expected_generation)
+        .bind(outcome)
+        .bind(now)
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .bind(expected_generation)
+        .bind(claim_job_id)
+        .bind(claim_job_id)
+        .bind(claim_generation)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
+        Ok(claimed > 0)
+    }
+
     pub(crate) async fn mark_reconciliation_retry(
         &self,
         candidate: &UpstreamReconciliationCandidate,
@@ -1363,11 +1489,25 @@ impl KeyStore {
         next_attempt_at: i64,
         reason: Option<&str>,
         outcome: &str,
+        fence: Option<ReconciliationWorkFence>,
     ) -> Result<(), ProxyError> {
         let now = self.backend_time.now_ts();
         let settlement_key = format!("v1:{}:{}", candidate.token_id, candidate.period_code);
         let normalized_reason = reason.map(|value| classify_reconciliation_retry_reason(Some(value)));
+        let expected_generation = fence.map(|fence| fence.work_generation);
+        let expected_claim = fence.and_then(|fence| fence.claimed_job);
         let mut tx = self.pool.begin().await?;
+        if !self
+            .lock_reconciliation_work_generation(
+                &mut tx,
+                candidate,
+                expected_generation,
+                expected_claim,
+            )
+            .await?
+        {
+            return Ok(());
+        }
         sqlx::query(
             r#"
             INSERT INTO upstream_reconciliation_settlements (
@@ -1403,6 +1543,7 @@ impl KeyStore {
             SET next_attempt_at = ?, last_outcome = ?, updated_at = ?
             WHERE token_id = ? AND period_code = ?
               AND completed_generation < work_generation
+              AND (? IS NULL OR work_generation = ?)
             "#,
         )
         .bind(next_attempt_at)
@@ -1410,6 +1551,8 @@ impl KeyStore {
         .bind(now)
         .bind(&candidate.token_id)
         .bind(&candidate.period_code)
+        .bind(expected_generation)
+        .bind(expected_generation)
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
@@ -1422,6 +1565,8 @@ impl KeyStore {
         candidate: &UpstreamReconciliationCandidate,
         upstream_usage: i64,
         local_billed_credits: i64,
+        expected_generation: Option<i64>,
+        expected_claim: Option<(i64, i64)>,
     ) -> Result<bool, ProxyError> {
         let now = self.backend_time.now_ts();
         let settlement_key = format!("v1:{}:{}", candidate.token_id, candidate.period_code);
@@ -1437,6 +1582,24 @@ impl KeyStore {
         let day_bucket = start_of_local_day_utc_ts(attributed_utc.with_timezone(&Local));
         let month_start = start_of_month(attributed_utc).timestamp();
         let mut tx = self.pool.begin().await?;
+        let completion_outcome = if delta == 0 {
+            RECONCILIATION_OUTCOME_NO_ADJUSTMENT
+        } else {
+            RECONCILIATION_OUTCOME_SETTLED
+        };
+        if !self
+            .claim_reconciliation_work_completion(
+                &mut tx,
+                candidate,
+                expected_generation,
+                expected_claim,
+                completion_outcome,
+                now,
+            )
+            .await?
+        {
+            return Ok(false);
+        }
         if delta == 0 {
             sqlx::query(
                 r#"
@@ -1481,17 +1644,22 @@ impl KeyStore {
             sqlx::query(
                 r#"
                 UPDATE upstream_reconciliation_work
-                SET completed_generation = work_generation,
+                SET completed_generation = COALESCE(?, work_generation),
                     next_attempt_at = 0,
                     last_outcome = ?,
                     updated_at = ?
                 WHERE token_id = ? AND period_code = ?
+                  AND completed_generation < work_generation
+                  AND (? IS NULL OR work_generation = ?)
                 "#,
             )
+            .bind(expected_generation)
             .bind(RECONCILIATION_OUTCOME_NO_ADJUSTMENT)
             .bind(now)
             .bind(&candidate.token_id)
             .bind(&candidate.period_code)
+            .bind(expected_generation)
+            .bind(expected_generation)
             .execute(&mut *tx)
             .await?;
             tx.commit().await?;
@@ -1521,17 +1689,22 @@ impl KeyStore {
             sqlx::query(
                 r#"
                 UPDATE upstream_reconciliation_work
-                SET completed_generation = work_generation,
+                SET completed_generation = COALESCE(?, work_generation),
                     next_attempt_at = 0,
                     last_outcome = ?,
                     updated_at = ?
                 WHERE token_id = ? AND period_code = ?
+                  AND completed_generation < work_generation
+                  AND (? IS NULL OR work_generation = ?)
                 "#,
             )
+            .bind(expected_generation)
             .bind(RECONCILIATION_OUTCOME_SETTLED)
             .bind(now)
             .bind(&candidate.token_id)
             .bind(&candidate.period_code)
+            .bind(expected_generation)
+            .bind(expected_generation)
             .execute(&mut *tx)
             .await?;
             tx.commit().await?;
@@ -1642,17 +1815,22 @@ impl KeyStore {
         sqlx::query(
             r#"
             UPDATE upstream_reconciliation_work
-            SET completed_generation = work_generation,
+            SET completed_generation = COALESCE(?, work_generation),
                 next_attempt_at = 0,
                 last_outcome = ?,
                 updated_at = ?
             WHERE token_id = ? AND period_code = ?
+              AND completed_generation < work_generation
+              AND (? IS NULL OR work_generation = ?)
             "#,
         )
+        .bind(expected_generation)
         .bind(RECONCILIATION_OUTCOME_SETTLED)
         .bind(now)
         .bind(&candidate.token_id)
         .bind(&candidate.period_code)
+        .bind(expected_generation)
+        .bind(expected_generation)
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
@@ -1664,6 +1842,8 @@ impl KeyStore {
         candidate: &UpstreamReconciliationCandidate,
         upstream_usage: i64,
         local_billed_credits: i64,
+        expected_generation: Option<i64>,
+        expected_claim: Option<(i64, i64)>,
     ) -> Result<bool, ProxyError> {
         let started_at = std::time::Instant::now();
         let now = self.backend_time.now_ts();
@@ -1671,6 +1851,24 @@ impl KeyStore {
         let delta = upstream_usage.saturating_sub(local_billed_credits);
         let attributed_at = candidate.period_end.saturating_sub(60);
         let mut tx = self.pool.begin().await?;
+        let completion_outcome = if delta == 0 {
+            RECONCILIATION_OUTCOME_NO_ADJUSTMENT
+        } else {
+            RECONCILIATION_OUTCOME_SETTLED
+        };
+        if !self
+            .claim_reconciliation_work_completion(
+                &mut tx,
+                candidate,
+                expected_generation,
+                expected_claim,
+                completion_outcome,
+                now,
+            )
+            .await?
+        {
+            return Ok(false);
+        }
         if delta == 0 {
             sqlx::query(
                 r#"
@@ -1739,17 +1937,22 @@ impl KeyStore {
             sqlx::query(
                 r#"
                 UPDATE upstream_reconciliation_work
-                SET completed_generation = work_generation,
+                SET completed_generation = COALESCE(?, work_generation),
                     next_attempt_at = 0,
                     last_outcome = ?,
                     updated_at = ?
                 WHERE token_id = ? AND period_code = ?
+                  AND completed_generation < work_generation
+                  AND (? IS NULL OR work_generation = ?)
                 "#,
             )
+            .bind(expected_generation)
             .bind(RECONCILIATION_OUTCOME_NO_ADJUSTMENT)
             .bind(now)
             .bind(&candidate.token_id)
             .bind(&candidate.period_code)
+            .bind(expected_generation)
+            .bind(expected_generation)
             .execute(&mut *tx)
             .await?;
             tx.commit().await?;
@@ -1779,17 +1982,22 @@ impl KeyStore {
             sqlx::query(
                 r#"
                 UPDATE upstream_reconciliation_work
-                SET completed_generation = work_generation,
+                SET completed_generation = COALESCE(?, work_generation),
                     next_attempt_at = 0,
                     last_outcome = ?,
                     updated_at = ?
                 WHERE token_id = ? AND period_code = ?
+                  AND completed_generation < work_generation
+                  AND (? IS NULL OR work_generation = ?)
                 "#,
             )
+            .bind(expected_generation)
             .bind(RECONCILIATION_OUTCOME_SETTLED)
             .bind(now)
             .bind(&candidate.token_id)
             .bind(&candidate.period_code)
+            .bind(expected_generation)
+            .bind(expected_generation)
             .execute(&mut *tx)
             .await?;
             tx.commit().await?;
@@ -1845,17 +2053,22 @@ impl KeyStore {
         sqlx::query(
             r#"
             UPDATE upstream_reconciliation_work
-            SET completed_generation = work_generation,
+            SET completed_generation = COALESCE(?, work_generation),
                 next_attempt_at = 0,
                 last_outcome = ?,
                 updated_at = ?
             WHERE token_id = ? AND period_code = ?
+              AND completed_generation < work_generation
+              AND (? IS NULL OR work_generation = ?)
             "#,
         )
+        .bind(expected_generation)
         .bind(RECONCILIATION_OUTCOME_SETTLED)
         .bind(now)
         .bind(&candidate.token_id)
         .bind(&candidate.period_code)
+        .bind(expected_generation)
+        .bind(expected_generation)
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -69,7 +69,7 @@ pub(crate) fn classify_reconciliation_retry_reason(reason: Option<&str>) -> &'st
     if reason == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
         return RECONCILIATION_RETRY_REASON_UPSTREAM_429;
     }
-    if reason.contains("usage http error 429") || reason.contains("429 Too Many Requests") {
+    if reason.starts_with("usage http error 429 ") {
         return RECONCILIATION_RETRY_REASON_UPSTREAM_429;
     }
     RECONCILIATION_RETRY_REASON_OTHER
@@ -97,6 +97,98 @@ impl KeyStore {
             cooldown_until,
             retry_after_secs,
         }))
+    }
+
+    pub(crate) async fn arm_api_key_transient_backoff_claimed(
+        &self,
+        arm: ApiKeyTransientBackoffArm<'_>,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<Option<ApiKeyTransientBackoffState>, ProxyError> {
+        let mut transaction = ImmediateSqliteTransaction::begin(self.pool.acquire().await?).await?;
+        if !Self::reconciliation_claim_is_current_locked(
+            &mut transaction,
+            Some((job_id, claim_generation)),
+        )
+        .await?
+        {
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
+        let previous_cooldown = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT cooldown_until
+            FROM api_key_transient_backoffs
+            WHERE key_id = ? AND scope = ?
+            LIMIT 1
+            "#,
+        )
+        .bind(arm.key_id)
+        .bind(arm.scope)
+        .fetch_optional(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO api_key_transient_backoffs (
+                key_id, scope, cooldown_until, retry_after_secs, reason_code,
+                source_request_log_id, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(key_id, scope) DO UPDATE SET
+                cooldown_until = MAX(api_key_transient_backoffs.cooldown_until, excluded.cooldown_until),
+                retry_after_secs = CASE
+                    WHEN excluded.cooldown_until >= api_key_transient_backoffs.cooldown_until
+                        THEN excluded.retry_after_secs
+                    ELSE api_key_transient_backoffs.retry_after_secs
+                END,
+                reason_code = CASE
+                    WHEN excluded.cooldown_until >= api_key_transient_backoffs.cooldown_until
+                        THEN COALESCE(excluded.reason_code, api_key_transient_backoffs.reason_code)
+                    ELSE api_key_transient_backoffs.reason_code
+                END,
+                source_request_log_id = COALESCE(
+                    excluded.source_request_log_id,
+                    api_key_transient_backoffs.source_request_log_id
+                ),
+                updated_at = CASE
+                    WHEN excluded.cooldown_until >= api_key_transient_backoffs.cooldown_until
+                        THEN excluded.updated_at
+                    ELSE api_key_transient_backoffs.updated_at
+                END
+            "#,
+        )
+        .bind(arm.key_id)
+        .bind(arm.scope)
+        .bind(arm.cooldown_until)
+        .bind(arm.retry_after_secs)
+        .bind(arm.reason_code)
+        .bind(arm.source_request_log_id)
+        .bind(arm.now)
+        .bind(arm.now)
+        .execute(&mut *transaction)
+        .await?;
+        let current = sqlx::query_as::<_, (i64, i64)>(
+            r#"
+            SELECT cooldown_until, retry_after_secs
+            FROM api_key_transient_backoffs
+            WHERE key_id = ? AND scope = ?
+            LIMIT 1
+            "#,
+        )
+        .bind(arm.key_id)
+        .bind(arm.scope)
+        .fetch_one(&mut *transaction)
+        .await?;
+        let state = previous_cooldown.is_none_or(|previous| previous < current.0).then_some(
+            ApiKeyTransientBackoffState {
+                cooldown_until: current.0,
+                retry_after_secs: current.1,
+            },
+        );
+        transaction.commit().await?;
+        Ok(state)
     }
 
     pub(crate) async fn count_active_upstream_mcp_sessions(
@@ -815,11 +907,43 @@ impl KeyStore {
         &self,
         timestamp: i64,
     ) -> Result<(), ProxyError> {
-        self.set_meta_i64(
-            META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_SWEEP_AT_V1,
+        self.mark_upstream_reconciliation_research_sweep_at_inner(timestamp, None)
+            .await
+    }
+
+    pub(crate) async fn mark_upstream_reconciliation_research_sweep_at_claimed(
+        &self,
+        timestamp: i64,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<(), ProxyError> {
+        self.mark_upstream_reconciliation_research_sweep_at_inner(
             timestamp,
+            Some((job_id, claim_generation)),
         )
         .await
+    }
+
+    async fn mark_upstream_reconciliation_research_sweep_at_inner(
+        &self,
+        timestamp: i64,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<(), ProxyError> {
+        let mut transaction = ImmediateSqliteTransaction::begin(self.pool.acquire().await?).await?;
+        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
+        sqlx::query("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+            .bind(META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_SWEEP_AT_V1)
+            .bind(timestamp.to_string())
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await
     }
 
     pub(crate) async fn record_upstream_reconciliation_usage(
@@ -920,7 +1044,38 @@ impl KeyStore {
         &self,
         request_id: &str,
     ) -> Result<bool, ProxyError> {
+        self.mark_upstream_reconciliation_research_terminal_inner(request_id, None)
+            .await
+    }
+
+    pub(crate) async fn mark_upstream_reconciliation_research_terminal_claimed(
+        &self,
+        request_id: &str,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<bool, ProxyError> {
+        self.mark_upstream_reconciliation_research_terminal_inner(
+            request_id,
+            Some((job_id, claim_generation)),
+        )
+        .await
+    }
+
+    async fn mark_upstream_reconciliation_research_terminal_inner(
+        &self,
+        request_id: &str,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<bool, ProxyError> {
         let now = self.backend_time.now_ts();
+        let mut transaction = ImmediateSqliteTransaction::begin(self.pool.acquire().await?).await?;
+        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
         let changed = sqlx::query(
             r#"
             UPDATE upstream_reconciliation_research
@@ -938,16 +1093,17 @@ impl KeyStore {
         .bind(now)
         .bind(now)
         .bind(request_id)
-        .execute(&self.pool)
+        .execute(&mut *transaction)
         .await?
         .rows_affected();
         if changed > 0 {
-            self.set_meta_i64(
-                META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_TERMINAL_AT_V1,
-                now,
-            )
-            .await?;
+            sqlx::query("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+                .bind(META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_TERMINAL_AT_V1)
+                .bind(now.to_string())
+                .execute(&mut *transaction)
+                .await?;
         }
+        transaction.commit().await?;
         Ok(changed > 0)
     }
 
@@ -1027,7 +1183,53 @@ impl KeyStore {
         outcome: &str,
         error_kind: Option<&str>,
     ) -> Result<(), ProxyError> {
+        self.record_upstream_reconciliation_research_poll_inner(
+            request_id,
+            next_poll_at,
+            outcome,
+            error_kind,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn record_upstream_reconciliation_research_poll_claimed(
+        &self,
+        request_id: &str,
+        next_poll_at: i64,
+        outcome: &str,
+        error_kind: Option<&str>,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<(), ProxyError> {
+        self.record_upstream_reconciliation_research_poll_inner(
+            request_id,
+            next_poll_at,
+            outcome,
+            error_kind,
+            Some((job_id, claim_generation)),
+        )
+        .await
+    }
+
+    async fn record_upstream_reconciliation_research_poll_inner(
+        &self,
+        request_id: &str,
+        next_poll_at: i64,
+        outcome: &str,
+        error_kind: Option<&str>,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<(), ProxyError> {
         let now = self.backend_time.now_ts();
+        let mut transaction = ImmediateSqliteTransaction::begin(self.pool.acquire().await?).await?;
+        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
         sqlx::query(
             r#"
             UPDATE upstream_reconciliation_research
@@ -1042,9 +1244,9 @@ impl KeyStore {
         .bind(error_kind)
         .bind(now)
         .bind(request_id)
-        .execute(&self.pool)
+        .execute(&mut *transaction)
         .await?;
-        Ok(())
+        transaction.commit().await
     }
 
     fn build_upstream_reconciliation_candidates(

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -395,8 +395,19 @@ impl KeyStore {
             LEFT JOIN upstream_reconciliation_settlements s
               ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
             WHERE w.work_generation > w.completed_generation
+              AND (
+                  w.period_end + 86400 <= ?
+                  OR NOT EXISTS (
+                      SELECT 1
+                      FROM upstream_reconciliation_research r
+                      WHERE r.token_id = w.token_id
+                        AND r.period_code = w.period_code
+                        AND r.terminal_at IS NULL
+                  )
+              )
             "#,
         )
+        .bind(now)
         .fetch_one(&self.pool)
         .await?;
         let research_at: Option<i64> = sqlx::query_scalar(
@@ -442,6 +453,29 @@ impl KeyStore {
         )
         .await?;
         Ok(())
+    }
+
+    async fn reconciliation_claim_is_current_locked(
+        transaction: &mut ImmediateSqliteTransaction,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<bool, ProxyError> {
+        let Some((job_id, claim_generation)) = claimed_job else {
+            return Ok(true);
+        };
+        let current: i64 = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM scheduled_jobs
+                WHERE id = ? AND status = 'running' AND claim_generation = ?
+            )
+            "#,
+        )
+        .bind(job_id)
+        .bind(claim_generation)
+        .fetch_one(&mut **transaction)
+        .await?;
+        Ok(current != 0)
     }
 
     async fn sync_upstream_reconciliation_representative_locked(
@@ -557,6 +591,14 @@ impl KeyStore {
             (0, 0, 0)
         };
         let mut transaction = ImmediateSqliteTransaction::begin(self.pool.acquire().await?).await?;
+        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
         sqlx::query(
             r#"INSERT INTO meta (key, value) VALUES (?, ?), (?, ?), (?, ?)
                ON CONFLICT(key) DO UPDATE SET value = excluded.value"#,
@@ -595,7 +637,6 @@ impl KeyStore {
             .await
     }
 
-    #[cfg(test)]
     pub(crate) async fn update_upstream_reconciliation_local_backoff_claimed(
         &self,
         pressure: bool,
@@ -672,7 +713,11 @@ impl KeyStore {
             self.upstream_reconciliation_global_backoff_state().await?;
         let (streak, level, until) = if pressure {
             let streak = previous_streak.saturating_add(1);
-            let level = previous_level.saturating_add(1).clamp(1, 4);
+            let level = if streak < 3 {
+                0
+            } else {
+                previous_level.saturating_add(1).clamp(1, 4)
+            };
             let delay_secs = match level {
                 1 => 2 * 60,
                 2 => 5 * 60,
@@ -689,6 +734,14 @@ impl KeyStore {
             (0, 0, 0)
         };
         let mut transaction = ImmediateSqliteTransaction::begin(self.pool.acquire().await?).await?;
+        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
         sqlx::query(
             r#"INSERT INTO meta (key, value) VALUES (?, ?), (?, ?), (?, ?)
                ON CONFLICT(key) DO UPDATE SET value = excluded.value"#,
@@ -729,6 +782,23 @@ impl KeyStore {
             now,
             retry_after_until,
             None,
+        )
+        .await
+    }
+
+    pub(crate) async fn update_upstream_reconciliation_global_backoff_claimed(
+        &self,
+        pressure: bool,
+        now: i64,
+        retry_after_until: Option<i64>,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<(i64, i64, i64), ProxyError> {
+        self.update_upstream_reconciliation_global_backoff_inner(
+            pressure,
+            now,
+            retry_after_until,
+            Some((job_id, claim_generation)),
         )
         .await
     }
@@ -1396,12 +1466,13 @@ impl KeyStore {
         &self,
         tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
         candidate: &UpstreamReconciliationCandidate,
-        expected_generation: Option<i64>,
-        expected_claim: Option<(i64, i64)>,
+        fence: Option<ReconciliationWorkFence>,
     ) -> Result<bool, ProxyError> {
-        let Some(expected_generation) = expected_generation else {
+        let Some(fence) = fence else {
             return Ok(true);
         };
+        let expected_generation = fence.work_generation;
+        let expected_claim = fence.claimed_job;
         let (claim_job_id, claim_generation) = expected_claim
             .map(|(job_id, generation)| (Some(job_id), Some(generation)))
             .unwrap_or((None, None));
@@ -1437,14 +1508,15 @@ impl KeyStore {
         &self,
         tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
         candidate: &UpstreamReconciliationCandidate,
-        expected_generation: Option<i64>,
-        expected_claim: Option<(i64, i64)>,
+        fence: Option<ReconciliationWorkFence>,
         outcome: &str,
         now: i64,
     ) -> Result<bool, ProxyError> {
-        let Some(expected_generation) = expected_generation else {
+        let Some(fence) = fence else {
             return Ok(true);
         };
+        let expected_generation = fence.work_generation;
+        let expected_claim = fence.claimed_job;
         let (claim_job_id, claim_generation) = expected_claim
             .map(|(job_id, generation)| (Some(job_id), Some(generation)))
             .unwrap_or((None, None));
@@ -1482,6 +1554,38 @@ impl KeyStore {
         Ok(claimed > 0)
     }
 
+    async fn mark_reconciliation_work_completed(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        candidate: &UpstreamReconciliationCandidate,
+        expected_generation: Option<i64>,
+        outcome: &str,
+        now: i64,
+    ) -> Result<(), ProxyError> {
+        sqlx::query(
+            r#"
+            UPDATE upstream_reconciliation_work
+            SET completed_generation = COALESCE(?, work_generation),
+                next_attempt_at = 0,
+                last_outcome = ?,
+                updated_at = ?
+            WHERE token_id = ? AND period_code = ?
+              AND completed_generation < work_generation
+              AND (? IS NULL OR work_generation = ?)
+            "#,
+        )
+        .bind(expected_generation)
+        .bind(outcome)
+        .bind(now)
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .bind(expected_generation)
+        .bind(expected_generation)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
     pub(crate) async fn mark_reconciliation_retry(
         &self,
         candidate: &UpstreamReconciliationCandidate,
@@ -1494,20 +1598,14 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let settlement_key = format!("v1:{}:{}", candidate.token_id, candidate.period_code);
         let normalized_reason = reason.map(|value| classify_reconciliation_retry_reason(Some(value)));
-        let expected_generation = fence.map(|fence| fence.work_generation);
-        let expected_claim = fence.and_then(|fence| fence.claimed_job);
         let mut tx = self.pool.begin().await?;
         if !self
-            .lock_reconciliation_work_generation(
-                &mut tx,
-                candidate,
-                expected_generation,
-                expected_claim,
-            )
+            .lock_reconciliation_work_generation(&mut tx, candidate, fence)
             .await?
         {
             return Ok(());
         }
+        let expected_generation = fence.map(|fence| fence.work_generation);
         sqlx::query(
             r#"
             INSERT INTO upstream_reconciliation_settlements (
@@ -1565,8 +1663,7 @@ impl KeyStore {
         candidate: &UpstreamReconciliationCandidate,
         upstream_usage: i64,
         local_billed_credits: i64,
-        expected_generation: Option<i64>,
-        expected_claim: Option<(i64, i64)>,
+        fence: Option<ReconciliationWorkFence>,
     ) -> Result<bool, ProxyError> {
         let now = self.backend_time.now_ts();
         let settlement_key = format!("v1:{}:{}", candidate.token_id, candidate.period_code);
@@ -1587,12 +1684,12 @@ impl KeyStore {
         } else {
             RECONCILIATION_OUTCOME_SETTLED
         };
+        let expected_generation = fence.map(|fence| fence.work_generation);
         if !self
             .claim_reconciliation_work_completion(
                 &mut tx,
                 candidate,
-                expected_generation,
-                expected_claim,
+                fence,
                 completion_outcome,
                 now,
             )
@@ -1641,26 +1738,13 @@ impl KeyStore {
             .bind(now)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
-                r#"
-                UPDATE upstream_reconciliation_work
-                SET completed_generation = COALESCE(?, work_generation),
-                    next_attempt_at = 0,
-                    last_outcome = ?,
-                    updated_at = ?
-                WHERE token_id = ? AND period_code = ?
-                  AND completed_generation < work_generation
-                  AND (? IS NULL OR work_generation = ?)
-                "#,
+            self.mark_reconciliation_work_completed(
+                &mut tx,
+                candidate,
+                expected_generation,
+                RECONCILIATION_OUTCOME_NO_ADJUSTMENT,
+                now,
             )
-            .bind(expected_generation)
-            .bind(RECONCILIATION_OUTCOME_NO_ADJUSTMENT)
-            .bind(now)
-            .bind(&candidate.token_id)
-            .bind(&candidate.period_code)
-            .bind(expected_generation)
-            .bind(expected_generation)
-            .execute(&mut *tx)
             .await?;
             tx.commit().await?;
             return Ok(true);
@@ -1686,26 +1770,13 @@ impl KeyStore {
         .await?
         .rows_affected();
         if inserted == 0 {
-            sqlx::query(
-                r#"
-                UPDATE upstream_reconciliation_work
-                SET completed_generation = COALESCE(?, work_generation),
-                    next_attempt_at = 0,
-                    last_outcome = ?,
-                    updated_at = ?
-                WHERE token_id = ? AND period_code = ?
-                  AND completed_generation < work_generation
-                  AND (? IS NULL OR work_generation = ?)
-                "#,
+            self.mark_reconciliation_work_completed(
+                &mut tx,
+                candidate,
+                expected_generation,
+                RECONCILIATION_OUTCOME_SETTLED,
+                now,
             )
-            .bind(expected_generation)
-            .bind(RECONCILIATION_OUTCOME_SETTLED)
-            .bind(now)
-            .bind(&candidate.token_id)
-            .bind(&candidate.period_code)
-            .bind(expected_generation)
-            .bind(expected_generation)
-            .execute(&mut *tx)
             .await?;
             tx.commit().await?;
             return Ok(false);
@@ -1812,26 +1883,13 @@ impl KeyStore {
         .bind(now)
         .execute(&mut *tx)
         .await?;
-        sqlx::query(
-            r#"
-            UPDATE upstream_reconciliation_work
-            SET completed_generation = COALESCE(?, work_generation),
-                next_attempt_at = 0,
-                last_outcome = ?,
-                updated_at = ?
-            WHERE token_id = ? AND period_code = ?
-              AND completed_generation < work_generation
-              AND (? IS NULL OR work_generation = ?)
-            "#,
+        self.mark_reconciliation_work_completed(
+            &mut tx,
+            candidate,
+            expected_generation,
+            RECONCILIATION_OUTCOME_SETTLED,
+            now,
         )
-        .bind(expected_generation)
-        .bind(RECONCILIATION_OUTCOME_SETTLED)
-        .bind(now)
-        .bind(&candidate.token_id)
-        .bind(&candidate.period_code)
-        .bind(expected_generation)
-        .bind(expected_generation)
-        .execute(&mut *tx)
         .await?;
         tx.commit().await?;
         Ok(true)
@@ -1842,8 +1900,7 @@ impl KeyStore {
         candidate: &UpstreamReconciliationCandidate,
         upstream_usage: i64,
         local_billed_credits: i64,
-        expected_generation: Option<i64>,
-        expected_claim: Option<(i64, i64)>,
+        fence: Option<ReconciliationWorkFence>,
     ) -> Result<bool, ProxyError> {
         let started_at = std::time::Instant::now();
         let now = self.backend_time.now_ts();
@@ -1856,12 +1913,12 @@ impl KeyStore {
         } else {
             RECONCILIATION_OUTCOME_SETTLED
         };
+        let expected_generation = fence.map(|fence| fence.work_generation);
         if !self
             .claim_reconciliation_work_completion(
                 &mut tx,
                 candidate,
-                expected_generation,
-                expected_claim,
+                fence,
                 completion_outcome,
                 now,
             )
@@ -1934,26 +1991,13 @@ impl KeyStore {
                 now,
             )
             .await?;
-            sqlx::query(
-                r#"
-                UPDATE upstream_reconciliation_work
-                SET completed_generation = COALESCE(?, work_generation),
-                    next_attempt_at = 0,
-                    last_outcome = ?,
-                    updated_at = ?
-                WHERE token_id = ? AND period_code = ?
-                  AND completed_generation < work_generation
-                  AND (? IS NULL OR work_generation = ?)
-                "#,
+            self.mark_reconciliation_work_completed(
+                &mut tx,
+                candidate,
+                expected_generation,
+                RECONCILIATION_OUTCOME_NO_ADJUSTMENT,
+                now,
             )
-            .bind(expected_generation)
-            .bind(RECONCILIATION_OUTCOME_NO_ADJUSTMENT)
-            .bind(now)
-            .bind(&candidate.token_id)
-            .bind(&candidate.period_code)
-            .bind(expected_generation)
-            .bind(expected_generation)
-            .execute(&mut *tx)
             .await?;
             tx.commit().await?;
             return Ok(true);
@@ -1979,26 +2023,13 @@ impl KeyStore {
         .await?
         .rows_affected();
         if inserted == 0 {
-            sqlx::query(
-                r#"
-                UPDATE upstream_reconciliation_work
-                SET completed_generation = COALESCE(?, work_generation),
-                    next_attempt_at = 0,
-                    last_outcome = ?,
-                    updated_at = ?
-                WHERE token_id = ? AND period_code = ?
-                  AND completed_generation < work_generation
-                  AND (? IS NULL OR work_generation = ?)
-                "#,
+            self.mark_reconciliation_work_completed(
+                &mut tx,
+                candidate,
+                expected_generation,
+                RECONCILIATION_OUTCOME_SETTLED,
+                now,
             )
-            .bind(expected_generation)
-            .bind(RECONCILIATION_OUTCOME_SETTLED)
-            .bind(now)
-            .bind(&candidate.token_id)
-            .bind(&candidate.period_code)
-            .bind(expected_generation)
-            .bind(expected_generation)
-            .execute(&mut *tx)
             .await?;
             tx.commit().await?;
             return Ok(false);
@@ -2050,26 +2081,13 @@ impl KeyStore {
             now,
         )
         .await?;
-        sqlx::query(
-            r#"
-            UPDATE upstream_reconciliation_work
-            SET completed_generation = COALESCE(?, work_generation),
-                next_attempt_at = 0,
-                last_outcome = ?,
-                updated_at = ?
-            WHERE token_id = ? AND period_code = ?
-              AND completed_generation < work_generation
-              AND (? IS NULL OR work_generation = ?)
-            "#,
+        self.mark_reconciliation_work_completed(
+            &mut tx,
+            candidate,
+            expected_generation,
+            RECONCILIATION_OUTCOME_SETTLED,
+            now,
         )
-        .bind(expected_generation)
-        .bind(RECONCILIATION_OUTCOME_SETTLED)
-        .bind(now)
-        .bind(&candidate.token_id)
-        .bind(&candidate.period_code)
-        .bind(expected_generation)
-        .bind(expected_generation)
-        .execute(&mut *tx)
         .await?;
         tx.commit().await?;
         tracing::info!(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -3,49 +3,95 @@ static LAST_RECONCILIATION_SUMMARY_LOG_AT: AtomicI64 = AtomicI64::new(0);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReconciliationOutcome {
     Settled,
+    NoAdjustment,
     Upstream429,
+    TransportFailure,
+    SemanticFailure,
     LocalPressure,
-    RemoteFailure,
-    Idle,
 }
 
 struct ReconciliationEngine;
+
+struct ReconciliationRunResult {
+    settled: i64,
+    completed: i64,
+    no_adjustment: i64,
+    transport_failure_windows: i64,
+    semantic_failure_windows: i64,
+    settled_recent: i64,
+    settled_backlog: i64,
+    upstream_429_retry_windows: i64,
+    local_usage_rate_limit_windows: i64,
+    other_retry_windows: i64,
+    key_backoff_window_count: i64,
+    skipped_by_key_backoff: i64,
+    attempted_candidate_count: i64,
+    budget_exhausted: bool,
+    request_start_cutoff_reached: bool,
+    remote_attempt_limit_reached: bool,
+    max_retry_after_until: Option<i64>,
+}
 
 impl ReconciliationEngine {
     const MAX_REMOTE_ATTEMPTS: i64 = 2;
 
     fn outcome(
         settled: i64,
+        no_adjustment: i64,
         upstream_429: bool,
         local_pressure: bool,
-        attempted: i64,
-    ) -> ReconciliationOutcome {
-        if settled > 0 {
-            ReconciliationOutcome::Settled
-        } else if upstream_429 {
-            ReconciliationOutcome::Upstream429
+        transport_failure: bool,
+        semantic_failure: bool,
+    ) -> Option<ReconciliationOutcome> {
+        if upstream_429 {
+            Some(ReconciliationOutcome::Upstream429)
+        } else if transport_failure {
+            Some(ReconciliationOutcome::TransportFailure)
+        } else if semantic_failure {
+            Some(ReconciliationOutcome::SemanticFailure)
         } else if local_pressure {
-            ReconciliationOutcome::LocalPressure
-        } else if attempted > 0 {
-            ReconciliationOutcome::RemoteFailure
+            Some(ReconciliationOutcome::LocalPressure)
+        } else if settled > no_adjustment {
+            Some(ReconciliationOutcome::Settled)
+        } else if no_adjustment > 0 {
+            Some(ReconciliationOutcome::NoAdjustment)
         } else {
-            ReconciliationOutcome::Idle
+            None
         }
+    }
+
+    fn is_transport_failure(err: &ProxyError) -> bool {
+        matches!(err, ProxyError::Http(_) | ProxyError::Database(_))
     }
 
     fn clears_local_pressure(outcome: ReconciliationOutcome) -> bool {
         matches!(
             outcome,
-            ReconciliationOutcome::Settled
-                | ReconciliationOutcome::Upstream429
-                | ReconciliationOutcome::RemoteFailure
+            ReconciliationOutcome::Settled | ReconciliationOutcome::NoAdjustment
         )
     }
 
     fn clears_upstream_429(outcome: ReconciliationOutcome) -> bool {
-        outcome == ReconciliationOutcome::Settled
+        matches!(
+            outcome,
+            ReconciliationOutcome::Settled | ReconciliationOutcome::NoAdjustment
+        )
     }
 }
+
+impl ReconciliationOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Settled => RECONCILIATION_OUTCOME_SETTLED,
+            Self::NoAdjustment => RECONCILIATION_OUTCOME_NO_ADJUSTMENT,
+            Self::Upstream429 => RECONCILIATION_OUTCOME_UPSTREAM_429,
+            Self::TransportFailure => RECONCILIATION_OUTCOME_TRANSPORT_FAILURE,
+            Self::SemanticFailure => RECONCILIATION_OUTCOME_SEMANTIC_FAILURE,
+            Self::LocalPressure => RECONCILIATION_OUTCOME_LOCAL_PRESSURE,
+        }
+    }
+}
+
 
 fn should_emit_reconciliation_summary(now: i64) -> bool {
     let mut previous = LAST_RECONCILIATION_SUMMARY_LOG_AT.load(Ordering::Relaxed);
@@ -838,7 +884,7 @@ impl TavilyProxy {
     async fn run_upstream_reconciliation_once_inner(
         &self,
         usage_base: &str,
-        claimed_job: Option<(i64, i64)>,
+        _claimed_job: Option<(i64, i64)>,
     ) -> Result<(i64, bool), ProxyError> {
         let started_at = std::time::Instant::now();
         let settings = self.key_store.get_system_settings().await?;
@@ -1085,6 +1131,10 @@ impl TavilyProxy {
         );
         let result = async {
             let mut settled = 0_i64;
+            let mut completed = 0_i64;
+            let mut no_adjustment = 0_i64;
+            let mut transport_failure_windows = 0_i64;
+            let mut semantic_failure_windows = 0_i64;
             let mut settled_recent = 0_i64;
             let mut settled_backlog = 0_i64;
             let mut upstream_429_retry_windows = 0_i64;
@@ -1142,6 +1192,7 @@ impl TavilyProxy {
                 let mut retry_at = None;
                 let mut retry_reason = None;
                 let mut retry_key_id = None;
+                let mut retry_outcome = None;
                 let mut candidate_attempted = false;
                 let key_count = key_ids.len();
                 let mut successful_key_count = 0_usize;
@@ -1197,6 +1248,7 @@ impl TavilyProxy {
                             retry_reason =
                                 Some(RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT.to_string());
                             retry_key_id = Some(key_id.clone());
+                            retry_outcome = Some(ReconciliationOutcome::LocalPressure);
                             break;
                         }
                     }
@@ -1219,7 +1271,10 @@ impl TavilyProxy {
                     .await;
                     match usage_result {
                         Err(_) => {
-                            budget_exhausted = true;
+                            transport_failure_windows += 1;
+                            retry_reason = Some("upstream transport timeout".to_string());
+                            retry_key_id = Some(key_id.clone());
+                            retry_outcome = Some(ReconciliationOutcome::TransportFailure);
                             break;
                         }
                         Ok(Ok(usage)) => {
@@ -1227,9 +1282,25 @@ impl TavilyProxy {
                             successful_key_count += 1;
                         }
                         Ok(Err((err, upstream_retry_at))) => {
+                            let outcome = if matches!(
+                                &err,
+                                ProxyError::UsageHttp { status, .. }
+                                    if *status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                            ) {
+                                ReconciliationOutcome::Upstream429
+                            } else if ReconciliationEngine::is_transport_failure(&err) {
+                                transport_failure_windows += 1;
+                                ReconciliationOutcome::TransportFailure
+                            } else if !matches!(&err, ProxyError::UsageHttp { status, .. } if *status == reqwest::StatusCode::TOO_MANY_REQUESTS) {
+                                semantic_failure_windows += 1;
+                                ReconciliationOutcome::SemanticFailure
+                            } else {
+                                ReconciliationOutcome::SemanticFailure
+                            };
                             retry_at = upstream_retry_at;
                             retry_reason = Some(err.to_string());
                             retry_key_id = Some(key_id.clone());
+                            retry_outcome = Some(outcome);
                             break;
                         }
                     }
@@ -1261,20 +1332,37 @@ impl TavilyProxy {
                                 "reconciliation retry bookkeeping deadline exceeded".to_string(),
                             ));
                         }
-                        let cooldown_until = tokio::time::timeout(
-                            remaining,
-                            self.arm_reconciliation_backoff(
-                                &retry_key_id,
-                                retry_at,
-                                reason_kind,
-                            ),
-                        )
-                        .await
-                        .map_err(|_| {
-                            ProxyError::Other(
-                                "reconciliation retry backoff persistence timed out".to_string(),
+                        let retry_outcome = retry_outcome.unwrap_or_else(|| {
+                            if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
+                                ReconciliationOutcome::Upstream429
+                            } else if reason_kind
+                                == RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT
+                            {
+                                ReconciliationOutcome::LocalPressure
+                            } else {
+                                ReconciliationOutcome::SemanticFailure
+                            }
+                        });
+                        let cooldown_until = if reason_kind
+                            == RECONCILIATION_RETRY_REASON_UPSTREAM_429
+                        {
+                            tokio::time::timeout(
+                                remaining,
+                                self.arm_reconciliation_backoff(
+                                    &retry_key_id,
+                                    retry_at,
+                                    reason_kind,
+                                ),
                             )
-                        })??;
+                            .await
+                            .map_err(|_| {
+                                ProxyError::Other(
+                                    "reconciliation retry backoff persistence timed out".to_string(),
+                                )
+                            })??
+                        } else {
+                            retry_at.unwrap_or_else(|| self.backend_time.now_ts().saturating_add(300))
+                        };
                         let remaining = retry_bookkeeping_deadline
                             .saturating_duration_since(std::time::Instant::now());
                         if remaining.is_zero() {
@@ -1286,9 +1374,14 @@ impl TavilyProxy {
                             remaining,
                             self.key_store.mark_reconciliation_retry(
                                 &candidate,
-                                RECONCILIATION_STATUS_RATE_LIMITED,
+                                if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
+                                    RECONCILIATION_STATUS_RATE_LIMITED
+                                } else {
+                                    "waiting"
+                                },
                                 cooldown_until,
                                 Some(retry_reason.as_str()),
+                                retry_outcome.as_str(),
                             ),
                         )
                         .await
@@ -1309,8 +1402,10 @@ impl TavilyProxy {
                                 other_retry_windows += affected_window_count;
                             }
                         }
-                        key_backoff_window_count += affected_window_count;
-                        cooling_keys.insert(retry_key_id.clone());
+                        if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
+                            key_backoff_window_count += affected_window_count;
+                            cooling_keys.insert(retry_key_id.clone());
+                        }
                         tracing::debug!(
                             component = "reconciliation",
                             event = "key_backoff_applied",
@@ -1402,6 +1497,10 @@ impl TavilyProxy {
                                 break;
                             }
                         };
+                        completed += 1;
+                        if upstream_usage == local_billed {
+                            no_adjustment += 1;
+                        }
                         if did_settle {
                             settled += 1;
                             if in_recent_lane {
@@ -1417,8 +1516,12 @@ impl TavilyProxy {
                 !main_preparation_blocked
                     && started_at.elapsed()
                         >= std::time::Duration::from_secs(remote_request_start_budget_secs);
-            Ok::<(i64, i64, i64, i64, i64, i64, i64, i64, i64, bool, bool, bool, Option<i64>), ProxyError>((
+            Ok::<ReconciliationRunResult, ProxyError>(ReconciliationRunResult {
                 settled,
+                completed,
+                no_adjustment,
+                transport_failure_windows,
+                semantic_failure_windows,
                 settled_recent,
                 settled_backlog,
                 upstream_429_retry_windows,
@@ -1431,11 +1534,17 @@ impl TavilyProxy {
                 request_start_cutoff_reached,
                 remote_attempt_limit_reached,
                 max_retry_after_until,
-            ))
+            })
         }
         .await;
-        let main_budget_exhausted = result.as_ref().map(|value| value.9).unwrap_or(true);
-        let main_request_start_cutoff_reached = result.as_ref().map(|value| value.10).unwrap_or(false);
+        let main_budget_exhausted = result
+            .as_ref()
+            .map(|value| value.budget_exhausted)
+            .unwrap_or(true);
+        let main_request_start_cutoff_reached = result
+            .as_ref()
+            .map(|value| value.request_start_cutoff_reached)
+            .unwrap_or(false);
         let pre_main_research_happened = pre_main_research_ran;
         let (
             research_polled_count,
@@ -1464,8 +1573,12 @@ impl TavilyProxy {
         )
         .await?;
         match result {
-            Ok((
+            Ok(ReconciliationRunResult {
                 settled,
+                completed,
+                no_adjustment,
+                transport_failure_windows,
+                semantic_failure_windows,
                 settled_recent,
                 settled_backlog,
                 upstream_429_retry_windows,
@@ -1475,10 +1588,10 @@ impl TavilyProxy {
                 skipped_by_key_backoff,
                 attempted_candidate_count,
                 mut budget_exhausted,
-                _request_start_cutoff_reached,
+                request_start_cutoff_reached: _,
                 remote_attempt_limit_reached,
                 max_retry_after_until,
-            )) => {
+            }) => {
                 // The cap stops partial settlement, but it is not a time or local
                 // preparation budget exhaustion in the persisted observation.
                 budget_exhausted &= !remote_attempt_limit_reached;
@@ -1561,41 +1674,26 @@ impl TavilyProxy {
                         budget_exhausted,
                     );
                 }
-                let remote_pressure = upstream_429_retry_windows > 0
-                    && upstream_429_retry_windows.saturating_mul(2)
-                        >= attempted_candidate_count.max(1);
-                let local_pressure = (candidate_count > 0 || preparation_budget_exhausted)
-                    && attempted_candidate_count == 0
-                    && budget_exhausted;
-                let remote_pressure = settled == 0 && remote_pressure;
+                let remote_pressure = upstream_429_retry_windows > 0;
+                let local_pressure = local_usage_rate_limit_windows > 0
+                    || ((candidate_count > 0 || preparation_budget_exhausted)
+                        && attempted_candidate_count == 0
+                        && budget_exhausted);
                 let reconciliation_outcome = ReconciliationEngine::outcome(
-                    settled,
+                    completed,
+                    no_adjustment,
                     remote_pressure,
                     local_pressure,
-                    attempted_candidate_count,
+                    transport_failure_windows > 0,
+                    semantic_failure_windows > 0,
                 );
-                let mut claim_handled = false;
                 let (_, previous_local_backoff_level, _) = await_reconciliation_post_process(
                     post_process_deadline,
                     self.key_store.upstream_reconciliation_local_backoff_state(),
                 )
                 .await?;
                 let (local_pressure_streak, local_backoff_level, local_backoff_until) =
-                    if reconciliation_outcome == ReconciliationOutcome::LocalPressure {
-                        if let Some((job_id, claim_generation)) = claimed_job {
-                            claim_handled = true;
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store
-                                    .update_upstream_reconciliation_local_backoff_claimed(
-                                        true,
-                                        self.backend_time.now_ts(),
-                                        job_id,
-                                        claim_generation,
-                                    ),
-                            )
-                            .await?
-                        } else {
+                    if local_pressure {
                             await_reconciliation_post_process(
                                 post_process_deadline,
                                 self.key_store.update_upstream_reconciliation_local_backoff(
@@ -1604,24 +1702,9 @@ impl TavilyProxy {
                                 ),
                             )
                             .await?
-                        }
-                    } else if ReconciliationEngine::clears_local_pressure(reconciliation_outcome) {
-                        if reconciliation_outcome == ReconciliationOutcome::RemoteFailure
-                            && let Some((job_id, claim_generation)) = claimed_job
-                        {
-                            claim_handled = true;
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store
-                                    .update_upstream_reconciliation_local_backoff_claimed(
-                                        false,
-                                        self.backend_time.now_ts(),
-                                        job_id,
-                                        claim_generation,
-                                    ),
-                            )
-                            .await?
-                        } else {
+                    } else if reconciliation_outcome
+                        .is_some_and(ReconciliationEngine::clears_local_pressure)
+                    {
                             await_reconciliation_post_process(
                                 post_process_deadline,
                                 self.key_store.update_upstream_reconciliation_local_backoff(
@@ -1630,11 +1713,8 @@ impl TavilyProxy {
                                 ),
                             )
                             .await?
-                        }
                     } else {
-                        self.key_store
-                            .upstream_reconciliation_local_backoff_state()
-                            .await?
+                        self.key_store.upstream_reconciliation_local_backoff_state().await?
                     };
                 if local_backoff_level > previous_local_backoff_level {
                     tracing::warn!(
@@ -1659,24 +1739,7 @@ impl TavilyProxy {
                     self.key_store.upstream_reconciliation_global_backoff_state(),
                 )
                 .await?;
-                let (pressure_streak, backoff_level, backoff_until) = if reconciliation_outcome
-                    == ReconciliationOutcome::Upstream429
-                {
-                    if let Some((job_id, claim_generation)) = claimed_job {
-                        claim_handled = true;
-                        await_reconciliation_post_process(
-                            post_process_deadline,
-                            self.key_store
-                                .update_upstream_reconciliation_global_backoff_claimed(
-                                    true,
-                                    self.backend_time.now_ts(),
-                                    max_retry_after_until,
-                                    job_id,
-                                    claim_generation,
-                                ),
-                        )
-                        .await?
-                    } else {
+                let (pressure_streak, backoff_level, backoff_until) = if remote_pressure {
                         await_reconciliation_post_process(
                             post_process_deadline,
                             self.key_store.update_upstream_reconciliation_global_backoff(
@@ -1686,23 +1749,9 @@ impl TavilyProxy {
                             ),
                         )
                         .await?
-                    }
-                } else if ReconciliationEngine::clears_upstream_429(reconciliation_outcome) {
-                    if let Some((job_id, claim_generation)) = claimed_job {
-                        claim_handled = true;
-                        await_reconciliation_post_process(
-                            post_process_deadline,
-                            self.key_store
-                                .update_upstream_reconciliation_global_backoff_claimed(
-                                    false,
-                                    self.backend_time.now_ts(),
-                                    None,
-                                    job_id,
-                                    claim_generation,
-                                ),
-                        )
-                        .await?
-                    } else {
+                } else if reconciliation_outcome
+                    .is_some_and(ReconciliationEngine::clears_upstream_429)
+                {
                         await_reconciliation_post_process(
                             post_process_deadline,
                             self.key_store.update_upstream_reconciliation_global_backoff(
@@ -1712,11 +1761,8 @@ impl TavilyProxy {
                             ),
                         )
                         .await?
-                    }
                 } else {
-                    self.key_store
-                        .upstream_reconciliation_global_backoff_state()
-                        .await?
+                    self.key_store.upstream_reconciliation_global_backoff_state().await?
                 };
                 if backoff_level > previous_backoff_level {
                     tracing::warn!(
@@ -1738,7 +1784,7 @@ impl TavilyProxy {
                         previous_backoff_level,
                     );
                 }
-                Ok((settled, claim_handled))
+                Ok((settled, false))
             }
             Err(err) => {
                 tracing::warn!(
@@ -2382,6 +2428,12 @@ impl TavilyProxy {
         Ok(global_backoff_until.max(local_backoff_until))
     }
 
+    pub async fn upstream_reconciliation_continuation_at(
+        &self,
+    ) -> Result<Option<i64>, ProxyError> {
+        self.key_store.upstream_reconciliation_continuation_at().await
+    }
+
     pub async fn record_upstream_reconciliation_budget_exhausted(
         &self,
         duration_ms: i64,
@@ -2500,9 +2552,12 @@ mod reconciliation_engine_tests {
     use super::{ReconciliationEngine, ReconciliationOutcome};
 
     #[test]
-    fn transport_and_local_pressure_do_not_clear_upstream_429_state() {
+    fn non_success_outcomes_do_not_clear_upstream_429_state() {
         assert!(!ReconciliationEngine::clears_upstream_429(
-            ReconciliationOutcome::RemoteFailure
+            ReconciliationOutcome::TransportFailure
+        ));
+        assert!(!ReconciliationEngine::clears_upstream_429(
+            ReconciliationOutcome::SemanticFailure
         ));
         assert!(!ReconciliationEngine::clears_upstream_429(
             ReconciliationOutcome::LocalPressure
@@ -2513,12 +2568,31 @@ mod reconciliation_engine_tests {
     }
 
     #[test]
-    fn any_remote_attempt_clears_only_local_pressure() {
+    fn successful_terminal_outcomes_clear_both_backoffs() {
         assert!(ReconciliationEngine::clears_local_pressure(
-            ReconciliationOutcome::RemoteFailure
+            ReconciliationOutcome::Settled
         ));
-        assert!(!ReconciliationEngine::clears_local_pressure(
-            ReconciliationOutcome::Idle
+        assert!(ReconciliationEngine::clears_local_pressure(
+            ReconciliationOutcome::NoAdjustment
         ));
+        assert!(ReconciliationEngine::clears_upstream_429(
+            ReconciliationOutcome::NoAdjustment
+        ));
+    }
+
+    #[test]
+    fn failure_outcomes_prevent_a_same_round_success_from_clearing_429() {
+        assert_eq!(
+            ReconciliationEngine::outcome(1, 1, false, false, true, false),
+            Some(ReconciliationOutcome::TransportFailure)
+        );
+        assert_eq!(
+            ReconciliationEngine::outcome(1, 0, false, false, false, true),
+            Some(ReconciliationOutcome::SemanticFailure)
+        );
+        assert_eq!(
+            ReconciliationEngine::outcome(1, 1, false, true, false, false),
+            Some(ReconciliationOutcome::LocalPressure)
+        );
     }
 }

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -27,7 +27,6 @@ struct ReconciliationRunResult {
     skipped_by_key_backoff: i64,
     attempted_candidate_count: i64,
     budget_exhausted: bool,
-    request_start_cutoff_reached: bool,
     remote_attempt_limit_reached: bool,
     max_retry_after_until: Option<i64>,
 }
@@ -596,6 +595,7 @@ impl TavilyProxy {
         started_at: &std::time::Instant,
         request_start_budget_secs: u64,
         request_deadline: std::time::Instant,
+        claimed_job: Option<(i64, i64)>,
     ) -> Result<(i64, i64, i64, i64, i64, bool), ProxyError> {
         let now = self.backend_time.now_ts();
         let remaining = request_deadline.saturating_duration_since(std::time::Instant::now());
@@ -681,6 +681,17 @@ impl TavilyProxy {
                 ),
             )
             .await;
+            if let Some((job_id, claim_generation)) = claimed_job
+                && !self
+                    .key_store
+                    .scheduled_job_claim_is_current(job_id, claim_generation)
+                    .await?
+            {
+                return Err(ProxyError::StaleClaim {
+                    job_id,
+                    claim_generation,
+                });
+            }
             match research_result {
                 Err(_) => {
                     budget_exhausted = true;
@@ -821,6 +832,17 @@ impl TavilyProxy {
         if remaining.is_zero() {
             budget_exhausted = true;
         } else {
+            if let Some((job_id, claim_generation)) = claimed_job
+                && !self
+                    .key_store
+                    .scheduled_job_claim_is_current(job_id, claim_generation)
+                    .await?
+            {
+                return Err(ProxyError::StaleClaim {
+                    job_id,
+                    claim_generation,
+                });
+            }
             match tokio::time::timeout(
                 remaining,
                 self.key_store.mark_upstream_reconciliation_research_sweep_at(now),
@@ -864,7 +886,6 @@ impl TavilyProxy {
     ) -> Result<i64, ProxyError> {
         self.run_upstream_reconciliation_once_inner(usage_base, None)
             .await
-            .map(|(settled, _)| settled)
     }
 
     #[doc(hidden)]
@@ -873,7 +894,7 @@ impl TavilyProxy {
         usage_base: &str,
         job_id: i64,
         claim_generation: i64,
-    ) -> Result<(i64, bool), ProxyError> {
+    ) -> Result<i64, ProxyError> {
         self.run_upstream_reconciliation_once_inner(
             usage_base,
             Some((job_id, claim_generation)),
@@ -885,7 +906,7 @@ impl TavilyProxy {
         &self,
         usage_base: &str,
         claimed_job: Option<(i64, i64)>,
-    ) -> Result<(i64, bool), ProxyError> {
+    ) -> Result<i64, ProxyError> {
         let started_at = std::time::Instant::now();
         if let Some((job_id, claim_generation)) = claimed_job
             && !self
@@ -899,7 +920,7 @@ impl TavilyProxy {
                 job_id,
                 claim_generation,
             );
-            return Ok((0, false));
+            return Ok(0);
         }
         let settings = self.key_store.get_system_settings().await?;
         let shadow_ready = settings.upstream_project_id_mode == UpstreamProjectIdMode::AccessToken
@@ -924,7 +945,7 @@ impl TavilyProxy {
                 candidate_count = 0_i64,
                 settled_count = 0_i64,
             );
-            return Ok((0, false));
+            return Ok(0);
         }
         let now = self.backend_time.now_ts();
         let (_, global_backoff_level, global_backoff_until) = self
@@ -942,7 +963,7 @@ impl TavilyProxy {
                 backoff_level = global_backoff_level,
                 backoff_until = global_backoff_until,
             );
-            return Ok((0, false));
+            return Ok(0);
         }
         let (_, local_backoff_level, local_backoff_until) = self
             .key_store
@@ -959,7 +980,7 @@ impl TavilyProxy {
                 backoff_level = local_backoff_level,
                 backoff_until = local_backoff_until,
             );
-            return Ok((0, false));
+            return Ok(0);
         }
         let preparation_deadline = started_at
             + std::time::Duration::from_secs(Self::RECONCILIATION_MAIN_PREP_BUDGET_SECS);
@@ -998,7 +1019,7 @@ impl TavilyProxy {
         let mut preparation_budget_exhausted = false;
         let candidate_remaining = preparation_deadline
             .saturating_duration_since(std::time::Instant::now());
-        let mut candidate_batch;
+        let candidate_batch;
         if candidate_remaining.is_zero() {
             preparation_budget_exhausted = true;
             candidate_batch = empty_candidate_batch();
@@ -1018,51 +1039,7 @@ impl TavilyProxy {
         }
         preparation_budget_exhausted |=
             std::time::Instant::now() >= preparation_deadline;
-        let mut pre_main_research = (0_i64, 0_i64, 0_i64, 0_i64, 0_i64, false);
-        let pre_main_research_ran =
-            candidate_batch.candidates.is_empty() && !preparation_budget_exhausted;
-        // If there is no main work, research is the only way to make a window
-        // eligible. Run one bounded sweep before hydrating the now-eligible
-        // page; this does not delay an already eligible settlement.
-        if candidate_batch.candidates.is_empty() && !preparation_budget_exhausted {
-            pre_main_research = self
-                .run_research_terminal_sweep(
-                    usage_base,
-                    &started_at,
-                    research_start_budget_secs,
-                    remote_request_deadline,
-                )
-                .await?;
-            if pre_main_research.1 > 0 {
-                let remaining = finalization_deadline
-                    .saturating_duration_since(std::time::Instant::now());
-                if remaining.is_zero() {
-                    preparation_budget_exhausted = true;
-                } else {
-                    candidate_batch = match tokio::time::timeout(
-                        remaining,
-                        self.key_store.next_upstream_reconciliation_candidates(20),
-                    )
-                    .await
-                    {
-                        Ok(batch) => batch?,
-                        Err(_) => {
-                            preparation_budget_exhausted = true;
-                            empty_candidate_batch()
-                        }
-                    };
-                }
-            }
-        }
-        // A terminal research sweep can make a previously ineligible window
-        // settleable after the two-second local-preparation window. Give that
-        // newly eligible page the remaining total budget for its bounded
-        // hydrate instead of dropping it until the next scheduler run.
-        let candidate_hydration_deadline = if pre_main_research_ran && pre_main_research.1 > 0 {
-            remote_request_deadline
-        } else {
-            preparation_deadline
-        };
+        let candidate_hydration_deadline = preparation_deadline;
         let recent_candidate_count = candidate_batch.recent_candidate_count;
         let backlog_candidate_count = candidate_batch.backlog_candidate_count;
         let recent_lane_budget = candidate_batch.recent_lane_budget;
@@ -1164,9 +1141,7 @@ impl TavilyProxy {
             let mut max_retry_after_until = None::<i64>;
             let mut cooling_keys = HashSet::<String>::new();
             let mut remote_request_started = false;
-            let mut request_start_cutoff_reached = false;
             let mut remote_attempt_limit_reached = false;
-            let main_preparation_blocked = preparation_budget_exhausted;
             let mut observed_candidates = Vec::<(
                 UpstreamReconciliationCandidate,
                 i64,
@@ -1180,7 +1155,6 @@ impl TavilyProxy {
                 if started_at.elapsed()
                     >= std::time::Duration::from_secs(remote_request_start_budget_secs)
                 {
-                    request_start_cutoff_reached = true;
                     budget_exhausted = true;
                     break;
                 }
@@ -1243,7 +1217,6 @@ impl TavilyProxy {
                         .saturating_duration_since(std::time::Instant::now());
                     let request_timeout = Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS);
                     if remote_remaining < request_timeout {
-                        request_start_cutoff_reached = true;
                         budget_exhausted = true;
                         break;
                     }
@@ -1334,6 +1307,17 @@ impl TavilyProxy {
                     break;
                 }
                     if let (Some(retry_reason), Some(retry_key_id)) = (retry_reason, retry_key_id) {
+                        if let Some((job_id, claim_generation)) = claimed_job
+                            && !self
+                                .key_store
+                                .scheduled_job_claim_is_current(job_id, claim_generation)
+                                .await?
+                        {
+                            return Err(ProxyError::StaleClaim {
+                                job_id,
+                                claim_generation,
+                            });
+                        }
                         let reason_kind =
                             classify_reconciliation_retry_reason(Some(retry_reason.as_str()));
                         if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429
@@ -1506,8 +1490,10 @@ impl TavilyProxy {
                                         &candidate,
                                         upstream_usage,
                                         local_billed,
-                                        Some(work_generation),
-                                        claimed_job,
+                                        Some(ReconciliationWorkFence {
+                                            work_generation,
+                                            claimed_job,
+                                        }),
                                     )
                                     .await
                             } else {
@@ -1516,8 +1502,10 @@ impl TavilyProxy {
                                         &candidate,
                                         upstream_usage,
                                         local_billed,
-                                        Some(work_generation),
-                                        claimed_job,
+                                        Some(ReconciliationWorkFence {
+                                            work_generation,
+                                            claimed_job,
+                                        }),
                                     )
                                     .await
                             }
@@ -1545,10 +1533,6 @@ impl TavilyProxy {
                     }
                 }
             }
-            request_start_cutoff_reached |=
-                !main_preparation_blocked
-                    && started_at.elapsed()
-                        >= std::time::Duration::from_secs(remote_request_start_budget_secs);
             Ok::<ReconciliationRunResult, ProxyError>(ReconciliationRunResult {
                 settled,
                 completed,
@@ -1564,21 +1548,29 @@ impl TavilyProxy {
                 skipped_by_key_backoff,
                 attempted_candidate_count,
                 budget_exhausted,
-                request_start_cutoff_reached,
                 remote_attempt_limit_reached,
                 max_retry_after_until,
             })
         }
         .await;
+        if let Some((job_id, claim_generation)) = claimed_job
+            && !self
+                .key_store
+                .scheduled_job_claim_is_current(job_id, claim_generation)
+                .await?
+        {
+            tracing::debug!(
+                component = "reconciliation",
+                event = "stale_claim_rejected",
+                job_id,
+                claim_generation,
+            );
+            return Ok(0);
+        }
         let main_budget_exhausted = result
             .as_ref()
             .map(|value| value.budget_exhausted)
             .unwrap_or(true);
-        let main_request_start_cutoff_reached = result
-            .as_ref()
-            .map(|value| value.request_start_cutoff_reached)
-            .unwrap_or(false);
-        let pre_main_research_happened = pre_main_research_ran;
         let (
             research_polled_count,
             research_terminal_count,
@@ -1586,16 +1578,32 @@ impl TavilyProxy {
             research_retry_count,
             research_skipped_cooldown_count,
             research_budget_exhausted,
-        ) = if pre_main_research_happened {
-            pre_main_research
-        } else if result.is_ok() && (!main_budget_exhausted || main_request_start_cutoff_reached) {
-            self.run_research_terminal_sweep(
-                usage_base,
-                &started_at,
-                research_start_budget_secs,
-                remote_request_deadline,
-            )
-            .await?
+        ) = if result.is_ok() {
+            match self
+                .run_research_terminal_sweep(
+                    usage_base,
+                    &started_at,
+                    research_start_budget_secs,
+                    remote_request_deadline,
+                    claimed_job,
+                )
+                .await
+            {
+                Ok(research) => research,
+                Err(ProxyError::StaleClaim {
+                    job_id,
+                    claim_generation,
+                }) => {
+                    tracing::debug!(
+                        component = "reconciliation",
+                        event = "stale_claim_rejected",
+                        job_id,
+                        claim_generation,
+                    );
+                    return Ok(0);
+                }
+                Err(err) => return Err(err),
+            }
         } else {
             (0, 0, 0, 0, 0, main_budget_exhausted)
         };
@@ -1621,7 +1629,6 @@ impl TavilyProxy {
                 skipped_by_key_backoff,
                 attempted_candidate_count,
                 mut budget_exhausted,
-                request_start_cutoff_reached: _,
                 remote_attempt_limit_reached,
                 max_retry_after_until,
             }) => {
@@ -1707,7 +1714,11 @@ impl TavilyProxy {
                         budget_exhausted,
                     );
                 }
-                let remote_pressure = upstream_429_retry_windows > 0;
+                let upstream_429_observed = upstream_429_retry_windows > 0;
+                let qualified_remote_pressure = upstream_429_observed
+                    && completed == 0
+                    && upstream_429_retry_windows.saturating_mul(2)
+                        >= attempted_candidate_count.max(1);
                 let local_pressure = local_usage_rate_limit_windows > 0
                     || ((candidate_count > 0 || preparation_budget_exhausted)
                         && attempted_candidate_count == 0
@@ -1715,7 +1726,7 @@ impl TavilyProxy {
                 let reconciliation_outcome = ReconciliationEngine::outcome(
                     completed,
                     no_adjustment,
-                    remote_pressure,
+                    upstream_429_observed,
                     local_pressure,
                     transport_failure_windows > 0,
                     semantic_failure_windows > 0,
@@ -1727,25 +1738,58 @@ impl TavilyProxy {
                 .await?;
                 let (local_pressure_streak, local_backoff_level, local_backoff_until) =
                     if local_pressure {
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store.update_upstream_reconciliation_local_backoff(
-                                    true,
-                                    self.backend_time.now_ts(),
-                                ),
-                            )
-                            .await?
+                        let now = self.backend_time.now_ts();
+                        match claimed_job {
+                            Some((job_id, claim_generation)) => {
+                                await_reconciliation_post_process(
+                                    post_process_deadline,
+                                    self.key_store
+                                        .update_upstream_reconciliation_local_backoff_claimed(
+                                            true,
+                                            now,
+                                            job_id,
+                                            claim_generation,
+                                        ),
+                                )
+                                .await?
+                            }
+                            None => {
+                                await_reconciliation_post_process(
+                                    post_process_deadline,
+                                    self.key_store
+                                        .update_upstream_reconciliation_local_backoff(true, now),
+                                )
+                                .await?
+                            }
+                        }
                     } else if reconciliation_outcome
                         .is_some_and(ReconciliationEngine::clears_local_pressure)
                     {
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store.update_upstream_reconciliation_local_backoff(
-                                    false,
-                                    self.backend_time.now_ts(),
-                                ),
-                            )
-                            .await?
+                        let now = self.backend_time.now_ts();
+                        match claimed_job {
+                            Some((job_id, claim_generation)) => {
+                                await_reconciliation_post_process(
+                                    post_process_deadline,
+                                    self.key_store
+                                        .update_upstream_reconciliation_local_backoff_claimed(
+                                            false,
+                                            now,
+                                            job_id,
+                                            claim_generation,
+                                        ),
+                                )
+                                .await?
+                            }
+                            None => {
+                                await_reconciliation_post_process(
+                                    post_process_deadline,
+                                    self.key_store.update_upstream_reconciliation_local_backoff(
+                                        false, now,
+                                    ),
+                                )
+                                .await?
+                            }
+                        }
                     } else {
                         self.key_store.upstream_reconciliation_local_backoff_state().await?
                     };
@@ -1772,28 +1816,64 @@ impl TavilyProxy {
                     self.key_store.upstream_reconciliation_global_backoff_state(),
                 )
                 .await?;
-                let (pressure_streak, backoff_level, backoff_until) = if remote_pressure {
-                        await_reconciliation_post_process(
-                            post_process_deadline,
-                            self.key_store.update_upstream_reconciliation_global_backoff(
-                                true,
-                                self.backend_time.now_ts(),
-                                max_retry_after_until,
-                            ),
-                        )
-                        .await?
+                let (pressure_streak, backoff_level, backoff_until) = if qualified_remote_pressure {
+                    let now = self.backend_time.now_ts();
+                    match claimed_job {
+                        Some((job_id, claim_generation)) => {
+                            await_reconciliation_post_process(
+                                post_process_deadline,
+                                self.key_store
+                                    .update_upstream_reconciliation_global_backoff_claimed(
+                                        true,
+                                        now,
+                                        max_retry_after_until,
+                                        job_id,
+                                        claim_generation,
+                                    ),
+                            )
+                            .await?
+                        }
+                        None => {
+                            await_reconciliation_post_process(
+                                post_process_deadline,
+                                self.key_store.update_upstream_reconciliation_global_backoff(
+                                    true,
+                                    now,
+                                    max_retry_after_until,
+                                ),
+                            )
+                            .await?
+                        }
+                    }
                 } else if reconciliation_outcome
                     .is_some_and(ReconciliationEngine::clears_upstream_429)
                 {
-                        await_reconciliation_post_process(
-                            post_process_deadline,
-                            self.key_store.update_upstream_reconciliation_global_backoff(
-                                false,
-                                self.backend_time.now_ts(),
-                                None,
-                            ),
-                        )
-                        .await?
+                    let now = self.backend_time.now_ts();
+                    match claimed_job {
+                        Some((job_id, claim_generation)) => {
+                            await_reconciliation_post_process(
+                                post_process_deadline,
+                                self.key_store
+                                    .update_upstream_reconciliation_global_backoff_claimed(
+                                        false,
+                                        now,
+                                        None,
+                                        job_id,
+                                        claim_generation,
+                                    ),
+                            )
+                            .await?
+                        }
+                        None => {
+                            await_reconciliation_post_process(
+                                post_process_deadline,
+                                self.key_store.update_upstream_reconciliation_global_backoff(
+                                    false, now, None,
+                                ),
+                            )
+                            .await?
+                        }
+                    }
                 } else {
                     self.key_store.upstream_reconciliation_global_backoff_state().await?
                 };
@@ -1817,7 +1897,7 @@ impl TavilyProxy {
                         previous_backoff_level,
                     );
                 }
-                Ok((settled, false))
+                Ok(settled)
             }
             Err(err) => {
                 tracing::warn!(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -554,6 +554,7 @@ impl TavilyProxy {
         key_id: &str,
         requested_until: Option<i64>,
         reason: &str,
+        claimed_job: Option<(i64, i64)>,
     ) -> Result<i64, ProxyError> {
         let now = self.backend_time.now_ts();
         let prior_retry_after_secs = self
@@ -574,18 +575,23 @@ impl TavilyProxy {
                 _ => 1800,
             });
         let cooldown_until = now.saturating_add(retry_after_secs);
-        let armed = self
-            .key_store
-            .arm_api_key_transient_backoff(ApiKeyTransientBackoffArm {
-                key_id,
-                scope: Self::RECONCILIATION_BACKOFF_SCOPE,
-                cooldown_until,
-                retry_after_secs,
-                reason_code: Some(classify_reconciliation_retry_reason(Some(reason))),
-                source_request_log_id: None,
-                now,
-            })
-            .await?;
+        let arm = ApiKeyTransientBackoffArm {
+            key_id,
+            scope: Self::RECONCILIATION_BACKOFF_SCOPE,
+            cooldown_until,
+            retry_after_secs,
+            reason_code: Some(classify_reconciliation_retry_reason(Some(reason))),
+            source_request_log_id: None,
+            now,
+        };
+        let armed = match claimed_job {
+            Some((job_id, claim_generation)) => {
+                self.key_store
+                    .arm_api_key_transient_backoff_claimed(arm, job_id, claim_generation)
+                    .await?
+            }
+            None => self.key_store.arm_api_key_transient_backoff(arm).await?,
+        };
         Ok(armed.map(|state| state.cooldown_until).unwrap_or(cooldown_until))
     }
 
@@ -703,13 +709,31 @@ impl TavilyProxy {
                         budget_exhausted = true;
                         break;
                     }
-                    match tokio::time::timeout(
-                        remaining,
-                        self.key_store
-                            .mark_upstream_reconciliation_research_terminal(&candidate.request_id),
-                    )
-                    .await
-                    {
+                    let marker = match claimed_job {
+                        Some((job_id, claim_generation)) => {
+                            tokio::time::timeout(
+                                remaining,
+                                self.key_store
+                                    .mark_upstream_reconciliation_research_terminal_claimed(
+                                        &candidate.request_id,
+                                        job_id,
+                                        claim_generation,
+                                    ),
+                            )
+                            .await
+                        }
+                        None => {
+                            tokio::time::timeout(
+                                remaining,
+                                self.key_store
+                                    .mark_upstream_reconciliation_research_terminal(
+                                        &candidate.request_id,
+                                    ),
+                            )
+                            .await
+                        }
+                    };
+                    match marker {
                         Ok(result) => {
                             result?;
                         }
@@ -733,18 +757,36 @@ impl TavilyProxy {
                         budget_exhausted = true;
                         break;
                     }
-                    match tokio::time::timeout(
-                        remaining,
-                        self.key_store
-                            .record_upstream_reconciliation_research_poll(
-                                &candidate.request_id,
-                                now.saturating_add(120),
-                                "pending",
-                                None,
-                            ),
-                    )
-                    .await
-                    {
+                    let marker = match claimed_job {
+                        Some((job_id, claim_generation)) => {
+                            tokio::time::timeout(
+                                remaining,
+                                self.key_store
+                                    .record_upstream_reconciliation_research_poll_claimed(
+                                        &candidate.request_id,
+                                        now.saturating_add(120),
+                                        "pending",
+                                        None,
+                                        job_id,
+                                        claim_generation,
+                                    ),
+                            )
+                            .await
+                        }
+                        None => {
+                            tokio::time::timeout(
+                                remaining,
+                                self.key_store.record_upstream_reconciliation_research_poll(
+                                    &candidate.request_id,
+                                    now.saturating_add(120),
+                                    "pending",
+                                    None,
+                                ),
+                            )
+                            .await
+                        }
+                    };
+                    match marker {
                         Ok(result) => {
                             result?;
                         }
@@ -756,7 +798,15 @@ impl TavilyProxy {
                     pending += 1;
                 }
                 Ok(Err((err, retry_after))) => {
-                    let reason = classify_reconciliation_retry_reason(Some(err.to_string().as_str()));
+                    let reason = if matches!(
+                        &err,
+                        ProxyError::UsageHttp { status, .. }
+                            if *status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                    ) {
+                        RECONCILIATION_RETRY_REASON_UPSTREAM_429
+                    } else {
+                        RECONCILIATION_RETRY_REASON_OTHER
+                    };
                     let next_poll_at = if reason == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
                         let remaining = request_deadline.saturating_duration_since(std::time::Instant::now());
                         if remaining.is_zero() {
@@ -765,7 +815,12 @@ impl TavilyProxy {
                         }
                         let until = match tokio::time::timeout(
                             remaining,
-                            self.arm_reconciliation_backoff(&candidate.key_id, retry_after, reason),
+                            self.arm_reconciliation_backoff(
+                                &candidate.key_id,
+                                retry_after,
+                                reason,
+                                claimed_job,
+                            ),
                         )
                         .await
                         {
@@ -800,22 +855,41 @@ impl TavilyProxy {
                         budget_exhausted = true;
                         break;
                     }
-                    match tokio::time::timeout(
-                        remaining,
-                        self.key_store
-                            .record_upstream_reconciliation_research_poll(
-                                &candidate.request_id,
-                                next_poll_at,
-                                if reason == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
-                                    "rate_limited"
-                                } else {
-                                    "retry"
-                                },
-                                Some(reason),
-                            ),
-                    )
-                    .await
-                    {
+                    let outcome = if reason == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
+                        "rate_limited"
+                    } else {
+                        "retry"
+                    };
+                    let marker = match claimed_job {
+                        Some((job_id, claim_generation)) => {
+                            tokio::time::timeout(
+                                remaining,
+                                self.key_store
+                                    .record_upstream_reconciliation_research_poll_claimed(
+                                        &candidate.request_id,
+                                        next_poll_at,
+                                        outcome,
+                                        Some(reason),
+                                        job_id,
+                                        claim_generation,
+                                    ),
+                            )
+                            .await
+                        }
+                        None => {
+                            tokio::time::timeout(
+                                remaining,
+                                self.key_store.record_upstream_reconciliation_research_poll(
+                                    &candidate.request_id,
+                                    next_poll_at,
+                                    outcome,
+                                    Some(reason),
+                                ),
+                            )
+                            .await
+                        }
+                    };
+                    match marker {
                         Ok(result) => {
                             result?;
                         }
@@ -843,12 +917,28 @@ impl TavilyProxy {
                     claim_generation,
                 });
             }
-            match tokio::time::timeout(
-                remaining,
-                self.key_store.mark_upstream_reconciliation_research_sweep_at(now),
-            )
-            .await
-            {
+            let marker = match claimed_job {
+                Some((job_id, claim_generation)) => {
+                    tokio::time::timeout(
+                        remaining,
+                        self.key_store
+                            .mark_upstream_reconciliation_research_sweep_at_claimed(
+                                now,
+                                job_id,
+                                claim_generation,
+                            ),
+                    )
+                    .await
+                }
+                None => {
+                    tokio::time::timeout(
+                        remaining,
+                        self.key_store.mark_upstream_reconciliation_research_sweep_at(now),
+                    )
+                    .await
+                }
+            };
+            match marker {
                 Ok(result) => {
                     result?;
                 }
@@ -1306,7 +1396,7 @@ impl TavilyProxy {
                 if budget_exhausted {
                     break;
                 }
-                    if let (Some(retry_reason), Some(retry_key_id)) = (retry_reason, retry_key_id) {
+                    if let (Some(_retry_reason), Some(retry_key_id)) = (retry_reason, retry_key_id) {
                         if let Some((job_id, claim_generation)) = claimed_job
                             && !self
                                 .key_store
@@ -1318,8 +1408,16 @@ impl TavilyProxy {
                                 claim_generation,
                             });
                         }
-                        let reason_kind =
-                            classify_reconciliation_retry_reason(Some(retry_reason.as_str()));
+                        let retry_outcome = retry_outcome.unwrap_or(ReconciliationOutcome::SemanticFailure);
+                        let reason_kind = match retry_outcome {
+                            ReconciliationOutcome::Upstream429 => {
+                                RECONCILIATION_RETRY_REASON_UPSTREAM_429
+                            }
+                            ReconciliationOutcome::LocalPressure => {
+                                RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT
+                            }
+                            _ => RECONCILIATION_RETRY_REASON_OTHER,
+                        };
                         if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429
                             && let Some(retry_after_until) = retry_at
                         {
@@ -1341,17 +1439,6 @@ impl TavilyProxy {
                                 "reconciliation retry bookkeeping deadline exceeded".to_string(),
                             ));
                         }
-                        let retry_outcome = retry_outcome.unwrap_or_else(|| {
-                            if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
-                                ReconciliationOutcome::Upstream429
-                            } else if reason_kind
-                                == RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT
-                            {
-                                ReconciliationOutcome::LocalPressure
-                            } else {
-                                ReconciliationOutcome::SemanticFailure
-                            }
-                        });
                         let cooldown_until = if reason_kind
                             == RECONCILIATION_RETRY_REASON_UPSTREAM_429
                         {
@@ -1361,6 +1448,7 @@ impl TavilyProxy {
                                     &retry_key_id,
                                     retry_at,
                                     reason_kind,
+                                    claimed_job,
                                 ),
                             )
                             .await
@@ -1389,7 +1477,7 @@ impl TavilyProxy {
                                     "waiting"
                                 },
                                 cooldown_until,
-                                Some(retry_reason.as_str()),
+                                Some(reason_kind),
                                 retry_outcome.as_str(),
                                 Some(ReconciliationWorkFence {
                                     work_generation,

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -884,9 +884,23 @@ impl TavilyProxy {
     async fn run_upstream_reconciliation_once_inner(
         &self,
         usage_base: &str,
-        _claimed_job: Option<(i64, i64)>,
+        claimed_job: Option<(i64, i64)>,
     ) -> Result<(i64, bool), ProxyError> {
         let started_at = std::time::Instant::now();
+        if let Some((job_id, claim_generation)) = claimed_job
+            && !self
+                .key_store
+                .scheduled_job_claim_is_current(job_id, claim_generation)
+                .await?
+        {
+            tracing::debug!(
+                component = "reconciliation",
+                event = "stale_claim_rejected",
+                job_id,
+                claim_generation,
+            );
+            return Ok((0, false));
+        }
         let settings = self.key_store.get_system_settings().await?;
         let shadow_ready = settings.upstream_project_id_mode == UpstreamProjectIdMode::AccessToken
             && settings.api_rebalance_enabled
@@ -975,6 +989,7 @@ impl TavilyProxy {
         let remote_request_start_budget_secs = research_start_budget_secs;
         let empty_candidate_batch = || UpstreamReconciliationCandidateBatch {
             candidates: Vec::new(),
+            work_generation_by_candidate: std::collections::HashMap::new(),
             recent_lane_budget: 0,
             backlog_lane_budget: 0,
             recent_candidate_count: 0,
@@ -1052,6 +1067,7 @@ impl TavilyProxy {
         let backlog_candidate_count = candidate_batch.backlog_candidate_count;
         let recent_lane_budget = candidate_batch.recent_lane_budget;
         let backlog_lane_budget = candidate_batch.backlog_lane_budget;
+        let work_generation_by_candidate = candidate_batch.work_generation_by_candidate;
         let candidates = candidate_batch.candidates;
         let candidate_count = candidates.len() as i64;
         let candidate_keys = candidates
@@ -1155,6 +1171,7 @@ impl TavilyProxy {
                 UpstreamReconciliationCandidate,
                 i64,
                 bool,
+                i64,
             )>::new();
             'candidates: for (index, candidate) in candidates.iter().cloned().enumerate() {
                 if budget_exhausted {
@@ -1168,6 +1185,14 @@ impl TavilyProxy {
                     break;
                 }
                 let in_recent_lane = index < recent_candidate_count as usize;
+                let work_generation = work_generation_by_candidate
+                    .get(&(candidate.token_id.clone(), candidate.period_code.clone()))
+                    .copied()
+                    .ok_or_else(|| {
+                        ProxyError::Other(
+                            "missing reconciliation work generation for candidate".to_string(),
+                        )
+                    })?;
                 let key_ids = key_ids_by_candidate
                     .get(&(candidate.token_id.clone(), candidate.period_code.clone()))
                     .cloned()
@@ -1382,6 +1407,10 @@ impl TavilyProxy {
                                 cooldown_until,
                                 Some(retry_reason.as_str()),
                                 retry_outcome.as_str(),
+                                Some(ReconciliationWorkFence {
+                                    work_generation,
+                                    claimed_job,
+                                }),
                             ),
                         )
                         .await
@@ -1423,7 +1452,7 @@ impl TavilyProxy {
                     budget_exhausted = true;
                     break;
                 }
-                observed_candidates.push((candidate, upstream_usage, in_recent_lane));
+                observed_candidates.push((candidate, upstream_usage, in_recent_lane, work_generation));
             }
 
             // Billing can become charged while the remote request is in flight. Re-read
@@ -1433,7 +1462,7 @@ impl TavilyProxy {
             if !observed_candidates.is_empty() {
                 let observed = observed_candidates
                     .iter()
-                    .map(|(candidate, _, _)| candidate.clone())
+                    .map(|(candidate, _, _, _)| candidate.clone())
                     .collect::<Vec<_>>();
                 let remaining = finalization_deadline
                     .saturating_duration_since(std::time::Instant::now());
@@ -1459,7 +1488,7 @@ impl TavilyProxy {
                 // request has already succeeded. Do not let that later timeout discard
                 // observations that still fit the bounded finalization window.
                 if let Some(fresh_local_billed_by_candidate) = fresh_local_billed_by_candidate {
-                    for (candidate, upstream_usage, in_recent_lane) in observed_candidates {
+                    for (candidate, upstream_usage, in_recent_lane, work_generation) in observed_candidates {
                         let remaining = finalization_deadline
                             .saturating_duration_since(std::time::Instant::now());
                         if remaining.is_zero() {
@@ -1477,6 +1506,8 @@ impl TavilyProxy {
                                         &candidate,
                                         upstream_usage,
                                         local_billed,
+                                        Some(work_generation),
+                                        claimed_job,
                                     )
                                     .await
                             } else {
@@ -1485,6 +1516,8 @@ impl TavilyProxy {
                                         &candidate,
                                         upstream_usage,
                                         local_billed,
+                                        Some(work_generation),
+                                        claimed_job,
                                     )
                                     .await
                             }
@@ -1497,11 +1530,11 @@ impl TavilyProxy {
                                 break;
                             }
                         };
-                        completed += 1;
-                        if upstream_usage == local_billed {
-                            no_adjustment += 1;
-                        }
                         if did_settle {
+                            completed += 1;
+                            if upstream_usage == local_billed {
+                                no_adjustment += 1;
+                            }
                             settled += 1;
                             if in_recent_lane {
                                 settled_recent += 1;
@@ -2432,6 +2465,14 @@ impl TavilyProxy {
         &self,
     ) -> Result<Option<i64>, ProxyError> {
         self.key_store.upstream_reconciliation_continuation_at().await
+    }
+
+    pub async fn ensure_upstream_reconciliation_representative_job(
+        &self,
+    ) -> Result<(), ProxyError> {
+        self.key_store
+            .ensure_upstream_reconciliation_representative_job()
+            .await
     }
 
     pub async fn record_upstream_reconciliation_budget_exhausted(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,6 +42,7 @@ mod request_rollup_public_metrics;
 mod schema_migrations;
 mod support;
 mod upstream_reconciliation;
+mod upstream_reconciliation_fencing;
 mod usage_series_and_backfills;
 mod user_business_calls_1h;
 mod user_pressure_analysis;

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -28,7 +28,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
             .fetch_all(&pool)
             .await
             .expect("read migration ledger");
-    assert_eq!(versions, vec![1, 2, 3]);
+    assert_eq!(versions, vec![1, 2, 3, 4]);
     sqlx::query("UPDATE schema_migrations SET checksum = 'drifted' WHERE version = 2")
         .execute(&pool)
         .await
@@ -80,6 +80,44 @@ async fn versioned_schema_migrations_reject_missing_recorded_objects() {
         error
             .to_string()
             .contains("object validation failed at version 3")
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn terminal_outcome_migration_rejects_a_missing_usage_update_trigger() {
+    let db_path = temp_db_path("schema-migration-terminal-outcome-trigger");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-schema-migration-terminal-outcome".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("create migrated database");
+    drop(proxy);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_update")
+        .execute(&pool)
+        .await
+        .expect("remove terminal outcome trigger");
+    pool.close().await;
+
+    let error = TavilyProxy::with_endpoint(
+        vec!["tvly-schema-migration-terminal-outcome".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect_err("missing terminal outcome trigger must reject startup");
+    assert!(
+        error
+            .to_string()
+            .contains("object validation failed at version 4")
     );
 
     let _ = std::fs::remove_file(&db_path);
@@ -348,7 +386,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
             .fetch_all(&proxy.key_store.pool)
             .await
             .expect("read adopted ledger");
-    assert_eq!(versions, vec![1, 2, 3]);
+    assert_eq!(versions, vec![1, 2, 3, 4]);
 
     drop(proxy);
     let _ = std::fs::remove_file(&db_path);

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -511,7 +511,7 @@ async fn warm_schema_verification_is_read_only_and_rejects_runtime_column_drift(
         .await
         .expect("hold writer lock");
     let verified = tokio::time::timeout(
-        std::time::Duration::from_millis(250),
+        std::time::Duration::from_secs(1),
         proxy.key_store.prepare_versioned_schema(),
     )
     .await

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -695,6 +695,165 @@ async fn run_upstream_reconciliation_once_updates_runtime_markers() {
 }
 
 #[tokio::test]
+async fn reconciliation_no_adjustment_completes_only_the_current_usage_generation() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-no-adjustment"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save reconciliation settings");
+    let token = proxy
+        .create_access_token(Some("reconciliation-no-adjustment"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-no-adjustment")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-no-adjustment', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert due reconciliation usage");
+
+    let usage_hits = Arc::new(AtomicUsize::new(0));
+    let app_hits = Arc::clone(&usage_hits);
+    let app = Router::new().route(
+        "/usage",
+        get(move || {
+            let app_hits = Arc::clone(&app_hits);
+            async move {
+                app_hits.fetch_add(1, Ordering::SeqCst);
+                Json(serde_json::json!({ "key": { "usage": 0 } }))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve no-adjustment upstream");
+    });
+
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("settle no-adjustment generation"),
+        1
+    );
+    let first_generation: (i64, i64, String) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, last_outcome FROM upstream_reconciliation_work WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read completed no-adjustment generation");
+    assert_eq!(first_generation, (1, 1, "no_adjustment".to_string()));
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_continuation_at()
+            .await
+            .expect("read continuation after completion"),
+        None
+    );
+    let queued_continuations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count queued continuations");
+    assert_eq!(
+        queued_continuations, 0,
+        "a completed no-adjustment generation must not create a minute retry loop"
+    );
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("skip completed no-adjustment generation"),
+        0
+    );
+    assert_eq!(usage_hits.load(Ordering::SeqCst), 1);
+
+    sqlx::query(
+        r#"
+        UPDATE upstream_reconciliation_usage
+        SET request_count = request_count + 1, updated_at = updated_at + 1
+        WHERE token_id = ? AND key_id = ? AND period_code = '2026-07-15/S1'
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("record new usage in the same settlement window");
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("settle new no-adjustment generation"),
+        1
+    );
+    let second_generation: (i64, i64, String) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, last_outcome FROM upstream_reconciliation_work WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read completed replacement generation");
+    assert_eq!(second_generation, (2, 2, "no_adjustment".to_string()));
+    assert_eq!(usage_hits.load(Ordering::SeqCst), 2);
+    let adjustment_delta: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(delta_credits), 0) FROM billing_reconciliation_shadow_adjustments WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("sum durable shadow adjustment impact");
+    assert_eq!(
+        adjustment_delta, 0,
+        "zero deltas must not alter billing truth even when shadow audit state is retained"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn reconciliation_request_cap_never_settles_partially_observed_candidate() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
@@ -1067,8 +1226,78 @@ async fn reconciliation_global_backoff_counts_only_attempted_candidates() {
         .await
         .expect("read global backoff state");
     assert_eq!(pressure_streak, 3);
-    assert_eq!(backoff_level, 1);
-    assert_eq!(backoff_until, now + 902 + 120);
+    assert_eq!(backoff_level, 3);
+    assert_eq!(backoff_until, now + 902 + 600);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn upstream_429_backoff_escalates_persists_across_restart_and_resets() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-429-states"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+
+    for (level, delay_secs) in [(1_i64, 120_i64), (2, 300), (3, 600), (4, 1_800)] {
+        let attempted_at = now + level * 10_000;
+        let state = proxy
+            .key_store
+            .update_upstream_reconciliation_global_backoff(true, attempted_at, None)
+            .await
+            .expect("persist upstream 429 backoff");
+        assert_eq!(state, (level, level, attempted_at + delay_secs));
+    }
+    let retry_after_until = now + 100_000;
+    assert_eq!(
+        proxy
+            .key_store
+            .update_upstream_reconciliation_global_backoff(
+                true,
+                now + 50_000,
+                Some(retry_after_until)
+            )
+            .await
+            .expect("honor upstream retry-after"),
+        (5, 4, retry_after_until)
+    );
+
+    drop(proxy);
+    let (restart_time, _) = BackendTime::manual_from_ts(now + 50_001);
+    let restarted = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-429-states"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        restart_time,
+    )
+    .await
+    .expect("restart proxy");
+    assert_eq!(
+        restarted
+            .key_store
+            .upstream_reconciliation_global_backoff_state()
+            .await
+            .expect("read persisted 429 backoff"),
+        (5, 4, retry_after_until)
+    );
+    assert_eq!(
+        restarted
+            .key_store
+            .update_upstream_reconciliation_global_backoff(false, now + 50_002, None)
+            .await
+            .expect("reset after successful reconciliation"),
+        (0, 0, 0)
+    );
 
     let _ = std::fs::remove_file(db_path);
 }
@@ -1121,7 +1350,26 @@ async fn local_reconciliation_pressure_is_separate_from_upstream_backoff() {
     .expect("read atomic delayed representative");
     assert_eq!(queued, (1, local_until));
 
-    proxy
+    drop(proxy);
+    let (restart_time, _) = BackendTime::manual_from_ts(now + 3);
+    let restarted = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-local-pressure"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        restart_time,
+    )
+    .await
+    .expect("restart proxy");
+    assert_eq!(
+        restarted
+            .key_store
+            .upstream_reconciliation_local_backoff_state()
+            .await
+            .expect("read persisted local pressure state"),
+        (local_streak, local_level, local_until)
+    );
+    restarted
         .key_store
         .update_upstream_reconciliation_local_backoff(false, now + 3)
         .await
@@ -1129,7 +1377,7 @@ async fn local_reconciliation_pressure_is_separate_from_upstream_backoff() {
     let queued_after_recovery: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status = 'queued' AND trigger_source = 'auto'",
     )
-    .fetch_one(&proxy.key_store.pool)
+    .fetch_one(&restarted.key_store.pool)
     .await
     .expect("read recovered representative state");
     assert_eq!(queued_after_recovery, 0);

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -272,14 +272,14 @@ async fn signed_reconciliation_adjustment_is_idempotent_and_restores_quota() {
     assert!(
         proxy
             .key_store
-            .settle_upstream_reconciliation(&candidate, 7, 10, None, None)
+            .settle_upstream_reconciliation(&candidate, 7, 10, None)
             .await
             .expect("first settlement")
     );
     assert!(
         !proxy
             .key_store
-            .settle_upstream_reconciliation(&candidate, 7, 10, None, None)
+            .settle_upstream_reconciliation(&candidate, 7, 10, None)
             .await
             .expect("duplicate settlement")
     );
@@ -509,7 +509,7 @@ async fn shadow_reconciliation_keeps_zero_delta_usage_and_updates_runtime_marker
     assert!(
         proxy
             .key_store
-            .settle_upstream_reconciliation_shadow(&candidate, 7, 7, None, None)
+            .settle_upstream_reconciliation_shadow(&candidate, 7, 7, None)
             .await
             .expect("shadow zero-delta settlement")
     );
@@ -1068,6 +1068,84 @@ async fn reconciliation_startup_resume_keeps_one_pending_representative_job() {
 }
 
 #[tokio::test]
+async fn reconciliation_continuation_waits_for_pending_research_poll() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-continuation"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-research-continuation")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-research-continuation', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind("research-continuation-token")
+    .bind(&key_id)
+    .bind("token:research-continuation-token")
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert pending reconciliation work");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, next_poll_at, updated_at
+        ) VALUES (?, ?, ?, '2026-07-15/S1', ?, NULL, ?, ?)
+        "#,
+    )
+    .bind("research-continuation-request")
+    .bind("research-continuation-token")
+    .bind(&key_id)
+    .bind(now - 900)
+    .bind(now + 120)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert delayed pending research");
+
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_continuation_at()
+            .await
+            .expect("read delayed research continuation"),
+        Some(now + 120)
+    );
+    proxy
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("enqueue delayed research continuation");
+    let scheduled: (i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), MAX(available_at) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read delayed representative");
+    assert_eq!(scheduled, (1, now + 120));
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn reconciliation_rejects_reclaimed_scheduled_job_claim() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
@@ -1143,7 +1221,7 @@ async fn reconciliation_rejects_reclaimed_scheduled_job_claim() {
             )
             .await
             .expect("reject stale claimed worker"),
-        (0, false)
+        0
     );
     let work: (i64, i64) = sqlx::query_as(
         "SELECT work_generation, completed_generation FROM upstream_reconciliation_work WHERE token_id = ?",
@@ -1152,6 +1230,158 @@ async fn reconciliation_rejects_reclaimed_scheduled_job_claim() {
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("read pending work after stale claim rejection");
+    assert_eq!(work, (1, 0));
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_rejects_reclaimed_claim_after_remote_fetch() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, clock) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-reclaimed-during-fetch"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save reconciliation settings");
+    let token = proxy
+        .create_access_token(Some("reconciliation-reclaimed-during-fetch"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-reclaimed-during-fetch")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-reclaimed-during-fetch', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert reconciliation usage");
+    proxy
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("enqueue representative job");
+    let job = proxy
+        .fetch_queued_scheduled_jobs(1)
+        .await
+        .expect("load representative job")
+        .into_iter()
+        .next()
+        .expect("representative job is queued");
+    let claimed = proxy
+        .scheduled_job_mark_running(job.id)
+        .await
+        .expect("claim representative job")
+        .expect("representative job became running");
+
+    let fetch_started = Arc::new(Notify::new());
+    let release_fetch = Arc::new(Notify::new());
+    let route_started = Arc::clone(&fetch_started);
+    let route_release = Arc::clone(&release_fetch);
+    let app = Router::new().route(
+        "/usage",
+        get(move || {
+            let route_started = Arc::clone(&route_started);
+            let route_release = Arc::clone(&route_release);
+            async move {
+                route_started.notify_one();
+                route_release.notified().await;
+                Json(serde_json::json!({ "key": { "usage": 0 } }))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve reclaim-during-fetch upstream");
+    });
+
+    let running_proxy = proxy.clone();
+    let running = tokio::spawn(async move {
+        running_proxy
+            .run_upstream_reconciliation_once_claimed(
+                &format!("http://{addr}"),
+                claimed.id,
+                claimed.claim_generation,
+            )
+            .await
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(2), fetch_started.notified())
+        .await
+        .expect("upstream usage fetch starts");
+    clock.set_now_ts(now + 61);
+    assert_eq!(
+        proxy
+            .recover_stale_scheduled_jobs()
+            .await
+            .expect("reclaim stale representative job"),
+        1
+    );
+    release_fetch.notify_one();
+
+    assert_eq!(
+        running
+            .await
+            .expect("join stale claimed worker")
+            .expect("stale claimed worker exits cleanly"),
+        0
+    );
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_local_backoff_state()
+            .await
+            .expect("read local backoff after stale worker"),
+        (0, 0, 0)
+    );
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_global_backoff_state()
+            .await
+            .expect("read global backoff after stale worker"),
+        (0, 0, 0)
+    );
+    let work: (i64, i64) = sqlx::query_as(
+        "SELECT work_generation, completed_generation FROM upstream_reconciliation_work WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read pending work after stale worker");
     assert_eq!(work, (1, 0));
 
     let _ = std::fs::remove_file(db_path);
@@ -1200,7 +1430,7 @@ async fn reconciliation_request_cap_never_settles_partially_observed_candidate()
                 .expect("create upstream key"),
         );
     }
-    for key_id in key_ids {
+    for key_id in &key_ids {
         sqlx::query(
             r#"INSERT INTO upstream_reconciliation_usage (
                  token_id, key_id, period_code, project_id, billing_subject,
@@ -1222,18 +1452,62 @@ async fn reconciliation_request_cap_never_settles_partially_observed_candidate()
         .expect("insert multi-key candidate usage");
     }
 
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_usage (
+             token_id, key_id, period_code, project_id, billing_subject,
+             period_start, period_end, request_count, first_used_at,
+             last_used_at, updated_at, settlement_mode
+           ) VALUES ('reconciliation-cap-research', ?, '2026-07-15/S2',
+             'project-reconciliation-cap-research', 'token:reconciliation-cap-research',
+             ?, ?, 1, ?, ?, ?, 'shadow')"#,
+    )
+    .bind(&key_ids[0])
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert pending research usage");
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_research (
+             request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+           ) VALUES ('reconciliation-cap-research', 'reconciliation-cap-research', ?,
+             '2026-07-15/S2', ?, NULL, ?)"#,
+    )
+    .bind(&key_ids[0])
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert pending research");
+
     let upstream_hits = Arc::new(AtomicUsize::new(0));
     let route_hits = Arc::clone(&upstream_hits);
-    let app = Router::new().route(
-        "/usage",
-        get(move || {
-            let route_hits = Arc::clone(&route_hits);
-            async move {
-                route_hits.fetch_add(1, Ordering::SeqCst);
-                Json(serde_json::json!({ "key": { "usage": 0 } }))
-            }
-        }),
-    );
+    let research_hits = Arc::new(AtomicUsize::new(0));
+    let research_route_hits = Arc::clone(&research_hits);
+    let app = Router::new()
+        .route(
+            "/usage",
+            get(move || {
+                let route_hits = Arc::clone(&route_hits);
+                async move {
+                    route_hits.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({ "key": { "usage": 0 } }))
+                }
+            }),
+        )
+        .route(
+            "/research/reconciliation-cap-research",
+            get(move || {
+                let research_route_hits = Arc::clone(&research_route_hits);
+                async move {
+                    research_route_hits.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({ "status": "completed" }))
+                }
+            }),
+        );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -1247,6 +1521,7 @@ async fn reconciliation_request_cap_never_settles_partially_observed_candidate()
         .await
         .expect("run capped reconciliation");
     assert_eq!(upstream_hits.load(Ordering::SeqCst), 2);
+    assert_eq!(research_hits.load(Ordering::SeqCst), 1);
     assert_eq!(settled, 0);
     let settlement_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM upstream_reconciliation_settlements WHERE token_id = ?",
@@ -1389,6 +1664,14 @@ async fn run_upstream_reconciliation_once_applies_key_scoped_backoff_for_429() {
     assert_eq!(settled, 1);
     assert_eq!(hot_hits.load(Ordering::SeqCst), 1);
     assert_eq!(cool_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_global_backoff_state()
+            .await
+            .expect("mixed successful settlement does not escalate global 429 backoff"),
+        (0, 0, 0)
+    );
 
     let hot_rate_limited: i64 = sqlx::query_scalar(
         r#"
@@ -1530,8 +1813,8 @@ async fn reconciliation_global_backoff_counts_only_attempted_candidates() {
         .await
         .expect("read global backoff state");
     assert_eq!(pressure_streak, 3);
-    assert_eq!(backoff_level, 3);
-    assert_eq!(backoff_until, now + 902 + 600);
+    assert_eq!(backoff_level, 1);
+    assert_eq!(backoff_until, now + 902 + 120);
 
     let _ = std::fs::remove_file(db_path);
 }
@@ -1552,14 +1835,21 @@ async fn upstream_429_backoff_escalates_persists_across_restart_and_resets() {
     .await
     .expect("create proxy");
 
-    for (level, delay_secs) in [(1_i64, 120_i64), (2, 300), (3, 600), (4, 1_800)] {
-        let attempted_at = now + level * 10_000;
+    for (streak, level, delay_secs) in [
+        (1_i64, 0_i64, 0_i64),
+        (2, 0, 0),
+        (3, 1, 120),
+        (4, 2, 300),
+        (5, 3, 600),
+        (6, 4, 1_800),
+    ] {
+        let attempted_at = now + streak * 10_000;
         let state = proxy
             .key_store
             .update_upstream_reconciliation_global_backoff(true, attempted_at, None)
             .await
             .expect("persist upstream 429 backoff");
-        assert_eq!(state, (level, level, attempted_at + delay_secs));
+        assert_eq!(state, (streak, level, attempted_at + delay_secs));
     }
     let retry_after_until = now + 100_000;
     assert_eq!(
@@ -1572,7 +1862,7 @@ async fn upstream_429_backoff_escalates_persists_across_restart_and_resets() {
             )
             .await
             .expect("honor upstream retry-after"),
-        (5, 4, retry_after_until)
+        (7, 4, retry_after_until)
     );
 
     drop(proxy);
@@ -1592,7 +1882,7 @@ async fn upstream_429_backoff_escalates_persists_across_restart_and_resets() {
             .upstream_reconciliation_global_backoff_state()
             .await
             .expect("read persisted 429 backoff"),
-        (5, 4, retry_after_until)
+        (7, 4, retry_after_until)
     );
     assert_eq!(
         restarted
@@ -2446,7 +2736,7 @@ async fn s3_next_day_settlement_does_not_restore_current_hour_quota() {
     assert!(
         proxy
             .key_store
-            .settle_upstream_reconciliation(&candidate, 7, 10, None, None)
+            .settle_upstream_reconciliation(&candidate, 7, 10, None)
             .await
             .expect("s3 settlement")
     );

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -4,6 +4,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
+use tokio::sync::Notify;
 
 fn local_ts(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> i64 {
     match Local.with_ymd_and_hms(year, month, day, hour, minute, 0) {
@@ -271,14 +272,14 @@ async fn signed_reconciliation_adjustment_is_idempotent_and_restores_quota() {
     assert!(
         proxy
             .key_store
-            .settle_upstream_reconciliation(&candidate, 7, 10)
+            .settle_upstream_reconciliation(&candidate, 7, 10, None, None)
             .await
             .expect("first settlement")
     );
     assert!(
         !proxy
             .key_store
-            .settle_upstream_reconciliation(&candidate, 7, 10)
+            .settle_upstream_reconciliation(&candidate, 7, 10, None, None)
             .await
             .expect("duplicate settlement")
     );
@@ -508,7 +509,7 @@ async fn shadow_reconciliation_keeps_zero_delta_usage_and_updates_runtime_marker
     assert!(
         proxy
             .key_store
-            .settle_upstream_reconciliation_shadow(&candidate, 7, 7)
+            .settle_upstream_reconciliation_shadow(&candidate, 7, 7, None, None)
             .await
             .expect("shadow zero-delta settlement")
     );
@@ -849,6 +850,309 @@ async fn reconciliation_no_adjustment_completes_only_the_current_usage_generatio
         adjustment_delta, 0,
         "zero deltas must not alter billing truth even when shadow audit state is retained"
     );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_rejects_usage_generation_changed_during_remote_fetch() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-generation-fence"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save reconciliation settings");
+    let token = proxy
+        .create_access_token(Some("reconciliation-generation-fence"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-generation-fence")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-generation-fence', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert due reconciliation usage");
+
+    let fetch_started = Arc::new(Notify::new());
+    let release_first_fetch = Arc::new(Notify::new());
+    let fetch_count = Arc::new(AtomicUsize::new(0));
+    let route_started = Arc::clone(&fetch_started);
+    let route_release = Arc::clone(&release_first_fetch);
+    let route_count = Arc::clone(&fetch_count);
+    let app = Router::new().route(
+        "/usage",
+        get(move || {
+            let route_started = Arc::clone(&route_started);
+            let route_release = Arc::clone(&route_release);
+            let route_count = Arc::clone(&route_count);
+            async move {
+                if route_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    route_started.notify_one();
+                    route_release.notified().await;
+                }
+                Json(serde_json::json!({ "key": { "usage": 0 } }))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve generation-fence upstream");
+    });
+
+    let first_run_proxy = proxy.clone();
+    let first_run = tokio::spawn(async move {
+        first_run_proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(2), fetch_started.notified())
+        .await
+        .expect("first upstream fetch starts");
+    sqlx::query(
+        r#"
+        UPDATE upstream_reconciliation_usage
+        SET request_count = request_count + 1, updated_at = updated_at + 1
+        WHERE token_id = ? AND key_id = ? AND period_code = '2026-07-15/S1'
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("record usage while the remote result is in flight");
+    release_first_fetch.notify_one();
+
+    assert_eq!(
+        first_run
+            .await
+            .expect("join first reconciliation")
+            .expect("finish stale reconciliation"),
+        0,
+        "the stale remote result must not settle a newer work generation"
+    );
+    let stale_generation: (i64, i64, Option<String>) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, last_outcome FROM upstream_reconciliation_work WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read fenced generation");
+    assert_eq!(stale_generation, (2, 0, None));
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_continuation_at()
+            .await
+            .expect("read continuation for newer generation"),
+        Some(now),
+    );
+
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("settle current generation"),
+        1
+    );
+    let current_generation: (i64, i64, String) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, last_outcome FROM upstream_reconciliation_work WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read completed current generation");
+    assert_eq!(current_generation, (2, 2, "no_adjustment".to_string()));
+    assert_eq!(fetch_count.load(Ordering::SeqCst), 2);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_startup_resume_keeps_one_pending_representative_job() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-startup-resume"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let token = proxy
+        .create_access_token(Some("reconciliation-startup-resume"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-startup-resume")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-startup-resume', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed durable pending work without a live request wake");
+
+    proxy
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("resume pending reconciliation work on startup");
+    proxy
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("coalesce repeated startup resume");
+    let representative_jobs: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status IN ('queued', 'running')",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count startup representative jobs");
+    assert_eq!(representative_jobs, 1);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_rejects_reclaimed_scheduled_job_claim() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, clock) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-stale-claim"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let token = proxy
+        .create_access_token(Some("reconciliation-stale-claim"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-stale-claim")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-stale-claim', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed durable reconciliation work");
+    proxy
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("enqueue representative job");
+    let job = proxy
+        .fetch_queued_scheduled_jobs(1)
+        .await
+        .expect("load representative job")
+        .into_iter()
+        .next()
+        .expect("representative job is queued");
+    let claimed = proxy
+        .scheduled_job_mark_running(job.id)
+        .await
+        .expect("claim representative job")
+        .expect("representative job became running");
+    clock.set_now_ts(now + 61);
+    assert_eq!(
+        proxy
+            .recover_stale_scheduled_jobs()
+            .await
+            .expect("recover stale representative job"),
+        1
+    );
+
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once_claimed(
+                "http://127.0.0.1:9",
+                claimed.id,
+                claimed.claim_generation,
+            )
+            .await
+            .expect("reject stale claimed worker"),
+        (0, false)
+    );
+    let work: (i64, i64) = sqlx::query_as(
+        "SELECT work_generation, completed_generation FROM upstream_reconciliation_work WHERE token_id = ?",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read pending work after stale claim rejection");
+    assert_eq!(work, (1, 0));
 
     let _ = std::fs::remove_file(db_path);
 }
@@ -2142,7 +2446,7 @@ async fn s3_next_day_settlement_does_not_restore_current_hour_quota() {
     assert!(
         proxy
             .key_store
-            .settle_upstream_reconciliation(&candidate, 7, 10)
+            .settle_upstream_reconciliation(&candidate, 7, 10, None, None)
             .await
             .expect("s3 settlement")
     );

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -6,14 +6,14 @@ use std::sync::{
 };
 use tokio::sync::Notify;
 
-fn local_ts(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> i64 {
+pub(super) fn local_ts(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> i64 {
     match Local.with_ymd_and_hms(year, month, day, hour, minute, 0) {
         LocalResult::Single(value) | LocalResult::Ambiguous(value, _) => value.timestamp(),
         LocalResult::None => panic!("local time is unavailable"),
     }
 }
 
-fn reconciliation_test_db_path() -> PathBuf {
+pub(super) fn reconciliation_test_db_path() -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
         "tavily-hikari-reconciliation-{}-{}",
         std::process::id(),

--- a/src/tests/upstream_reconciliation_fencing.rs
+++ b/src/tests/upstream_reconciliation_fencing.rs
@@ -379,3 +379,62 @@ async fn claimed_backoff_recovery_leaves_representative_for_scheduler_continuati
 
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn startup_resume_schedules_pending_research_with_default_poll_time() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-restart"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time.clone(),
+    )
+    .await
+    .expect("create first proxy");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES ('default-poll-research', 'default-poll-token', 'default-poll-key',
+                  '2026-07-15/S1', ?, NULL, ?)
+        "#,
+    )
+    .bind(now)
+    .bind(now)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("persist historical pending research with default poll time");
+    drop(proxy);
+
+    let restarted = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-restart"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("restart proxy");
+    restarted
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("resume historical pending research");
+    let representative: (i64, i64) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*), MIN(available_at)
+        FROM scheduled_jobs
+        WHERE job_type = 'upstream_reconciliation'
+          AND status IN ('queued', 'running')
+        "#,
+    )
+    .fetch_one(&restarted.key_store.pool)
+    .await
+    .expect("read resumed representative job");
+    assert_eq!(representative, (1, now));
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/upstream_reconciliation_fencing.rs
+++ b/src/tests/upstream_reconciliation_fencing.rs
@@ -1,0 +1,301 @@
+use super::upstream_reconciliation::{local_ts, reconciliation_test_db_path};
+use super::*;
+
+#[tokio::test]
+async fn reconciliation_rejects_reclaimed_claim_before_research_writes() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, clock) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-stale-research"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    for request_id in ["stale-research-terminal", "stale-research-poll"] {
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_research (
+                request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+            ) VALUES (?, 'stale-research-token', 'stale-research-key', '2026-07-15/S1', ?, NULL, ?)
+            "#,
+        )
+        .bind(request_id)
+        .bind(now)
+        .bind(now)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert pending research");
+    }
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue representative job");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim representative job")
+        .expect("representative job becomes running");
+    clock.set_now_ts(now + 61);
+    assert_eq!(
+        proxy
+            .recover_stale_scheduled_jobs()
+            .await
+            .expect("recover stale representative job"),
+        1
+    );
+
+    assert!(matches!(
+        proxy
+            .key_store
+            .mark_upstream_reconciliation_research_terminal_claimed(
+                "stale-research-terminal",
+                claim.id,
+                claim.claim_generation,
+            )
+            .await,
+        Err(ProxyError::StaleClaim { .. })
+    ));
+    assert!(matches!(
+        proxy
+            .key_store
+            .arm_api_key_transient_backoff_claimed(
+                ApiKeyTransientBackoffArm {
+                    key_id: "stale-research-key",
+                    scope: "period_reconciliation",
+                    cooldown_until: now + 300,
+                    retry_after_secs: 300,
+                    reason_code: Some(RECONCILIATION_RETRY_REASON_UPSTREAM_429),
+                    source_request_log_id: None,
+                    now,
+                },
+                claim.id,
+                claim.claim_generation,
+            )
+            .await,
+        Err(ProxyError::StaleClaim { .. })
+    ));
+    assert!(matches!(
+        proxy
+            .key_store
+            .record_upstream_reconciliation_research_poll_claimed(
+                "stale-research-poll",
+                now + 120,
+                "pending",
+                None,
+                claim.id,
+                claim.claim_generation,
+            )
+            .await,
+        Err(ProxyError::StaleClaim { .. })
+    ));
+    assert!(matches!(
+        proxy
+            .key_store
+            .mark_upstream_reconciliation_research_sweep_at_claimed(
+                now + 61,
+                claim.id,
+                claim.claim_generation,
+            )
+            .await,
+        Err(ProxyError::StaleClaim { .. })
+    ));
+
+    let research_rows: Vec<(String, Option<i64>, i64)> = sqlx::query_as(
+        r#"
+        SELECT request_id, terminal_at, poll_attempt_count
+        FROM upstream_reconciliation_research
+        ORDER BY request_id
+        "#,
+    )
+    .fetch_all(&proxy.key_store.pool)
+    .await
+    .expect("read unchanged research rows");
+    assert_eq!(
+        research_rows,
+        vec![
+            ("stale-research-poll".to_string(), None, 0),
+            ("stale-research-terminal".to_string(), None, 0),
+        ]
+    );
+    assert_eq!(
+        proxy
+            .key_store
+            .get_meta_i64("upstream_reconciliation_last_research_sweep_at_v1")
+            .await
+            .expect("read unchanged research sweep marker"),
+        None
+    );
+    let transient_backoff_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM api_key_transient_backoffs WHERE key_id = 'stale-research-key' AND scope = 'period_reconciliation'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read unchanged key backoff");
+    assert_eq!(transient_backoff_count, 0);
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_ignores_429_text_in_non_429_responses() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-real-status"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save reconciliation settings");
+    let token = proxy
+        .create_access_token(Some("reconciliation-real-status"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-real-status")
+        .await
+        .expect("create upstream key");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S1', 'project-real-status', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert main reconciliation usage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, '2026-07-15/S2', 'project-real-status-research', ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert research reconciliation usage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES ('research-real-status', ?, ?, '2026-07-15/S2', ?, NULL, ?)
+        "#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert pending research");
+
+    let app = Router::new()
+        .route(
+            "/usage",
+            get(|| async {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": "429 Too Many Requests" })),
+                )
+            }),
+        )
+        .route(
+            "/research/research-real-status",
+            get(|| async {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": "429 Too Many Requests" })),
+                )
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve misleading 429 upstream");
+    });
+
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("run reconciliation with non-429 failures"),
+        0
+    );
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_global_backoff_state()
+            .await
+            .expect("read global backoff state"),
+        (0, 0, 0)
+    );
+    let transient_backoff_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM api_key_transient_backoffs WHERE key_id = ? AND scope = 'period_reconciliation'",
+    )
+    .bind(&key_id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read key backoff state");
+    assert_eq!(transient_backoff_count, 0);
+    let main_status: String = sqlx::query_scalar(
+        "SELECT status FROM upstream_reconciliation_settlements WHERE token_id = ? AND period_code = '2026-07-15/S1'",
+    )
+    .bind(&token.id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read semantic failure settlement");
+    assert_eq!(main_status, "waiting");
+    let research_poll: (String, Option<String>) = sqlx::query_as(
+        "SELECT last_poll_outcome, last_poll_error_kind FROM upstream_reconciliation_research WHERE request_id = 'research-real-status'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read semantic failure research poll");
+    assert_eq!(
+        research_poll,
+        ("retry".to_string(), Some("other".to_string()))
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/upstream_reconciliation_fencing.rs
+++ b/src/tests/upstream_reconciliation_fencing.rs
@@ -299,3 +299,83 @@ async fn reconciliation_ignores_429_text_in_non_429_responses() {
 
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn claimed_backoff_recovery_leaves_representative_for_scheduler_continuation() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-continuation-fence"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue reconciliation representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim reconciliation representative")
+        .expect("representative job becomes running");
+
+    proxy
+        .key_store
+        .update_upstream_reconciliation_local_backoff_claimed(
+            false,
+            now,
+            queued.job_id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("clear claimed backoff without finishing job");
+    assert_eq!(
+        proxy
+            .scheduled_job_by_id(queued.job_id)
+            .await
+            .expect("read representative job")
+            .expect("representative job exists")
+            .status,
+        "running"
+    );
+
+    let continuation = proxy
+        .scheduled_job_finish_and_enqueue_auto_at(
+            queued.job_id,
+            claim.claim_generation,
+            "upstream_reconciliation",
+            None,
+            1,
+            Some("settled=0 continuation_at=next"),
+            now + 60,
+        )
+        .await
+        .expect("scheduler finishes claimed representative and queues continuation");
+    assert!(continuation.created);
+    assert_eq!(
+        proxy
+            .scheduled_job_by_id(queued.job_id)
+            .await
+            .expect("read completed representative job")
+            .expect("completed representative job exists")
+            .status,
+        "success"
+    );
+    assert_eq!(
+        proxy
+            .scheduled_job_by_id(continuation.job_id)
+            .await
+            .expect("read continuation job")
+            .expect("continuation job exists")
+            .status,
+        "queued"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
## Summary
- persist typed reconciliation outcomes with generation and claimed-job fencing
- recover pending work and default-poll Research through one delayed representative job
- preserve independent local pressure and real-429 backoff state

## Validation
- cargo test --all --no-fail-fast
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- cargo test --lib upstream_reconciliation -- --nocapture

Refs #518