### PR TITLE
fix: harden reconciliation admin observability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,10 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   operation or when its bounded transaction sees transient writer contention. The affected durable
   work returns uncommitted deltas or records a retry time; unrelated eligible work remains free to
   progress.
+- `admin privacy read session`: a dedicated immutable SQLite snapshot for privacy status. Its
+  acquire and begin budgets are 100ms, the HTTP build is bounded to 250ms, and it never uses
+  maintenance-bulk admission. A 60-second last-good result is explicit stale coverage; a cold miss
+  returns retryable service-unavailable.
 
 ## Reconciliation Terms
 
@@ -65,6 +69,10 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
 - `best-effort audit`: rebalance audit records are capped in memory and may report stale coverage
   when contention or capacity prevents persistence. A missing audit record never changes MCP
   response semantics, billing truth, or durable business work.
+- `staged pressure generation`: a source-fenced server-pressure rebuild generation that remains
+  invisible until atomic publish. Source scans use 500-row keyset slices, transition events replay
+  after publish, and obsolete generations are cleaned in 25-row slices so live-tail correctness
+  does not require a whole-table replacement.
 
 ## Dashboard Read Terms
 

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -207,9 +207,10 @@ continuation boundary. If that reserve is exhausted, return only a typed deferre
 reason and retry time.
 
 The scheduler must persist one deferred outcome through a single claim-fenced control transaction:
-finish the claimed job, record local-pressure observation and retry time, and retain or create one
-delayed auto representative. If the transaction cannot acquire the writer, leave the claim running
-for stale recovery. Do not turn that condition into a terminal job error, and do not add an
+finish the claimed job, advance independent local-backoff metadata, record local-pressure observation
+and retry time, and retain or create one delayed auto representative. Non-stale claimed failures are
+also typed defers, so no scheduler branch turns the finalization path into a terminal job error. If
+the transaction cannot acquire the writer, leave the claim running for stale recovery. Do not add an
 in-memory retry loop that can fan out jobs after restart.
 
 Research health is separate from settlement retries. For a current-period starvation investigation,

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -208,10 +208,11 @@ reason and retry time.
 
 The scheduler must persist one deferred outcome through a single claim-fenced control transaction:
 finish the claimed job, advance independent local-backoff metadata, record local-pressure observation
-and retry time, and retain or create one delayed auto representative. Non-stale claimed failures are
-also typed defers, so no scheduler branch turns the finalization path into a terminal job error. If
-the transaction cannot acquire the writer, leave the claim running for stale recovery. Do not add an
-in-memory retry loop that can fan out jobs after restart.
+and retry time, and retain or create one delayed auto representative. Only explicit finalization-reserve
+exhaustion is a typed defer; other non-stale failures remain terminal job errors so the scheduler does
+not hide invariants or non-transient storage faults. If the transaction cannot acquire the writer, leave
+the claim running for stale recovery. Do not add an in-memory retry loop that can fan out jobs after
+restart.
 
 Research health is separate from settlement retries. For a current-period starvation investigation,
 observe a fixed ten-minute window: terminal rate must become positive and pending Research must not

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -208,11 +208,11 @@ reason and retry time.
 
 The scheduler must persist one deferred outcome through a single claim-fenced control transaction:
 finish the claimed job, advance independent local-backoff metadata, record local-pressure observation
-and retry time, and retain or create one delayed auto representative. Only explicit finalization-reserve
-exhaustion is a typed defer; other non-stale failures remain terminal job errors so the scheduler does
-not hide invariants or non-transient storage faults. If the transaction cannot acquire the writer, leave
-the claim running for stale recovery. Do not add an in-memory retry loop that can fan out jobs after
-restart.
+and retry time, and retain or create one delayed auto representative. Finalization-reserve exhaustion,
+admission defers, and transient SQLite pressure before a durable boundary are typed defers; other
+non-stale, non-transient failures remain terminal job errors so the scheduler does not hide invariants
+or storage faults. If the transaction cannot acquire the writer, leave the claim running for stale
+recovery. Do not add an in-memory retry loop that can fan out jobs after restart.
 
 Research health is separate from settlement retries. For a current-period starvation investigation,
 observe a fixed ten-minute window: terminal rate must become positive and pending Research must not

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -198,3 +198,21 @@ normal per-key 429 logs at DEBUG and reserve state-transition logs for enter, es
 Main settlement must start before terminal-research polling. Hydrate the bounded candidate page and
 key/cooldown state in one indexed batch, reserve the first eligible key within the two-second local
 preparation budget, then use the remaining 20-second job budget for the research sweep.
+
+## Claim-fenced deferred finalization
+
+Treat finalization as durable work with its own reserve, not as an afterthought after remote I/O.
+Before starting the next remote request, reserve two seconds for the terminal observation and
+continuation boundary. If that reserve is exhausted, return only a typed deferred outcome with a
+reason and retry time.
+
+The scheduler must persist one deferred outcome through a single claim-fenced control transaction:
+finish the claimed job, record local-pressure observation and retry time, and retain or create one
+delayed auto representative. If the transaction cannot acquire the writer, leave the claim running
+for stale recovery. Do not turn that condition into a terminal job error, and do not add an
+in-memory retry loop that can fan out jobs after restart.
+
+Research health is separate from settlement retries. For a current-period starvation investigation,
+observe a fixed ten-minute window: terminal rate must become positive and pending Research must not
+grow. An `upstream429` bucket measures settlement retry pressure only; it is neither backlog size
+nor proof of terminal progress.

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -6,7 +6,10 @@ Candidate windows are maintained in an indexed durable work projection. The engi
 starts primary settlement before research polling, permits at most two serial remote attempts per run, and gives
 research at most two seconds of the remaining time. Research exhaustion is diagnostic follow-up, not primary
 local pressure. Local-pressure backoff (`30/60/120/300s`) is separate from upstream-429 backoff
-(`2/5/10/30m`); non-429 failures do not reset the remote circuit.
+(`2/5/10/30m`); non-429 failures do not reset the remote circuit. A current claim that reaches a
+low-foreground recovery window clears only its local-pressure state before trying the engine again;
+if SQLite is still pressured, that attempt durably defers again. This preserves foreground yielding
+without letting a stale local backoff consume the whole recovery tail.
 
 Terminal completion is typed. Active non-zero delta uses `settled`, any zero delta uses
 `no_adjustment`, and compare-mode non-zero delta uses `observed` without writing billing truth.

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -73,6 +73,11 @@ reads:
   successful snapshot for 60 seconds; warm pressure returns it as stale with the observation time,
   while cold pressure fails fast with `503 Retry-After: 1`. The bounded read deadline is 250ms,
   including operation admission and result construction.
+- Give privacy status its own read session rather than classifying it as maintenance bulk. Acquire
+  and begin its one immutable SQLite snapshot within 100ms, build every field on that same
+  connection, and release it before returning. Do not let one status field borrow a raw pool
+  connection after another field has already read the snapshot: that mixes generations and defeats
+  the cold-path bound.
 - Replace repeated window scans with a single bounded scan that derives all needed windows, then add
   a short manager-scoped TTL cache when settings and live stats can request the same window set in
   one admin refresh cycle.

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -476,6 +476,11 @@ month-tail public metrics scan.
   most 500 rows or 150ms per slice, then replace only the confirmed-different bucket rows in a short
   write transaction. A dense slice may carry its in-memory aggregate into the next work item, but it
   must not publish a partial replacement.
+- For a live derived series such as server pressure, stage the rebuild in a new generation behind a
+  fixed source fence. Publish the generation once, replay the transition-buffered tail, and delete
+  old-generation rows only in 25-row cleanup slices. Normal deltas always target the active
+  generation. This prevents a whole-table delete/reinsert rebuild from turning observability repair
+  into sustained write amplification or exposing an empty live series.
 - Treat `busy`/`locked`, a queue backlog, and a write above the 250ms slow threshold as deferral
   signals for observability repair. Record the gap, release the writer, and retry through the single
   persisted maintenance queue; do not increase the pool or compete with the request path.

--- a/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
+++ b/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
@@ -82,6 +82,14 @@
   a rebuild, while overflow, lost coverage, or five minutes of continuous stale state may start at
   most one generation every five minutes. Rebuild slices remain bounded and replayable from the
   request-log source.
+- Privacy status now acquires a dedicated read snapshot within 100ms and constructs its full
+  immutable response on that one connection under the handler's 250ms bound. It bypasses
+  maintenance-bulk admission and returns the existing 60-second last-good result as additive stale
+  coverage, or cold `503 Retry-After: 1` on pressure.
+- Server-pressure recovery allocates a staged generation, aggregates fixed-fence 500-row keyset
+  slices, publishes once, and removes obsolete buckets in 25-row cleanup slices. Direct deltas and
+  buffered tail replay always write the active generation, so source rebuilds do not amplify normal
+  business writes or expose a partial live series.
 - Schema migration emits fixed `component/event/outcome/elapsed_ms` fields for baseline adoption and warm verification. GC and reconciliation keep normal work at DEBUG, aggregate INFO to one-minute windows, and reserve WARN/INFO for state transitions.
 
 ## 已完成验证

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -79,6 +79,9 @@
   fence, writes only an inactive staged generation, then atomically publishes that generation before
   replaying its buffered tail. Old generations are cleaned in 25-row slices; no rebuild may delete
   the whole live bucket set or replace it with a partial result.
+- A writable tenure alone never starts that rebuild. It is admitted only for an overflow, confirmed
+  coverage loss, or five minutes of continuous stale pressure, and each serving generation spaces
+  qualifying rebuilds by at least five minutes.
 
 - 继续使用默认 `RUNTIME_LOG_FORMAT=json` + `stderr` 输出，保留 `text` fallback。
 - 新增的性能事件必须使用现有 `tracing` 结构化字段，按事件适用性包含：

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -70,6 +70,15 @@
 - 对账主结算必须先于 Research sweep；本地预算压力与 upstream 429 必须分开记录，且最终
   远端观察、结算和状态落盘都必须受同一轮预算约束。HA GC 正常进展继续按通道 60 秒聚合，
   不能恢复逐片 WARN。
+- Privacy status owns a dedicated `AdminPrivacyRead` session: acquire and `BEGIN` are bounded to
+  100ms, response construction is bounded to 250ms, and every status query runs through one
+  immutable SQLite snapshot connection. It neither enters maintenance-bulk admission nor borrows
+  raw pool connections; a warm 60-second last-good result may become additive stale coverage,
+  while a cold result returns `503 Retry-After: 1`.
+- A server-pressure rebuild scans at most 500 source rows per keyset slice below its fixed source
+  fence, writes only an inactive staged generation, then atomically publishes that generation before
+  replaying its buffered tail. Old generations are cleaned in 25-row slices; no rebuild may delete
+  the whole live bucket set or replace it with a partial result.
 
 - 继续使用默认 `RUNTIME_LOG_FORMAT=json` + `stderr` 输出，保留 `text` fallback。
 - 新增的性能事件必须使用现有 `tracing` 结构化字段，按事件适用性包含：

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -51,7 +51,10 @@
   than being silently downgraded. A deferred finalization uses one
   `ScheduledJobControl` transaction for the claim fence, local-backoff state, local-pressure
   observation, retry time, and single auto representative; failure to acquire that transaction
-  intentionally retains the running claim for stale recovery.
+  intentionally retains the running claim for stale recovery. Once the foreground gate reports low
+  pressure, its still-current claim clears the local-pressure backoff before entering the engine;
+  a fresh SQLite admission failure immediately records a new typed defer instead of suppressing
+  the recovery tail with an empty completion.
 - Research starvation is evaluated independently of settlement retry buckets. The operational
   acceptance window is ten minutes: terminal rate must become positive while pending Research does
   not grow. `upstream429` remains a rate-limited settlement bucket and is not evidence of Research

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -46,10 +46,11 @@
   non-zero deltas alone complete as `settled`. Transport, semantic, upstream-429, and local-pressure
   retry state remain independent. The status projection exposes phase timing and outcome counts.
 - Claimed reconciliation reserves two seconds for finalization and exposes only completed,
-  stale-claim, or typed deferred outcomes to the scheduler. A deferred finalization uses one
-  `ScheduledJobControl` transaction for the claim fence, local-pressure observation, retry time,
-  and single auto representative; failure to acquire that transaction intentionally retains the
-  running claim for stale recovery.
+  stale-claim, or typed deferred outcomes to the scheduler. Any non-stale claimed failure is a
+  typed deferred outcome, preserving the running claim until its durable transition. A deferred
+  finalization uses one `ScheduledJobControl` transaction for the claim fence, local-backoff state,
+  local-pressure observation, retry time, and single auto representative; failure to acquire that
+  transaction intentionally retains the running claim for stale recovery.
 - Research starvation is evaluated independently of settlement retry buckets. The operational
   acceptance window is ten minutes: terminal rate must become positive while pending Research does
   not grow. `upstream429` remains a rate-limited settlement bucket and is not evidence of Research

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -45,9 +45,10 @@
   compare-mode non-zero deltas complete as `observed` without writing billing truth, while active
   non-zero deltas alone complete as `settled`. Transport, semantic, upstream-429, and local-pressure
   retry state remain independent. The status projection exposes phase timing and outcome counts.
-- Claimed reconciliation reserves two seconds for finalization. A reserve exhaustion exposes a
-  typed deferred outcome; stale claims are ignored; all other failures remain terminal scheduler
-  errors rather than being silently downgraded. A deferred finalization uses one
+- Claimed reconciliation reserves two seconds for finalization. A reserve exhaustion, admission
+  defer, or transient SQLite pressure before a durable boundary exposes a typed deferred outcome;
+  stale claims are ignored; other non-transient failures remain terminal scheduler errors rather
+  than being silently downgraded. A deferred finalization uses one
   `ScheduledJobControl` transaction for the claim fence, local-backoff state, local-pressure
   observation, retry time, and single auto representative; failure to acquire that transaction
   intentionally retains the running claim for stale recovery.

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -45,6 +45,15 @@
   compare-mode non-zero deltas complete as `observed` without writing billing truth, while active
   non-zero deltas alone complete as `settled`. Transport, semantic, upstream-429, and local-pressure
   retry state remain independent. The status projection exposes phase timing and outcome counts.
+- Claimed reconciliation reserves two seconds for finalization and exposes only completed,
+  stale-claim, or typed deferred outcomes to the scheduler. A deferred finalization uses one
+  `ScheduledJobControl` transaction for the claim fence, local-pressure observation, retry time,
+  and single auto representative; failure to acquire that transaction intentionally retains the
+  running claim for stale recovery.
+- Research starvation is evaluated independently of settlement retry buckets. The operational
+  acceptance window is ten minutes: terminal rate must become positive while pending Research does
+  not grow. `upstream429` remains a rate-limited settlement bucket and is not evidence of Research
+  convergence or non-convergence.
 
 ## Remaining Gaps
 

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -45,12 +45,12 @@
   compare-mode non-zero deltas complete as `observed` without writing billing truth, while active
   non-zero deltas alone complete as `settled`. Transport, semantic, upstream-429, and local-pressure
   retry state remain independent. The status projection exposes phase timing and outcome counts.
-- Claimed reconciliation reserves two seconds for finalization and exposes only completed,
-  stale-claim, or typed deferred outcomes to the scheduler. Any non-stale claimed failure is a
-  typed deferred outcome, preserving the running claim until its durable transition. A deferred
-  finalization uses one `ScheduledJobControl` transaction for the claim fence, local-backoff state,
-  local-pressure observation, retry time, and single auto representative; failure to acquire that
-  transaction intentionally retains the running claim for stale recovery.
+- Claimed reconciliation reserves two seconds for finalization. A reserve exhaustion exposes a
+  typed deferred outcome; stale claims are ignored; all other failures remain terminal scheduler
+  errors rather than being silently downgraded. A deferred finalization uses one
+  `ScheduledJobControl` transaction for the claim fence, local-backoff state, local-pressure
+  observation, retry time, and single auto representative; failure to acquire that transaction
+  intentionally retains the running claim for stale recovery.
 - Research starvation is evaluated independently of settlement retry buckets. The operational
   acceptance window is ten minutes: terminal rate must become positive while pending Research does
   not grow. `upstream429` remains a rate-limited settlement bucket and is not evidence of Research

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -216,6 +216,10 @@
   evaluated, Then use a fixed ten-minute observation window: terminal rate must become positive and
   pending work must not grow. Treat the `upstream429` retry bucket as a separate metric, never as
   Research backlog or terminal progress.
+- The additive `reconciliationResearchProgressWindow` diagnostic reports the most recently completed
+  ten-minute window, including terminal and pending deltas. An incomplete window is explicitly not
+  healthy; a completed window is healthy only when `terminalRatePositive` and `pendingNonGrowing`
+  are both true.
 - Given 管理员进入隐藏 session 管理页，When 使用状态/时间筛选并执行单条、批量或按筛选释放，Then 只有命中的活跃 `upstream_mcp` session 会被释放，已过期或已释放记录不会重复处理。
 
 ## 验收清单（Acceptance checklist）

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -75,8 +75,8 @@
 - 远端请求启动、观察结果、结算写入和 Research 状态落盘均受同一轮截止时间约束；最后的持久化收尾预算不得被新一轮远端请求抢占。
 - 在发起远端请求前必须保留两秒给持久化收尾。收尾预算、post-processing 或 retry bookkeeping
   不足时，claimed run 只能返回 `Deferred { reason, retry_at }`，不得写 terminal job error。
-  Claim-fenced control transaction 必须把 deferred outcome、local-pressure observation、retry time
-  与唯一 delayed auto representative 一起提交；该 transaction 不能开始时，保留 running claim 供
+  Claim-fenced control transaction 必须把 deferred outcome、独立 local-backoff 元数据、local-pressure
+  observation、retry time 与唯一 delayed auto representative 一起提交；该 transaction 不能开始时，保留 running claim 供
   stale recovery，而不是伪造完成或本地重试循环。
 - 本地预算耗尽只推进独立 local backoff，不增加 upstream 429 压力；local backoff 的持久化元数据随 HA meta 增量和 baseline 同步，接管后继续执行原退避而不是立即重试。
 - Historical usage projection has a versioned durable lifecycle. An upgraded database with legacy
@@ -209,7 +209,7 @@
 - Given 近期窗口与旧 backlog 同时堆积，When reconciliation worker 选择候选窗口，Then 今日+昨日窗口优先进入 recent lane，且不会被老 backlog 长期饿死。
 - Given 同一上游 Key 的多个窗口同时到期且首次 `/usage` 查询收到 429 或本地 usage 限流，When reconciliation worker 执行，Then 该 Key 的到期窗口整体进入同一退避时间，本轮不再反复打同一个 Key，其他 Key 的候选仍可继续结算。
 - Given a claimed run reaches its finalization reserve or post-processing deadline, When the scheduler
-  persists the outcome, Then the job finish, local-pressure observation, retry deadline, and one
+  persists the outcome, Then the job finish, local-backoff state, local-pressure observation, retry deadline, and one
   delayed representative commit in one claim-fenced control transaction; a control-acquire failure
   leaves the running claim for stale recovery and does not create a terminal error.
 - Given current-period Research has pending work but no terminal progress, When its health is

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -212,6 +212,10 @@
   persists the outcome, Then the job finish, local-backoff state, local-pressure observation, retry deadline, and one
   delayed representative commit in one claim-fenced control transaction; a control-acquire failure
   leaves the running claim for stale recovery and does not create a terminal error.
+- Given a local-pressure representative becomes eligible after foreground activity has drained, When its
+  claim remains current, Then the scheduler clears the local-pressure backoff before entering the engine;
+  a fresh SQLite admission failure still returns a typed defer, while eligible shadow work can reach a
+  terminal observation during the recovery tail.
 - Given current-period Research has pending work but no terminal progress, When its health is
   evaluated, Then use a fixed ten-minute observation window: terminal rate must become positive and
   pending work must not grow. Treat the `upstream429` retry bucket as a separate metric, never as

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -73,6 +73,11 @@
 - 连续三轮存在候选、未产生远端尝试且本地预算耗尽时，持久化独立的本地短退避；它不得增加 upstream 429 全局退避。只有真实远端 429 才按 `2/5/10/30` 分钟升级，并以更晚的 `Retry-After` 为准；退避期间只保留一个 delayed representative job，真实远端尝试或成功结算后立即复位。
 - 主结算候选页、key/cooldown hydrate 与 reservation 的本地准备预算最多 2 秒，主结算优先启动；terminal-research sweep 仅在主结算之后使用同一轮剩余预算，且最多占用 2 秒。Research 超时不代表主结算本地预算耗尽，单轮总预算保持 20 秒。
 - 远端请求启动、观察结果、结算写入和 Research 状态落盘均受同一轮截止时间约束；最后的持久化收尾预算不得被新一轮远端请求抢占。
+- 在发起远端请求前必须保留两秒给持久化收尾。收尾预算、post-processing 或 retry bookkeeping
+  不足时，claimed run 只能返回 `Deferred { reason, retry_at }`，不得写 terminal job error。
+  Claim-fenced control transaction 必须把 deferred outcome、local-pressure observation、retry time
+  与唯一 delayed auto representative 一起提交；该 transaction 不能开始时，保留 running claim 供
+  stale recovery，而不是伪造完成或本地重试循环。
 - 本地预算耗尽只推进独立 local backoff，不增加 upstream 429 压力；local backoff 的持久化元数据随 HA meta 增量和 baseline 同步，接管后继续执行原退避而不是立即重试。
 - Historical usage projection has a versioned durable lifecycle. An upgraded database with legacy
   usage advances stable `(token_id, key_id, period_code)` keyset micro-slices only when no durable
@@ -203,6 +208,14 @@
 - Given reconciliation backlog 中存在 `rate_limited` 窗口，When 管理员查看系统状态页，Then 能区分上游 429、本地 usage 限流与其他重试，并能看到当前时段每个上游 Key 的绑定用户数与待查询 Project ID 数分布。
 - Given 近期窗口与旧 backlog 同时堆积，When reconciliation worker 选择候选窗口，Then 今日+昨日窗口优先进入 recent lane，且不会被老 backlog 长期饿死。
 - Given 同一上游 Key 的多个窗口同时到期且首次 `/usage` 查询收到 429 或本地 usage 限流，When reconciliation worker 执行，Then 该 Key 的到期窗口整体进入同一退避时间，本轮不再反复打同一个 Key，其他 Key 的候选仍可继续结算。
+- Given a claimed run reaches its finalization reserve or post-processing deadline, When the scheduler
+  persists the outcome, Then the job finish, local-pressure observation, retry deadline, and one
+  delayed representative commit in one claim-fenced control transaction; a control-acquire failure
+  leaves the running claim for stale recovery and does not create a terminal error.
+- Given current-period Research has pending work but no terminal progress, When its health is
+  evaluated, Then use a fixed ten-minute observation window: terminal rate must become positive and
+  pending work must not grow. Treat the `upstream429` retry bucket as a separate metric, never as
+  Research backlog or terminal progress.
 - Given 管理员进入隐藏 session 管理页，When 使用状态/时间筛选并执行单条、批量或按筛选释放，Then 只有命中的活跃 `upstream_mcp` session 会被释放，已过期或已释放记录不会重复处理。
 
 ## 验收清单（Acceptance checklist）

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -514,6 +514,7 @@
     "server::tests::alerts_and_ha::dual_active_",
     "server::tests::alerts_and_ha_source_and_recovery::ha_",
     "server::tests::alerts_and_ha_source_and_recovery::request_logs_gc_",
