### PR TITLE
test: widen request stats flush observation window

### DIFF
--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -798,7 +798,10 @@ async fn admin_summary_does_not_start_a_slow_background_flush() {
 
     let flush_arrived = pause.arrived.clone().notified_owned();
     proxy.nudge_request_stats_flush().await;
-    tokio::time::timeout(Duration::from_secs(1), flush_arrived)
+    // The worker's production slice remains wall-clock bounded to 50ms, but
+    // CI can spend more than one scheduler second starting a fresh SQLite
+    // worker after this test is launched alongside the neighboring admin cases.
+    tokio::time::timeout(Duration::from_secs(5), flush_arrived)
         .await
         .expect("explicit background flush reached post-flush pause");
 


### PR DESCRIPTION
Delivery role: direct

Spec: -
Spec Disposition: not applicable; test-only CI follow-up
Solutions: -
Project Docs: -

Summary
- Widen the test-only observation window for the explicit request-stats background flush from 1s to 5s.
- Keep the production 50ms background slice budget and flush behavior unchanged.

Root cause
- The test ran beside neighboring admin cases on a loaded CI runner. The worker could spend more than one scheduler second starting its SQLite path before reaching the existing post-flush pause; the 1s test observer timed out even though the flush path remained valid.
- The pause notification is registered before nudge; this patch only removes the remaining startup timing false negative.

Validation
- cargo test --lib tests::request_rollup_public_metrics::admin_summary_does_not_start_a_slow_background_flush -- --exact --nocapture
- request_rollup_public_metrics module: 21 passed, 0 failed
- CI-style admin_ group: 10/10 passed
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- git diff --check

Visual evidence: not applicable; no visible UI behavior changed.