### PR TITLE
fix(reconciliation): bound control writes under pressure

### DIFF
--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -2647,7 +2647,14 @@ async fn run_manual_claimed_job(
                         err = %error,
                         "reconciliation retained its claim while low-pressure recovery could not start"
                     );
-                    return false;
+                    return defer_reconciliation_for_sqlite_admission(
+                        &state,
+                        job_id,
+                        claim_generation,
+                        "local_pressure",
+                        state.proxy.backend_time().now_ts().saturating_add(30),
+                    )
+                    .await;
                 }
                 Err(error) => return finish(state, "error", error.to_string()).await,
             }

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -2690,6 +2690,24 @@ async fn run_manual_claimed_job(
                             ),
                         )
                         .await,
+                        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
+                            tracing::warn!(
+                                component = "reconciliation",
+                                event = "completed_claim_deferred",
+                                job_id,
+                                claim_generation,
+                                defer_reason = "local_pressure",
+                                "reconciliation completion bookkeeping deferred under local pressure"
+                            );
+                            defer_reconciliation_for_sqlite_admission(
+                                &state,
+                                job_id,
+                                claim_generation,
+                                "local_pressure",
+                                state.proxy.backend_time().now_ts().saturating_add(30),
+                            )
+                            .await
+                        }
                         Err(err) => finish(state, "error", err.to_string()).await,
                     }
                 }
@@ -2704,6 +2722,25 @@ async fn run_manual_claimed_job(
                     .await
                 }
                 Ok(ClaimedReconciliationRunOutcome::StaleClaim) => false,
+                Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
+                    tracing::warn!(
+                        component = "reconciliation",
+                        event = "claimed_run_deferred",
+                        job_id,
+                        claim_generation,
+                        defer_reason = "local_pressure",
+                        error_kind = "unclassified",
+                        "reconciliation run did not reach a typed terminal outcome"
+                    );
+                    defer_reconciliation_for_sqlite_admission(
+                        &state,
+                        job_id,
+                        claim_generation,
+                        "local_pressure",
+                        state.proxy.backend_time().now_ts().saturating_add(30),
+                    )
+                    .await
+                }
                 Err(err) => finish(state, "error", err.to_string()).await,
             }
         }

--- a/src/server/schedulers.rs
+++ b/src/server/schedulers.rs
@@ -2660,89 +2660,7 @@ async fn run_manual_claimed_job(
                     remote_io_permit.take(),
                 )
                 .await;