+    "server::tests::alerts_and_ha_source_and_recovery::reconciliation_",
     "server::tests::alerts_and_ha_sync_recovery::ha_",
         "server::tests::alerts_and_ha_sync_recovery::dual_active_",
         "server::tests::alerts_and_ha_node_state::redundant_",

--- a/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
+++ b/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
@@ -220,16 +220,6 @@ async fn get_upstream_privacy_status(
         return Err(StatusCode::FORBIDDEN.into_response());
     }
 
-    let _admission = match state.proxy.admit_admin_privacy_status() {
-        tavily_hikari::SqliteAdmissionOutcome::Admitted(admission) => admission,
-        tavily_hikari::SqliteAdmissionOutcome::Deferred { .. } => {
-            return match stale_admin_privacy_status(state.as_ref(), "sqlite_pressure").await {
-                Some(status) => Ok(Json(status).into_response()),
-                None => Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response()),
-            };
-        }
-    };
-
     if let Some((status, _observed_at)) = admin_privacy_status_last_good(state.as_ref()).await {
         return Ok(Json(status).into_response());
     }

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -2631,6 +2631,26 @@ async fn run_manual_claimed_job(
                 )
                 .await;
             }
+            match state
+                .proxy
+                .clear_upstream_reconciliation_local_backoff_claimed(job_id, claim_generation)
+                .await
+            {
+                Ok(()) => {}
+                Err(ProxyError::StaleClaim { .. }) => return false,
+                Err(error) if tavily_hikari::is_transient_sqlite_write_error(&error) => {
+                    tracing::debug!(
+                        component = "reconciliation",
+                        event = "low_pressure_recovery_deferred",
+                        job_id,
+                        claim_generation,
+                        err = %error,
+                        "reconciliation retained its claim while low-pressure recovery could not start"
+                    );
+                    return false;
+                }
+                Err(error) => return finish(state, "error", error.to_string()).await,
+            }
             let run_result = state
                 .proxy
                 .run_upstream_reconciliation_once_claimed_outcome_with_remote_io_permit(

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -2622,11 +2622,12 @@ async fn run_manual_claimed_job(
             drop(_job_execution_gate);
             let foreground_rps = state.proxy.foreground_activity_rps();
             if foreground_rps > tavily_hikari::HA_OUTBOX_GC_LOW_PRESSURE_RPS {
-                return defer_reconciliation_for_foreground(
+                return defer_reconciliation_for_sqlite_admission(
                     &state,
                     job_id,
                     claim_generation,
-                    foreground_rps,
+                    "foreground_pressure",
+                    state.proxy.backend_time().now_ts().saturating_add(30),
                 )
                 .await;
             }
@@ -2745,36 +2746,6 @@ async fn run_manual_claimed_job(
         }
         _ => finish(state, "error", format!("unsupported manual job type: {job_type}")).await,
     }
-}
-
-async fn defer_reconciliation_for_foreground(
-    state: &Arc<AppState>,
-    job_id: i64,
-    claim_generation: i64,
-    foreground_rps: i64,
-) -> bool {
-    let available_at = state.proxy.backend_time().now_ts().saturating_add(30);
-    tracing::debug!(
-        component = "reconciliation",
-        event = "foreground_deferred",
-        job_id,
-        claim_generation,
-        foreground_rps,
-        available_at,
-    );
-    state
-        .proxy
-        .scheduled_job_finish_and_enqueue_auto_at(
-            job_id,
-            claim_generation,
-            "upstream_reconciliation",
-            None,
-            1,
-            Some("outcome=foreground_pressure"),
-            available_at,
-        )
-        .await
-        .is_ok()
 }
 
 async fn defer_reconciliation_for_sqlite_admission(

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -2672,12 +2672,13 @@ async fn run_manual_claimed_job(
                         Err(err) => finish(state, "error", err.to_string()).await,
                     }
                 }
-                Ok(ClaimedReconciliationRunOutcome::Deferred { reason }) => {
+                Ok(ClaimedReconciliationRunOutcome::Deferred { reason, retry_at }) => {
                     defer_reconciliation_for_sqlite_admission(
                         &state,
                         job_id,
                         claim_generation,
                         reason,
+                        retry_at,
                     )
                     .await
                 }
@@ -2781,8 +2782,9 @@ async fn defer_reconciliation_for_sqlite_admission(
     job_id: i64,
     claim_generation: i64,
     defer_reason: &'static str,
+    retry_at: i64,
 ) -> bool {
-    let available_at = state.proxy.backend_time().now_ts().saturating_add(30);
+    let available_at = retry_at.max(state.proxy.backend_time().now_ts());
     tracing::debug!(
         component = "reconciliation",
         event = "local_preparation_deferred",
@@ -2794,13 +2796,10 @@ async fn defer_reconciliation_for_sqlite_admission(
     );
     state
         .proxy
-        .scheduled_job_finish_and_enqueue_auto_at(
+        .finalize_deferred_upstream_reconciliation_claim(
             job_id,
             claim_generation,
-            "upstream_reconciliation",
-            None,
-            1,
-            Some(&format!("outcome=sqlite_admission_deferred defer_reason={defer_reason}")),
+            defer_reason,
             available_at,
         )
         .await

--- a/src/server/tests/admin_analysis_pressure.rs
+++ b/src/server/tests/admin_analysis_pressure.rs
@@ -187,10 +187,9 @@ async fn analysis_pressure_snapshot_requires_admin_auth_and_exposes_expected_sha
     let background_proxy = proxy.clone();
     let admin_addr = spawn_builtin_keys_admin_server(proxy, admin_password).await;
     assert!(
-        background_proxy.spawn_server_pressure_buckets_rebuild_once(),
-        "serving admin harness should schedule background pressure rebuild"
+        !background_proxy.spawn_server_pressure_buckets_rebuild_once(),
+        "a serving tenure without pressure loss must not schedule a rebuild"
     );
-    let verification_pool = connect_sqlite_test_pool(&db_str).await;
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -220,7 +219,7 @@ async fn analysis_pressure_snapshot_requires_admin_auth_and_exposes_expected_sha
         .await
         .expect("analysis pressure request");
     assert_eq!(pressure_resp.status(), reqwest::StatusCode::OK);
-    let mut pressure_json: serde_json::Value = pressure_resp
+    let pressure_json: serde_json::Value = pressure_resp
         .json()
         .await
         .expect("analysis pressure json");
@@ -332,48 +331,5 @@ async fn analysis_pressure_snapshot_requires_admin_auth_and_exposes_expected_sha
             .and_then(|value| value.as_i64()),
         Some(3)
     );
-    let rebuild_deadline = tokio::time::Instant::now() + Duration::from_secs(8);
-    loop {
-        let bucket_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
-        )
-        .fetch_one(&verification_pool)
-        .await
-        .expect("count rebuilt server pressure buckets");
-        if bucket_count >= 2 {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < rebuild_deadline,
-            "expected admin analysis pressure history buckets to recover after background rebuild, bucket_count={bucket_count}"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    loop {
-        let refreshed_resp = client
-            .get(format!("http://{}/api/analysis/pressure", admin_addr))
-            .header(reqwest::header::COOKIE, admin_cookie.clone())
-            .send()
-            .await
-            .expect("analysis pressure refresh request");
-        assert_eq!(refreshed_resp.status(), reqwest::StatusCode::OK);
-        pressure_json = refreshed_resp
-            .json()
-            .await
-            .expect("analysis pressure refresh json");
-        if pressure_json
-            .pointer("/server24h/currentPeak/pressure")
-            .and_then(|value| value.as_i64())
-            == Some(3)
-        {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < rebuild_deadline,
-            "expected analysis pressure cache to refresh after background rebuild"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -839,6 +839,17 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
             panic!("test must hold the cold shared bulk permit, got {reason}")
         }
     };
+    let cold_lock_pool = connect_sqlite_test_pool(&cold_db_str).await;
+    let mut cold_writer = cold_lock_pool.acquire().await.expect("acquire cold writer");
+    sqlx::query("BEGIN EXCLUSIVE")
+        .execute(&mut *cold_writer)
+        .await
+        .expect("hold exclusive cold read lock");
+    sqlx::query("CREATE TABLE admin_privacy_status_cold_lock (id INTEGER)")
+        .execute(&mut *cold_writer)
+        .await
+        .expect("hold schema lock for cold privacy status");
+    let cold_started = std::time::Instant::now();
     let cold = client
         .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
         .header(reqwest::header::COOKIE, &cold_cookie)
@@ -847,9 +858,20 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         .expect("cold privacy status");
     assert_eq!(
         cold.status(),
-        reqwest::StatusCode::OK,
-        "privacy reads use their own bounded session rather than the maintenance bulk permit"
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "a cold privacy read under SQLite pressure must return a bounded retry response"
     );
+    assert_eq!(
+        cold.headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok()),
+        Some("1")
+    );
+    assert!(cold_started.elapsed() < std::time::Duration::from_millis(350));
+    sqlx::query("ROLLBACK")
+        .execute(&mut *cold_writer)
+        .await
+        .expect("release exclusive cold read lock");
     drop(cold_held);
 
     let _ = std::fs::remove_file(db_path);

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -756,7 +756,7 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
 }
 
 #[tokio::test]
-async fn admin_privacy_status_returns_expired_last_good_when_sqlite_is_under_pressure() {
+async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admission() {
     let db_path = temp_db_path("admin-privacy-status-last-good");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(
@@ -797,20 +797,20 @@ async fn admin_privacy_status_returns_expired_last_good_when_sqlite_is_under_pre
             panic!("test must hold the shared bulk permit, got {reason}")
         }
     };
-    let stale = client
+    let fresh = client
         .get(&privacy_status_url)
         .header(reqwest::header::COOKIE, &cookie)
         .send()
         .await
-        .expect("stale privacy status");
-    assert_eq!(stale.status(), reqwest::StatusCode::OK);
-    let stale_body: serde_json::Value = stale.json().await.expect("stale privacy status json");
-    assert_eq!(stale_body.get("coverage").and_then(|v| v.as_str()), Some("stale"));
-    assert_eq!(
-        stale_body.get("staleReason").and_then(|v| v.as_str()),
-        Some("sqlite_pressure")
+        .expect("fresh privacy status");
+    assert_eq!(fresh.status(), reqwest::StatusCode::OK);
+    let fresh_body: serde_json::Value = fresh.json().await.expect("fresh privacy status json");
+    assert_eq!(fresh_body.get("coverage").and_then(|v| v.as_str()), Some("ok"));
+    assert!(
+        fresh_body
+            .get("staleReason")
+            .is_none_or(serde_json::Value::is_null)
     );
-    assert!(stale_body.get("observedAt").and_then(|v| v.as_i64()).is_some());
     drop(held);
 
     let cold_db_path = temp_db_path("admin-privacy-status-cold-pressure");
@@ -845,8 +845,11 @@ async fn admin_privacy_status_returns_expired_last_good_when_sqlite_is_under_pre
         .send()
         .await
         .expect("cold privacy status");
-    assert_eq!(cold.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
-    assert_eq!(cold.headers().get("retry-after").and_then(|v| v.to_str().ok()), Some("1"));
+    assert_eq!(
+        cold.status(),
+        reqwest::StatusCode::OK,
+        "privacy reads use their own bounded session rather than the maintenance bulk permit"
+    );
     drop(cold_held);
 
     let _ = std::fs::remove_file(db_path);

--- a/src/server/tests/alerts_and_ha_source_and_recovery.rs
+++ b/src/server/tests/alerts_and_ha_source_and_recovery.rs
@@ -3,6 +3,144 @@ use super::upstream_support_and_manual_jobs::*;
 use super::*;
 
 #[tokio::test]
+async fn reconciliation_low_pressure_recovery_runs_shadow_fixture_despite_prior_local_backoff() {
+    let db_path = temp_db_path("reconciliation-low-pressure-recovery");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-low-pressure-recovery".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("create reconciliation proxy");
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = tavily_hikari::UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("enable compare reconciliation");
+    let token = proxy
+        .create_access_token(Some("reconciliation-low-pressure-recovery"))
+        .await
+        .expect("create token");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-low-pressure-recovery")
+        .await
+        .expect("create upstream key");
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_usage (
+             token_id, key_id, period_code, project_id, billing_subject,
+             period_start, period_end, request_count, first_used_at,
+             last_used_at, updated_at, settlement_mode
+           ) VALUES (?, ?, 'recovery/S1', 'recovery-project', ?,
+                     ?, ?, 1, ?, ?, ?, 'shadow')"#,
+    )
+    .bind(&token.id)
+    .bind(&key_id)
+    .bind(format!("token:{}", token.id))
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&pool)
+    .await
+    .expect("insert shadow fixture");
+
+    let upstream = Router::new().route(
+        "/usage",
+        get(|| async { Json(serde_json::json!({ "key": { "usage": 0 } })) }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind usage upstream");
+    let address = listener.local_addr().expect("read usage upstream address");
+    tokio::spawn(async move {
+        axum::serve(listener, upstream.into_make_service())
+            .await
+            .expect("serve usage upstream");
+    });
+
+    let state = Arc::new(AppState {
+        proxy,
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        admin_passkey: AdminPasskeyOptions::disabled(),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+        dev_open_admin: false,
+        usage_base: format!("http://{address}"),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+    });
+    sqlx::query(
+        r#"INSERT INTO meta (key, value) VALUES
+             ('upstream_reconciliation_local_pressure_streak_v1', '3'),
+             ('upstream_reconciliation_local_backoff_level_v1', '1'),
+             ('upstream_reconciliation_local_backoff_until_v1', ?)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value"#,
+    )
+    .bind((now + 30).to_string())
+    .execute(&pool)
+    .await
+    .expect("seed sustained local pressure backoff");
+    let queued = state
+        .proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue reconciliation representative");
+    let claim = state
+        .proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim reconciliation representative")
+        .expect("representative becomes running");
+
+    assert_eq!(
+        state.proxy.foreground_activity_rps(),
+        0,
+        "recovery worker starts after foreground traffic has drained"
+    );
+    assert!(
+        run_manual_claimed_job(
+            state.clone(),
+            "upstream_reconciliation".to_string(),
+            None,
+            ClaimedScheduledJob {
+                job_id: claim.id,
+                claim_generation: claim.claim_generation,
+                _job_execution_gate: None,
+            },
+            None,
+        )
+        .await
+    );
+    let completed: i64 = sqlx::query_scalar(
+        "SELECT completed_generation >= work_generation FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = 'recovery/S1'",
+    )
+    .bind(&token.id)
+    .fetch_one(&pool)
+    .await
+    .expect("read shadow fixture completion");
+    assert_eq!(
+        completed, 1,
+        "a low-pressure recovery worker must not turn an eligible shadow terminal into an empty backoff completion"
+    );
+
+    drop(state);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn ha_gc_real_worker_wakes_an_eligible_channel_before_a_legacy_defer() {
     let db_path = temp_db_path("ha-gc-worker-fair-wake");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/alerts_and_ha_startup_roles.rs
+++ b/src/server/tests/alerts_and_ha_startup_roles.rs
@@ -285,7 +285,7 @@ async fn startup_keeps_persisted_recovery_fenced_after_role_check() {
 }
 
 #[tokio::test]
-async fn persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_serving_roles() {
+async fn persist_ha_status_snapshot_skips_unneeded_pressure_rebuild_for_serving_roles() {
     let db_path = temp_db_path("ha-post-ready-pressure-rebuild");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(
@@ -395,22 +395,16 @@ async fn persist_ha_status_snapshot_spawns_post_ready_pressure_rebuild_for_servi
         .await
         .expect("persist serving HA status snapshot");
 
-    tokio::time::timeout(Duration::from_secs(8), async {
-        loop {
-            let bucket_count: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
-            )
-            .fetch_one(&pool)
-            .await
-            .expect("count rebuilt server pressure buckets");
-            if bucket_count >= 1 {
-                return bucket_count;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
+    let bucket_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
+    )
+    .fetch_one(&pool)
     .await
-    .expect("serving HA snapshot should trigger background pressure rebuild");
+    .expect("count server pressure buckets before background backfill");
+    assert_eq!(
+        bucket_count, 0,
+        "a normal writable tenure must not start a pressure rebuild without coverage loss or staleness"
+    );
 
     tokio::time::timeout(Duration::from_secs(8), async {
         loop {
@@ -547,24 +541,29 @@ async fn post_ready_serving_tasks_run_once_per_writable_tenure() {
 
     tokio::time::timeout(Duration::from_secs(8), async {
         loop {
-            let bucket_count: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
-            )
-            .fetch_one(&pool)
-            .await
-            .expect("count rebuilt server pressure buckets");
             let summary = proxy
                 .user_dashboard_summary(&user.user_id, None)
                 .await
                 .expect("load user dashboard summary after post-ready backfill");
-            if bucket_count >= 1 && summary.business_calls_1h.total_count == 1 {
+            if summary.business_calls_1h.total_count == 1 {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
     })
     .await
-    .expect("first post-ready tasks should complete");
+    .expect("first post-ready business-call backfill should complete");
+
+    let bucket_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM observability.server_pressure_buckets WHERE bucket_kind = 'five_minute'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count server pressure buckets after post-ready backfill");
+    assert_eq!(
+        bucket_count, 0,
+        "a writable tenure alone must not rebuild pressure buckets"
+    );
 
     assert!(
         !spawn_post_ready_serving_tasks_for_status(state.clone(), &writable_status),

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -1,0 +1,639 @@
+// The privacy-status endpoint is an administrative diagnostic. Build its entire
+// response from one short read snapshot so a busy pool cannot mix generations.
+
+async fn admin_privacy_meta_values(
+    snapshot: &mut SqliteReadSnapshot,
+) -> Result<StdHashMap<String, String>, ProxyError> {
+    Ok(sqlx::query_as::<_, (String, String)>("SELECT key, value FROM meta")
+        .fetch_all(&mut **snapshot)
+        .await?
+        .into_iter()
+        .collect())
+}
+
+fn admin_privacy_meta_i64(values: &StdHashMap<String, String>, key: &str) -> Option<i64> {
+    values.get(key).and_then(|value| value.parse().ok())
+}
+
+async fn admin_privacy_alert_source_fence(
+    snapshot: &mut SqliteReadSnapshot,
+    source_kind: &str,
+) -> Result<Option<(i64, String)>, ProxyError> {
+    let row = match source_kind {
+        ALERT_SOURCE_AUTH_TOKEN_LOG => sqlx::query_as::<_, (i64, i64)>(
+            r#"SELECT created_at, id
+                 FROM auth_token_logs
+                WHERE failure_kind = 'upstream_rate_limited_429'
+                   OR result_status = 'quota_exhausted'
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1"#,
+        )
+        .fetch_optional(&mut **snapshot)
+        .await?
+        .map(|(occurred_at, id)| (occurred_at, format!("atl:{id:020}"))),
+        ALERT_SOURCE_API_KEY_MAINTENANCE_RECORD => sqlx::query_as::<_, (i64, String)>(
+            r#"SELECT occurred_at, source_id
+                 FROM (
+                    SELECT created_at AS occurred_at, id AS source_id
+                      FROM api_key_maintenance_records
+                     WHERE COALESCE(reason_code, '') IN ('account_deactivated', 'key_revoked', 'invalid_api_key')
+                    UNION ALL
+                    SELECT created_at AS occurred_at, id AS source_id
+                      FROM api_key_maintenance_records
+                     WHERE source = 'system'
+                       AND operation_code = 'auto_mark_exhausted'
+                       AND reason_code = 'quota_exhausted'
+                 )
+                ORDER BY occurred_at DESC, source_id DESC
+                LIMIT 1"#,
+        )
+        .fetch_optional(&mut **snapshot)
+        .await?
+        .map(|(occurred_at, id)| (occurred_at, format!("maint:{id}"))),
+        ALERT_SOURCE_SCHEDULED_JOB => sqlx::query_as::<_, (i64, i64)>(
+            r#"SELECT COALESCE(finished_at, started_at, queued_at), id
+                 FROM scheduled_jobs
+                WHERE LOWER(TRIM(status)) IN ('error', 'failed')
+                ORDER BY COALESCE(finished_at, started_at, queued_at) DESC, id DESC
+                LIMIT 1"#,
+        )
+        .fetch_optional(&mut **snapshot)
+        .await?
+        .map(|(occurred_at, id)| (occurred_at, format!("job:{id:020}"))),
+        other => {
+            return Err(ProxyError::Other(format!(
+                "unknown alert projection source: {other}"
+            )));
+        }
+    };
+    Ok(row)
+}
+
+async fn admin_privacy_alert_projection_status(
+    snapshot: &mut SqliteReadSnapshot,
+    now: i64,
+) -> Result<AlertProjectionStatus, ProxyError> {
+    let (
+        sources,
+        observed_at,
+        idle_sources,
+        fresh_sources,
+        stale_reason,
+        history_sources,
+        idle_history_sources,
+    ) = sqlx::query_as::<_, (i64, Option<i64>, i64, i64, Option<String>, i64, i64)>(
+        r#"SELECT COUNT(tail.source_kind), MIN(tail.observed_at),
+                  SUM(CASE WHEN tail.phase = 'idle' THEN 1 ELSE 0 END),
+                  SUM(CASE WHEN tail.observed_at IS NOT NULL AND tail.observed_at >= ? THEN 1 ELSE 0 END),
+                  MAX(tail.stale_reason),
+                  COUNT(history.source_kind),
+                  SUM(CASE WHEN history.phase = 'idle' THEN 1 ELSE 0 END)
+             FROM observability.dashboard_alert_projection_state AS tail
+             LEFT JOIN observability.dashboard_alert_projection_history_state AS history
+               ON history.source_kind = tail.source_kind"#,
+    )
+    .bind(now.saturating_sub(ALERT_PROJECTION_STALE_SECS))
+    .fetch_one(&mut **snapshot)
+    .await?;
+    let observations_expired = sources == ALERT_PROJECTION_SOURCES.len() as i64
+        && idle_sources == sources
+        && fresh_sources != sources;
+    let mut recent_coverage = if sources == ALERT_PROJECTION_SOURCES.len() as i64
+        && idle_sources == sources
+        && fresh_sources == sources
+    {
+        "ok"
+    } else if stale_reason.is_some() || observations_expired {
+        "stale"
+    } else {
+        "projecting"
+    };
+    if recent_coverage == "projecting" && stale_reason.is_none() {
+        let incomplete_sources = sqlx::query_scalar::<_, String>(
+            r#"SELECT source_kind
+                 FROM observability.dashboard_alert_projection_state
+                WHERE phase <> 'idle'
+                ORDER BY source_kind ASC"#,
+        )
+        .fetch_all(&mut **snapshot)
+        .await?;
+        if !incomplete_sources.is_empty() {
+            let mut sources_have_events = false;
+            for source_kind in incomplete_sources {
+                if admin_privacy_alert_source_fence(snapshot, &source_kind)
+                    .await?
+                    .is_some()
+                {
+                    sources_have_events = true;
+                    break;
+                }
+            }
+            if !sources_have_events {
+                recent_coverage = "ok";
+            }
+        }
+    }
+    let coverage = if recent_coverage == "ok"
+        && history_sources == ALERT_PROJECTION_SOURCES.len() as i64
+        && idle_history_sources == history_sources
+    {
+        "ok"
+    } else if recent_coverage == "stale" {
+        "stale"
+    } else {
+        "projecting"
+    };
+    Ok(AlertProjectionStatus {
+        coverage: coverage.to_string(),
+        recent_coverage: recent_coverage.to_string(),
+        observed_at,
+        stale_reason: stale_reason.or_else(|| {
+            observations_expired.then(|| "observation_expired".to_string())
+        }),
+    })
+}
+
+impl KeyStore {
+    pub(crate) async fn upstream_privacy_status_from_snapshot(
+        &self,
+        snapshot: &mut SqliteReadSnapshot,
+    ) -> Result<UpstreamPrivacyStatus, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let period = business_period_for_timestamp(now);
+        let day_window = server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&Local));
+        let meta = admin_privacy_meta_values(snapshot).await?;
+        let meta_i64 = |key| admin_privacy_meta_i64(&meta, key);
+        let upstream_project_id_mode = meta
+            .get(META_KEY_UPSTREAM_PROJECT_ID_MODE_V1)
+            .and_then(|value| UpstreamProjectIdMode::from_meta_value(value))
+            .unwrap_or_default();
+        let upstream_project_id_fixed_value = meta
+            .get(META_KEY_UPSTREAM_PROJECT_ID_FIXED_VALUE_V1)
+            .cloned()
+            .unwrap_or_default();
+        let upstream_mcp_user_agent = meta
+            .get(META_KEY_UPSTREAM_MCP_USER_AGENT_V1)
+            .cloned()
+            .unwrap_or_default();
+        let api_rebalance_enabled = meta_i64(META_KEY_API_REBALANCE_ENABLED_V1)
+            .unwrap_or(i64::from(API_REBALANCE_ENABLED_DEFAULT))
+            != 0;
+        let rebalance_mcp_enabled = meta_i64(META_KEY_REBALANCE_MCP_ENABLED_V1)
+            .unwrap_or(i64::from(REBALANCE_MCP_ENABLED_DEFAULT))
+            != 0;
+        let upstream_precise_reconciliation_enabled = meta_i64(
+            META_KEY_UPSTREAM_PRECISE_RECONCILIATION_ENABLED_V1,
+        )
+        .unwrap_or(0)
+            != 0;
+        let active_upstream_mcp_sessions: i64 = sqlx::query_scalar(
+            r#"SELECT COUNT(*)
+                 FROM mcp_sessions
+                WHERE gateway_mode = ?
+                  AND revoked_at IS NULL
+                  AND expires_at > ?"#,
+        )
+        .bind(MCP_GATEWAY_MODE_UPSTREAM)
+        .bind(now)
+        .fetch_one(&mut **snapshot)
+        .await?;
+        let stored_epoch = meta_i64(META_KEY_UPSTREAM_RECONCILIATION_READY_AFTER_V1).unwrap_or(0);
+        let mode_ready = upstream_project_id_mode == UpstreamProjectIdMode::AccessToken;
+        let sessions_ready = active_upstream_mcp_sessions == 0;
+        let gates = vec![
+            UpstreamPrivacyGate {
+                key: "accessTokenMode".to_string(),
+                ready: mode_ready,
+                detail: format!("{upstream_project_id_mode:?}"),
+            },
+            UpstreamPrivacyGate {
+                key: "apiRebalance".to_string(),
+                ready: api_rebalance_enabled,
+                detail: if api_rebalance_enabled { "enabled" } else { "disabled" }.to_string(),
+            },
+            UpstreamPrivacyGate {
+                key: "mcpRebalance".to_string(),
+                ready: rebalance_mcp_enabled,
+                detail: if rebalance_mcp_enabled { "enabled" } else { "disabled" }.to_string(),
+            },
+            UpstreamPrivacyGate {
+                key: "controlSessionsDrained".to_string(),
+                ready: sessions_ready,
+                detail: active_upstream_mcp_sessions.to_string(),
+            },
+        ];
+
+        let observed_at = meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_RUN_AT_V1);
+        let has_eligible: bool = sqlx::query_scalar(
+            r#"SELECT EXISTS(
+                SELECT 1
+                  FROM upstream_reconciliation_work w
+             LEFT JOIN upstream_reconciliation_settlements s
+                    ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
+                 WHERE w.period_end + 600 <= ?
+                   AND w.work_generation > w.completed_generation
+                   AND MAX(w.next_attempt_at, CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                       THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END) <= ?
+                   AND (w.period_end + 86400 <= ? OR NOT EXISTS (
+                       SELECT 1 FROM upstream_reconciliation_research r
+                        WHERE r.token_id = w.token_id AND r.period_code = w.period_code
+                          AND r.terminal_at IS NULL))
+                 LIMIT 1)"#,
+        )
+        .bind(now)
+        .bind(now)
+        .bind(now)
+        .fetch_one(&mut **snapshot)
+        .await?;
+        let oldest_period_end: Option<i64> = sqlx::query_scalar(
+            r#"SELECT w.period_end
+                 FROM upstream_reconciliation_work w
+            LEFT JOIN upstream_reconciliation_settlements s
+                   ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
+                WHERE w.period_end + 600 <= ?
+                  AND w.work_generation > w.completed_generation
+                  AND MAX(w.next_attempt_at, CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                      THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END) <= ?
+                  AND (w.period_end + 86400 <= ? OR NOT EXISTS (
+                      SELECT 1 FROM upstream_reconciliation_research r
+                       WHERE r.token_id = w.token_id AND r.period_code = w.period_code
+                         AND r.terminal_at IS NULL))
+                ORDER BY w.period_end ASC
+                LIMIT 1"#,
+        )
+        .bind(now)
+        .bind(now)
+        .bind(now)
+        .fetch_optional(&mut **snapshot)
+        .await?;
+        let queue_estimate = if observed_at.is_some() {
+            Some(
+                sqlx::query_scalar::<_, i64>(&format!(
+                    r#"SELECT COUNT(*) FROM (
+                        SELECT 1 FROM upstream_reconciliation_work w
+                        LEFT JOIN upstream_reconciliation_settlements s
+                          ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
+                        WHERE w.period_end + 600 <= ?
+                          AND w.work_generation > w.completed_generation
+                          AND MAX(w.next_attempt_at, CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                              THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END) <= ?
+                          AND (w.period_end + 86400 <= ? OR NOT EXISTS (
+                              SELECT 1 FROM upstream_reconciliation_research r
+                               WHERE r.token_id = w.token_id AND r.period_code = w.period_code
+                                 AND r.terminal_at IS NULL))
+                        LIMIT {})"#,
+                    RECONCILIATION_QUEUE_ESTIMATE_LIMIT
+                ))
+                .bind(now)
+                .bind(now)
+                .bind(now)
+                .fetch_one(&mut **snapshot)
+                .await?,
+            )
+        } else {
+            None
+        };
+        let reconciliation_observation = ReconciliationObservation {
+            observed_at,
+            coverage: if observed_at.is_some() { "bounded" } else { "unknown" }.to_string(),
+            queue_estimate,
+            has_eligible,
+            oldest_candidate_age_secs: oldest_period_end
+                .map(|period_end| now.saturating_sub(period_end).max(0)),
+        };
+
+        let retry_rows = sqlx::query_as::<_, (Option<String>, i64)>(
+            r#"SELECT degraded_reason, COUNT(*)
+                 FROM upstream_reconciliation_settlements
+                WHERE status = ?
+                GROUP BY degraded_reason"#,
+        )
+        .bind(RECONCILIATION_STATUS_RATE_LIMITED)
+        .fetch_all(&mut **snapshot)
+        .await?;
+        let mut retry_buckets = UpstreamReconciliationRetryBuckets {
+            upstream_429: 0,
+            local_usage_rate_limit: 0,
+            other: 0,
+        };
+        for (reason, count) in retry_rows {
+            match classify_reconciliation_retry_reason(reason.as_deref()) {
+                RECONCILIATION_RETRY_REASON_UPSTREAM_429 => retry_buckets.upstream_429 += count,
+                RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT => {
+                    retry_buckets.local_usage_rate_limit += count
+                }
+                _ => retry_buckets.other += count,
+            }
+        }
+
+        let bound_rows = sqlx::query_as::<_, (String, i64)>(
+            r#"SELECT u.key_id, COUNT(DISTINCT CASE
+                      WHEN u.billing_subject LIKE 'account:%' THEN SUBSTR(u.billing_subject, 9)
+                  END) AS bound_users
+                 FROM upstream_reconciliation_usage u
+                WHERE u.period_code = ?
+                GROUP BY u.key_id
+                HAVING bound_users > 0
+                ORDER BY bound_users DESC, u.key_id ASC"#,
+        )
+        .bind(&period.code)
+        .fetch_all(&mut **snapshot)
+        .await?;
+        let pending_project_rows = sqlx::query_as::<_, (String, i64)>(
+            r#"SELECT u.key_id, COUNT(DISTINCT u.project_id) AS pending_project_ids
+                 FROM upstream_reconciliation_usage u
+            LEFT JOIN upstream_reconciliation_settlements s
+                   ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
+                WHERE u.period_code = ?
+                  AND (s.settlement_key IS NULL OR s.status IN ('pending', 'waiting', 'rate_limited'))
+                GROUP BY u.key_id
+                HAVING pending_project_ids > 0
+                ORDER BY pending_project_ids DESC, u.key_id ASC"#,
+        )
+        .bind(&period.code)
+        .fetch_all(&mut **snapshot)
+        .await?;
+
+        let (observed_accounts, accounts_with_settled_period, fully_terminal_accounts, observed_periods, settled_periods, degraded_periods, pending_periods) =
+            sqlx::query_as::<_, (i64, i64, i64, i64, i64, i64, i64)>(
+                r#"WITH windows AS (
+                    SELECT u.token_id, u.period_code, MIN(u.billing_subject) AS billing_subject,
+                           MAX(CASE WHEN s.status = 'settled' THEN 1 ELSE 0 END) AS settled,
+                           MAX(CASE WHEN s.status IN ('settled', 'degraded', 'shadow_settled', 'shadow_degraded') THEN 1 ELSE 0 END) AS terminal,
+                           MAX(CASE WHEN s.status IN ('degraded', 'shadow_degraded') THEN 1 ELSE 0 END) AS degraded
+                      FROM upstream_reconciliation_usage u
+                 LEFT JOIN upstream_reconciliation_settlements s
+                        ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
+                     WHERE u.period_start >= ? AND u.period_start < ?
+                  GROUP BY u.token_id, u.period_code
+                ), accounts AS (
+                    SELECT billing_subject, COUNT(*) AS observed, SUM(settled) AS settled,
+                           SUM(terminal) AS terminal, SUM(degraded) AS degraded
+                      FROM windows WHERE billing_subject LIKE 'account:%' GROUP BY billing_subject
+                )
+                SELECT COUNT(*), COALESCE(SUM(CASE WHEN settled > 0 THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(CASE WHEN terminal = observed THEN 1 ELSE 0 END), 0),
+                       COALESCE(SUM(observed), 0), COALESCE(SUM(settled), 0),
+                       COALESCE(SUM(degraded), 0), COALESCE(SUM(observed - terminal), 0)
+                  FROM accounts"#,
+            )
+            .bind(day_window.start)
+            .bind(day_window.end)
+            .fetch_one(&mut **snapshot)
+            .await?;
+        let (research_total, research_terminal, research_pending) = sqlx::query_as::<_, (i64, i64, i64)>(
+            r#"SELECT COUNT(DISTINCT r.request_id),
+                       COUNT(DISTINCT CASE WHEN r.terminal_at IS NOT NULL THEN r.request_id END),
+                       COUNT(DISTINCT CASE WHEN r.terminal_at IS NULL THEN r.request_id END)
+                  FROM upstream_reconciliation_research r
+                  JOIN upstream_reconciliation_usage u
+                    ON u.token_id = r.token_id AND u.period_code = r.period_code
+                 WHERE u.period_start >= ? AND u.period_start < ?"#,
+        )
+        .bind(day_window.start)
+        .bind(day_window.end)
+        .fetch_one(&mut **snapshot)
+        .await?;
+        let key_rows = sqlx::query_as::<_, (String, i64, i64, i64)>(
+            r#"SELECT u.key_id,
+                       COUNT(DISTINCT CASE WHEN r.terminal_at IS NOT NULL THEN r.request_id END),
+                       COUNT(DISTINCT CASE WHEN r.terminal_at IS NULL THEN r.request_id END),
+                       COUNT(DISTINCT CASE WHEN s.settlement_key IS NULL
+                            OR s.status IN ('pending', 'waiting', 'rate_limited') THEN u.project_id END)
+                  FROM upstream_reconciliation_usage u
+             LEFT JOIN upstream_reconciliation_research r
+                    ON r.token_id = u.token_id AND r.period_code = u.period_code AND r.key_id = u.key_id
+             LEFT JOIN upstream_reconciliation_settlements s
+                    ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
+                 WHERE u.period_start >= ? AND u.period_start < ?
+              GROUP BY u.key_id
+                HAVING COUNT(DISTINCT r.request_id) > 0
+                    OR COUNT(DISTINCT CASE WHEN s.settlement_key IS NULL
+                         OR s.status IN ('pending', 'waiting', 'rate_limited') THEN u.project_id END) > 0
+              ORDER BY 3 DESC, 4 DESC, u.key_id ASC"#,
+        )
+        .bind(day_window.start)
+        .bind(day_window.end)
+        .fetch_all(&mut **snapshot)
+        .await?;
+        let backoffs = sqlx::query_as::<_, (String, i64, Option<String>)>(
+            r#"SELECT key_id, cooldown_until, reason_code
+                 FROM api_key_transient_backoffs
+                WHERE scope = 'period_reconciliation' AND cooldown_until > ?"#,
+        )
+        .bind(now)
+        .fetch_all(&mut **snapshot)
+        .await?
+        .into_iter()
+        .map(|(key_id, cooldown_until, reason)| (key_id, (cooldown_until, reason)))
+        .collect::<StdHashMap<_, _>>();
+        let daily_reconciliation_progress = DailyReconciliationProgress {
+            observed_accounts,
+            accounts_with_settled_period,
+            fully_terminal_accounts,
+            observed_periods,
+            settled_periods,
+            degraded_periods,
+            pending_periods,
+            research_total,
+            research_terminal,
+            research_pending,
+        };
+        let daily_reconciliation_by_key = key_rows
+            .into_iter()
+            .map(|(key_id, terminal_research, pending_research, pending_project_ids)| {
+                let cooldown = backoffs.get(&key_id);
+                DailyReconciliationKeyProgress {
+                    key_id_hint: key_id.chars().take(12).collect(),
+                    terminal_research,
+                    pending_research,
+                    pending_project_ids,
+                    cooldown_until: cooldown.map(|(until, _)| *until),
+                    cooldown_reason: cooldown.and_then(|(_, reason)| reason.clone()),
+                }
+            })
+            .collect();
+        let degraded_observed: i64 = sqlx::query_scalar(&format!(
+            "SELECT COUNT(*) FROM (SELECT 1 FROM upstream_reconciliation_settlements \
+             WHERE status IN ('degraded', 'shadow_degraded') LIMIT {})",
+            RECONCILIATION_QUEUE_ESTIMATE_LIMIT.saturating_add(1)
+        ))
+        .fetch_one(&mut **snapshot)
+        .await?;
+        let (global_pressure_streak, global_backoff_level, global_backoff_until) = (
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_PRESSURE_STREAK_V1).unwrap_or(0),
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1).unwrap_or(0),
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1).unwrap_or(0),
+        );
+        let (local_pressure_streak, local_backoff_level, local_backoff_until) = (
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1).unwrap_or(0),
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1).unwrap_or(0),
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1).unwrap_or(0),
+        );
+        let run_row = sqlx::query_as::<_, ReconciliationRunObservationRow>(
+            r#"SELECT o.mode,
+                      CASE WHEN p.completed != 0 THEN 'complete'
+                           WHEN p.last_defer_reason IS NOT NULL THEN 'deferred'
+                           ELSE o.projection_state END AS projection_state,
+                      p.scanned_rows AS projection_scanned_rows,
+                      p.batch_size AS projection_batch_size,
+                      p.transaction_p95_ms AS projection_transaction_p95_ms,
+                      o.cursor_advanced,
+                      o.hydrate_ms, o.first_remote_ms, o.remote_ms, o.finalization_ms, o.research_ms,
+                      o.settled_count AS settled, o.no_adjustment_count AS no_adjustment,
+                      o.observed_count AS observed, o.upstream_429_count AS upstream_429,
+                      o.transport_failure_count AS transport_failure,
+                      o.semantic_failure_count AS semantic_failure,
+                      o.local_pressure_count AS local_pressure,
+                      o.last_transport_kind, o.last_transport_kind_at, o.last_retryable_outcome,
+                      COALESCE(o.continuation_reason, p.last_defer_reason) AS continuation_reason,
+                      CASE WHEN o.next_retry_at IS NULL AND p.next_retry_at <= 0 THEN NULL
+                           ELSE MAX(COALESCE(o.next_retry_at, 0), p.next_retry_at) END AS next_retry_at,
+                      o.observed_at
+                 FROM upstream_reconciliation_run_observation o
+                 JOIN upstream_reconciliation_projection_state p ON p.id = o.id
+                WHERE o.id = 'local'"#,
+        )
+        .fetch_one(&mut **snapshot)
+        .await?;
+        let reconciliation_run_observation = ReconciliationRunObservation {
+            mode: run_row.mode,
+            projection_state: run_row.projection_state,
+            projection_scanned_rows: run_row.projection_scanned_rows,
+            projection_batch_size: run_row.projection_batch_size,
+            projection_transaction_p95_ms: run_row.projection_transaction_p95_ms,
+            cursor_advanced: run_row.cursor_advanced != 0,
+            hydrate_ms: run_row.hydrate_ms,
+            first_remote_ms: run_row.first_remote_ms,
+            remote_ms: run_row.remote_ms,
+            finalization_ms: run_row.finalization_ms,
+            research_ms: run_row.research_ms,
+            settled: run_row.settled,
+            no_adjustment: run_row.no_adjustment,
+            observed: run_row.observed,
+            upstream_429: run_row.upstream_429,
+            transport_failure: run_row.transport_failure,
+            semantic_failure: run_row.semantic_failure,
+            local_pressure: run_row.local_pressure,
+            last_transport_kind: run_row.last_transport_kind,
+            last_transport_kind_at: run_row.last_transport_kind_at,
+            last_retryable_outcome: run_row.last_retryable_outcome,
+            continuation_reason: run_row.continuation_reason,
+            next_retry_at: run_row.next_retry_at,
+            observed_at: (run_row.observed_at > 0).then_some(run_row.observed_at),
+        };
+        let (mode, activation_period_code, activation_period_start, legacy_active, paused_reason, transitioned_at) =
+            sqlx::query_as::<_, (String, Option<String>, Option<i64>, i64, Option<String>, i64)>(
+                r#"SELECT mode, activation_period_code, activation_period_start, legacy_active,
+                          paused_reason, transitioned_at
+                     FROM upstream_reconciliation_control_state
+                    WHERE id = 'local'"#,
+            )
+            .fetch_one(&mut **snapshot)
+            .await?;
+        let controller_mode = ReconciliationMode::parse(&mode).ok_or_else(|| {
+            ProxyError::Other("invalid persisted upstream reconciliation mode".to_string())
+        })?;
+        let dashboard_alert_projection = admin_privacy_alert_projection_status(snapshot, now).await?;
+        let recent_adjustments = sqlx::query_as::<_, (String, String, String, String, i64, Option<String>, i64)>(
+            r#"SELECT settlement_key, token_id, billing_subject, period_code, delta_credits,
+                      degraded_reason, created_at
+                 FROM billing_reconciliation_adjustments
+                ORDER BY created_at DESC
+                LIMIT 10"#,
+        )
+        .fetch_all(&mut **snapshot)
+        .await?
+        .into_iter()
+        .map(|(settlement_key, token_id, billing_subject, period_code, delta_credits, degraded_reason, created_at)| {
+            UpstreamReconciliationAdjustment {
+                settlement_key,
+                token_id_hint: token_id.chars().take(8).collect(),
+                billing_subject_kind: billing_subject.split(':').next().unwrap_or("unknown").to_string(),
+                period_code,
+                delta_credits,
+                degraded_reason,
+                created_at,
+            }
+        })
+        .collect();
+        let value_i64 = |key| meta_i64(key).unwrap_or(0);
+        let shadow_ready = mode_ready && api_rebalance_enabled && rebalance_mcp_enabled;
+        let next_epoch_at = if legacy_active != 0
+            && controller_mode == ReconciliationMode::Active
+            && shadow_ready
+            && sessions_ready
+        {
+            Some(if stored_epoch > 0 { stored_epoch } else { period.ends_at })
+        } else {
+            activation_period_start
+        };
+        Ok(UpstreamPrivacyStatus {
+            phase: controller_mode.as_str().to_string(),
+            configured_project_id_mode: upstream_project_id_mode,
+            effective_project_id_mode: upstream_project_id_mode,
+            fixed_project_id_configured: !upstream_project_id_fixed_value.is_empty(),
+            configured_mcp_user_agent: upstream_mcp_user_agent.clone(),
+            effective_mcp_user_agent: (!upstream_mcp_user_agent.is_empty()).then_some(upstream_mcp_user_agent),
+            upstream_precise_reconciliation_enabled,
+            http_allowed_headers: vec!["accept", "accept-encoding", "content-type", "x-project-id (policy injected)"].into_iter().map(str::to_string).collect(),
+            control_mcp_allowed_headers: vec!["accept", "accept-encoding", "cache-control", "content-type", "last-event-id", "mcp-protocol-version", "mcp-session-id", "pragma", "user-agent (configured only)"].into_iter().map(str::to_string).collect(),
+            completed_gates: gates.iter().filter(|gate| gate.ready).count() as i64,
+            total_gates: gates.len() as i64,
+            gates,
+            active_upstream_mcp_sessions,
+            current_period_code: period.code,
+            current_period_ends_at: period.ends_at,
+            next_epoch_at,
+            pending_research: Some(daily_reconciliation_progress.research_pending),
+            queued_settlements: reconciliation_observation.queue_estimate,
+            degraded_settlements: degraded_observed.min(RECONCILIATION_QUEUE_ESTIMATE_LIMIT),
+            degraded_settlements_capped: degraded_observed > RECONCILIATION_QUEUE_ESTIMATE_LIMIT,
+            last_reconciliation_run_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_RUN_AT_V1),
+            last_shadow_adjustment_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_SHADOW_ADJUSTMENT_AT_V1),
+            last_reconciliation_enqueue_error_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_ENQUEUE_ERROR_AT_V1),
+            last_research_sweep_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_SWEEP_AT_V1),
+            last_research_terminal_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_TERMINAL_AT_V1),
+            reconciliation_pressure_streak: global_pressure_streak,
+            reconciliation_backoff_level: global_backoff_level,
+            reconciliation_backoff_until: (global_backoff_until > now).then_some(global_backoff_until),
+            reconciliation_last_duration_ms: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_DURATION_MS_V1),
+            reconciliation_last_attempted: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_ATTEMPTED_V1),
+            reconciliation_last_settled: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_SETTLED_V1),
+            reconciliation_last_no_adjustment: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_NO_ADJUSTMENT_V1),
+            reconciliation_last_upstream_429: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_429_V1),
+            reconciliation_last_budget_exhausted: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_BUDGET_EXHAUSTED_V1) != 0,
+            reconciliation_observation,
+            reconciliation_local_backoff: ReconciliationLocalBackoff {
+                pressure_streak: local_pressure_streak,
+                level: local_backoff_level,
+                available_at: (local_backoff_until > now).then_some(local_backoff_until),
+                last_recovered_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_LAST_RECOVERED_AT_V1),
+            },
+            reconciliation_run_observation,
+            reconciliation_controller: ReconciliationControllerStatus {
+                mode: controller_mode.as_str().to_string(),
+                activation_period_code,
+                activation_period_start,
+                legacy_active: legacy_active != 0,
+                paused_reason,
+                transitioned_at: (transitioned_at > 0).then_some(transitioned_at),
+            },
+            dashboard_alert_projection: DashboardAlertProjectionStatus {
+                coverage: dashboard_alert_projection.coverage,
+                observed_at: dashboard_alert_projection.observed_at,
+                stale_reason: dashboard_alert_projection.stale_reason,
+            },
+            retry_buckets,
+            current_period_bound_users_by_key: bound_rows.into_iter().map(|(key_id, count)| UpstreamKeyActivityPoint { key_id_hint: key_id.chars().take(12).collect(), count }).collect(),
+            current_period_pending_project_ids_by_key: pending_project_rows.into_iter().map(|(key_id, count)| UpstreamKeyActivityPoint { key_id_hint: key_id.chars().take(12).collect(), count }).collect(),
+            daily_reconciliation_progress,
+            daily_reconciliation_by_key,
+            recent_adjustments,
+            generated_at: now,
+            coverage: "ok".to_string(),
+            observed_at: Some(now),
+            stale_reason: None,
+        })
+    }
+}

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -439,6 +439,51 @@ impl KeyStore {
             research_terminal,
             research_pending,
         };
