### PR TITLE
fix(ci): stabilize deferred maintenance tests

### DIFF
--- a/src/server/tests/system_settings_and_forward_proxy.rs
+++ b/src/server/tests/system_settings_and_forward_proxy.rs
@@ -2372,6 +2372,12 @@ use super::upstream_support_and_manual_jobs::*;
             "invalid rebalance tool args should never hit upstream"
         );
 
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            proxy.wait_for_rebalance_audits_idle_for_test(),
+        )
+            .await
+            .expect("rebalance audits should finish before the test reads them");
         let pool = connect_sqlite_test_pool(&db_str).await;
         let rows = super::observability_audit_support::wait_for_rebalance_audit_count(
             &pool,

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -2741,10 +2741,26 @@ mod alert_grouping_tests {
         insert_upstream_usage_limit_alert(&store, token_id, key_id, 1_700_100_000).await;
         insert_upstream_usage_limit_alert(&store, token_id, key_id, 1_700_100_120).await;
 
-        let page = store
-            .fetch_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
-            .await
-            .expect("fetch grouped alerts page");
+        let page = {
+            const MAX_ATTEMPTS: usize = 48;
+            let mut attempt = 0;
+            loop {
+                match store
+                    .fetch_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
+                    .await
+                {
+                    Ok(page) => break page,
+                    Err(error)
+                        if crate::store::is_transient_sqlite_write_error(&error)
+                            && attempt + 1 < MAX_ATTEMPTS =>
+                    {
+                        attempt += 1;
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                    Err(error) => panic!("fetch grouped alerts page: {error}"),
+                }
+            }
+        };
 
         assert_eq!(page.total, 2);
 

--- a/src/store/key_store_request_stats_coalescer.rs
+++ b/src/store/key_store_request_stats_coalescer.rs
@@ -525,9 +525,11 @@ impl RequestStatsCoalescer {
     pub(crate) async fn nudge_flush(&self) {
         {
             let mut state = self.state.lock().await;
-            Self::mark_flush_deadline_if_pending(&mut state);
+            if Self::pending_key_count(&state) > 0 {
+                state.flush_deadline = Some(Instant::now());
+            }
         }
-        self.wake.notify_waiters();
+        self.wake.notify_one();
     }
 
     pub(crate) async fn wait_until_worker_stopped(&self) {

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -157,6 +157,8 @@ impl ServerPressureBucketCounts {
 struct ObservabilityDeferredWriter {
     pressure_deltas: BTreeMap<ServerPressureBucketKey, ServerPressureBucketCounts>,
     pressure_flush_running: bool,
+    #[cfg(test)]
+    pressure_flush_completed: std::sync::Arc<tokio::sync::Notify>,
     pressure_stale: bool,
     pressure_stale_since: Option<i64>,
     pressure_unrecoverable_overflow: bool,

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -1039,6 +1039,8 @@ impl TavilyProxy {
                 let keys: Vec<_> = writer.pressure_deltas.keys().take(25).cloned().collect();
                 if keys.is_empty() {
                     writer.pressure_flush_running = false;
+                    #[cfg(test)]
+                    writer.pressure_flush_completed.notify_waiters();
                     return;
                 }
                 keys.into_iter()
@@ -1195,6 +1197,17 @@ impl TavilyProxy {
             .pressure_stale_since
             .get_or_insert_with(|| self.backend_time.now_ts());
         writer.pressure_rebuild_requested = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn server_pressure_flush_completed_notifier_for_test(
+        &self,
+    ) -> std::sync::Arc<tokio::sync::Notify> {
+        self.observability_deferred_writer
+            .lock()
+            .await
+            .pressure_flush_completed
+            .clone()
     }
 
     #[cfg(test)]

--- a/src/tavily_proxy/proxy_usage_and_metrics.rs
+++ b/src/tavily_proxy/proxy_usage_and_metrics.rs
@@ -141,6 +141,21 @@ impl TavilyProxy {
         }
     }
 
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn wait_for_rebalance_audits_idle_for_test(&self) {
+        loop {
+            let idle = {
+                let writer = self.observability_deferred_writer.lock().await;
+                writer.rebalance_audits.is_empty() && !writer.rebalance_audit_flush_running
+            };
+            if idle {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     async fn requeue_rebalance_audits(&self, mut entries: Vec<RebalanceAuditEntry>) {
         let mut writer = self.observability_deferred_writer.lock().await;
         while let Some(entry) = entries.pop() {

--- a/src/tests/alert_projection.rs
+++ b/src/tests/alert_projection.rs
@@ -47,7 +47,7 @@ async fn insert_projected_rate_limit_alert(proxy: &TavilyProxy, token_id: &str, 
 
 async fn advance_alert_projection_until(proxy: &TavilyProxy, projected_events: i64) {
     let mut outcomes = Vec::new();
-    for _ in 0..12 {
+    for _ in 0..48 {
         let dashboard_dirty = proxy
             .advance_dashboard_alert_projection_slice()
             .await
@@ -90,7 +90,7 @@ async fn advance_alert_projection_until(proxy: &TavilyProxy, projected_events: i
 async fn advance_alert_projection_slice_until_admitted(
     proxy: &TavilyProxy,
 ) -> AlertProjectionSliceOutcome {
-    for _ in 0..12 {
+    for _ in 0..48 {
         let outcome = proxy
             .key_store
             .advance_alert_projection_slice()
@@ -104,9 +104,25 @@ async fn advance_alert_projection_slice_until_admitted(
     panic!("alert projection remained admission-deferred");
 }
 
+async fn refresh_alert_projection_observation_until_admitted(proxy: &TavilyProxy) {
+    for _ in 0..48 {
+        if proxy
+            .refresh_dashboard_alert_projection_observation()
+            .await
+            .expect("refresh idle projection observation")
+        {
+            return;
+        }
+        // The maintenance admission policy can defer immediately after the
+        // foreground state reads in this test.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("idle projection observation remained admission-deferred");
+}
+
 async fn advance_alert_projection_until_full_coverage(proxy: &TavilyProxy) {
     let mut outcomes = Vec::new();
-    for _ in 0..24 {
+    for _ in 0..48 {
         let outcome = advance_alert_projection_slice_until_admitted(proxy).await;
         outcomes.push(format!("{outcome:?}"));
         let status = proxy
@@ -129,7 +145,7 @@ async fn advance_alert_projection_until_full_coverage(proxy: &TavilyProxy) {
 
 async fn refresh_projected_recent_alerts_until_fresh(proxy: &TavilyProxy) -> RecentAlertsSummary {
     let mut last_summary = None;
-    for _ in 0..12 {
+    for _ in 0..48 {
         proxy
             .key_store
             .refresh_dashboard_alert_projection_summary()
@@ -226,13 +242,8 @@ async fn alert_projection_materializes_empty_dashboard_summary_without_read_side
     .expect("create proxy");
 
     advance_alert_projection_until_full_coverage(&proxy).await;
-    assert!(
-        proxy
-            .key_store
-            .refresh_dashboard_alert_projection_summary()
-            .await
-            .expect("materialize empty dashboard summary")
-    );
+    let materialized = refresh_projected_recent_alerts_until_fresh(&proxy).await;
+    assert_eq!(materialized.total_events, 0);
     let cached_rows: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM observability.dashboard_alert_projection_recent_summaries WHERE window_hours = 24",
     )
@@ -346,11 +357,8 @@ async fn alert_projection_materializes_dashboard_summary_before_dashboard_reads(
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     }
-    proxy
-        .key_store
-        .refresh_dashboard_alert_projection_summary()
-        .await
-        .expect("refresh materialized summary");
+    let materialized = refresh_projected_recent_alerts_until_fresh(&proxy).await;
+    assert_eq!(materialized.total_events, 1);
     let cached_rows: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM observability.dashboard_alert_projection_recent_summaries WHERE window_hours = 24",
     )
@@ -1060,12 +1068,7 @@ async fn alert_projection_idle_probe_does_not_persist_empty_cursors() {
         .await
         .expect("read expired tail coverage");
     assert_eq!(stale.recent_coverage, "stale");
-    assert!(
-        proxy
-            .refresh_dashboard_alert_projection_observation()
-            .await
-            .expect("refresh idle projection observation")
-    );
+    refresh_alert_projection_observation_until_admitted(&proxy).await;
     let recovered = proxy
         .dashboard_alert_projection_status()
         .await

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -796,8 +796,9 @@ async fn admin_summary_does_not_start_a_slow_background_flush() {
         "summary reads must not start the background flush"
     );
 
+    let flush_arrived = pause.arrived.clone().notified_owned();
     proxy.nudge_request_stats_flush().await;
-    tokio::time::timeout(Duration::from_secs(1), pause.arrived.notified())
+    tokio::time::timeout(Duration::from_secs(1), flush_arrived)
         .await
         .expect("explicit background flush reached post-flush pause");
 

--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -328,6 +328,10 @@ async fn analysis_pressure_snapshot_live_local_mcp_logs_update_server_buckets() 
     let now = manual_clock.now_ts();
     manual_clock.set_now_ts(now);
     let headers: [String; 0] = [];
+    let pressure_flush_complete = proxy
+        .server_pressure_flush_completed_notifier_for_test()
+        .await
+        .notified_owned();
 
     let request_log_id = proxy
         .record_local_request_log_without_key_with_diagnostics(
@@ -354,6 +358,10 @@ async fn analysis_pressure_snapshot_live_local_mcp_logs_update_server_buckets() 
         .await
         .expect("record local mcp request log");
 
+    tokio::time::timeout(Duration::from_secs(3), pressure_flush_complete)
+        .await
+        .expect("deferred pressure writer should drain the live local mcp log");
+
     let canonical_rows: i64 = sqlx::query_scalar(
         r#"
         SELECT COUNT(*)
@@ -373,8 +381,6 @@ async fn analysis_pressure_snapshot_live_local_mcp_logs_update_server_buckets() 
     .await
     .expect("count canonical pressure request logs");
     assert_eq!(canonical_rows, 1);
-
-    wait_for_server_pressure_totals(&proxy, 1, 0).await;
 
     let five_minute_pressure: i64 = sqlx::query_scalar(
         r#"


### PR DESCRIPTION
## Summary
- make explicit request-stat flush nudges immediately eligible and preserve a worker wake
- synchronize deferred server-pressure assertions with the writer completion boundary
- retry valid alert-projection maintenance admission deferrals within bounded test helpers

## Root Cause
The merged HA diagnostics change did not alter these paths. Alert-projection and pressure tests treated deferred maintenance work as completed state, while request-stat nudges left an existing delayed deadline unchanged and could lose a pre-registration wake.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/ci_backend_tests.py verify`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-misc`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-account-user`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-request-rollup`

## Delivery
- Delivery role: direct
- Spec: -
- Spec disposition: not_needed
- Solutions: -
- Project docs: -
- Documentation sync: not needed