-            match run_result {
-                Ok(ClaimedReconciliationRunOutcome::Completed {
-                    settled,
-                    no_adjustment,
-                    observed,
-                }) => {
-                    match state.proxy.upstream_reconciliation_representative_available_at().await {
-                        Ok(Some(available_at)) => state
-                            .proxy
-                            .scheduled_job_finish_and_enqueue_auto_at(
-                                job_id,
-                                claim_generation,
-                                "upstream_reconciliation",
-                                None,
-                                1,
-                                Some(&format!(
-                                    "settled={settled} no_adjustment={no_adjustment} observed={observed} continuation_at={available_at}"
-                                )),
-                                available_at,
-                            )
-                            .await
-                            .is_ok(),
-                        Ok(None) => finish(
-                            state,
-                            "success",
-                            format!(
-                                "settled={settled} no_adjustment={no_adjustment} observed={observed}"
-                            ),
-                        )
-                        .await,
-                        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
-                            tracing::warn!(
-                                component = "reconciliation",
-                                event = "completed_claim_deferred",
-                                job_id,
-                                claim_generation,
-                                defer_reason = "local_pressure",
-                                "reconciliation completion bookkeeping deferred under local pressure"
-                            );
-                            defer_reconciliation_for_sqlite_admission(
-                                &state,
-                                job_id,
-                                claim_generation,
-                                "local_pressure",
-                                state.proxy.backend_time().now_ts().saturating_add(30),
-                            )
-                            .await
-                        }
-                        Err(err) => finish(state, "error", err.to_string()).await,
-                    }
-                }
-                Ok(ClaimedReconciliationRunOutcome::Deferred { reason, retry_at }) => {
-                    defer_reconciliation_for_sqlite_admission(
-                        &state,
-                        job_id,
-                        claim_generation,
-                        reason,
-                        retry_at,
-                    )
-                    .await
-                }
-                Ok(ClaimedReconciliationRunOutcome::StaleClaim) => false,
-                Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
-                    tracing::warn!(
-                        component = "reconciliation",
-                        event = "claimed_run_deferred",
-                        job_id,
-                        claim_generation,
-                        defer_reason = "local_pressure",
-                        error_kind = "unclassified",
-                        "reconciliation run did not reach a typed terminal outcome"
-                    );
-                    defer_reconciliation_for_sqlite_admission(
-                        &state,
-                        job_id,
-                        claim_generation,
-                        "local_pressure",
-                        state.proxy.backend_time().now_ts().saturating_add(30),
-                    )
-                    .await
-                }
-                Err(err) => finish(state, "error", err.to_string()).await,
-            }
+            persist_claimed_reconciliation_run(state, job_id, claim_generation, run_result).await
         }
         "auth_token_logs_gc" => {
             let _maintenance = acquire_db_maintenance_read_gate().await;
@@ -2802,6 +2720,106 @@ async fn run_manual_claimed_job(
             run_db_compaction_claimed_job(state, job_id, claim_generation).await
         }
         _ => finish(state, "error", format!("unsupported manual job type: {job_type}")).await,
+    }
+}
+
+async fn persist_claimed_reconciliation_run(
+    state: Arc<AppState>,
+    job_id: i64,
+    claim_generation: i64,
+    run_result: Result<ClaimedReconciliationRunOutcome, ProxyError>,
+) -> bool {
+    let finish = |state: Arc<AppState>, status: &'static str, message: String| async move {
+        let succeeded = status == "success";
+        let _ = state
+            .proxy
+            .scheduled_job_finish_claimed(job_id, claim_generation, status, Some(&message))
+            .await;
+        succeeded
+    };
+
+    match run_result {
+        Ok(ClaimedReconciliationRunOutcome::Completed {
+            settled,
+            no_adjustment,
+            observed,
+        }) => {
+            match state.proxy.upstream_reconciliation_representative_available_at().await {
+                Ok(Some(available_at)) => state
+                    .proxy
+                    .scheduled_job_finish_and_enqueue_auto_at(
+                        job_id,
+                        claim_generation,
+                        "upstream_reconciliation",
+                        None,
+                        1,
+                        Some(&format!(
+                            "settled={settled} no_adjustment={no_adjustment} observed={observed} continuation_at={available_at}"
+                        )),
+                        available_at,
+                    )
+                    .await
+                    .is_ok(),
+                Ok(None) => finish(
+                    state,
+                    "success",
+                    format!(
+                        "settled={settled} no_adjustment={no_adjustment} observed={observed}"
+                    ),
+                )
+                .await,
+                Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
+                    tracing::warn!(
+                        component = "reconciliation",
+                        event = "completed_claim_deferred",
+                        job_id,
+                        claim_generation,
+                        defer_reason = "local_pressure",
+                        "reconciliation completion bookkeeping deferred under local pressure"
+                    );
+                    defer_reconciliation_for_sqlite_admission(
+                        &state,
+                        job_id,
+                        claim_generation,
+                        "local_pressure",
+                        state.proxy.backend_time().now_ts().saturating_add(30),
+                    )
+                    .await
+                }
+                Err(err) => finish(state, "error", err.to_string()).await,
+            }
+        }
+        Ok(ClaimedReconciliationRunOutcome::Deferred { reason, retry_at }) => {
+            defer_reconciliation_for_sqlite_admission(
+                &state,
+                job_id,
+                claim_generation,
+                reason,
+                retry_at,
+            )
+            .await
+        }
+        Ok(ClaimedReconciliationRunOutcome::StaleClaim) => false,
+        Err(err) if tavily_hikari::is_transient_sqlite_write_error(&err) => {
+            tracing::warn!(
+                component = "reconciliation",
+                event = "claimed_run_deferred",
+                job_id,
+                claim_generation,
+                defer_reason = "local_pressure",
+                error_kind = "unclassified",
+                "reconciliation run did not reach a typed terminal outcome"
+            );
+            defer_reconciliation_for_sqlite_admission(
+                &state,
+                job_id,
+                claim_generation,
+                "local_pressure",
+                state.proxy.backend_time().now_ts().saturating_add(30),
+            )
+            .await
+        }
+        Err(err) => finish(state, "error", err.to_string()).await,
     }
 }
 

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -873,6 +873,18 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         .await
         .expect("release exclusive cold read lock");
     drop(cold_held);