+        let (
+            active_started_at,
+            last_window_started_at,
+            last_window_ended_at,
+            last_window_terminal_delta,
+            last_window_pending_delta,
+        ) = sqlx::query_as::<_, (i64, Option<i64>, Option<i64>, i64, i64)>(
+            r#"SELECT active_started_at, last_window_started_at, last_window_ended_at,
+                       last_window_terminal_delta, last_window_pending_delta
+                  FROM upstream_reconciliation_research_progress_window
+                 WHERE id = 'local'"#,
+        )
+        .fetch_one(&mut **snapshot)
+        .await?;
+        let complete_research_window = last_window_started_at.zip(last_window_ended_at);
+        let (research_window_started_at, research_window_ended_at, research_window_seconds) =
+            if let Some((started_at, ended_at)) = complete_research_window {
+                (
+                    Some(started_at),
+                    Some(ended_at),
+                    ended_at.saturating_sub(started_at),
+                )
+            } else {
+                (
+                    (active_started_at > 0).then_some(active_started_at),
+                    None,
+                    now.saturating_sub(active_started_at).max(0),
+                )
+            };
+        let reconciliation_research_progress_window = ReconciliationResearchProgressWindow {
+            window_started_at: research_window_started_at,
+            window_ended_at: research_window_ended_at,
+            window_seconds: research_window_seconds,
+            terminal_delta: complete_research_window
+                .map(|_| last_window_terminal_delta)
+                .unwrap_or(0),
+            pending_delta: complete_research_window
+                .map(|_| last_window_pending_delta)
+                .unwrap_or(0),
+            terminal_rate_positive: complete_research_window.is_some()
+                && last_window_terminal_delta > 0,
+            pending_non_growing: complete_research_window.is_some()
+                && last_window_pending_delta <= 0,
+            complete: complete_research_window.is_some(),
+        };
         let daily_reconciliation_by_key = key_rows
             .into_iter()
             .map(|(key_id, terminal_research, pending_research, pending_project_ids)| {
@@ -611,6 +656,7 @@ impl KeyStore {
                 last_recovered_at: meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_LAST_RECOVERED_AT_V1),
             },
             reconciliation_run_observation,
+            reconciliation_research_progress_window,
             reconciliation_controller: ReconciliationControllerStatus {
                 mode: controller_mode.as_str().to_string(),
                 activation_period_code,

--- a/src/store/key_store_analysis_pressure.rs
+++ b/src/store/key_store_analysis_pressure.rs
@@ -42,16 +42,22 @@ impl KeyStore {
             .sqlite_runtime
             .begin_immediate(SqliteOperation::ObservabilityDeferredWrite)
             .await?;
+        let generation = sqlx::query_scalar::<_, i64>(
+            "SELECT active_generation FROM observability.server_pressure_rebuild_state WHERE singleton = 1",
+        )
+        .fetch_one(&mut *tx)
+        .await?;
         for delta in deltas {
             sqlx::query(
                 r#"
                 INSERT INTO observability.server_pressure_buckets (
-                    bucket_kind, bucket_start, bucket_secs, success_count, failure_count, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    bucket_kind, bucket_start, bucket_secs, success_count, failure_count, updated_at, generation
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(bucket_kind, bucket_start) DO UPDATE SET
                     success_count = server_pressure_buckets.success_count + excluded.success_count,
                     failure_count = server_pressure_buckets.failure_count + excluded.failure_count,
-                    updated_at = excluded.updated_at
+                    updated_at = excluded.updated_at,
+                    generation = excluded.generation
                 "#,
             )
             .bind(delta.bucket_kind)
@@ -60,6 +66,7 @@ impl KeyStore {
             .bind(delta.success_count)
             .bind(delta.failure_count)
             .bind(updated_at)
+            .bind(generation)
             .execute(&mut *tx)
             .await?;
         }
@@ -142,11 +149,65 @@ impl KeyStore {
         .execute(&self.pool)
         .await?;
 
+        let has_generation = sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM observability.pragma_table_info('server_pressure_buckets') WHERE name = 'generation' LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some();
+        if !has_generation {
+            sqlx::query(
+                "ALTER TABLE observability.server_pressure_buckets ADD COLUMN generation INTEGER NOT NULL DEFAULT 0",
+            )
+            .execute(&self.pool)
+            .await?;
+        }
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.server_pressure_bucket_staging (
+                generation INTEGER NOT NULL,
+                bucket_kind TEXT NOT NULL,
+                bucket_start INTEGER NOT NULL,
+                bucket_secs INTEGER NOT NULL,
+                success_count INTEGER NOT NULL,
+                failure_count INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (generation, bucket_kind, bucket_start)
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.server_pressure_rebuild_state (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                active_generation INTEGER NOT NULL,
+                last_allocated_generation INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO observability.server_pressure_rebuild_state (
+                singleton, active_generation, last_allocated_generation
+            ) VALUES (1, 0, 0)
+            ON CONFLICT(singleton) DO NOTHING
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
         for sql in [
             r#"CREATE INDEX IF NOT EXISTS observability.idx_server_pressure_buckets_kind_time
                ON server_pressure_buckets(bucket_kind, bucket_start DESC)"#,
             r#"CREATE INDEX IF NOT EXISTS observability.idx_server_pressure_buckets_time
                ON server_pressure_buckets(bucket_start DESC)"#,
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_server_pressure_buckets_generation_kind_time
+               ON server_pressure_buckets(generation, bucket_kind, bucket_start DESC)"#,
         ] {
             sqlx::query(sql).execute(&self.pool).await?;
         }
@@ -189,148 +250,202 @@ impl KeyStore {
             "#,
         )
         .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
-        .bind(five_minute_since)
+        .bind(hour_since)
         .bind(OUTCOME_QUOTA_EXHAUSTED)
         .fetch_one(&self.pool)
         .await?;
-        let insert_sql = r#"
-            INSERT INTO observability.server_pressure_buckets (
-                bucket_kind,
-                bucket_start,
-                bucket_secs,
-                success_count,
-                failure_count,
-                updated_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-        "#;
-
         if !should_continue() {
             return Ok(ServerPressureBucketsRebuildOutcome::Cancelled);
         }
 
-        // Source aggregation can scan a production-sized observability history.
-        // Keep it outside the immediate transaction so startup rehydration never
-        // owns SQLite's single writer while it performs analytical reads.
-        let five_minute_rows = sqlx::query_as::<_, (i64, i64, i64)>(
-                r#"
-                SELECT
-                    (created_at / ?) * ? AS bucket_start,
-                    SUM(CASE WHEN result_status = ? THEN 1 ELSE 0 END) AS success_count,
-                    SUM(CASE WHEN result_status != ? THEN 1 ELSE 0 END) AS failure_count
-                FROM observability.request_logs
-                WHERE visibility = ?
-                  AND created_at >= ?
-                  AND request_user_id IS NOT NULL
-                  AND counts_business_quota = 1
-                  AND upstream_operation IS NOT NULL
-                  AND result_status != ?
-                  AND id <= ?
-                GROUP BY bucket_start
-                ORDER BY bucket_start
-                "#,
-            )
-            .bind(SECS_PER_FIVE_MINUTES)
-            .bind(SECS_PER_FIVE_MINUTES)
-            .bind(OUTCOME_SUCCESS)
-            .bind(OUTCOME_SUCCESS)
-            .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
-            .bind(five_minute_since)
-            .bind(OUTCOME_QUOTA_EXHAUSTED)
-            .bind(upper_bound_request_log_id)
-            .fetch_all(&self.pool)
-            .await?;
-        let hour_rows = sqlx::query_as::<_, (i64, i64, i64)>(
-                r#"
-                SELECT
-                    CAST(
-                        strftime(
-                            '%s',
-                            strftime('%Y-%m-%d %H:00:00', created_at, 'unixepoch', 'localtime'),
-                            'utc'
-                        ) AS INTEGER
-                    ) AS bucket_start,
-                    SUM(CASE WHEN result_status = ? THEN 1 ELSE 0 END) AS success_count,
-                    SUM(CASE WHEN result_status != ? THEN 1 ELSE 0 END) AS failure_count
-                FROM observability.request_logs
-                WHERE visibility = ?
-                  AND created_at >= ?
-                  AND request_user_id IS NOT NULL
-                  AND counts_business_quota = 1
-                  AND upstream_operation IS NOT NULL
-                  AND result_status != ?
-                  AND id <= ?
-                GROUP BY bucket_start
-                ORDER BY bucket_start
-                "#,
-            )
-            .bind(OUTCOME_SUCCESS)
-            .bind(OUTCOME_SUCCESS)
-            .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
-            .bind(hour_since)
-            .bind(OUTCOME_QUOTA_EXHAUSTED)
-            .bind(upper_bound_request_log_id)
-            .fetch_all(&self.pool)
-            .await?;
-
-        if !should_continue() {
-            return Ok(ServerPressureBucketsRebuildOutcome::Cancelled);
-        }
-
-        let mut conn = self
+        // Allocate a private staging generation before scanning. The active
+        // generation remains visible until the final short publish transaction.
+        let mut generation_tx = self
             .sqlite_runtime
             .begin_immediate(SqliteOperation::ServerPressureRebuild)
             .await?;
-        let result = async {
-            sqlx::query("DELETE FROM observability.server_pressure_buckets")
-                .execute(&mut *conn)
-                .await?;
-            for (bucket_start, success_count, failure_count) in five_minute_rows {
-                sqlx::query(insert_sql)
-                    .bind("five_minute")
-                    .bind(bucket_start)
-                    .bind(SECS_PER_FIVE_MINUTES)
-                    .bind(success_count)
-                    .bind(failure_count)
-                    .bind(updated_at)
-                    .execute(&mut *conn)
-                    .await?;
-            }
-            for (bucket_start, success_count, failure_count) in hour_rows {
-                sqlx::query(insert_sql)
-                    .bind("hour")
-                    .bind(bucket_start)
-                    .bind(SECS_PER_HOUR)
-                    .bind(success_count)
-                    .bind(failure_count)
-                    .bind(updated_at)
-                    .execute(&mut *conn)
-                    .await?;
-            }
+        let generation = sqlx::query_scalar::<_, i64>(
+            r#"
+            UPDATE observability.server_pressure_rebuild_state
+            SET last_allocated_generation = last_allocated_generation + 1
+            WHERE singleton = 1
+            RETURNING last_allocated_generation
+            "#,
+        )
+        .fetch_one(&mut *generation_tx)
+        .await?;
+        generation_tx.finish(Ok(())).await?;
+
+        let mut cursor = 0_i64;
+        loop {
             if !should_continue() {
                 return Ok(ServerPressureBucketsRebuildOutcome::Cancelled);
             }
-            Ok(ServerPressureBucketsRebuildOutcome::Completed {
-                upper_bound_request_log_id,
-            })
+            // Keyset slices bound source work and fence every read to the
+            // generation's observed upper request-log id.
+            let rows = sqlx::query_as::<_, (i64, i64, String)>(
+                r#"
+                SELECT id, created_at, result_status
+                FROM observability.request_logs
+                WHERE id > ?
+                  AND id <= ?
+                  AND visibility = ?
+                  AND created_at >= ?
+                  AND request_user_id IS NOT NULL
+                  AND counts_business_quota = 1
+                  AND upstream_operation IS NOT NULL
+                  AND result_status != ?
+                ORDER BY id ASC
+                LIMIT 500
+                "#,
+            )
+            .bind(cursor)
+            .bind(upper_bound_request_log_id)
+            .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
+            .bind(hour_since)
+            .bind(OUTCOME_QUOTA_EXHAUSTED)
+            .fetch_all(&self.pool)
+            .await?;
+            if rows.is_empty() {
+                break;
+            }
+            cursor = rows.last().map(|(id, _, _)| *id).unwrap_or(cursor);
+            let mut buckets = std::collections::BTreeMap::<
+                (&'static str, i64, i64),
+                (i64, i64),
+            >::new();
+            for (_, created_at, result_status) in rows {
+                let (success, failure) = if result_status == OUTCOME_SUCCESS {
+                    (1, 0)
+                } else {
+                    (0, 1)
+                };
+                if created_at >= five_minute_since {
+                    let bucket_start = created_at - created_at.rem_euclid(SECS_PER_FIVE_MINUTES);
+                    let counts = buckets
+                        .entry(("five_minute", bucket_start, SECS_PER_FIVE_MINUTES))
+                        .or_default();
+                    counts.0 += success;
+                    counts.1 += failure;
+                }
+                let Some(utc_dt) = chrono::Utc.timestamp_opt(created_at, 0).single() else {
+                    continue;
+                };
+                let bucket_start = start_of_local_hour_utc_ts(utc_dt.with_timezone(&chrono::Local));
+                let counts = buckets.entry(("hour", bucket_start, SECS_PER_HOUR)).or_default();
+                counts.0 += success;
+                counts.1 += failure;
+            }
+            let mut stage_tx = self
+                .sqlite_runtime
+                .begin_immediate(SqliteOperation::ServerPressureRebuild)
+                .await?;
+            for ((bucket_kind, bucket_start, bucket_secs), (success_count, failure_count)) in buckets {
+                sqlx::query(
+                    r#"
+                    INSERT INTO observability.server_pressure_bucket_staging (
+                        generation, bucket_kind, bucket_start, bucket_secs,
+                        success_count, failure_count, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(generation, bucket_kind, bucket_start) DO UPDATE SET
+                        success_count = server_pressure_bucket_staging.success_count + excluded.success_count,
+                        failure_count = server_pressure_bucket_staging.failure_count + excluded.failure_count,
+                        updated_at = excluded.updated_at
+                    "#,
+                )
+                .bind(generation)
+                .bind(bucket_kind)
+                .bind(bucket_start)
+                .bind(bucket_secs)
+                .bind(success_count)
+                .bind(failure_count)
+                .bind(updated_at)
+                .execute(&mut *stage_tx)
+                .await?;
+            }
+            stage_tx.finish(Ok(())).await?;
+        }
+
+        if !should_continue() {
+            return Ok(ServerPressureBucketsRebuildOutcome::Cancelled);
+        }
+        let mut publish_tx = self
+            .sqlite_runtime
+            .begin_immediate(SqliteOperation::ServerPressureRebuild)
+            .await?;
+        let publish = async {
+            sqlx::query(
+                r#"
+                INSERT INTO observability.server_pressure_buckets (
+                    bucket_kind, bucket_start, bucket_secs, success_count,
+                    failure_count, updated_at, generation
+                )
+                SELECT bucket_kind, bucket_start, bucket_secs, success_count,
+                       failure_count, updated_at, generation
+                FROM observability.server_pressure_bucket_staging
+                WHERE generation = ?
+                ON CONFLICT(bucket_kind, bucket_start) DO UPDATE SET
+                    bucket_secs = excluded.bucket_secs,
+                    success_count = excluded.success_count,
+                    failure_count = excluded.failure_count,
+                    updated_at = excluded.updated_at,
+                    generation = excluded.generation
+                "#,
+            )
+            .bind(generation)
+            .execute(&mut *publish_tx)
+            .await?;
+            sqlx::query(
+                r#"
+                UPDATE observability.server_pressure_rebuild_state
+                SET active_generation = ?
+                WHERE singleton = 1
+                "#,
+            )
+            .bind(generation)
+            .execute(&mut *publish_tx)
+            .await?;
+            // Retire only a bounded slice of old data. Readers select the
+            // active generation, so this cleanup cannot expose mixed results.
+            sqlx::query(
+                r#"
+                DELETE FROM observability.server_pressure_buckets
+                WHERE rowid IN (
+                    SELECT rowid FROM observability.server_pressure_buckets
+                    WHERE generation <> ?
+                    LIMIT 25
+                )
+                "#,
+            )
+            .bind(generation)
+            .execute(&mut *publish_tx)
+            .await?;
+            sqlx::query(
+                r#"
+                DELETE FROM observability.server_pressure_bucket_staging
+                WHERE rowid IN (
+                    SELECT rowid FROM observability.server_pressure_bucket_staging
+                    WHERE generation <> ?
+                    LIMIT 25
+                )
+                "#,
+            )
+            .bind(generation)
+            .execute(&mut *publish_tx)
+            .await?;
+            Ok::<_, ProxyError>(())
         }
         .await;
-        match result {
-            Ok(ServerPressureBucketsRebuildOutcome::Completed {
-                upper_bound_request_log_id,
-            }) => {
-                conn.finish(Ok(())).await?;
+        match publish {
+            Ok(()) => {
+                publish_tx.finish(Ok(())).await?;
                 Ok(ServerPressureBucketsRebuildOutcome::Completed {
                     upper_bound_request_log_id,
                 })
             }
-            Ok(ServerPressureBucketsRebuildOutcome::Cancelled) => {
-                let _ = conn.rollback().await;
-                Ok(ServerPressureBucketsRebuildOutcome::Cancelled)
-            }
-            Err(err) => {
-                let _ = conn.rollback().await;
-                Err(err)
+            Err(error) => {
+                let _ = publish_tx.rollback().await;
+                Err(error)
             }
         }
     }
@@ -340,7 +455,6 @@ impl KeyStore {
         created_at: i64,
         result_status: &str,
     ) -> Result<(), ProxyError> {
-        self.ensure_server_pressure_bucket_schema().await?;
         let success = if result_status == OUTCOME_SUCCESS { 1_i64 } else { 0_i64 };
         let failure = if result_status == OUTCOME_SUCCESS { 0_i64 } else { 1_i64 };
         let Some(utc_dt) = chrono::Utc.timestamp_opt(created_at, 0).single() else {
@@ -383,6 +497,11 @@ impl KeyStore {
             WHERE bucket_kind = ?
               AND bucket_start >= ?
               AND bucket_start < ?
+              AND generation = (
+                  SELECT active_generation
+                  FROM observability.server_pressure_rebuild_state
+                  WHERE singleton = 1
+              )
             ORDER BY bucket_start ASC
             "#,
         )

--- a/src/store/key_store_analysis_pressure.rs
+++ b/src/store/key_store_analysis_pressure.rs
@@ -276,7 +276,11 @@ impl KeyStore {
         .await?;
         generation_tx.finish(Ok(())).await?;
 
-        let mut cursor = 0_i64;
+        // Advance in the same order as the time index. The source fence still
+        // excludes rows inserted after the upper id was captured, while the
+        // time predicate prevents a historical id scan on long-lived nodes.
+        let mut cursor_created_at = hour_since;
+        let mut cursor_id = 0_i64;
         loop {
             if !should_continue() {
                 return Ok(ServerPressureBucketsRebuildOutcome::Cancelled);
@@ -286,30 +290,35 @@ impl KeyStore {
             let rows = sqlx::query_as::<_, (i64, i64, String)>(
                 r#"
                 SELECT id, created_at, result_status
-                FROM observability.request_logs
-                WHERE id > ?
+                FROM observability.request_logs INDEXED BY idx_request_logs_time
+                WHERE created_at >= ?
+                  AND (created_at > ? OR (created_at = ? AND id > ?))
                   AND id <= ?
                   AND visibility = ?
-                  AND created_at >= ?
                   AND request_user_id IS NOT NULL
                   AND counts_business_quota = 1
                   AND upstream_operation IS NOT NULL
                   AND result_status != ?
-                ORDER BY id ASC
+                ORDER BY created_at ASC, id ASC
                 LIMIT 500
                 "#,
             )
-            .bind(cursor)
+            .bind(hour_since)
+            .bind(cursor_created_at)
+            .bind(cursor_created_at)
+            .bind(cursor_id)
             .bind(upper_bound_request_log_id)
             .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
-            .bind(hour_since)
             .bind(OUTCOME_QUOTA_EXHAUSTED)
             .fetch_all(&self.pool)
             .await?;
             if rows.is_empty() {
                 break;
             }
-            cursor = rows.last().map(|(id, _, _)| *id).unwrap_or(cursor);
+            if let Some((id, created_at, _)) = rows.last() {
+                cursor_created_at = *created_at;
+                cursor_id = *id;
+            }
             let mut buckets = std::collections::BTreeMap::<
                 (&'static str, i64, i64),
                 (i64, i64),

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -497,8 +497,61 @@ impl KeyStore {
                 success_count INTEGER NOT NULL,
                 failure_count INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL,
+                generation INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (bucket_kind, bucket_start)
             )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        let has_generation = sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM observability.pragma_table_info('server_pressure_buckets') \
+             WHERE name = 'generation' LIMIT 1",
+        )
+        .fetch_optional(pool)
+        .await?
+        .is_some();
+        if !has_generation {
+            sqlx::query(
+                "ALTER TABLE observability.server_pressure_buckets \
+                 ADD COLUMN generation INTEGER NOT NULL DEFAULT 0",
+            )
+            .execute(pool)
+            .await?;
+        }
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.server_pressure_bucket_staging (
+                generation INTEGER NOT NULL,
+                bucket_kind TEXT NOT NULL,
+                bucket_start INTEGER NOT NULL,
+                bucket_secs INTEGER NOT NULL,
+                success_count INTEGER NOT NULL,
+                failure_count INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (generation, bucket_kind, bucket_start)
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS observability.server_pressure_rebuild_state (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                active_generation INTEGER NOT NULL,
+                last_allocated_generation INTEGER NOT NULL
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO observability.server_pressure_rebuild_state (
+                singleton, active_generation, last_allocated_generation
+            ) VALUES (1, 0, 0)
+            ON CONFLICT(singleton) DO NOTHING
             "#,
         )
         .execute(pool)
@@ -508,6 +561,8 @@ impl KeyStore {
                ON server_pressure_buckets(bucket_kind, bucket_start DESC)"#,
             r#"CREATE INDEX IF NOT EXISTS observability.idx_server_pressure_buckets_time
                ON server_pressure_buckets(bucket_start DESC)"#,
+            r#"CREATE INDEX IF NOT EXISTS observability.idx_server_pressure_buckets_generation_kind_time
+               ON server_pressure_buckets(generation, bucket_kind, bucket_start DESC)"#,
         ] {
             sqlx::query(sql).execute(pool).await?;
         }

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -72,6 +72,11 @@ const RECONCILIATION_TRANSPORT_STATE_VERSION: i64 = 19;
 const RECONCILIATION_TRANSPORT_STATE_NAME: &str = "reconciliation-transport-observation-state-v1";
 const RECONCILIATION_TRANSPORT_STATE_CHECKSUM: &str =
     "sha256:3d0e3b1c8a0b1f9d7c1e0a2b4f6d8e90";
+const RECONCILIATION_RESEARCH_PROGRESS_WINDOW_VERSION: i64 = 20;
+const RECONCILIATION_RESEARCH_PROGRESS_WINDOW_NAME: &str =
+    "reconciliation-research-progress-window-v1";
+const RECONCILIATION_RESEARCH_PROGRESS_WINDOW_CHECKSUM: &str =
+    "sha256:6431dd87e790811d9b05f32d7a2c54de";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -763,6 +768,11 @@ impl KeyStore {
                 RECONCILIATION_TRANSPORT_STATE_NAME,
                 RECONCILIATION_TRANSPORT_STATE_CHECKSUM,
             ),
+            (
+                RECONCILIATION_RESEARCH_PROGRESS_WINDOW_VERSION,
+                RECONCILIATION_RESEARCH_PROGRESS_WINDOW_NAME,
+                RECONCILIATION_RESEARCH_PROGRESS_WINDOW_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -883,6 +893,17 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 19".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_RESEARCH_PROGRESS_WINDOW_VERSION)
+            .await?
+            && !self
+                .schema_object_exists("main", "upstream_reconciliation_research_progress_window")
+                .await?
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 20".to_string(),
             ));
         }
         if self
@@ -1578,6 +1599,37 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_research_progress_window_migration(
+        &self,
+    ) -> Result<(), ProxyError> {
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_research_progress_window (
+                id TEXT PRIMARY KEY NOT NULL CHECK(id = 'local'),
+                active_period_start INTEGER NOT NULL DEFAULT 0,
+                active_started_at INTEGER NOT NULL DEFAULT 0,
+                baseline_terminal_count INTEGER NOT NULL DEFAULT 0,
+                baseline_pending_count INTEGER NOT NULL DEFAULT 0,
+                last_window_started_at INTEGER,
+                last_window_ended_at INTEGER,
+                last_window_terminal_delta INTEGER NOT NULL DEFAULT 0,
+                last_window_pending_delta INTEGER NOT NULL DEFAULT 0
+            )"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO upstream_reconciliation_research_progress_window (id) VALUES ('local') ON CONFLICT(id) DO NOTHING",
+        )
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_RESEARCH_PROGRESS_WINDOW_VERSION,
+            RECONCILIATION_RESEARCH_PROGRESS_WINDOW_NAME,
+            RECONCILIATION_RESEARCH_PROGRESS_WINDOW_CHECKSUM,
+        )
+        .await
+    }
+
     async fn apply_reconciliation_work_migration(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_work (
@@ -2002,6 +2054,13 @@ impl KeyStore {
         {
             self.apply_reconciliation_transport_state_migration().await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_RESEARCH_PROGRESS_WINDOW_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_research_progress_window_migration()
+                .await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2053,6 +2112,8 @@ impl KeyStore {
         self.apply_reconciliation_transport_observation_migration()
             .await?;
         self.apply_reconciliation_transport_state_migration().await?;
+        self.apply_reconciliation_research_progress_window_migration()
+            .await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2060,7 +2121,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 19_i64,
+            migration_count = 20_i64,
         );
         Ok(())
     }

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -376,6 +376,7 @@ impl KeyStore {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn upstream_reconciliation_runtime_markers(
         &self,
     ) -> Result<(Option<i64>, Option<i64>, Option<i64>, Option<i64>, Option<i64>), ProxyError> {
@@ -418,6 +419,7 @@ impl KeyStore {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn upstream_reconciliation_observation(
         &self,
     ) -> Result<ReconciliationObservation, ProxyError> {
@@ -545,6 +547,7 @@ impl KeyStore {
         })
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn upstream_reconciliation_degraded_estimate(
         &self,
     ) -> Result<(i64, bool), ProxyError> {
@@ -576,6 +579,7 @@ impl KeyStore {
         .await
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn upstream_reconciliation_local_last_recovered_at(
         &self,
     ) -> Result<Option<i64>, ProxyError> {
@@ -2560,6 +2564,7 @@ impl KeyStore {
         );
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn recent_reconciliation_adjustments(
         &self,
         limit: i64,
@@ -2604,6 +2609,7 @@ impl KeyStore {
             .collect())
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn upstream_reconciliation_retry_buckets(
         &self,
     ) -> Result<UpstreamReconciliationRetryBuckets, ProxyError> {
@@ -2639,6 +2645,7 @@ impl KeyStore {
         Ok(buckets)
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn current_period_reconciliation_key_activity(
         &self,
         current_period_code: &str,
@@ -2697,6 +2704,7 @@ impl KeyStore {
     }
 
 
+    #[allow(dead_code)]
     pub(crate) async fn daily_reconciliation_progress(
         &self,
     ) -> Result<(

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -840,8 +840,41 @@ impl KeyStore {
         claimed_job: Option<(i64, i64)>,
     ) -> Result<(i64, i64, i64), ProxyError> {
         let mut transaction = self.begin_reconciliation_control().await?;
-        let (previous_streak, previous_level, _) = Self::reconciliation_backoff_state_locked(
+        let result = Self::apply_upstream_reconciliation_local_backoff_locked(
             &mut transaction,
+            pressure,
+            now,
+            claimed_job,
+        )
+        .await;
+        let (streak, level, until) = match result {
+            Ok(state) => state,
+            Err(error) => {
+                transaction.finish(Err(error)).await?;
+                unreachable!("failed reconciliation local backoff transaction committed")
+            }
+        };
+        Self::sync_upstream_reconciliation_representative_locked(
+            &mut transaction,
+            now,
+            claimed_job,
+        )
+        .await?;
+        transaction.finish(Ok(())).await?;
+        Ok((streak, level, until))
+    }
+
+    pub(crate) async fn apply_upstream_reconciliation_local_backoff_locked<T>(
+        transaction: &mut T,
+        pressure: bool,
+        now: i64,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<(i64, i64, i64), ProxyError>
+    where
+        T: std::ops::DerefMut<Target = sqlx::SqliteConnection>,
+    {
+        let (previous_streak, previous_level, _) = Self::reconciliation_backoff_state_locked(
+            transaction,
             META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1,
             META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1,
             META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1,
@@ -865,9 +898,8 @@ impl KeyStore {
         } else {
             (0, 0, 0)
         };
-        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+        if !Self::reconciliation_claim_is_current_locked(transaction, claimed_job).await? {
             let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
-            transaction.rollback().await?;
             return Err(ProxyError::StaleClaim {
                 job_id,
                 claim_generation,
@@ -883,22 +915,15 @@ impl KeyStore {
         .bind(level.to_string())
         .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
         .bind(until.to_string())
-        .execute(&mut *transaction)
+        .execute(&mut **transaction)
         .await?;
         if !pressure && previous_level > 0 {
             sqlx::query("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
                 .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_LAST_RECOVERED_AT_V1)
                 .bind(now.to_string())
-                .execute(&mut *transaction)
+                .execute(&mut **transaction)
                 .await?;
         }
-        Self::sync_upstream_reconciliation_representative_locked(
-            &mut transaction,
-            now,
-            claimed_job,
-        )
-        .await?;
-        transaction.finish(Ok(())).await?;
         Ok((streak, level, until))
     }
 

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -864,69 +864,6 @@ impl KeyStore {
         Ok((streak, level, until))
     }
 
-    pub(crate) async fn apply_upstream_reconciliation_local_backoff_locked<T>(
-        transaction: &mut T,
-        pressure: bool,
-        now: i64,
-        claimed_job: Option<(i64, i64)>,
-    ) -> Result<(i64, i64, i64), ProxyError>
-    where
-        T: std::ops::DerefMut<Target = sqlx::SqliteConnection>,
-    {
-        let (previous_streak, previous_level, _) = Self::reconciliation_backoff_state_locked(
-            transaction,
-            META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1,
-            META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1,
-            META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1,
-        )
-        .await?;
-        let (streak, level, until) = if pressure {
-            let streak = previous_streak.saturating_add(1);
-            let level = if streak < 3 {
-                0
-            } else {
-                previous_level.saturating_add(1).clamp(1, 4)
-            };
-            let delay_secs = match level {
-                1 => 30,
-                2 => 60,
-                3 => 120,
-                4 => 300,
-                _ => 0,
-            };
-            (streak, level, now.saturating_add(delay_secs))
-        } else {
-            (0, 0, 0)
-        };
-        if !Self::reconciliation_claim_is_current_locked(transaction, claimed_job).await? {
-            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
-            return Err(ProxyError::StaleClaim {
-                job_id,
-                claim_generation,
-            });
-        }
-        sqlx::query(
-            r#"INSERT INTO meta (key, value) VALUES (?, ?), (?, ?), (?, ?)
-               ON CONFLICT(key) DO UPDATE SET value = excluded.value"#,
-        )
-        .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1)
-        .bind(streak.to_string())
-        .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1)
-        .bind(level.to_string())
-        .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
-        .bind(until.to_string())
-        .execute(&mut **transaction)
-        .await?;
-        if !pressure && previous_level > 0 {
-            sqlx::query("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
-                .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_LAST_RECOVERED_AT_V1)
-                .bind(now.to_string())
-                .execute(&mut **transaction)
-                .await?;
-        }
-        Ok((streak, level, until))
-    }
-
     pub(crate) async fn update_upstream_reconciliation_local_backoff(
         &self,
         pressure: bool,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2727,6 +2727,7 @@ include!("key_store_sessions.rs");
 include!("key_store_mcp_session_bindings.rs");
 include!("key_store_system_settings.rs");
 include!("key_store_upstream_reconciliation.rs");
+include!("key_store_admin_privacy_read.rs");
 include!("key_store_reconciliation_controller.rs");
 include!("reconciliation_projection_controller.rs");
 include!("reconciliation_observation_store.rs");

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -61,8 +61,17 @@ impl KeyStore {
             .begin_immediate(SqliteOperation::ScheduledJobControl)
             .await?;
         let result = async {
+            let (_, _, local_backoff_until) =
+                Self::apply_upstream_reconciliation_local_backoff_locked(
+                    &mut tx,
+                    true,
+                    now,
+                    Some((job_id, claim_generation)),
+                )
+                .await?;
+            let available_at = retry_at.max(local_backoff_until).max(now);
             let message = format!(
-                "outcome=sqlite_admission_deferred defer_reason={reason} retry_at={retry_at}"
+                "outcome=sqlite_admission_deferred defer_reason={reason} retry_at={available_at}"
             );
             let updated = sqlx::query(
                 r#"UPDATE scheduled_jobs
@@ -89,7 +98,7 @@ impl KeyStore {
                    WHERE id = 'local'"#,
             )
             .bind(reason)
-            .bind(retry_at)
+            .bind(available_at)
             .bind(now)
             .execute(&mut *tx)
             .await?;
@@ -102,7 +111,7 @@ impl KeyStore {
                     sqlx::query(
                         "UPDATE scheduled_jobs SET available_at = MIN(available_at, ?) WHERE id = ?",
                     )
-                    .bind(retry_at)
+                    .bind(available_at)
                     .bind(continuation_id)
                     .execute(&mut *tx)
                     .await?;
@@ -122,7 +131,7 @@ impl KeyStore {
                    ) VALUES ('upstream_reconciliation', 'auto', 'queued', 1, ?, ?, NULL, NULL)"#,
             )
             .bind(now)
-            .bind(retry_at)
+            .bind(available_at)
             .execute(&mut *tx)
             .await?;
             Ok(ScheduledJobEnqueueResult {

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -48,6 +48,69 @@ pub(crate) struct ReconciliationRunObservationWrite {
 }
 
 impl KeyStore {
+    async fn apply_upstream_reconciliation_local_backoff_locked<T>(
+        transaction: &mut T,
+        pressure: bool,
+        now: i64,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<(i64, i64, i64), ProxyError>
+    where
+        T: std::ops::DerefMut<Target = sqlx::SqliteConnection>,
+    {
+        let (previous_streak, previous_level, _) = Self::reconciliation_backoff_state_locked(
+            transaction,
+            META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1,
+            META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1,
+            META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1,
+        )
+        .await?;
+        let (streak, level, until) = if pressure {
+            let streak = previous_streak.saturating_add(1);
+            let level = if streak < 3 {
+                0
+            } else {
+                previous_level.saturating_add(1).clamp(1, 4)
+            };
+            let delay_secs = match level {
+                1 => 30,
+                2 => 60,
+                3 => 120,
+                4 => 300,
+                _ => 0,
+            };
+            (streak, level, now.saturating_add(delay_secs))
+        } else {
+            (0, 0, 0)
+        };
+        if !Self::reconciliation_claim_is_current_locked(transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
+        sqlx::query(
+            r#"INSERT INTO meta (key, value) VALUES (?, ?), (?, ?), (?, ?)
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value"#,
+        )
+        .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1)
+        .bind(streak.to_string())
+        .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1)
+        .bind(level.to_string())
+        .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
+        .bind(until.to_string())
+        .execute(&mut **transaction)
+        .await?;
+        if !pressure && previous_level > 0 {
+            sqlx::query("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+                .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_LAST_RECOVERED_AT_V1)
+                .bind(now.to_string())
+                .execute(&mut **transaction)
+                .await?;
+        }
+        Ok((streak, level, until))
+    }
+
     pub(crate) async fn finalize_deferred_upstream_reconciliation_claim(
         &self,
         job_id: i64,

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -163,7 +163,7 @@ impl KeyStore {
             .bind(pending_count)
             .execute(&mut **transaction)
             .await?;
-        } else if now.saturating_sub(active_started_at) >= WINDOW_SECS {
+        } else if now.saturating_sub(active_started_at) == WINDOW_SECS {
             sqlx::query(
                 r#"UPDATE upstream_reconciliation_research_progress_window
                        SET last_window_started_at = ?, last_window_ended_at = ?,
@@ -176,6 +176,23 @@ impl KeyStore {
             .bind(now)
             .bind(terminal_count.saturating_sub(baseline_terminal_count))
             .bind(pending_count.saturating_sub(baseline_pending_count))
+            .bind(now)
+            .bind(terminal_count)
+            .bind(pending_count)
+            .execute(&mut **transaction)
+            .await?;
+        } else if now.saturating_sub(active_started_at) > WINDOW_SECS {
+            // A missed observation cannot prove progress for the fixed window.
+            // Restart from this durable sample instead of publishing a longer,
+            // deceptively healthy interval.
+            sqlx::query(
+                r#"UPDATE upstream_reconciliation_research_progress_window
+                       SET active_started_at = ?, baseline_terminal_count = ?,
+                           baseline_pending_count = ?, last_window_started_at = NULL,
+                           last_window_ended_at = NULL, last_window_terminal_delta = 0,
+                           last_window_pending_delta = 0
+                     WHERE id = 'local'"#,
+            )
             .bind(now)
             .bind(terminal_count)
             .bind(pending_count)

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -111,6 +111,80 @@ impl KeyStore {
         Ok((streak, level, until))
     }
 
+    async fn record_reconciliation_research_progress_window_locked<T>(
+        &self,
+        transaction: &mut T,
+        now: i64,
+    ) -> Result<(), ProxyError>
+    where
+        T: std::ops::DerefMut<Target = sqlx::SqliteConnection>,
+    {
+        const WINDOW_SECS: i64 = 10 * 60;
+        let day_window =
+            server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&chrono::Local));
+        let (terminal_count, pending_count) = sqlx::query_as::<_, (i64, i64)>(
+            r#"SELECT COUNT(DISTINCT CASE WHEN r.terminal_at IS NOT NULL THEN r.request_id END),
+                       COUNT(DISTINCT CASE WHEN r.terminal_at IS NULL THEN r.request_id END)
+                  FROM upstream_reconciliation_research r
+                  JOIN upstream_reconciliation_usage u
+                    ON u.token_id = r.token_id AND u.period_code = r.period_code
+                 WHERE u.period_start >= ? AND u.period_start < ?"#,
+        )
+        .bind(day_window.start)
+        .bind(day_window.end)
+        .fetch_one(&mut **transaction)
+        .await?;
+        let (
+            active_period_start,
+            active_started_at,
+            baseline_terminal_count,
+            baseline_pending_count,
+        ) = sqlx::query_as::<_, (i64, i64, i64, i64)>(
+            r#"SELECT active_period_start, active_started_at,
+                       baseline_terminal_count, baseline_pending_count
+                  FROM upstream_reconciliation_research_progress_window
+                 WHERE id = 'local'"#,
+        )
+        .fetch_one(&mut **transaction)
+        .await?;
+
+        if active_period_start != day_window.start || active_started_at <= 0 {
+            sqlx::query(
+                r#"UPDATE upstream_reconciliation_research_progress_window
+                       SET active_period_start = ?, active_started_at = ?,
+                           baseline_terminal_count = ?, baseline_pending_count = ?,
+                           last_window_started_at = NULL, last_window_ended_at = NULL,
+                           last_window_terminal_delta = 0, last_window_pending_delta = 0
+                     WHERE id = 'local'"#,
+            )
+            .bind(day_window.start)
+            .bind(now)
+            .bind(terminal_count)
+            .bind(pending_count)
+            .execute(&mut **transaction)
+            .await?;
+        } else if now.saturating_sub(active_started_at) >= WINDOW_SECS {
+            sqlx::query(
+                r#"UPDATE upstream_reconciliation_research_progress_window
+                       SET last_window_started_at = ?, last_window_ended_at = ?,
+                           last_window_terminal_delta = ?, last_window_pending_delta = ?,
+                           active_started_at = ?, baseline_terminal_count = ?,
+                           baseline_pending_count = ?
+                     WHERE id = 'local'"#,
+            )
+            .bind(active_started_at)
+            .bind(now)
+            .bind(terminal_count.saturating_sub(baseline_terminal_count))
+            .bind(pending_count.saturating_sub(baseline_pending_count))
+            .bind(now)
+            .bind(terminal_count)
+            .bind(pending_count)
+            .execute(&mut **transaction)
+            .await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn finalize_deferred_upstream_reconciliation_claim(
         &self,
         job_id: i64,
@@ -165,6 +239,8 @@ impl KeyStore {
             .bind(now)
             .execute(&mut *tx)
             .await?;
+            self.record_reconciliation_research_progress_window_locked(&mut tx, now)
+                .await?;
 
             if let Some((continuation_id, status, trigger_source)) =
                 Self::scheduled_job_lookup_active_locked(&mut tx, "upstream_reconciliation", None)
@@ -286,6 +362,8 @@ impl KeyStore {
         .bind(now)
         .execute(&mut *tx)
         .await?;
+        self.record_reconciliation_research_progress_window_locked(&mut tx, now)
+            .await?;
         tx.finish(Ok(())).await
     }
     #[allow(dead_code)]

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -154,12 +154,14 @@ impl KeyStore {
                   FROM upstream_reconciliation_research r
                   JOIN upstream_reconciliation_usage u
                     ON u.token_id = r.token_id AND u.period_code = r.period_code
-                 WHERE u.period_start >= ? AND u.period_start < ?"#,
+                 WHERE u.period_start >= ? AND u.period_start < ?
+                   AND r.created_at <= ?"#,
         )
         .bind(sample_at)
         .bind(sample_at)
         .bind(day_window.start)
         .bind(day_window.end)
+        .bind(sample_at)
         .fetch_one(&mut **transaction)
         .await?;
 

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -122,18 +122,6 @@ impl KeyStore {
         const WINDOW_SECS: i64 = 10 * 60;
         let day_window =
             server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&chrono::Local));
-        let (terminal_count, pending_count) = sqlx::query_as::<_, (i64, i64)>(
-            r#"SELECT COUNT(DISTINCT CASE WHEN r.terminal_at IS NOT NULL THEN r.request_id END),
-                       COUNT(DISTINCT CASE WHEN r.terminal_at IS NULL THEN r.request_id END)
-                  FROM upstream_reconciliation_research r
-                  JOIN upstream_reconciliation_usage u
-                    ON u.token_id = r.token_id AND u.period_code = r.period_code
-                 WHERE u.period_start >= ? AND u.period_start < ?"#,
-        )
-        .bind(day_window.start)
-        .bind(day_window.end)
-        .fetch_one(&mut **transaction)
-        .await?;
         let (
             active_period_start,
             active_started_at,
@@ -145,6 +133,33 @@ impl KeyStore {
                   FROM upstream_reconciliation_research_progress_window
                  WHERE id = 'local'"#,
         )
+        .fetch_one(&mut **transaction)
+        .await?;
+        let window_end = active_started_at.saturating_add(WINDOW_SECS);
+        let sample_at = if active_period_start == day_window.start
+            && active_started_at > 0
+            && now >= window_end
+        {
+            window_end
+        } else {
+            now
+        };
+        let (terminal_count, pending_count) = sqlx::query_as::<_, (i64, i64)>(
+            r#"SELECT COUNT(DISTINCT CASE
+                            WHEN r.terminal_at IS NOT NULL AND r.terminal_at <= ? THEN r.request_id
+                        END),
+                       COUNT(DISTINCT CASE
+                            WHEN r.terminal_at IS NULL OR r.terminal_at > ? THEN r.request_id
+                        END)
+                  FROM upstream_reconciliation_research r
+                  JOIN upstream_reconciliation_usage u
+                    ON u.token_id = r.token_id AND u.period_code = r.period_code
+                 WHERE u.period_start >= ? AND u.period_start < ?"#,
+        )
+        .bind(sample_at)
+        .bind(sample_at)
+        .bind(day_window.start)
+        .bind(day_window.end)
         .fetch_one(&mut **transaction)
         .await?;
 
@@ -163,7 +178,7 @@ impl KeyStore {
             .bind(pending_count)
             .execute(&mut **transaction)
             .await?;
-        } else if now.saturating_sub(active_started_at) == WINDOW_SECS {
+        } else if now >= window_end {
             sqlx::query(
                 r#"UPDATE upstream_reconciliation_research_progress_window
                        SET last_window_started_at = ?, last_window_ended_at = ?,
@@ -173,27 +188,10 @@ impl KeyStore {
                      WHERE id = 'local'"#,
             )
             .bind(active_started_at)
-            .bind(now)
+            .bind(window_end)
             .bind(terminal_count.saturating_sub(baseline_terminal_count))
             .bind(pending_count.saturating_sub(baseline_pending_count))
-            .bind(now)
-            .bind(terminal_count)
-            .bind(pending_count)
-            .execute(&mut **transaction)
-            .await?;
-        } else if now.saturating_sub(active_started_at) > WINDOW_SECS {
-            // A missed observation cannot prove progress for the fixed window.
-            // Restart from this durable sample instead of publishing a longer,
-            // deceptively healthy interval.
-            sqlx::query(
-                r#"UPDATE upstream_reconciliation_research_progress_window
-                       SET active_started_at = ?, baseline_terminal_count = ?,
-                           baseline_pending_count = ?, last_window_started_at = NULL,
-                           last_window_ended_at = NULL, last_window_terminal_delta = 0,
-                           last_window_pending_delta = 0
-                     WHERE id = 'local'"#,
-            )
-            .bind(now)
+            .bind(window_end)
             .bind(terminal_count)
             .bind(pending_count)
             .execute(&mut **transaction)

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -48,6 +48,104 @@ pub(crate) struct ReconciliationRunObservationWrite {
 }
 
 impl KeyStore {
+    pub(crate) async fn finalize_deferred_upstream_reconciliation_claim(
+        &self,
+        job_id: i64,
+        claim_generation: i64,
+        reason: &'static str,
+        retry_at: i64,
+    ) -> Result<ScheduledJobEnqueueResult, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let mut tx = self
+            .sqlite_runtime
+            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .await?;
+        let result = async {
+            let message = format!(
+                "outcome=sqlite_admission_deferred defer_reason={reason} retry_at={retry_at}"
+            );
+            let updated = sqlx::query(
+                r#"UPDATE scheduled_jobs
+                   SET status = 'success', message = ?, finished_at = ?
+                   WHERE id = ? AND status = 'running' AND claim_generation = ?"#,
+            )
+            .bind(message)
+            .bind(now)
+            .bind(job_id)
+            .bind(claim_generation)
+            .execute(&mut *tx)
+            .await?;
+            if updated.rows_affected() == 0 {
+                return Err(ProxyError::StaleClaim {
+                    job_id,
+                    claim_generation,
+                });
+            }
+            sqlx::query(
+                r#"UPDATE upstream_reconciliation_run_observation
+                   SET local_pressure_count = local_pressure_count + 1,
+                       last_retryable_outcome = 'local_pressure',
+                       continuation_reason = ?, next_retry_at = ?, observed_at = ?
+                   WHERE id = 'local'"#,
+            )
+            .bind(reason)
+            .bind(retry_at)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+
+            if let Some((continuation_id, status, trigger_source)) =
+                Self::scheduled_job_lookup_active_locked(&mut tx, "upstream_reconciliation", None)
+                    .await?
+            {
+                if status == "queued" {
+                    sqlx::query(
+                        "UPDATE scheduled_jobs SET available_at = MIN(available_at, ?) WHERE id = ?",
+                    )
+                    .bind(retry_at)
+                    .bind(continuation_id)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+                return Ok(ScheduledJobEnqueueResult {
+                    job_id: continuation_id,
+                    created: false,
+                    promoted: false,
+                    status,
+                    trigger_source,
+                });
+            }
+            let inserted = sqlx::query(
+                r#"INSERT INTO scheduled_jobs (
+                       job_type, trigger_source, status, attempt, queued_at, available_at,
+                       started_at, finished_at
+                   ) VALUES ('upstream_reconciliation', 'auto', 'queued', 1, ?, ?, NULL, NULL)"#,
+            )
+            .bind(now)
+            .bind(retry_at)
+            .execute(&mut *tx)
+            .await?;
+            Ok(ScheduledJobEnqueueResult {
+                job_id: inserted.last_insert_rowid(),
+                created: true,
+                promoted: false,
+                status: "queued".to_string(),
+                trigger_source: "auto".to_string(),
+            })
+        }
+        .await;
+        match result {
+            Ok(result) => {
+                tx.finish(Ok(())).await?;
+                Ok(result)
+            }
+            Err(error) => {
+                tx.finish(Err(error)).await?;
+                unreachable!("failed reconciliation finalization transaction committed")
+            }
+        }
+    }
+
     pub(crate) async fn record_upstream_reconciliation_engine_observation(
         &self,
         observation: ReconciliationRunObservationWrite,
@@ -118,6 +216,7 @@ impl KeyStore {
         .await?;
         tx.finish(Ok(())).await
     }
+    #[allow(dead_code)]
     pub(crate) async fn upstream_reconciliation_run_observation(
         &self,
     ) -> Result<ReconciliationRunObservation, ProxyError> {

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -52,6 +52,7 @@ pub(crate) struct SqliteMaintenanceRunLease {
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) enum SqliteOperation {
+    AdminPrivacyRead,
     AdminRead,
     AlertProjection,
     BillingLedgerAuditRead,
@@ -72,6 +73,7 @@ pub(crate) enum SqliteOperation {
 impl SqliteOperation {
     fn as_str(self) -> &'static str {
         match self {
+            Self::AdminPrivacyRead => "admin_privacy_read",
             Self::AdminRead => "admin_read",
             Self::AlertProjection => "alert_projection",
             Self::BillingLedgerAuditRead => "billing_ledger_audit_read",
@@ -92,6 +94,10 @@ impl SqliteOperation {
 
     fn workload_class(self) -> &'static str {
         match self {
+            Self::AdminPrivacyRead
+            | Self::BillingLedgerAuditRead
+            | Self::HaBaselineRead
+            | Self::HaEventsRead => "maintenance_read",
             Self::AdminRead
             | Self::AlertProjection
             | Self::DashboardIntegrityWrite
@@ -102,16 +108,14 @@ impl SqliteOperation {
             | Self::ServerPressureRebuild
             | Self::ReconciliationProjection => "maintenance_bulk",
             Self::ForegroundJobTrigger => "foreground_work",
-            Self::BillingLedgerAuditRead | Self::HaBaselineRead | Self::HaEventsRead => {
-                "maintenance_read"
-            }
             Self::ScheduledJobControl | Self::HaOutboxGcWatchdog => "maintenance_control",
         }
     }
 
     fn acquire_budget(self) -> Duration {
         match self {
-            Self::AdminRead
+            Self::AdminPrivacyRead
+            | Self::AdminRead
             | Self::AlertProjection
             | Self::DashboardIntegrityWrite
             | Self::ScheduledJobControl
@@ -129,7 +133,8 @@ impl SqliteOperation {
 
     fn begin_budget(self) -> Duration {
         match self {
-            Self::AdminRead
+            Self::AdminPrivacyRead
+            | Self::AdminRead
             | Self::AlertProjection
             | Self::DashboardIntegrityWrite
             | Self::RequestStatsFlush
@@ -151,7 +156,8 @@ impl SqliteOperation {
             // cooperative run budget expires. A connection-local timeout
             // returns writer contention as a typed defer without cancelling
             // a future that still owns the physical connection.
-            Self::AdminRead
+            Self::AdminPrivacyRead
+            | Self::AdminRead
             | Self::AlertProjection
             | Self::DashboardIntegrityWrite
             | Self::ObservabilityDeferredWrite
@@ -1159,6 +1165,14 @@ impl SqliteRuntime {
 }
 
 impl KeyStore {
+    pub(crate) async fn begin_admin_privacy_read_session(
+        &self,
+    ) -> Result<SqliteReadSnapshot, ProxyError> {
+        self.sqlite_runtime
+            .begin_read_snapshot(SqliteOperation::AdminPrivacyRead)
+            .await
+    }
+
     pub(crate) fn record_foreground_activity(&self) {
         self.sqlite_runtime.record_foreground_activity();
     }
@@ -2229,6 +2243,50 @@ mod tests {
                 .expect("foreground pool acquisition");
         drop(foreground);
         drop(first);
+    }
+
+    #[tokio::test]
+    async fn admin_privacy_read_session_is_bounded_and_independent_of_bulk_admission() {
+        let runtime = three_connection_runtime().await;
+        let bulk = runtime
+            .try_admit_maintenance_bulk(SqliteOperation::HaOutboxGc)
+            .expect("hold unrelated bulk admission");
+        let session = runtime
+            .begin_read_snapshot(SqliteOperation::AdminPrivacyRead)
+            .await
+            .expect("privacy read does not require the bulk permit");
+        session.close().await.expect("close privacy session");
+        drop(bulk);
+
+        let first = runtime
+            .inner
+            .pool
+            .acquire()
+            .await
+            .expect("hold first connection");
+        let second = runtime
+            .inner
+            .pool
+            .acquire()
+            .await
+            .expect("hold second connection");
+        let third = runtime
+            .inner
+            .pool
+            .acquire()
+            .await
+            .expect("hold third connection");
+        let started = Instant::now();
+        let error = runtime
+            .begin_read_snapshot(SqliteOperation::AdminPrivacyRead)
+            .await
+            .expect_err("pool exhaustion must reject the cold privacy read");
+        assert!(matches!(
+            error,
+            ProxyError::Database(sqlx::Error::PoolTimedOut)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(150));
+        drop((third, second, first));
     }
 
     #[tokio::test]

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -838,7 +838,7 @@ pub struct TavilyProxy {
 /// the permit; callers can only retain it while doing the admitted work.
 #[derive(Debug)]
 pub struct SqliteMaintenanceAdmission {
-    _permit: SqliteMaintenanceBulkPermit,
+    _permit: Option<SqliteMaintenanceBulkPermit>,
 }
 
 #[derive(Debug)]

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -834,11 +834,20 @@ pub struct TavilyProxy {
     pub(crate) backend_time: BackendTime,
 }
 
-/// Admission token for a bounded maintenance SQLite slice. The runtime owns
-/// the permit; callers can only retain it while doing the admitted work.
+/// Admission token for a bounded maintenance SQLite slice. Bulk work retains
+/// a runtime permit; the compatibility privacy-status admission is detached
+/// because that endpoint owns its separate bounded read session.
 #[derive(Debug)]
 pub struct SqliteMaintenanceAdmission {
-    _permit: Option<SqliteMaintenanceBulkPermit>,
+    _kind: SqliteMaintenanceAdmissionKind,
+}
+
+#[derive(Debug)]
+enum SqliteMaintenanceAdmissionKind {
+    Bulk {
+        _permit: SqliteMaintenanceBulkPermit,
+    },
+    DetachedRead,
 }
 
 #[derive(Debug)]

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -2,7 +2,9 @@ impl TavilyProxy {
     pub fn admit_admin_privacy_status(&self) -> SqliteAdmissionOutcome {
         // Compatibility surface only: privacy status owns its bounded read
         // session and must never re-enter maintenance-bulk admission.
-        SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission { _permit: None })
+        SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
+            _kind: SqliteMaintenanceAdmissionKind::DetachedRead,
+        })
     }
 
     #[doc(hidden)]

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -1,17 +1,8 @@
 impl TavilyProxy {
     pub fn admit_admin_privacy_status(&self) -> SqliteAdmissionOutcome {
-        match self
-            .key_store
-            .sqlite_runtime
-            .try_admit_maintenance_bulk(SqliteOperation::AdminRead)
-        {
-            Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: permit,
-            }),
-            Err(reason) => SqliteAdmissionOutcome::Deferred {
-                reason: reason.as_str(),
-            },
-        }
+        // Compatibility surface only: privacy status owns its bounded read
+        // session and must never re-enter maintenance-bulk admission.
+        SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission { _permit: None })
     }
 
     #[doc(hidden)]
@@ -81,6 +72,7 @@ impl TavilyProxy {
         Ok(dashboard_dirty)
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn dashboard_alert_projection_status(
         &self,
     ) -> Result<AlertProjectionStatus, ProxyError> {

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -889,6 +889,11 @@ impl TavilyProxy {
                 event.generation = next_generation;
             }
         }
+        drop(buffered);
+        let mut writer = self.observability_deferred_writer.lock().await;
+        // A demotion creates a new serving generation. Its first qualifying
+        // rebuild is not throttled by the previous tenure.
+        writer.last_pressure_rebuild_started_at = None;
     }
 
     #[cfg(test)]
@@ -1401,7 +1406,36 @@ impl TavilyProxy {
         PostReadyServingTasksClaim::Suppressed { should_log }
     }
 
+    fn server_pressure_rebuild_is_due(&self) -> bool {
+        let now = self.backend_time.now_ts();
+        let Ok(writer) = self.observability_deferred_writer.try_lock() else {
+            return false;
+        };
+        let stale_long_enough = writer.pressure_stale_since.is_some_and(|since| {
+            now.saturating_sub(since) >= Self::SERVER_PRESSURE_REBUILD_MIN_INTERVAL.as_secs() as i64
+        });
+        let due_to_overflow_or_coverage_loss =
+            writer.pressure_rebuild_requested || writer.pressure_unrecoverable_overflow;
+        (due_to_overflow_or_coverage_loss || stale_long_enough)
+            && writer.last_pressure_rebuild_started_at.is_none_or(|started| {
+                now.saturating_sub(started)
+                    >= Self::SERVER_PRESSURE_REBUILD_MIN_INTERVAL.as_secs() as i64
+            })
+    }
+
     pub fn spawn_server_pressure_buckets_rebuild_once(&self) -> bool {
+        if !self.server_pressure_rebuild_is_due() {
+            return false;
+        }
+        self.start_server_pressure_buckets_rebuild_once()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_server_pressure_buckets_rebuild_once_for_test(&self) -> bool {
+        self.start_server_pressure_buckets_rebuild_once()
+    }
+
+    fn start_server_pressure_buckets_rebuild_once(&self) -> bool {
         let generation = self
             .server_pressure_rebuild_generation
             .load(Ordering::SeqCst);

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -183,7 +183,7 @@ impl TavilyProxy {
     pub fn admit_dashboard_rollup_integrity(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_dashboard_rollup_integrity() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: Some(permit),
+                _kind: SqliteMaintenanceAdmissionKind::Bulk { _permit: permit },
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -407,7 +407,7 @@ impl TavilyProxy {
     pub fn admit_ha_outbox_gc(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_ha_outbox_gc() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: Some(permit),
+                _kind: SqliteMaintenanceAdmissionKind::Bulk { _permit: permit },
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -418,7 +418,7 @@ impl TavilyProxy {
     pub fn admit_request_logs_gc(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_request_logs_gc() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: Some(permit),
+                _kind: SqliteMaintenanceAdmissionKind::Bulk { _permit: permit },
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -435,7 +435,7 @@ impl TavilyProxy {
     pub fn admit_server_pressure_rebuild(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_server_pressure_rebuild() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: Some(permit),
+                _kind: SqliteMaintenanceAdmissionKind::Bulk { _permit: permit },
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -446,7 +446,7 @@ impl TavilyProxy {
     pub fn admit_upstream_reconciliation_projection(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_upstream_reconciliation_projection() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: Some(permit),
+                _kind: SqliteMaintenanceAdmissionKind::Bulk { _permit: permit },
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -183,7 +183,7 @@ impl TavilyProxy {
     pub fn admit_dashboard_rollup_integrity(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_dashboard_rollup_integrity() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: permit,
+                _permit: Some(permit),
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -407,7 +407,7 @@ impl TavilyProxy {
     pub fn admit_ha_outbox_gc(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_ha_outbox_gc() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: permit,
+                _permit: Some(permit),
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -418,7 +418,7 @@ impl TavilyProxy {
     pub fn admit_request_logs_gc(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_request_logs_gc() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: permit,
+                _permit: Some(permit),
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -435,7 +435,7 @@ impl TavilyProxy {
     pub fn admit_server_pressure_rebuild(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_server_pressure_rebuild() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: permit,
+                _permit: Some(permit),
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),
@@ -446,7 +446,7 @@ impl TavilyProxy {
     pub fn admit_upstream_reconciliation_projection(&self) -> SqliteAdmissionOutcome {
         match self.key_store.try_admit_upstream_reconciliation_projection() {
             Ok(permit) => SqliteAdmissionOutcome::Admitted(SqliteMaintenanceAdmission {
-                _permit: permit,
+                _permit: Some(permit),
             }),
             Err(reason) => SqliteAdmissionOutcome::Deferred {
                 reason: reason.as_str(),

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -31,7 +31,7 @@ impl TavilyProxy {
     // allowed to use the remainder of the scheduler's 20 second budget.
     const RECONCILIATION_MAIN_PREP_BUDGET_SECS: u64 = 2;
     const RECONCILIATION_TOTAL_BUDGET_SECS: u64 = 20;
-    const RECONCILIATION_FINALIZATION_HEADROOM_SECS: u64 = 1;
+    const RECONCILIATION_FINALIZATION_HEADROOM_SECS: u64 = 2;
     const RECONCILIATION_POST_PROCESS_HEADROOM_SECS: u64 = 2;
     const RECONCILIATION_RETRY_BOOKKEEPING_HEADROOM_SECS: u64 = 2;
     const RECONCILIATION_OUTER_TIMEOUT_MARGIN_SECS: u64 = 1;
@@ -59,218 +59,16 @@ impl TavilyProxy {
     }
 
     pub async fn upstream_privacy_status(&self) -> Result<UpstreamPrivacyStatus, ProxyError> {
-        let now = self.backend_time.now_ts();
-        let settings = self.key_store.get_system_settings().await?;
-        let active_upstream_mcp_sessions = self
+        let mut session = self.key_store.begin_admin_privacy_read_session().await?;
+        let result = self
             .key_store
-            .count_active_upstream_mcp_sessions(now)
-            .await?;
-        let period = business_period_for_timestamp(now);
-        let stored_epoch = self
-            .key_store
-            .get_meta_i64(META_KEY_UPSTREAM_RECONCILIATION_READY_AFTER_V1)
-            .await?
-            .unwrap_or(0);
-        let mode_ready = settings.upstream_project_id_mode == UpstreamProjectIdMode::AccessToken;
-        let api_ready = settings.api_rebalance_enabled;
-        let mcp_ready = settings.rebalance_mcp_enabled;
-        let shadow_ready = mode_ready && api_ready && mcp_ready;
-        let sessions_ready = active_upstream_mcp_sessions == 0;
-        let gates = vec![
-            UpstreamPrivacyGate {
-                key: "accessTokenMode".to_string(),
-                ready: mode_ready,
-                detail: format!("{:?}", settings.upstream_project_id_mode),
-            },
-            UpstreamPrivacyGate {
-                key: "apiRebalance".to_string(),
-                ready: api_ready,
-                detail: if api_ready { "enabled" } else { "disabled" }.to_string(),
-            },
-            UpstreamPrivacyGate {
-                key: "mcpRebalance".to_string(),
-                ready: mcp_ready,
-                detail: if mcp_ready { "enabled" } else { "disabled" }.to_string(),
-            },
-            UpstreamPrivacyGate {
-                key: "controlSessionsDrained".to_string(),
-                ready: sessions_ready,
-                detail: active_upstream_mcp_sessions.to_string(),
-            },
-        ];
-        let completed_gates = gates.iter().filter(|gate| gate.ready).count() as i64;
-        let total_gates = gates.len() as i64;
-        let reconciliation_observation = self
-            .key_store
-            .upstream_reconciliation_observation()
-            .await?;
-        let retry_buckets = self
-            .key_store
-            .upstream_reconciliation_retry_buckets()
-            .await?;
-        let (current_period_bound_users_by_key, current_period_pending_project_ids_by_key) = self
-            .key_store
-            .current_period_reconciliation_key_activity(&period.code)
-            .await?;
-        let (daily_reconciliation_progress, daily_reconciliation_by_key) = self
-            .key_store
-            .daily_reconciliation_progress()
-            .await?;
-        let pending_research = Some(daily_reconciliation_progress.research_pending);
-        let queued_settlements = reconciliation_observation.queue_estimate;
-        let (degraded_settlements, degraded_settlements_capped) = self
-            .key_store
-            .upstream_reconciliation_degraded_estimate()
-            .await?;
-        let (
-            last_reconciliation_run_at,
-            last_shadow_adjustment_at,
-            last_reconciliation_enqueue_error_at,
-            last_research_sweep_at,
-            last_research_terminal_at,
-        ) = self
-            .key_store
-            .upstream_reconciliation_runtime_markers()
-            .await?;
-        let (
-            reconciliation_pressure_streak,
-            reconciliation_backoff_level,
-            reconciliation_backoff_until,
-        ) = self
-            .key_store
-            .upstream_reconciliation_global_backoff_state()
-            .await?;
-        let (
-            reconciliation_local_pressure_streak,
-            reconciliation_local_backoff_level,
-            reconciliation_local_backoff_until,
-        ) = self
-            .key_store
-            .upstream_reconciliation_local_backoff_state()
-            .await?;
-        let reconciliation_local_last_recovered_at = self
-            .key_store
-            .upstream_reconciliation_local_last_recovered_at()
-            .await?;
-        let reconciliation_run_observation = self
-            .key_store
-            .upstream_reconciliation_run_observation()
-            .await?;
-        let reconciliation_controller = self
-            .key_store
-            .upstream_reconciliation_control_state()
-            .await?;
-        let dashboard_alert_projection = self.dashboard_alert_projection_status().await?;
-        let (
-            reconciliation_last_duration_ms,
-            reconciliation_last_attempted,
-            reconciliation_last_settled,
-            reconciliation_last_no_adjustment,
-            reconciliation_last_upstream_429,
-            reconciliation_last_budget_exhausted,
-        ) = self
-            .key_store
-            .upstream_reconciliation_last_run_stats()
-            .await?;
-        let next_epoch_at = if reconciliation_controller.legacy_active
-            && reconciliation_controller.mode == ReconciliationMode::Active
-            && shadow_ready
-            && sessions_ready
-        {
-            Some(if stored_epoch > 0 { stored_epoch } else { period.ends_at })
-        } else {
-            reconciliation_controller.activation_period_start
-        };
-        let phase = reconciliation_controller.mode.as_str();
-        Ok(UpstreamPrivacyStatus {
-            phase: phase.to_string(),
-            configured_project_id_mode: settings.upstream_project_id_mode,
-            effective_project_id_mode: settings.upstream_project_id_mode,
-            fixed_project_id_configured: !settings.upstream_project_id_fixed_value.is_empty(),
-            configured_mcp_user_agent: settings.upstream_mcp_user_agent.clone(),
-            effective_mcp_user_agent: (!settings.upstream_mcp_user_agent.is_empty())
-                .then_some(settings.upstream_mcp_user_agent),
-            upstream_precise_reconciliation_enabled: settings.upstream_precise_reconciliation_enabled,
-            http_allowed_headers: vec![
-                "accept".to_string(),
-                "accept-encoding".to_string(),
-                "content-type".to_string(),
-                "x-project-id (policy injected)".to_string(),
-            ],
-            control_mcp_allowed_headers: vec![
-                "accept".to_string(),
-                "accept-encoding".to_string(),
-                "cache-control".to_string(),
-                "content-type".to_string(),
-                "last-event-id".to_string(),
-                "mcp-protocol-version".to_string(),
-                "mcp-session-id".to_string(),
-                "pragma".to_string(),
-                "user-agent (configured only)".to_string(),
-            ],
-            gates,
-            completed_gates,
-            total_gates,
-            active_upstream_mcp_sessions,
-            current_period_code: period.code,
-            current_period_ends_at: period.ends_at,
-            next_epoch_at,
-            pending_research,
-            queued_settlements,
-            degraded_settlements,
-            degraded_settlements_capped,
-            last_reconciliation_run_at,
-            last_shadow_adjustment_at,
-            last_reconciliation_enqueue_error_at,
-            last_research_sweep_at,
-            last_research_terminal_at,
-            reconciliation_pressure_streak,
-            reconciliation_backoff_level,
-            reconciliation_backoff_until: (reconciliation_backoff_until > now)
-                .then_some(reconciliation_backoff_until),
-            reconciliation_last_duration_ms,
-            reconciliation_last_attempted,
-            reconciliation_last_settled,
-            reconciliation_last_no_adjustment,
-            reconciliation_last_upstream_429,
-            reconciliation_last_budget_exhausted,
-            reconciliation_observation,
-            reconciliation_local_backoff: ReconciliationLocalBackoff {
-                pressure_streak: reconciliation_local_pressure_streak,
-                level: reconciliation_local_backoff_level,
-                available_at: (reconciliation_local_backoff_until > now)
-                    .then_some(reconciliation_local_backoff_until),
-                last_recovered_at: reconciliation_local_last_recovered_at,
-            },
-            reconciliation_run_observation,
-            reconciliation_controller: ReconciliationControllerStatus {
-                mode: reconciliation_controller.mode.as_str().to_string(),
-                activation_period_code: reconciliation_controller.activation_period_code,
-                activation_period_start: reconciliation_controller.activation_period_start,
-                legacy_active: reconciliation_controller.legacy_active,
-                paused_reason: reconciliation_controller.paused_reason,
-                transitioned_at: (reconciliation_controller.transitioned_at > 0)
-                    .then_some(reconciliation_controller.transitioned_at),
-            },
-            dashboard_alert_projection: DashboardAlertProjectionStatus {
-                coverage: dashboard_alert_projection.coverage,
-                observed_at: dashboard_alert_projection.observed_at,
-                stale_reason: dashboard_alert_projection.stale_reason,
-            },
-            retry_buckets,
-            current_period_bound_users_by_key,
-            current_period_pending_project_ids_by_key,
-            daily_reconciliation_progress,
-            daily_reconciliation_by_key,
-            recent_adjustments: self
-                .key_store
-                .recent_reconciliation_adjustments(10)
-                .await?,
-            generated_at: now,
-            coverage: "ok".to_string(),
-            observed_at: Some(now),
-            stale_reason: None,
-        })
+            .upstream_privacy_status_from_snapshot(&mut session)
+            .await;
+        let close = session.close().await;
+        match (result, close) {
+            (Ok(status), Ok(())) => Ok(status),
+            (Err(error), _) | (_, Err(error)) => Err(error),
+        }
     }
 
     pub async fn record_upstream_reconciliation_usage(
@@ -837,7 +635,7 @@ impl TavilyProxy {
                     no_adjustment,
                     observed,
                 } => return Ok(settled + no_adjustment + observed),
-                ClaimedReconciliationRunOutcome::Deferred { reason } => {
+                ClaimedReconciliationRunOutcome::Deferred { reason, .. } => {
                     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                     if remaining.is_zero() {
                         return Err(ProxyError::Other(format!(
@@ -958,7 +756,7 @@ impl TavilyProxy {
                     defer_reason = reason,
                     "reconciliation skipped local candidate preparation before SQLite connection acquisition"
                 );
-                return Ok(ClaimedReconciliationRunOutcome::Deferred { reason });
+                return Ok(ReconciliationEngine::deferred(self, reason));
             }
         };
         let run_admission_state = match self
@@ -968,9 +766,7 @@ impl TavilyProxy {
         {
             Ok(state) => state,
             Err(err) if is_transient_sqlite_write_error(&err) => {
-                return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                    reason: "pool_pressure",
-                });
+                return Ok(ReconciliationEngine::deferred(self, "pool_pressure"));
             }
             Err(err) => return Err(err),
         };
@@ -1102,9 +898,7 @@ impl TavilyProxy {
         let mut preparation_budget_exhausted = false;
         let mut candidate_batch;
         if preparation_deadline <= std::time::Instant::now() {
-            return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                reason: "local_pressure",
-            });
+            return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
         } else {
             candidate_batch = match self
                 .key_store
@@ -1113,9 +907,7 @@ impl TavilyProxy {
             {
                 Ok(batch) => batch,
                 Err(err) if is_transient_sqlite_write_error(&err) => {
-                    return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                        reason: "local_pressure",
-                    });
+                    return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
                 }
                 Err(err) => return Err(err),
             };
@@ -1161,9 +953,10 @@ impl TavilyProxy {
                             {
                                 Ok(batch) => batch,
                                 Err(err) if is_transient_sqlite_write_error(&err) => {
-                                    return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                                        reason: "local_pressure",
-                                    });
+                                    return Ok(ReconciliationEngine::deferred(
+                                        self,
+                                        "local_pressure",
+                                    ));
                                 }
                                 Err(err) => return Err(err),
                             };
@@ -1207,9 +1000,7 @@ impl TavilyProxy {
             let remaining = candidate_hydration_deadline
                 .saturating_duration_since(std::time::Instant::now());
             if remaining.is_zero() {
-                return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                    reason: "local_pressure",
-                });
+                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
             } else {
                 match self
                     .key_store
@@ -1218,9 +1009,7 @@ impl TavilyProxy {
                 {
                     Ok(result) => result,
                     Err(err) if is_transient_sqlite_write_error(&err) => {
-                        return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                            reason: "local_pressure",
-                        });
+                        return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
                     }
                     Err(err) => return Err(err),
                 }
@@ -1236,9 +1025,7 @@ impl TavilyProxy {
             let remaining = candidate_hydration_deadline
                 .saturating_duration_since(std::time::Instant::now());
             if remaining.is_zero() {
-                return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                    reason: "local_pressure",
-                });
+                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
             } else {
                 match self
                     .key_store
@@ -1251,9 +1038,7 @@ impl TavilyProxy {
                 {
                     Ok(result) => result,
                     Err(err) if is_transient_sqlite_write_error(&err) => {
-                        return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                            reason: "local_pressure",
-                        });
+                        return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
                     }
                     Err(err) => return Err(err),
                 }
@@ -1840,9 +1625,7 @@ impl TavilyProxy {
                     reason = "local_pressure",
                     err = %err,
                 );
-                return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                    reason: "local_pressure",
-                });
+                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
             }
             return Err(err);
         }
@@ -2220,9 +2003,7 @@ impl TavilyProxy {
                     reason = "local_pressure",
                     err = %err,
                 );
-                Ok(ClaimedReconciliationRunOutcome::Deferred {
-                    reason: "local_pressure",
-                })
+                Ok(ReconciliationEngine::deferred(self, "local_pressure"))
             }
             Err(err) => {
                 tracing::warn!(
@@ -2866,6 +2647,23 @@ impl TavilyProxy {
                 attempt,
                 message,
                 available_at,
+            )
+            .await
+    }
+
+    pub async fn finalize_deferred_upstream_reconciliation_claim(
+        &self,
+        job_id: i64,
+        claim_generation: i64,
+        reason: &'static str,
+        retry_at: i64,
+    ) -> Result<ScheduledJobEnqueueResult, ProxyError> {
+        self.key_store
+            .finalize_deferred_upstream_reconciliation_claim(
+                job_id,
+                claim_generation,
+                reason,
+                retry_at,
             )
             .await
     }

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -720,14 +720,14 @@ impl TavilyProxy {
         claim_generation: i64,
         remote_io_permit: Option<tokio::sync::OwnedSemaphorePermit>,
     ) -> Result<ClaimedReconciliationRunOutcome, ProxyError> {
-        ReconciliationEngine::run_claimed(
+        Ok(ReconciliationEngine::run_claimed(
             self,
             usage_base,
             job_id,
             claim_generation,
             remote_io_permit,
         )
-        .await
+        .await)
     }
 
     async fn run_upstream_reconciliation_once_inner(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -720,14 +720,14 @@ impl TavilyProxy {
         claim_generation: i64,
         remote_io_permit: Option<tokio::sync::OwnedSemaphorePermit>,
     ) -> Result<ClaimedReconciliationRunOutcome, ProxyError> {
-        Ok(ReconciliationEngine::run_claimed(
+        ReconciliationEngine::run_claimed(
             self,
             usage_base,
             job_id,
             claim_generation,
             remote_io_permit,
         )
-        .await)
+        .await
     }
 
     async fn run_upstream_reconciliation_once_inner(
@@ -1338,13 +1338,7 @@ impl TavilyProxy {
                                 Self::RECONCILIATION_TOTAL_BUDGET_SECS
                                     .saturating_sub(Self::RECONCILIATION_POST_PROCESS_HEADROOM_SECS),
                             );
-                        let remaining = retry_bookkeeping_deadline
-                            .saturating_duration_since(std::time::Instant::now());
-                        if remaining.is_zero() {
-                            return Err(ProxyError::Other(
-                                "reconciliation retry bookkeeping deadline exceeded".to_string(),
-                            ));
-                        }
+                        ensure_reconciliation_post_process_reserve(retry_bookkeeping_deadline)?;
                         let cooldown_until = if reason_kind
                             == RECONCILIATION_RETRY_REASON_UPSTREAM_429
                         {
@@ -1358,13 +1352,6 @@ impl TavilyProxy {
                         } else {
                             retry_at.unwrap_or_else(|| self.backend_time.now_ts().saturating_add(300))
                         };
-                        let remaining = retry_bookkeeping_deadline
-                            .saturating_duration_since(std::time::Instant::now());
-                        if remaining.is_zero() {
-                            return Err(ProxyError::Other(
-                                "reconciliation retry bookkeeping deadline exceeded".to_string(),
-                            ));
-                        }
                         self.key_store
                             .mark_reconciliation_retry(
                                 &candidate,
@@ -1611,12 +1598,14 @@ impl TavilyProxy {
             .elapsed()
             .as_millis()
             .min(i64::MAX as u128) as i64;
-        let run_marker_result = await_reconciliation_post_process(
-            post_process_deadline,
-            self.key_store
-                .mark_upstream_reconciliation_run_completed_at(self.backend_time.now_ts()),
-        )
-        .await;
+        // Do the only cooperative deadline check before any post-processing
+        // write. Once durable work begins, do not turn a partially applied
+        // sequence into a second local-pressure transition.
+        ensure_reconciliation_post_process_reserve(post_process_deadline)?;
+        let run_marker_result = self
+            .key_store
+            .mark_upstream_reconciliation_run_completed_at(self.backend_time.now_ts())
+            .await;
         if let Err(err) = run_marker_result {
             if is_transient_sqlite_write_error(&err) {
                 tracing::debug!(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -2657,6 +2657,23 @@ impl TavilyProxy {
             .await
     }
 
+    #[doc(hidden)]
+    pub async fn clear_upstream_reconciliation_local_backoff_claimed(
+        &self,
+        job_id: i64,
+        claim_generation: i64,
+    ) -> Result<(), ProxyError> {
+        self.key_store
+            .update_upstream_reconciliation_local_backoff_claimed(
+                false,
+                self.backend_time.now_ts(),
+                job_id,
+                claim_generation,
+            )
+            .await
+            .map(|_| ())
+    }
+
     pub async fn scheduled_job_finish_claimed(
         &self,
         job_id: i64,

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -115,7 +115,7 @@ impl ReconciliationEngine {
         job_id: i64,
         claim_generation: i64,
         remote_io_permit: Option<tokio::sync::OwnedSemaphorePermit>,
-    ) -> ClaimedReconciliationRunOutcome {
+    ) -> Result<ClaimedReconciliationRunOutcome, ProxyError> {
         let proxy = proxy.clone();
         let finalization_proxy = proxy.clone();
         let usage_base = usage_base.to_string();
@@ -133,37 +133,22 @@ impl ReconciliationEngine {
         })
         .await;
         match run_result {
-            Ok(Ok(outcome)) => outcome,
-            Ok(Err(ProxyError::StaleClaim { .. })) => ClaimedReconciliationRunOutcome::StaleClaim,
-            Ok(Err(error)) => {
-                let reason = Self::deferred_reason_for_claimed_failure(&error);
+            Ok(Ok(outcome)) => Ok(outcome),
+            Ok(Err(ProxyError::StaleClaim { .. })) => Ok(ClaimedReconciliationRunOutcome::StaleClaim),
+            Ok(Err(error)) if Self::post_process_exhaustion_is_deferred(&error) => {
                 tracing::warn!(
                     component = "reconciliation",
                     event = "claimed_run_deferred",
-                    defer_reason = reason,
+                    defer_reason = "local_pressure",
                     err = %error,
-                    "claimed reconciliation failure is retained for durable deferred finalization"
+                    "claimed reconciliation exhausted its reserved durable finalization window"
                 );
-                Self::deferred(&finalization_proxy, reason)
+                Ok(Self::deferred(&finalization_proxy, "local_pressure"))
             }
-            Err(error) => {
-                tracing::warn!(
-                    component = "reconciliation",
-                    event = "claimed_run_task_deferred",
-                    defer_reason = "retryable_failure",
-                    err = %error,
-                    "claimed reconciliation task ended before a durable transition"
-                );
-                Self::deferred(&finalization_proxy, "retryable_failure")
-            }
-        }
-    }
-
-    fn deferred_reason_for_claimed_failure(error: &ProxyError) -> &'static str {
-        if Self::post_process_exhaustion_is_deferred(error) {
-            "local_pressure"
-        } else {
-            "retryable_failure"
+            Ok(Err(error)) => Err(error),
+            Err(error) => Err(ProxyError::Other(format!(
+                "claimed reconciliation task join failed: {error}"
+            ))),
         }
     }
 
@@ -311,19 +296,9 @@ mod reconciliation_engine_tests {
     fn post_process_exhaustion_is_a_durable_defer_not_a_terminal_error() {
         let error = ProxyError::Other("reconciliation post-processing deadline exceeded".to_string());
         assert!(ReconciliationEngine::post_process_exhaustion_is_deferred(&error));
-        assert_eq!(
-            ReconciliationEngine::deferred_reason_for_claimed_failure(&error),
-            "local_pressure"
-        );
         assert!(!ReconciliationEngine::post_process_exhaustion_is_deferred(
             &ProxyError::Other("unrelated reconciliation failure".to_string())
         ));
-        assert_eq!(
-            ReconciliationEngine::deferred_reason_for_claimed_failure(&ProxyError::Other(
-                "unrelated reconciliation failure".to_string()
-            )),
-            "retryable_failure"
-        );
     }
 
     #[test]
@@ -412,9 +387,15 @@ impl ReconciliationOutcome {
     }
 }
 async fn await_reconciliation_post_process<T>(
-    deadline: std::time::Instant,
+    _deadline: std::time::Instant,
     operation: impl std::future::Future<Output = Result<T, ProxyError>>,
 ) -> Result<T, ProxyError> {
+    operation.await
+}
+
+fn ensure_reconciliation_post_process_reserve(
+    deadline: std::time::Instant,
+) -> Result<(), ProxyError> {
     if deadline
         .saturating_duration_since(std::time::Instant::now())
         .is_zero()
@@ -423,5 +404,5 @@ async fn await_reconciliation_post_process<T>(
             "reconciliation post-processing deadline exceeded".to_string(),
         ));
     }
-    operation.await
+    Ok(())
 }

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -115,38 +115,56 @@ impl ReconciliationEngine {
         job_id: i64,
         claim_generation: i64,
         remote_io_permit: Option<tokio::sync::OwnedSemaphorePermit>,
-    ) -> Result<ClaimedReconciliationRunOutcome, ProxyError> {
+    ) -> ClaimedReconciliationRunOutcome {
         let proxy = proxy.clone();
+        let finalization_proxy = proxy.clone();
         let usage_base = usage_base.to_string();
-        tokio::spawn(async move {
+        let run_result = tokio::spawn(async move {
             let _remote_io_permit = remote_io_permit;
             let Some(_run_lease) = proxy.key_store.sqlite_runtime.try_start_maintenance_run() else {
                 return Ok(Self::deferred(&proxy, "shutdown"));
             };
-            match proxy
+            proxy
                 .run_upstream_reconciliation_once_inner(
                     &usage_base,
                     Some((job_id, claim_generation)),
                 )
                 .await
-            {
-                Err(ProxyError::StaleClaim { .. }) => {
-                    Ok(ClaimedReconciliationRunOutcome::StaleClaim)
-                }
-                Err(error) if Self::post_process_exhaustion_is_deferred(&error) => {
-                    tracing::debug!(
-                        component = "reconciliation",
-                        event = "durable_finalization_deferred",
-                        reason = "local_pressure",
-                        "reserved finalization time elapsed before a durable reconciliation transition"
-                    );
-                    Ok(Self::deferred(&proxy, "local_pressure"))
-                }
-                result => result,
-            }
         })
-        .await
-        .map_err(|err| ProxyError::Other(format!("reconciliation engine task failed: {err}")))?
+        .await;
+        match run_result {
+            Ok(Ok(outcome)) => outcome,
+            Ok(Err(ProxyError::StaleClaim { .. })) => ClaimedReconciliationRunOutcome::StaleClaim,
+            Ok(Err(error)) => {
+                let reason = Self::deferred_reason_for_claimed_failure(&error);
+                tracing::warn!(
+                    component = "reconciliation",
+                    event = "claimed_run_deferred",
+                    defer_reason = reason,
+                    err = %error,
+                    "claimed reconciliation failure is retained for durable deferred finalization"
+                );
+                Self::deferred(&finalization_proxy, reason)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    component = "reconciliation",
+                    event = "claimed_run_task_deferred",
+                    defer_reason = "retryable_failure",
+                    err = %error,
+                    "claimed reconciliation task ended before a durable transition"
+                );
+                Self::deferred(&finalization_proxy, "retryable_failure")
+            }
+        }
+    }
+
+    fn deferred_reason_for_claimed_failure(error: &ProxyError) -> &'static str {
+        if Self::post_process_exhaustion_is_deferred(error) {
+            "local_pressure"
+        } else {
+            "retryable_failure"
+        }
     }
 
     fn outcome(
@@ -293,9 +311,19 @@ mod reconciliation_engine_tests {
     fn post_process_exhaustion_is_a_durable_defer_not_a_terminal_error() {
         let error = ProxyError::Other("reconciliation post-processing deadline exceeded".to_string());
         assert!(ReconciliationEngine::post_process_exhaustion_is_deferred(&error));
+        assert_eq!(
+            ReconciliationEngine::deferred_reason_for_claimed_failure(&error),
+            "local_pressure"
+        );
         assert!(!ReconciliationEngine::post_process_exhaustion_is_deferred(
             &ProxyError::Other("unrelated reconciliation failure".to_string())
         ));
+        assert_eq!(
+            ReconciliationEngine::deferred_reason_for_claimed_failure(&ProxyError::Other(
+                "unrelated reconciliation failure".to_string()
+            )),
+            "retryable_failure"
+        );
     }
 
     #[test]

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -41,7 +41,7 @@ pub enum ClaimedReconciliationRunOutcome {
         no_adjustment: i64,
         observed: i64,
     },
-    Deferred { reason: &'static str },
+    Deferred { reason: &'static str, retry_at: i64 },
     StaleClaim,
 }
 
@@ -86,8 +86,28 @@ impl TransportFailureKind {
 
 impl ReconciliationEngine {
     const MAX_REMOTE_ATTEMPTS: i64 = 2;
+    const DEFER_RETRY_DELAY_SECS: i64 = 30;
     // The compatibility one-shot API has no durable representative job.
     const ONE_SHOT_ADMISSION_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
+
+    fn deferred(proxy: &TavilyProxy, reason: &'static str) -> ClaimedReconciliationRunOutcome {
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason,
+            retry_at: proxy
+                .backend_time()
+                .now_ts()
+                .saturating_add(Self::DEFER_RETRY_DELAY_SECS),
+        }
+    }
+
+    fn post_process_exhaustion_is_deferred(error: &ProxyError) -> bool {
+        matches!(
+            error,
+            ProxyError::Other(message)
+                if message.contains("reconciliation post-processing deadline exceeded")
+                    || message.contains("reconciliation retry bookkeeping deadline exceeded")
+        )
+    }
 
     async fn run_claimed(
         proxy: &TavilyProxy,
@@ -101,9 +121,7 @@ impl ReconciliationEngine {
         tokio::spawn(async move {
             let _remote_io_permit = remote_io_permit;
             let Some(_run_lease) = proxy.key_store.sqlite_runtime.try_start_maintenance_run() else {
-                return Ok(ClaimedReconciliationRunOutcome::Deferred {
-                    reason: "shutdown",
-                });
+                return Ok(Self::deferred(&proxy, "shutdown"));
             };
             match proxy
                 .run_upstream_reconciliation_once_inner(
@@ -114,6 +132,15 @@ impl ReconciliationEngine {
             {
                 Err(ProxyError::StaleClaim { .. }) => {
                     Ok(ClaimedReconciliationRunOutcome::StaleClaim)
+                }
+                Err(error) if Self::post_process_exhaustion_is_deferred(&error) => {
+                    tracing::debug!(
+                        component = "reconciliation",
+                        event = "durable_finalization_deferred",
+                        reason = "local_pressure",
+                        "reserved finalization time elapsed before a durable reconciliation transition"
+                    );
+                    Ok(Self::deferred(&proxy, "local_pressure"))
                 }
                 result => result,
             }
@@ -208,7 +235,7 @@ impl ReconciliationEngine {
 mod reconciliation_engine_tests {
     use std::sync::atomic::AtomicI64;
 
-    use crate::ProxyError;
+    use crate::{ProxyError, TavilyProxy};
 
     use super::{
         ReconciliationEngine, ReconciliationOutcome, TransportFailureKind,
@@ -250,6 +277,24 @@ mod reconciliation_engine_tests {
         ));
         assert!(ReconciliationEngine::clears_upstream_429(
             ReconciliationOutcome::NoAdjustment
+        ));
+    }
+
+    #[test]
+    fn claimed_runs_reserve_two_seconds_for_durable_finalization() {
+        assert_eq!(
+            TavilyProxy::RECONCILIATION_FINALIZATION_HEADROOM_SECS,
+            2,
+            "a remote attempt must leave a durable finalization reserve"
+        );
+    }
+
+    #[test]
+    fn post_process_exhaustion_is_a_durable_defer_not_a_terminal_error() {
+        let error = ProxyError::Other("reconciliation post-processing deadline exceeded".to_string());
+        assert!(ReconciliationEngine::post_process_exhaustion_is_deferred(&error));
+        assert!(!ReconciliationEngine::post_process_exhaustion_is_deferred(
+            &ProxyError::Other("unrelated reconciliation failure".to_string())
         ));
     }
 

--- a/src/tests/maintenance_control_admission.rs
+++ b/src/tests/maintenance_control_admission.rs
@@ -226,12 +226,17 @@ async fn reconciliation_candidate_preparation_defers_before_a_saturated_pool() {
         )
         .await
         .expect("admission defer is a typed reconciliation outcome");
-    assert!(matches!(
-        outcome,
+    let retry_at = match outcome {
         crate::tavily_proxy::ClaimedReconciliationRunOutcome::Deferred {
-            reason: "pool_pressure"
-        }
-    ));
+            reason: "pool_pressure",
+            retry_at,
+        } => retry_at,
+        other => panic!("expected a pool-pressure deferred outcome, got {other:?}"),
+    };
+    assert!(
+        retry_at >= proxy.backend_time().now_ts().saturating_add(30),
+        "a typed defer must carry its durable retry time"
+    );
     assert!(
         started.elapsed() < Duration::from_millis(250),
         "reconciliation must defer before candidate reads wait on foreground pool capacity: {:?}",

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -31,7 +31,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
     assert_eq!(
         versions,
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
         ]
     );
     let transport_observation_column: i64 = sqlx::query_scalar(
@@ -48,6 +48,13 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
     .await
     .expect("read transport state columns");
     assert_eq!(transport_state_columns, 2);
+    let research_progress_window: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'upstream_reconciliation_research_progress_window'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read research progress window table");
+    assert_eq!(research_progress_window, 1);
     let projection_state: (i64, i64, i64) = sqlx::query_as(
         "SELECT batch_size, scanned_rows, completed FROM upstream_reconciliation_projection_state WHERE id = 'local'",
     )
@@ -920,7 +927,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
     assert_eq!(
         versions,
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
         ]
     );
 

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -313,14 +313,35 @@ async fn research_progress_window_requires_terminal_progress_without_pending_gro
             .pending_non_growing
     );
 
+    clock.set_now_ts(now + 1_201);
+    record_research_progress_window_observation(&proxy)
+        .await
+        .expect("restart after missing the fixed research observation window");
+    let missed_window = proxy
+        .upstream_privacy_status()
+        .await
+        .expect("read missed research observation window");
+    assert!(
+        !missed_window
+            .reconciliation_research_progress_window
+            .complete,
+        "a late sample must not be treated as a longer healthy ten-minute window"
+    );
+    assert_eq!(
+        missed_window
+            .reconciliation_research_progress_window
+            .window_seconds,
+        0
+    );
+
     proxy
         .mark_upstream_reconciliation_research_terminal("research-window-request")
         .await
-        .expect("mark research terminal");
-    clock.set_now_ts(now + 1_200);
+        .expect("mark research terminal in the next fixed window");
+    clock.set_now_ts(now + 1_801);
     record_research_progress_window_observation(&proxy)
         .await
-        .expect("complete advancing research observation window");
+        .expect("complete the next fixed research observation window");
     let advancing = proxy
         .upstream_privacy_status()
         .await

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -313,40 +313,32 @@ async fn research_progress_window_requires_terminal_progress_without_pending_gro
             .pending_non_growing
     );
 
-    clock.set_now_ts(now + 1_201);
-    record_research_progress_window_observation(&proxy)
-        .await
-        .expect("restart after missing the fixed research observation window");
-    let missed_window = proxy
-        .upstream_privacy_status()
-        .await
-        .expect("read missed research observation window");
-    assert!(
-        !missed_window
-            .reconciliation_research_progress_window
-            .complete,
-        "a late sample must not be treated as a longer healthy ten-minute window"
-    );
-    assert_eq!(
-        missed_window
-            .reconciliation_research_progress_window
-            .window_seconds,
-        0
-    );
-
+    clock.set_now_ts(now + 601);
     proxy
         .mark_upstream_reconciliation_research_terminal("research-window-request")
         .await
-        .expect("mark research terminal in the next fixed window");
-    clock.set_now_ts(now + 1_801);
+        .expect("mark research terminal before the fixed window boundary");
+    clock.set_now_ts(now + 1_201);
     record_research_progress_window_observation(&proxy)
         .await
-        .expect("complete the next fixed research observation window");
+        .expect("complete the fixed window from a late observation");
     let advancing = proxy
         .upstream_privacy_status()
         .await
         .expect("read advancing research observation");
     assert!(advancing.reconciliation_research_progress_window.complete);
+    assert_eq!(
+        advancing
+            .reconciliation_research_progress_window
+            .window_seconds,
+        600
+    );
+    assert_eq!(
+        advancing
+            .reconciliation_research_progress_window
+            .window_ended_at,
+        Some(now + 1_200)
+    );
     assert!(
         advancing
             .reconciliation_research_progress_window

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -164,6 +164,43 @@ async fn post_process_defer_finalization_is_atomic_and_never_marks_the_claim_err
         Some("local_pressure")
     );
     assert_eq!(observation.next_retry_at, Some(retry_at));
+    let local_backoff: Vec<(String, String)> = sqlx::query_as(
+        "SELECT key, value FROM meta WHERE key IN ('upstream_reconciliation_local_pressure_streak_v1', 'upstream_reconciliation_local_backoff_level_v1') ORDER BY key",
+    )
+    .fetch_all(&proxy.key_store.pool)
+    .await
+    .expect("read atomically updated local backoff");
+    assert_eq!(
+        local_backoff,
+        vec![
+            (
+                "upstream_reconciliation_local_backoff_level_v1".to_string(),
+                "0".to_string(),
+            ),
+            (
+                "upstream_reconciliation_local_pressure_streak_v1".to_string(),
+                "1".to_string(),
+            ),
+        ]
+    );
+    assert!(matches!(
+        proxy
+            .finalize_deferred_upstream_reconciliation_claim(
+                claim.id,
+                claim.claim_generation,
+                "local_pressure",
+                retry_at,
+            )
+            .await,
+        Err(ProxyError::StaleClaim { .. })
+    ));
+    let stale_backoff: String = sqlx::query_scalar(
+        "SELECT value FROM meta WHERE key = 'upstream_reconciliation_local_pressure_streak_v1'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read stale-finalization backoff state");
+    assert_eq!(stale_backoff, "1");
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -95,6 +95,79 @@ async fn reconciliation_transport_observation_survives_a_following_non_transport
     drop(proxy);
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn post_process_defer_finalization_is_atomic_and_never_marks_the_claim_error() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 8, 21, 1, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-atomic-defer"],
+        DEFAULT_UPSTREAM,
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim representative")
+        .expect("representative is claimed");
+    let retry_at = now + 30;
+
+    let continuation = proxy
+        .finalize_deferred_upstream_reconciliation_claim(
+            claim.id,
+            claim.claim_generation,
+            "local_pressure",
+            retry_at,
+        )
+        .await
+        .expect("atomically finalize deferred claim");
+    let current: (String, String) =
+        sqlx::query_as("SELECT status, message FROM scheduled_jobs WHERE id = ?")
+            .bind(claim.id)
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read completed claim");
+    assert_eq!(current.0, "success");
+    assert_ne!(current.0, "error");
+    assert!(current.1.contains("defer_reason=local_pressure"));
+    let active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status IN ('queued', 'running')",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count active representatives");
+    assert_eq!(active_count, 1);
+    let continuation_available_at: i64 =
+        sqlx::query_scalar("SELECT available_at FROM scheduled_jobs WHERE id = ?")
+            .bind(continuation.job_id)
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read continuation schedule");
+    assert_eq!(continuation_available_at, retry_at);
+    let observation = proxy
+        .key_store
+        .upstream_reconciliation_run_observation()
+        .await
+        .expect("read deferred observation");
+    assert_eq!(
+        observation.last_retryable_outcome.as_deref(),
+        Some("local_pressure")
+    );
+    assert_eq!(observation.next_retry_at, Some(retry_at));
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
 use axum::{Json, Router, routing::get};
 use tokio::net::TcpListener;
 
@@ -804,19 +877,21 @@ async fn settlement_sqlite_pressure_returns_a_typed_defer_without_completing_wor
         .expect("claim representative")
         .expect("representative is claimed");
 
-    assert_eq!(
-        proxy
-            .run_upstream_reconciliation_once_claimed_outcome(
-                &format!("http://{address}"),
-                claim.id,
-                claim.claim_generation,
-            )
-            .await
-            .expect("SQLite pressure is a typed run outcome"),
+    let outcome = proxy
+        .run_upstream_reconciliation_once_claimed_outcome(
+            &format!("http://{address}"),
+            claim.id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("SQLite pressure is a typed run outcome");
+    assert!(matches!(
+        outcome,
         ClaimedReconciliationRunOutcome::Deferred {
-            reason: "local_pressure"
-        }
-    );
+            reason: "local_pressure",
+            retry_at,
+        } if retry_at >= proxy.backend_time().now_ts().saturating_add(30)
+    ));
     let generations: (i64, i64) = sqlx::query_as(
         "SELECT work_generation, completed_generation FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = '2026-07-15/S1'",
     )

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -318,6 +318,22 @@ async fn research_progress_window_requires_terminal_progress_without_pending_gro
         .mark_upstream_reconciliation_research_terminal("research-window-request")
         .await
         .expect("mark research terminal before the fixed window boundary");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+        "#,
+    )
+    .bind("research-window-late-request")
+    .bind("research-window-token")
+    .bind("research-window-key")
+    .bind(period_code)
+    .bind(now + 1_201)
+    .bind(now + 1_201)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed pending research after the fixed window boundary");
     clock.set_now_ts(now + 1_201);
     record_research_progress_window_observation(&proxy)
         .await
@@ -338,6 +354,13 @@ async fn research_progress_window_requires_terminal_progress_without_pending_gro
             .reconciliation_research_progress_window
             .window_ended_at,
         Some(now + 1_200)
+    );
+    assert_eq!(
+        advancing
+            .reconciliation_research_progress_window
+            .pending_delta,
+        -1,
+        "research created after the boundary must not be counted in the completed window"
     );
     assert!(
         advancing

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -205,6 +205,147 @@ async fn post_process_defer_finalization_is_atomic_and_never_marks_the_claim_err
     drop(proxy);
     let _ = std::fs::remove_file(db_path);
 }
+
+async fn record_research_progress_window_observation(
+    proxy: &TavilyProxy,
+) -> Result<(), ProxyError> {
+    proxy
+        .key_store
+        .record_upstream_reconciliation_engine_observation(
+            crate::store::ReconciliationRunObservationWrite {
+                claimed_job: None,
+                mode: "compare",
+                hydrate_ms: 0,
+                first_remote_ms: None,
+                remote_ms: 0,
+                finalization_ms: 0,
+                research_ms: 0,
+                settled: 0,
+                no_adjustment: 0,
+                observed: 0,
+                upstream_429: 0,
+                transport_failure: 0,
+                semantic_failure: 0,
+                local_pressure: 0,
+                last_transport_kind: None,
+                last_retryable_outcome: None,
+                continuation_reason: Some("observed"),
+                next_retry_at: None,
+            },
+        )
+        .await
+}
+
+#[tokio::test]
+async fn research_progress_window_requires_terminal_progress_without_pending_growth() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 8, 21, 12, 0);
+    let (backend_time, clock) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-window"],
+        DEFAULT_UPSTREAM,
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let period_code = "2026-08-21/S1";
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject,
+            period_start, period_end, request_count, first_used_at, last_used_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+        "#,
+    )
+    .bind("research-window-token")
+    .bind("research-window-key")
+    .bind(period_code)
+    .bind("research-window-project")
+    .bind("token:research-window-token")
+    .bind(now - 60)
+    .bind(now + 3_600)
+    .bind(now - 60)
+    .bind(now - 60)
+    .bind(now - 60)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed current-period research usage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+        "#,
+    )
+    .bind("research-window-request")
+    .bind("research-window-token")
+    .bind("research-window-key")
+    .bind(period_code)
+    .bind(now - 60)
+    .bind(now - 60)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed pending research");
+
+    record_research_progress_window_observation(&proxy)
+        .await
+        .expect("start research observation window");
+    clock.set_now_ts(now + 600);
+    record_research_progress_window_observation(&proxy)
+        .await
+        .expect("complete stalled research observation window");
+    let stalled = proxy
+        .upstream_privacy_status()
+        .await
+        .expect("read stalled research observation");
+    assert!(stalled.reconciliation_research_progress_window.complete);
+    assert!(
+        !stalled
+            .reconciliation_research_progress_window
+            .terminal_rate_positive
+    );
+    assert!(
+        stalled
+            .reconciliation_research_progress_window
+            .pending_non_growing
+    );
+
+    proxy
+        .mark_upstream_reconciliation_research_terminal("research-window-request")
+        .await
+        .expect("mark research terminal");
+    clock.set_now_ts(now + 1_200);
+    record_research_progress_window_observation(&proxy)
+        .await
+        .expect("complete advancing research observation window");
+    let advancing = proxy
+        .upstream_privacy_status()
+        .await
+        .expect("read advancing research observation");
+    assert!(advancing.reconciliation_research_progress_window.complete);
+    assert!(
+        advancing
+            .reconciliation_research_progress_window
+            .terminal_rate_positive
+    );
+    assert!(
+        advancing
+            .reconciliation_research_progress_window
+            .pending_non_growing
+    );
+    assert_eq!(
+        advancing
+            .reconciliation_research_progress_window
+            .window_seconds,
+        600
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
 use axum::{Json, Router, routing::get};
 use tokio::net::TcpListener;
 

--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -103,6 +103,83 @@ async fn seed_pressure_attempt(
 }
 
 #[tokio::test]
+async fn analysis_pressure_rebuild_waits_for_overflow_coverage_loss_or_sustained_staleness() {
+    let db_path = temp_db_path("analysis-pressure-rebuild-hysteresis");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+    )
+    .await
+    .expect("create proxy");
+
+    assert!(
+        !proxy.spawn_server_pressure_buckets_rebuild_once(),
+        "a writable tenure alone must not rebuild pressure buckets"
+    );
+    assert!(!proxy.server_pressure_rebuild_is_active_for_test());
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn analysis_pressure_rebuild_source_slice_uses_the_time_cursor_index() {
+    let db_path = temp_db_path("analysis-pressure-rebuild-time-cursor");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+    )
+    .await
+    .expect("create proxy");
+
+    let plan = sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT id, created_at, result_status
+        FROM observability.request_logs INDEXED BY idx_request_logs_time
+        WHERE created_at >= 0
+          AND (created_at > 0 OR (created_at = 0 AND id > 0))
+          AND id <= 9223372036854775807
+          AND visibility = 'visible'
+          AND request_user_id IS NOT NULL
+          AND counts_business_quota = 1
+          AND upstream_operation IS NOT NULL
+          AND result_status != 'quota_exhausted'
+        ORDER BY created_at ASC, id ASC
+        LIMIT 500
+        "#,
+    )
+    .fetch_all(&proxy.key_store.pool)
+    .await
+    .expect("explain server pressure rebuild source slice");
+    let details = plan
+        .iter()
+        .map(|row| {
+            row.try_get::<String, _>("detail")
+                .expect("query-plan detail")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        details.contains("idx_request_logs_time"),
+        "expected time-keyset source scan, got query plan:\n{details}"
+    );
+    assert!(
+        !details.contains("USE TEMP B-TREE"),
+        "time-keyset source scan must not sort the historical log range:\n{details}"
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn analysis_pressure_snapshot_uses_rolling_1h_and_excludes_non_upstream_events() {
     let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_000_000);
     let db_path = temp_db_path("analysis-pressure-snapshot-live");
@@ -549,11 +626,11 @@ async fn analysis_pressure_snapshot_background_rebuild_rehydrates_server_pressur
     );
 
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "reopened proxy should schedule exactly one background rebuild"
     );
     assert!(
-        !reopened.spawn_server_pressure_buckets_rebuild_once(),
+        !reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "background rebuild scheduling should be idempotent"
     );
     assert!(
@@ -686,11 +763,11 @@ async fn analysis_pressure_background_rebuild_retries_after_transient_failure() 
     let lock_handle =
         hold_sqlite_write_lock_for_test_for(&reopened.key_store.pool, Duration::from_secs(6)).await;
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "first background rebuild attempt should schedule"
     );
     assert!(
-        !reopened.spawn_server_pressure_buckets_rebuild_once(),
+        !reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "concurrent background rebuild attempts should still dedupe"
     );
     lock_handle
@@ -951,7 +1028,7 @@ async fn analysis_pressure_background_rebuild_cancels_and_can_be_rescheduled() {
     let lock_handle =
         hold_sqlite_write_lock_for_test_for(&reopened.key_store.pool, Duration::from_secs(6)).await;
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "first background rebuild attempt should schedule"
     );
     reopened.cancel_server_pressure_buckets_rebuild().await;
@@ -977,7 +1054,7 @@ async fn analysis_pressure_background_rebuild_cancels_and_can_be_rescheduled() {
         .sqlite_runtime
         .mark_recent_contention_for_test();
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "serving promotion should reschedule after cancellation through the contention cooldown"
     );
 
@@ -1138,7 +1215,7 @@ async fn observability_deferred_writer_source_fence_does_not_double_count_rebuil
     drop(held);
 
     assert!(
-        proxy.spawn_server_pressure_buckets_rebuild_once(),
+        proxy.force_server_pressure_buckets_rebuild_once_for_test(),
         "source rebuild should schedule while the old delta remains queued"
     );
     tokio::time::timeout(Duration::from_secs(8), async {
@@ -1299,7 +1376,7 @@ async fn analysis_pressure_background_rebuild_releases_latch_after_success() {
     .expect("reopen proxy");
 
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "first background rebuild attempt should schedule"
     );
 
@@ -1335,7 +1412,7 @@ async fn analysis_pressure_background_rebuild_releases_latch_after_success() {
 
     tokio::time::timeout(Duration::from_secs(8), async {
         loop {
-            if reopened.spawn_server_pressure_buckets_rebuild_once() {
+            if reopened.force_server_pressure_buckets_rebuild_once_for_test() {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
@@ -1442,7 +1519,7 @@ async fn analysis_pressure_cancel_requeues_buffered_events_for_next_generation()
     .expect("reopen proxy");
 
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "first background rebuild attempt should schedule"
     );
     reopened
@@ -1451,7 +1528,7 @@ async fn analysis_pressure_cancel_requeues_buffered_events_for_next_generation()
     reopened.cancel_server_pressure_buckets_rebuild().await;
 
     assert!(
-        reopened.spawn_server_pressure_buckets_rebuild_once(),
+        reopened.force_server_pressure_buckets_rebuild_once_for_test(),
         "next serving generation should be able to reschedule rebuild"
     );
 
@@ -1517,7 +1594,7 @@ async fn analysis_pressure_rebuild_drains_events_arriving_during_tail_replay() {
             .await;
     }
     proxy.pause_server_pressure_tail_replay_for_test();
-    assert!(proxy.spawn_server_pressure_buckets_rebuild_once());
+    assert!(proxy.force_server_pressure_buckets_rebuild_once_for_test());
     tokio::time::timeout(
         Duration::from_secs(2),
         proxy.wait_for_server_pressure_tail_replay_for_test(),
@@ -1584,7 +1661,7 @@ async fn analysis_pressure_rebuild_releases_phase_after_tail_replay_error() {
         .inject_server_pressure_buffered_event_for_test(Some(9_999), now - 30, OUTCOME_ERROR)
         .await;
     proxy.pause_server_pressure_tail_replay_for_test();
-    assert!(proxy.spawn_server_pressure_buckets_rebuild_once());
+    assert!(proxy.force_server_pressure_buckets_rebuild_once_for_test());
     tokio::time::timeout(
         Duration::from_secs(2),
         proxy.wait_for_server_pressure_tail_replay_for_test(),
@@ -1603,7 +1680,7 @@ async fn analysis_pressure_rebuild_releases_phase_after_tail_replay_error() {
     .await
     .expect("tail replay write error should release the rebuild phase");
     assert!(
-        proxy.spawn_server_pressure_buckets_rebuild_once(),
+        proxy.force_server_pressure_buckets_rebuild_once_for_test(),
         "a failed tail replay must leave the next rebuild schedulable"
     );
     proxy.cancel_server_pressure_buckets_rebuild().await;

--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -803,6 +803,102 @@ async fn analysis_pressure_rebuild_does_not_hold_writer_during_source_aggregatio
 }
 
 #[tokio::test]
+async fn analysis_pressure_rebuild_never_deletes_the_live_generation() {
+    let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_395_000);
+    let db_path = temp_db_path("analysis-pressure-staged-generation");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_options_and_time(
+        Vec::<String>::new(),
+        DEFAULT_UPSTREAM,
+        &db_str,
+        TavilyProxyOptions::from_database_path(&db_str),
+        backend_time,
+    )
+    .await
+    .expect("proxy created");
+    let now = manual_clock.now_ts();
+    sqlx::query(
+        r#"
+        INSERT INTO observability.request_logs (
+            method, path, status_code, tavily_status_code, result_status,
+            request_kind_key, request_kind_label, counts_business_quota,
+            request_user_id, upstream_operation, created_at
+        ) VALUES ('POST', '/api/tavily/search', 200, 200, 'success',
+                  'api:search', 'API | search', 1, 'staged-generation', 'search', ?)
+        "#,
+    )
+    .bind(now - 120)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed pressure request log");
+    proxy
+        .key_store
+        .ensure_server_pressure_bucket_schema()
+        .await
+        .expect("initialize pressure generation schema");
+    for bucket_start in 0..26 {
+        sqlx::query(
+            r#"
+            INSERT INTO observability.server_pressure_buckets (
+                bucket_kind, bucket_start, bucket_secs, success_count,
+                failure_count, updated_at, generation
+            ) VALUES ('five_minute', ?, 300, 1, 0, ?, 0)
+            "#,
+        )
+        .bind(bucket_start)
+        .bind(now)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("seed old live generation");
+    }
+    sqlx::query(
+        "CREATE TABLE observability.server_pressure_delete_counter (count INTEGER NOT NULL)",
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("create delete counter");
+    sqlx::query("INSERT INTO observability.server_pressure_delete_counter (count) VALUES (0)")
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("initialize delete counter");
+    sqlx::query(
+        r#"
+        CREATE TRIGGER observability.forbid_server_pressure_generation_delete
+        BEFORE DELETE ON server_pressure_buckets
+        BEGIN
+            UPDATE server_pressure_delete_counter SET count = count + 1;
+            SELECT CASE WHEN (SELECT count FROM server_pressure_delete_counter) > 25
+                THEN RAISE(ABORT, 'live pressure cleanup exceeded its bounded slice') END;
+        END
+        "#,
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("forbid destructive pressure publication");
+
+    proxy
+        .key_store
+        .rebuild_server_pressure_buckets_with_cancel(|| true)
+        .await
+        .expect("staged rebuild should publish without deleting live buckets");
+    let total: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COALESCE(SUM(success_count + failure_count), 0)
+        FROM observability.server_pressure_buckets
+        WHERE generation = (
+            SELECT active_generation FROM observability.server_pressure_rebuild_state WHERE singleton = 1
+        )
+        "#,
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read staged pressure generation");
+    assert_eq!(total, 2, "both staged bucket resolutions are published");
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn analysis_pressure_background_rebuild_cancels_and_can_be_rescheduled() {
     let (backend_time, manual_clock) = crate::BackendTime::manual_from_ts(1_700_400_000);
     let db_path = temp_db_path("analysis-pressure-background-cancel");

--- a/src/upstream_privacy_status.rs
+++ b/src/upstream_privacy_status.rs
@@ -93,6 +93,22 @@ pub struct ReconciliationRunObservation {
     pub observed_at: Option<i64>,
 }
 
+/// A completed, fixed-duration observation of current-period Research. A
+/// window is healthy only when it observes terminal progress without pending
+/// Research growing; upstream 429 remains a separate retry diagnostic.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ReconciliationResearchProgressWindow {
+    pub window_started_at: Option<i64>,
+    pub window_ended_at: Option<i64>,
+    pub window_seconds: i64,
+    pub terminal_delta: i64,
+    pub pending_delta: i64,
+    pub terminal_rate_positive: bool,
+    pub pending_non_growing: bool,
+    pub complete: bool,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ReconciliationControllerStatus {
@@ -159,6 +175,8 @@ pub struct UpstreamPrivacyStatus {
     pub reconciliation_local_backoff: ReconciliationLocalBackoff,
     #[serde(default)]
     pub reconciliation_run_observation: ReconciliationRunObservation,
+    #[serde(default)]
+    pub reconciliation_research_progress_window: ReconciliationResearchProgressWindow,
     #[serde(default)]
     pub reconciliation_controller: ReconciliationControllerStatus,
     #[serde(default)]


### PR DESCRIPTION
Delivery role: direct

Spec: docs/specs/upstream-privacy-period-reconciliation/
Spec Disposition: refreshed; spec drift check passed
Solutions: period-scoped-upstream-usage-reconciliation, sqlite-admin-read-containment, sqlite-write-lock-contention
Project Docs: CONTEXT.md

Summary
- Claim-fenced reconciliation Deferred finalization atomically updates outcome, local backoff, observation, retry time, and one delayed representative. Non-stale claimed failures never become terminal scheduler errors.
- Admin privacy status uses a dedicated 100ms acquire / 250ms whole-build immutable read session with a 60s last-good cache and no maintenance-bulk admission.
- Server-pressure rebuild uses source-fenced staged generations, 500-row keyset slices, atomic publish/tail replay, hysteresis, and bounded 25-row cleanup.

Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- full cargo test passed: 752 library tests and 473 server tests, with integration/doc tests passing
- targeted reconciliation, low-pressure recovery, and admin privacy tests passed
- web source budgets, bun tests, and bun build passed
- dprint and spec drift checks passed
- CI Pipeline, Quality Gates, and Docs Pages are green on head 2a920553

Operational evidence
- Current-period research evidence remains pending=131, terminal=0, with the required ten-minute terminal-rate/non-growth observation window; upstream429=1692 remains a separate metric.
- Read-only 101 dual-database baseline/candidate comparison completed for 600 seconds each from locked baseline 3077a82. Candidate terminalDelta=4 with fixture terminal=1; billing adjustments remained 0 count / 0 sum; HTTP 5xx and final SQLite lock errors were 0.
- Testbox run and temporary snapshots were cleaned after the comparison. No 101 data or production configuration was modified.

Visual evidence: not applicable; no visible UI behavior changed.