### PR TITLE
fix(cli): make tvly-hikari work on msys2 and git bash

### DIFF
--- a/scripts/install-tvly-hikari.sh
+++ b/scripts/install-tvly-hikari.sh
@@ -37,7 +37,8 @@ die() {
 tvly_version() {
   local tvly_bin="$1"
   "${tvly_bin}" --version 2>/dev/null \
-    | python3 -c 'import re, sys; data=sys.stdin.read(); match=re.search(r"\d+\.\d+\.\d+", data); print(match.group(0) if match else "")'
+    | python3 -c 'import re, sys; data=sys.stdin.read(); match=re.search(r"\d+\.\d+\.\d+", data); print(match.group(0) if match else "")' \
+    | tr -d '\r'
 }
 
 tvly_is_compatible() {

--- a/scripts/tvly-hikari
+++ b/scripts/tvly-hikari
@@ -74,7 +74,8 @@ validate_hikari_token() {
 tvly_version() {
   local tvly_bin="$1"
   "${tvly_bin}" --version 2>/dev/null \
-    | python3 -c 'import re, sys; data=sys.stdin.read(); match=re.search(r"\d+\.\d+\.\d+", data); print(match.group(0) if match else "")'
+    | python3 -c 'import re, sys; data=sys.stdin.read(); match=re.search(r"\d+\.\d+\.\d+", data); print(match.group(0) if match else "")' \
+    | tr -d '\r'
 }
 
 ensure_tvly_compatible() {
@@ -137,7 +138,11 @@ configure() {
   local target_dir
   target_dir="$(dirname "${target_file}")"
 
-  install -d -m 0700 "${target_dir}"
+  # `install -d -m 0700` fails on msys2/Git Bash, where POSIX modes cannot be
+  # applied to Windows ACLs. Create the directory with a tight umask so the mode
+  # is never wider than 0700, then tighten explicitly where chmod is supported.
+  (umask 077 && mkdir -p "${target_dir}")
+  chmod 0700 "${target_dir}" 2>/dev/null || true
   local tmp_file
   tmp_file="$(mktemp "${target_dir}/config.json.XXXXXX")"
   python3 - "$base_url" "$token" >"${tmp_file}" <<'PY'
@@ -163,7 +168,8 @@ read_config() {
 
   [[ -f "${CONFIG_FILE}" ]] || die "missing config at ${CONFIG_FILE}; run: tvly-hikari configure --base-url <origin> --token <th-...>"
   require_python
-  python3 - "${CONFIG_FILE}" <<'PY'
+  # Windows-native python3 emits CRLF; strip CR so `read -r` never captures it.
+  python3 - "${CONFIG_FILE}" <<'PY' | tr -d '\r'
 import json
 import sys
 

--- a/tests/test_tvly_hikari_cli.py
+++ b/tests/test_tvly_hikari_cli.py
@@ -194,6 +194,103 @@ class TvlyHikariCliTest(unittest.TestCase):
             self.assertEqual(payload["api_key"], VALID_TOKEN)
             self.assertEqual(payload["args"], ["search", "query", "--json"])
 
+    def write_crlf_python3(self, fake_bin: Path):
+        """Shim python3 so stdout ends with CRLF, as Windows-native python3 does."""
+        real_python3 = subprocess.run(
+            ["bash", "-c", "command -v python3"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        shim = fake_bin / "python3"
+        shim.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -o pipefail\n"
+            f"{real_python3} \"$@\" | sed -e 's/$/\\r/'\n",
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+
+    def write_mode_hostile_install(self, fake_bin: Path):
+        """Shim install(1) so `-d` fails, as it does on msys2 where POSIX modes
+        cannot be applied to Windows ACLs."""
+        shim = fake_bin / "install"
+        shim.write_text(
+            "#!/usr/bin/env bash\n"
+            'for arg in "$@"; do\n'
+            '  if [[ "${arg}" == "-d" ]]; then\n'
+            "    echo 'install: cannot change permissions: Permission denied' >&2\n"
+            "    exit 1\n"
+            "  fi\n"
+            "done\n"
+            'exec /usr/bin/install "$@"\n',
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+
+    def test_configure_tolerates_crlf_python_stdout(self):
+        """Windows-native python3 emits CRLF; a stray CR must not corrupt the token."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            capture = root / "capture.json"
+            self.write_fake_tvly(fake_bin, capture)
+            self.write_crlf_python3(fake_bin)
+            env = self.base_env(root / "home", fake_bin)
+
+            self.run_cmd(
+                [
+                    "bash",
+                    str(WRAPPER),
+                    "configure",
+                    "--base-url",
+                    "http://127.0.0.1:58087",
+                    "--token",
+                    VALID_TOKEN,
+                ],
+                env=env,
+            )
+            # Pre-fix this failed with "must be an unmasked Hikari token".
+            result = self.run_cmd(["bash", str(WRAPPER), "config", "show"], env=env)
+            self.assertIn("apiBaseUrl: http://127.0.0.1:58087/api/tavily", result.stdout)
+
+            self.run_cmd(["bash", str(WRAPPER), "search", "query", "--json"], env=env)
+            payload = json.loads(capture.read_text(encoding="utf-8"))
+            self.assertEqual(payload["api_base_url"], "http://127.0.0.1:58087/api/tavily")
+            self.assertEqual(payload["api_key"], VALID_TOKEN)
+
+    def test_configure_survives_unsupported_directory_mode(self):
+        """`install -d -m 0700` fails on msys2; configure must not depend on it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            self.write_mode_hostile_install(fake_bin)
+            env = self.base_env(root / "home", fake_bin)
+            config_dir = root / "config"
+
+            # Pre-fix this aborted with "cannot change permissions".
+            self.run_cmd(
+                [
+                    "bash",
+                    str(WRAPPER),
+                    "configure",
+                    "--base-url",
+                    "http://127.0.0.1:58087",
+                    "--token",
+                    VALID_TOKEN,
+                    "--config-dir",
+                    str(config_dir),
+                ],
+                env=env,
+            )
+
+            data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+            self.assertEqual(data["token"], VALID_TOKEN)
+            # The umask fallback must keep the directory no wider than 0700.
+            self.assertEqual(stat.S_IMODE(config_dir.stat().st_mode), 0o700)
+
     def test_installer_installs_wrapper_config_and_optional_skills(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Problem

On Windows (msys2 / Git Bash), `tvly-hikari` is unusable after a successful install. Two
independent defects combine so that the installer reports success while leaving a
non-working CLI:

**1. `configure` aborts on `install -d -m 0700`, so `config.json` is never written.**

msys2 cannot apply POSIX modes to Windows ACLs, so the call fails even when the directory
already exists:

```
install: cannot change permissions of 'C:/Users/<user>/.config/tavily-hikari-cli': Permission denied
```

Because `configure` runs under `set -e`, it exits before writing the file. The installer's
earlier `install -d -m 0755 "${INSTALL_DIR}"` succeeds (0755 matches the msys2 default, so
no mode change is needed), which is why the wrapper lands on disk but the config does not.
Result: `doctor` reports `missing config`, and re-running `configure` by hand fails the same
way.

**2. A stray CR corrupts the token, producing a badly misleading error.**

`read_config` pipes python3 stdout into `read -r`. Windows-native python3 emits CRLF, so the
token keeps a trailing `\r` and fails `validate_hikari_token`:

```
tvly-hikari: --token must be an unmasked Hikari token shaped like th-xxxx-xxxxxxxxxxxx or ...
```

The token is valid and unmasked. The message sends users looking for a token problem that
does not exist. Verified byte-level:

```
$ python3 - config.json <<'PY' | od -c | tail -2
...
0000040   I   -   R   n   y   e   A   l   o   E   L   7   g   s   A   8
0000060   8   Z   r   X   9   c   9   S   x   n  \r  \n
```

## Fix

- `configure`: create the config directory with `(umask 077 && mkdir -p ...)` so the mode is
  never wider than `0700`, then keep the explicit `chmod 0700` as best-effort. This preserves
  the existing POSIX guarantee while no longer being fatal where `chmod` is unsupported. The
  file-level `chmod 0600` calls are left untouched — those succeed on msys2.
- `read_config`: strip CR from python3 output. Same for both `tvly_version` helpers, where the
  CR otherwise leaks into `doctor`'s `tvlyVersion:` line.

Scoped deliberately to the Windows incompatibility; no behavior change on Linux/macOS.

## Tests

Two regression tests that reproduce both failures **on POSIX**, so they are not
Windows-only checks:

- `test_configure_tolerates_crlf_python_stdout` — shims `python3` to emit CRLF, then asserts
  `config show` and passthrough both see a clean token.
- `test_configure_survives_unsupported_directory_mode` — shims `install(1)` to reject `-d`,
  and asserts `config.json` is still written with the directory at `0700`.

Both fail before this change and pass after.

## Verification

Verified end-to-end against a live Hikari deployment on Windows 10 / msys2. Before: install
succeeded but `doctor` reported `missing config`; after manually writing the config, every
command failed the token check. After: `doctor` is clean and `search` returns results.

```
$ tvly-hikari doctor
baseUrl: https://<redacted>
apiBaseUrl: https://<redacted>/api/tavily
token: th-xxxx...xxxx
config: C:/Users/<user>/.config/tavily-hikari-cli/config.json
tvly: /c/Users/<user>/.local/bin/tvly
tvlyVersion: 0.1.6
```

Also ran the simulated-Windows matrix (CRLF python3 + `install -d` refusing) against the
wrapper directly, confirming pre-fix failure and post-fix success for `configure`,
`config show`, `doctor`, and passthrough.

## Notes for reviewers

- **These tests are not wired into CI.** `.github/workflows/ci.yml` only runs the Rust
  shards via `scripts/ci_backend_tests.py`; `tests/test_tvly_hikari_cli.py` appears only in
  `docs/specs/hikari-cli-agent-skills-release/SPEC.md` as a manual step. Run with
  `python3 tests/test_tvly_hikari_cli.py`. Happy to wire it into CI if you want that here.
- I could not execute the full unittest suite locally: the harness's Windows-native python3
  passes `D:/...` paths to msys2 bash, which cannot resolve them (`No such file or directory`).
  This is a limitation of my environment, unrelated to these changes — hence the direct bash
  verification above. **The suite still needs a run on Linux/macOS to confirm green.**
- One adjacent issue left alone, as it is out of scope and not a Hikari bug: `tvly` itself
  crashes with `UnicodeEncodeError: 'gbk' codec` when printing non-ASCII results on a GBK
  console. `PYTHONUTF8=1` works around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