+    let retry = client
+        .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
+        .header(reqwest::header::COOKIE, &cold_cookie)
+        .send()
+        .await
+        .expect("retry cold privacy status after pressure drains");
+    assert_eq!(retry.status(), reqwest::StatusCode::OK);
+    let retry_body: serde_json::Value = retry
+        .json()
+        .await
+        .expect("retry cold privacy status json");
+    assert_eq!(retry_body.get("coverage").and_then(|v| v.as_str()), Some("ok"));
 
     let _ = std::fs::remove_file(db_path);
     let _ = std::fs::remove_file(cold_db_path);

--- a/src/server/tests/alerts_and_ha_source_and_recovery.rs
+++ b/src/server/tests/alerts_and_ha_source_and_recovery.rs
@@ -141,6 +141,66 @@ async fn reconciliation_low_pressure_recovery_runs_shadow_fixture_despite_prior_
 }
 
 #[tokio::test]
+async fn reconciliation_scheduler_preserves_unclassified_terminal_errors() {
+    let db_path = temp_db_path("reconciliation-unclassified-run-failure");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-unclassified-run-failure".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("create reconciliation proxy");
+    let (_addr, state) = spawn_builtin_keys_admin_server_with_state(
+        proxy,
+        "reconciliation-unclassified-run-failure-password",
+    )
+    .await;
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let queued = state
+        .proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue reconciliation representative");
+    let claim = state
+        .proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim reconciliation representative")
+        .expect("representative becomes running");
+
+    sqlx::query("DROP TABLE upstream_reconciliation_control_state")
+        .execute(&pool)
+        .await
+        .expect("inject an unclassified reconciliation read failure");
+
+    let succeeded = run_manual_claimed_job(
+        state.clone(),
+        "upstream_reconciliation".to_string(),
+        None,
+        ClaimedScheduledJob {
+            job_id: claim.id,
+            claim_generation: claim.claim_generation,
+            _job_execution_gate: None,
+        },
+        None,
+    )
+    .await;
+    assert!(!succeeded, "unclassified run failures must remain observable");
+    let statuses: Vec<(String,)> = sqlx::query_as(
+        "SELECT status FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' ORDER BY id",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("read deferred reconciliation jobs");
+    assert_eq!(statuses.first().map(|row| row.0.as_str()), Some("error"));
+    assert!(statuses.iter().all(|row| row.0 != "queued"));
+
+    drop(state);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn ha_gc_real_worker_wakes_an_eligible_channel_before_a_legacy_defer() {
     let db_path = temp_db_path("ha-gc-worker-fair-wake");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/alerts_and_ha_source_and_recovery.rs
+++ b/src/server/tests/alerts_and_ha_source_and_recovery.rs
@@ -201,6 +201,78 @@ async fn reconciliation_scheduler_preserves_unclassified_terminal_errors() {
 }
 
 #[tokio::test]
+async fn reconciliation_scheduler_persists_typed_defer_without_a_terminal_error() {
+    let db_path = temp_db_path("reconciliation-scheduler-typed-defer");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-scheduler-typed-defer".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("create reconciliation proxy");
+    let (_addr, state) = spawn_builtin_keys_admin_server_with_state(
+        proxy,
+        "reconciliation-scheduler-typed-defer-password",
+    )
+    .await;
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let queued = state
+        .proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue reconciliation representative");
+    let claim = state
+        .proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim reconciliation representative")
+        .expect("representative becomes running");
+    let retry_at = state.proxy.backend_time().now_ts().saturating_add(30);
+
+    let succeeded = persist_claimed_reconciliation_run(
+        state.clone(),
+        claim.id,
+        claim.claim_generation,
+        Ok(ClaimedReconciliationRunOutcome::Deferred {
+            reason: "local_pressure",
+            retry_at,
+        }),
+    )
+    .await;
+    assert!(succeeded, "typed deadline defer must finalize the claim");
+
+    let statuses: Vec<(String,)> = sqlx::query_as(
+        "SELECT status FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' ORDER BY id",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("read deferred reconciliation jobs");
+    assert_eq!(statuses.first().map(|row| row.0.as_str()), Some("success"));
+    assert_eq!(statuses.get(1).map(|row| row.0.as_str()), Some("queued"));
+    assert!(statuses.iter().all(|row| row.0 != "error"));
+
+    let observation: (Option<String>, Option<i64>) = sqlx::query_as(
+        "SELECT last_retryable_outcome, next_retry_at FROM upstream_reconciliation_run_observation WHERE id = 'local'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read deferred observation");
+    assert_eq!(observation.0.as_deref(), Some("local_pressure"));
+    assert_eq!(observation.1, Some(retry_at));
+    let continuation_available_at: i64 = sqlx::query_scalar(
+        "SELECT available_at FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read delayed representative");
+    assert_eq!(continuation_available_at, retry_at);
+
+    drop(state);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn ha_gc_real_worker_wakes_an_eligible_channel_before_a_legacy_defer() {
     let db_path = temp_db_path("ha-gc-worker-fair-wake");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/store/key_store_jobs.rs
+++ b/src/store/key_store_jobs.rs
@@ -337,7 +337,7 @@ impl KeyStore {
         let started_at = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
             if let Some((job_id, status, _current_trigger_source)) =
@@ -759,7 +759,7 @@ impl KeyStore {
         let finished_at = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
             // A deferred online slice must not turn a short SQLite writer conflict
@@ -996,7 +996,7 @@ impl KeyStore {
         let started_at = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
                 let updated = sqlx::query(
@@ -1217,7 +1217,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
             Self::abandon_stale_quota_sync_job_locked(&mut conn, job_type, key_id, now).await?;
@@ -1272,7 +1272,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = sqlx::query(
                 r#"
@@ -1342,7 +1342,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = sqlx::query(
             r#"UPDATE scheduled_jobs
@@ -1403,7 +1403,7 @@ impl KeyStore {
         let finished_at = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = sqlx::query(
             r#"UPDATE scheduled_jobs SET status = ?, message = ?, finished_at = ? WHERE id = ?"#,
@@ -1429,7 +1429,7 @@ impl KeyStore {
         let finished_at = self.backend_time.now_ts();
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let write_result = match sqlx::query(
             r#"UPDATE scheduled_jobs
@@ -1461,7 +1461,7 @@ impl KeyStore {
     ) -> Result<(), ProxyError> {
         let mut conn = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = sqlx::query(r#"UPDATE scheduled_jobs SET message = ? WHERE id = ?"#)
             .bind(message)

--- a/src/store/key_store_reconciliation_controller.rs
+++ b/src/store/key_store_reconciliation_controller.rs
@@ -80,7 +80,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut tx = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
             let (mode, activation_period_code, activation_period_start, legacy_active, paused_reason, action): (
@@ -158,7 +158,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut tx = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
             sqlx::query(

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -398,10 +398,7 @@ impl KeyStore {
         &self,
         timestamp: i64,
     ) -> Result<(), ProxyError> {
-        let mut conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ScheduledJobControl)
-            .await?;
+        let mut transaction = self.sqlite_runtime.begin_scheduled_job_control().await?;
         let result = sqlx::query(
             r#"
             INSERT INTO meta (key, value)
@@ -411,11 +408,11 @@ impl KeyStore {
         )
         .bind(META_KEY_UPSTREAM_RECONCILIATION_LAST_RUN_AT_V1)
         .bind(timestamp.to_string())
-        .execute(&mut *conn)
+        .execute(&mut *transaction)
         .await;
         match result {
-            Ok(_) => conn.close().await,
-            Err(err) => Err(ProxyError::Database(err)),
+            Ok(_) => transaction.finish(Ok(())).await,
+            Err(err) => transaction.finish(Err(ProxyError::Database(err))).await,
         }
     }
 

--- a/src/store/key_store_upstream_reconciliation_admission.rs
+++ b/src/store/key_store_upstream_reconciliation_admission.rs
@@ -59,7 +59,7 @@ impl KeyStore {
 
     async fn begin_reconciliation_control(&self) -> Result<SqliteImmediateTransaction, ProxyError> {
         self.sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await
     }
 

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -212,7 +212,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut tx = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         let result = async {
             let (_, _, local_backoff_until) =
@@ -318,7 +318,7 @@ impl KeyStore {
         let now = self.backend_time.now_ts();
         let mut tx = self
             .sqlite_runtime
-            .begin_immediate(SqliteOperation::ScheduledJobControl)
+            .begin_scheduled_job_control()
             .await?;
         if let Some((job_id, claim_generation)) = observation.claimed_job {
             let claim_current: i64 = sqlx::query_scalar(

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -896,6 +896,19 @@ impl SqliteRuntime {
         }
     }
 
+    pub(crate) async fn begin_scheduled_job_control(
+        &self,
+    ) -> Result<SqliteImmediateTransaction, ProxyError> {
+        // Control writes must yield before reconciliation loses its durable
+        // finalization reserve; cancellation leaves the running claim fenced
+        // for stale recovery instead of inventing a terminal result.
+        self.begin_immediate_before(
+            SqliteOperation::ScheduledJobControl,
+            Instant::now() + Duration::from_millis(100),
+        )
+        .await
+    }
+
     fn record_success(
         &self,
         operation: SqliteOperation,
@@ -2168,6 +2181,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scheduled_job_control_begin_respects_a_short_deadline() {
+        let runtime = single_connection_runtime().await;
+        let held = runtime
+            .inner
+            .pool
+            .acquire()
+            .await
+            .expect("hold the only connection");
+        let started = Instant::now();
+        let error = runtime
+            .begin_scheduled_job_control()
+            .await
+            .expect_err("scheduled-job control must yield under pool pressure");
+        assert!(is_transient_sqlite_write_error(&error));
+        assert!(started.elapsed() < Duration::from_millis(250));
+        drop(held);
+    }
+
+    #[tokio::test]
     async fn alert_projection_read_snapshot_uses_and_restores_short_busy_timeout() {
         let runtime = single_connection_runtime().await;
         let mut snapshot = runtime
@@ -2505,7 +2537,7 @@ mod tests {
 
         let transaction = tokio::time::timeout(
             Duration::from_millis(100),
-            runtime.begin_immediate(SqliteOperation::ScheduledJobControl),
+            runtime.begin_scheduled_job_control(),
         )
         .await
         .expect("control transaction must not wait for the bulk permit")


### PR DESCRIPTION
## Delivery role\ndirect\n\n## Summary\n- Bound every ScheduledJobControl write transaction to a 100ms caller deadline so SQLite contention yields before reconciliation finalization reserve expires.\n- Routed transient completion bookkeeping and claimed-run SQLite pressure through the existing atomic deferred finalizer; non-transient failures remain observable terminal errors.\n- Added cold/warm admin privacy contention coverage and control-budget regression tests.\n\n## Spec\n- docs/specs/upstream-privacy-period-reconciliation/SPEC.md\n- docs/specs/sqlite-write-lock-hardening/SPEC.md\n\n## Spec Disposition\nExisting contracts already define the bounded control transaction, durable local-pressure defer, and cold 503 privacy response; this change closes the remaining control-write admission path.\n\n## Solutions\n-\n\n## Project Docs\n-\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- focused reconciliation, SQLite runtime, privacy cold/warm, and source/recovery tests\n\n## Scope\nNo production deployment, configuration, pool/PRAGMA changes, or machine-101 writes.\n\n<!-- CUSTOM_NOTES_START -->\n<!-- CUSTOM_NOTES_END -->