### PR TITLE
fix(admin): isolate privacy status refresh

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,10 +28,12 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   operation or when its bounded transaction sees transient writer contention. The affected durable
   work returns uncommitted deltas or records a retry time; unrelated eligible work remains free to
   progress.
-- `admin privacy read session`: a dedicated immutable SQLite snapshot for privacy status. Its
-  acquire and begin budgets are 100ms, the HTTP build is bounded to 250ms, and it never uses
-  maintenance-bulk admission. A 60-second last-good result is explicit stale coverage; a cold miss
-  returns retryable service-unavailable.
+- `admin privacy read controller`: an AppState-owned immutable privacy-status last-good value,
+  observation time, and singleflight refresh flag. It schedules its dedicated SQLite snapshot only
+  after ready and outside the HTTP response path. Snapshot acquire and `BEGIN` remain bounded to
+  100ms and close explicitly at a cooperative completion boundary; cached readers immediately
+  receive `stale` coverage while a refresh is in flight or deferred. A true cold miss returns
+  `503 Retry-After: 1` without opening a request-owned SQLite transaction.
 
 ## Reconciliation Terms
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,8 +34,9 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   100ms through operation admission and a connection-local busy timeout, then close explicitly at
   a cooperative completion boundary; cached readers immediately
   receive `stale` coverage while a refresh is in flight or deferred. Shutdown fences new refreshes
-  and waits for an active snapshot's explicit close. A true cold miss returns `503 Retry-After: 1`
-  without opening a request-owned SQLite transaction.
+  and waits for an active snapshot's explicit close. A deferred startup prewarm retries in the
+  background until it publishes last-good or shutdown fences it. A true cold miss returns
+  `503 Retry-After: 1` without opening a request-owned SQLite transaction.
 
 ## Reconciliation Terms
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,7 +31,8 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
 - `admin privacy read controller`: an AppState-owned immutable privacy-status last-good value,
   observation time, and singleflight refresh flag. It schedules its dedicated SQLite snapshot only
   after ready and outside the HTTP response path. Snapshot acquire and `BEGIN` remain bounded to
-  100ms and close explicitly at a cooperative completion boundary; cached readers immediately
+  100ms through operation admission and a connection-local busy timeout, then close explicitly at
+  a cooperative completion boundary; cached readers immediately
   receive `stale` coverage while a refresh is in flight or deferred. Shutdown fences new refreshes
   and waits for an active snapshot's explicit close. A true cold miss returns `503 Retry-After: 1`
   without opening a request-owned SQLite transaction.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,8 +32,9 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   observation time, and singleflight refresh flag. It schedules its dedicated SQLite snapshot only
   after ready and outside the HTTP response path. Snapshot acquire and `BEGIN` remain bounded to
   100ms and close explicitly at a cooperative completion boundary; cached readers immediately
-  receive `stale` coverage while a refresh is in flight or deferred. A true cold miss returns
-  `503 Retry-After: 1` without opening a request-owned SQLite transaction.
+  receive `stale` coverage while a refresh is in flight or deferred. Shutdown fences new refreshes
+  and waits for an active snapshot's explicit close. A true cold miss returns `503 Retry-After: 1`
+  without opening a request-owned SQLite transaction.
 
 ## Reconciliation Terms
 

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -71,13 +71,15 @@ reads:
   `503 Retry-After: 1` rather than starting a raw alert CTE.
 - Apply the same last-good boundary to the single-key privacy-status read. Keep the immutable
   successful snapshot for 60 seconds; warm pressure returns it as stale with the observation time,
-  while cold pressure fails fast with `503 Retry-After: 1`. The bounded read deadline is 250ms,
-  including operation admission and result construction.
-- Give privacy status its own read session rather than classifying it as maintenance bulk. Acquire
-  and begin its one immutable SQLite snapshot within 100ms, build every field on that same
-  connection, and release it before returning. Do not let one status field borrow a raw pool
-  connection after another field has already read the snapshot: that mixes generations and defeats
-  the cold-path bound.
+  while cold pressure fails fast with `503 Retry-After: 1`. The HTTP path is bounded to 250ms and,
+  after authentication, only copies last-good data rather than building status or awaiting refresh.
+- Give privacy status an AppState-owned controller and its own bounded background read operation,
+  rather than classifying it as maintenance bulk. Ready schedules a low-priority singleflight
+  prewarm; the worker acquires and begins one immutable SQLite snapshot, builds every field on that
+  snapshot, then explicitly closes it before publishing last-good. A two-second connection-local
+  progress handler stops the next cooperative SQLite boundary, while pressure defers the next
+  refresh phase. Do not cancel an open snapshot with an outer task timeout or let a later field
+  borrow a raw pool connection: both patterns risk transaction pollution or mixed generations.
 - Replace repeated window scans with a single bounded scan that derives all needed windows, then add
   a short manager-scoped TTL cache when settings and live stats can request the same window set in
   one admin refresh cycle.

--- a/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
+++ b/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
@@ -85,8 +85,10 @@
   most one generation every five minutes. Rebuild slices remain bounded and replayable from the
   request-log source.
 - Privacy status refresh acquires one dedicated read snapshot within 100ms and constructs its full
-  immutable result on that connection outside the HTTP path. The refresh closes explicitly before
-  its result is published, so request timeouts never discard an open read snapshot. It bypasses
+  immutable result on that connection outside the HTTP path. Its `BEGIN` uses the connection-local
+  100ms busy timeout rather than task cancellation, restoring the connection to the pool on
+  contention. The refresh closes explicitly before its result is published, so request timeouts
+  never discard an open read snapshot. It bypasses
   maintenance-bulk admission; cached reads return stale coverage during pressure or refresh, while
   true cold reads return `503 Retry-After: 1`.
 - Server-pressure recovery allocates a staged generation, aggregates fixed-fence 500-row keyset

--- a/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
+++ b/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
@@ -74,9 +74,9 @@
   audit defer/retry events stay DEBUG, while stale/recovered coverage changes and fixed transport
   categories are safe owner-facing diagnostics without SQL, request bodies, endpoints, or tokens.
 - Administrator privacy status uses an AppState-owned immutable last-good controller with one
-  refresh flight. Ready startup schedules a non-blocking prewarm; requests copy cached data rather
-  than building the status synchronously. An expired cached value returns fixed-reason stale
-  coverage while the controller refreshes or defers, and a true cold miss returns
+  refresh flight. Ready startup schedules a non-blocking retrying prewarm; requests copy cached
+  data rather than building the status synchronously. An expired cached value returns fixed-reason
+  stale coverage while the controller refreshes or defers, and a true cold miss returns
   `503 Retry-After: 1`. Administrator alert Events, Groups, and Catalog use a normalized
   exact-query cache with a five-minute cap; a bounded read may return the matching stale entry,
   while a cold key returns `503 Retry-After: 1` rather than waiting for a raw alert CTE.

--- a/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
+++ b/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
@@ -73,19 +73,22 @@
 - The workload window includes bounded derived-observability flushes. Server-pressure and rebalance
   audit defer/retry events stay DEBUG, while stale/recovered coverage changes and fixed transport
   categories are safe owner-facing diagnostics without SQL, request bodies, endpoints, or tokens.
-- Administrator privacy status uses one immutable 60-second last-good entry. Administrator alert
-  Events, Groups, and Catalog use a normalized exact-query cache with a five-minute cap; a bounded
-  read may return the matching stale entry, while a cold key returns `503 Retry-After: 1` rather
-  than waiting for a raw alert CTE. These fallback states expose coverage, observed time, and a
-  fixed stale reason only.
+- Administrator privacy status uses an AppState-owned immutable last-good controller with one
+  refresh flight. Ready startup schedules a non-blocking prewarm; requests copy cached data rather
+  than building the status synchronously. An expired cached value returns fixed-reason stale
+  coverage while the controller refreshes or defers, and a true cold miss returns
+  `503 Retry-After: 1`. Administrator alert Events, Groups, and Catalog use a normalized
+  exact-query cache with a five-minute cap; a bounded read may return the matching stale entry,
+  while a cold key returns `503 Retry-After: 1` rather than waiting for a raw alert CTE.
 - Server-pressure rebuilds are source-fenced and hysteretic: ordinary deferred deltas do not start
   a rebuild, while overflow, lost coverage, or five minutes of continuous stale state may start at
   most one generation every five minutes. Rebuild slices remain bounded and replayable from the
   request-log source.
-- Privacy status now acquires a dedicated read snapshot within 100ms and constructs its full
-  immutable response on that one connection under the handler's 250ms bound. It bypasses
-  maintenance-bulk admission and returns the existing 60-second last-good result as additive stale
-  coverage, or cold `503 Retry-After: 1` on pressure.
+- Privacy status refresh acquires one dedicated read snapshot within 100ms and constructs its full
+  immutable result on that connection outside the HTTP path. The refresh closes explicitly before
+  its result is published, so request timeouts never discard an open read snapshot. It bypasses
+  maintenance-bulk admission; cached reads return stale coverage during pressure or refresh, while
+  true cold reads return `503 Retry-After: 1`.
 - Server-pressure recovery allocates a staged generation, aggregates fixed-fence 500-row keyset
   slices, publishes once, and removes obsolete buckets in 25-row cleanup slices. Direct deltas and
   buffered tail replay always write the active generation, so source rebuilds do not amplify normal

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -162,6 +162,8 @@
 - `cargo test --lib store::tests::perf_logs_are_info_level_and_include_memory_budget_fields -- --nocapture`
 - `cargo test alerts_and_ha -- --nocapture`
 - `cargo test log_catalog_and_dashboard_sse -- --nocapture`
+- `cargo test --bin tavily-hikari listener_ready_hook_schedules_privacy_status_prewarm -- --nocapture`
+- `cargo test --lib admin_privacy_read_run_budget_interrupts_before_discarding_its_session -- --nocapture`
 
 ## Notes
 

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -76,7 +76,8 @@
   enter maintenance-bulk admission, and explicitly close at a cooperative completion boundary.
   HTTP only copies last-good data: a cached value, including one older than 60 seconds, returns
   additive `stale` coverage within 250ms while refresh is in flight or deferred; a true cold miss
-  returns `503 Retry-After: 1` without canceling an open SQLite transaction.
+  returns `503 Retry-After: 1` without canceling an open SQLite transaction. Shutdown fences new
+  refreshes and waits for an active snapshot to close cooperatively.
 - A server-pressure rebuild scans at most 500 source rows per keyset slice below its fixed source
   fence, writes only an inactive staged generation, then atomically publishes that generation before
   replaying its buffered tail. Old generations are cleaned in 25-row slices; no rebuild may delete

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -75,6 +75,9 @@
   shutdown fences it, without delaying readiness or competing with foreground work.
   The controller's `AdminPrivacyRead` snapshot acquire and `BEGIN` are bounded to 100ms, never
   enter maintenance-bulk admission, and explicitly close at a cooperative completion boundary.
+  Its complete diagnostic run is bounded to two seconds by SQLite's progress handler, which interrupts
+  only the active SQL statement and is cleared before the explicit rollback; HTTP and shutdown
+  never cancel the task while it owns a snapshot.
   HTTP only copies last-good data: a cached value, including one older than 60 seconds, returns
   additive `stale` coverage within 250ms while refresh is in flight or deferred; a true cold miss
   returns `503 Retry-After: 1` without canceling an open SQLite transaction. Shutdown fences new

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -70,11 +70,13 @@
 - 对账主结算必须先于 Research sweep；本地预算压力与 upstream 429 必须分开记录，且最终
   远端观察、结算和状态落盘都必须受同一轮预算约束。HA GC 正常进展继续按通道 60 秒聚合，
   不能恢复逐片 WARN。
-- Privacy status owns a dedicated `AdminPrivacyRead` session: acquire and `BEGIN` are bounded to
-  100ms, response construction is bounded to 250ms, and every status query runs through one
-  immutable SQLite snapshot connection. It neither enters maintenance-bulk admission nor borrows
-  raw pool connections; a warm 60-second last-good result may become additive stale coverage,
-  while a cold result returns `503 Retry-After: 1`.
+- Privacy status owns an AppState-owned immutable last-good controller. After ready it starts one
+  low-priority prewarm; prewarm failure never delays readiness or competes with foreground work.
+  The controller's `AdminPrivacyRead` snapshot acquire and `BEGIN` are bounded to 100ms, never
+  enter maintenance-bulk admission, and explicitly close at a cooperative completion boundary.
+  HTTP only copies last-good data: a cached value, including one older than 60 seconds, returns
+  additive `stale` coverage within 250ms while refresh is in flight or deferred; a true cold miss
+  returns `503 Retry-After: 1` without canceling an open SQLite transaction.
 - A server-pressure rebuild scans at most 500 source rows per keyset slice below its fixed source
   fence, writes only an inactive staged generation, then atomically publishes that generation before
   replaying its buffered tail. Old generations are cleaned in 25-row slices; no rebuild may delete
@@ -136,7 +138,8 @@
   - `component=admin_read event=token_logs_list_completed`
   - `component=admin_read event=/api/alerts/events phase=projection_sidecar|alerts_projection`
   - `component=admin_read event=/api/alerts/groups phase=projection_sidecar|alerts_grouping`
-  - `component=admin_read event=alerts_last_good_served|alerts_cold_pressure`
+- `component=admin_read event=alerts_last_good_served|alerts_cold_pressure`
+- `component=startup event=admin_privacy_status_prewarm_started|admin_privacy_status_prewarm_deferred`
   - `component=admin_read event=low_memory_protection_decision`
 - `sqlite_workload_window` aggregates `observability_deferred_write` alongside other operation
   classes. Per-flush defer/retry records remain DEBUG; queue recovery or a persistent stale state

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -71,7 +71,8 @@
   远端观察、结算和状态落盘都必须受同一轮预算约束。HA GC 正常进展继续按通道 60 秒聚合，
   不能恢复逐片 WARN。
 - Privacy status owns an AppState-owned immutable last-good controller. After ready it starts one
-  low-priority prewarm; prewarm failure never delays readiness or competes with foreground work.
+  low-priority prewarm; deferred prewarm retries in the background until last-good is published or
+  shutdown fences it, without delaying readiness or competing with foreground work.
   The controller's `AdminPrivacyRead` snapshot acquire and `BEGIN` are bounded to 100ms, never
   enter maintenance-bulk admission, and explicitly close at a cooperative completion boundary.
   HTTP only copies last-good data: a cached value, including one older than 60 seconds, returns

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -76,8 +76,9 @@
   The controller's `AdminPrivacyRead` snapshot acquire and `BEGIN` are bounded to 100ms, never
   enter maintenance-bulk admission, and explicitly close at a cooperative completion boundary.
   Its complete diagnostic run is bounded to two seconds by SQLite's progress handler and an
-  explicit check before every next SQLite phase. The handler interrupts the active statement; the
-  phase check prevents a series of short statements from extending the snapshot past its run budget.
+  explicit check before every next SQLite phase and each row of unbounded result shaping. The handler
+  interrupts the active statement; the phase checks prevent a series of short statements or a large
+  in-memory diagnostic projection from extending the snapshot past its run budget.
   Both are cleared before the explicit rollback; HTTP and shutdown never cancel the task while it
   owns a snapshot.
   HTTP only copies last-good data: a cached value, including one older than 60 seconds, returns

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -75,9 +75,11 @@
   shutdown fences it, without delaying readiness or competing with foreground work.
   The controller's `AdminPrivacyRead` snapshot acquire and `BEGIN` are bounded to 100ms, never
   enter maintenance-bulk admission, and explicitly close at a cooperative completion boundary.
-  Its complete diagnostic run is bounded to two seconds by SQLite's progress handler, which interrupts
-  only the active SQL statement and is cleared before the explicit rollback; HTTP and shutdown
-  never cancel the task while it owns a snapshot.
+  Its complete diagnostic run is bounded to two seconds by SQLite's progress handler and an
+  explicit check before every next SQLite phase. The handler interrupts the active statement; the
+  phase check prevents a series of short statements from extending the snapshot past its run budget.
+  Both are cleared before the explicit rollback; HTTP and shutdown never cancel the task while it
+  owns a snapshot.
   HTTP only copies last-good data: a cached value, including one older than 60 seconds, returns
   additive `stale` coverage within 250ms while refresh is in flight or deferred; a true cold miss
   returns `503 Retry-After: 1` without canceling an open SQLite transaction. Shutdown fences new
@@ -164,6 +166,7 @@
 - `cargo test log_catalog_and_dashboard_sse -- --nocapture`
 - `cargo test --bin tavily-hikari listener_ready_hook_schedules_privacy_status_prewarm -- --nocapture`
 - `cargo test --lib admin_privacy_read_run_budget_interrupts_before_discarding_its_session -- --nocapture`
+- `cargo test --lib privacy_status_stops_at_a_safe_boundary_and_closes_its_snapshot -- --nocapture`
 
 ## Notes
 

--- a/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -20,8 +20,9 @@
   typed deferred outcome, while a control write can reuse an already durable representative row.
 - Administrator alert and privacy reads are bounded operations. Alerts use the complete projection
   through the `AlertProjection` runtime connection and exact-query last-good cache; privacy status
-  uses a 250ms cold-build deadline and a 60-second immutable last-good entry. Pressure never
-  releases an admission check and then waits on an unbounded raw pool acquire.
+  uses an AppState-owned immutable last-good controller and one low-priority refresh flight.
+  Pressure never releases an admission check and then waits on an unbounded raw pool acquire; HTTP
+  never cancels an open privacy read snapshot, and a cold cache returns retryable unavailable.
 - Server-pressure deltas and rebalance audit persistence use an instance-owned deferred writer.
   Pressure batches contain at most 25 bucket keys per `ObservabilityDeferredWrite` transaction and
   return to a bounded queue after transient contention; its source-fenced rebuild remains the

--- a/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -21,8 +21,10 @@
 - Administrator alert and privacy reads are bounded operations. Alerts use the complete projection
   through the `AlertProjection` runtime connection and exact-query last-good cache; privacy status
   uses an AppState-owned immutable last-good controller and one low-priority refresh flight.
-  Pressure never releases an admission check and then waits on an unbounded raw pool acquire; HTTP
-  never cancels an open privacy read snapshot, and a cold cache returns retryable unavailable.
+  Pressure never releases an admission check and then waits on an unbounded raw pool acquire; the
+  privacy read's connection-local busy timeout returns contention without cancelling or discarding
+  its connection, HTTP never cancels an open privacy read snapshot, and a cold cache returns
+  retryable unavailable.
 - Server-pressure deltas and rebalance audit persistence use an instance-owned deferred writer.
   Pressure batches contain at most 25 bucket keys per `ObservabilityDeferredWrite` transaction and
   return to a bounded queue after transient contention; its source-fenced rebuild remains the

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -103,7 +103,8 @@ source when a usable persisted runtime already exists.
 - Administrator privacy-status reads use one AppState-owned last-good controller. HTTP handlers
   only copy its immutable value: an expired cached value must return additive stale coverage while
   one low-priority refresh runs or is deferred, and a true cold miss must return
-  `503 Retry-After: 1`. A refresh must explicitly close its `AdminPrivacyRead` snapshot at a
+  `503 Retry-After: 1`. A deferred startup prewarm retries in the background without consuming
+  foreground capacity. A refresh must explicitly close its `AdminPrivacyRead` snapshot at a
   cooperative completion boundary; an HTTP deadline or graceful shutdown must never cancel an open
   SQLite transaction.
 - The pressure-bucket rebuild must compute its bounded source aggregates without an immediate write

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -105,8 +105,9 @@ source when a usable persisted runtime already exists.
   one low-priority refresh runs or is deferred, and a true cold miss must return
   `503 Retry-After: 1`. A deferred startup prewarm retries in the background without consuming
   foreground capacity. A refresh must explicitly close its `AdminPrivacyRead` snapshot at a
-  cooperative completion boundary; an HTTP deadline or graceful shutdown must never cancel an open
-  SQLite transaction.
+  cooperative completion boundary. Its two-second SQLite progress-handler run budget interrupts only
+  the active statement, is cleared before rollback, and reports the failed operation; an HTTP
+  deadline or graceful shutdown must never cancel an open SQLite transaction.
 - The pressure-bucket rebuild must compute its bounded source aggregates without an immediate write
   transaction. It may acquire SQLite's writer only for the final small bucket replacement; the
   upper-bound request-log id and buffered live-event replay preserve the handoff across those two

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -100,6 +100,11 @@ source when a usable persisted runtime already exists.
   writer. They enter instance-owned bounded deferred queues; pressure deltas are replayable from
   request logs, while a rejected rebalance audit records explicit stale coverage without changing
   MCP success or billing truth. Every deferred flush uses `SqliteRuntime` operation budgets.
+- Administrator privacy-status reads use one AppState-owned last-good controller. HTTP handlers
+  only copy its immutable value: an expired cached value must return additive stale coverage while
+  one low-priority refresh runs or is deferred, and a true cold miss must return
+  `503 Retry-After: 1`. A refresh must explicitly close its `AdminPrivacyRead` snapshot at a
+  cooperative completion boundary; an HTTP deadline must never cancel an open SQLite transaction.
 - The pressure-bucket rebuild must compute its bounded source aggregates without an immediate write
   transaction. It may acquire SQLite's writer only for the final small bucket replacement; the
   upper-bound request-log id and buffered live-event replay preserve the handoff across those two

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -105,9 +105,11 @@ source when a usable persisted runtime already exists.
   one low-priority refresh runs or is deferred, and a true cold miss must return
   `503 Retry-After: 1`. A deferred startup prewarm retries in the background without consuming
   foreground capacity. A refresh must explicitly close its `AdminPrivacyRead` snapshot at a
-  cooperative completion boundary. Its two-second SQLite progress-handler run budget interrupts only
-  the active statement, is cleared before rollback, and reports the failed operation; an HTTP
-  deadline or graceful shutdown must never cancel an open SQLite transaction.
+  cooperative completion boundary. Its two-second SQLite run budget combines a progress handler for
+  the active statement with an explicit check before every next SQLite phase, so a series of short
+  statements cannot extend the snapshot past the budget. Both boundaries are cleared before
+  rollback and report the failed operation; an HTTP deadline or graceful shutdown must never cancel
+  an open SQLite transaction.
 - The pressure-bucket rebuild must compute its bounded source aggregates without an immediate write
   transaction. It may acquire SQLite's writer only for the final small bucket replacement; the
   upper-bound request-log id and buffered live-event replay preserve the handoff across those two

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -104,7 +104,8 @@ source when a usable persisted runtime already exists.
   only copy its immutable value: an expired cached value must return additive stale coverage while
   one low-priority refresh runs or is deferred, and a true cold miss must return
   `503 Retry-After: 1`. A refresh must explicitly close its `AdminPrivacyRead` snapshot at a
-  cooperative completion boundary; an HTTP deadline must never cancel an open SQLite transaction.
+  cooperative completion boundary; an HTTP deadline or graceful shutdown must never cancel an open
+  SQLite transaction.
 - The pressure-bucket rebuild must compute its bounded source aggregates without an immediate write
   transaction. It may acquire SQLite's writer only for the final small bucket replacement; the
   upper-bound request-log id and buffered live-event replay preserve the handoff across those two

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -175,9 +175,9 @@
 - 系统设置页在“启用 Rebalance MCP”行只在活跃异常 session 数量大于 0 时显示 warning 图标，并跳转到隐藏管理页。
 - 系统状态页始终显示“活跃 `upstream_mcp` session”统计卡；数量大于 0 时使用 warning 语义，数量为 0 时使用 neutral/success 语义。
 - `/api/settings/system/privacy-status` 维持既有诊断字段并可添加 freshness 元数据。服务 ready 后以低优先级
-  预热 immutable last-good；有缓存的读取不得同步重建，在 refresh 或本地 SQLite 压力下直接返回
-  `200 stale`，真冷缓存返回 `503 Retry-After: 1`。请求 deadline 不得取消开放的 SQLite read snapshot。
-  优雅停机必须 fence 新 refresh，并等待已开始的 snapshot 显式 close。
+  预热 immutable last-good；defer 后后台重试至发布或停机。有缓存的读取不得同步重建，在 refresh 或本地
+  SQLite 压力下直接返回 `200 stale`，真冷缓存返回 `503 Retry-After: 1`。请求 deadline 不得取消开放的
+  SQLite read snapshot。优雅停机必须 fence 新 refresh，并等待已开始的 snapshot 显式 close。
 
 ## 接口契约（Interfaces & Contracts）
 

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -174,6 +174,9 @@
 - 页面展示今日对账收敛进度：账号至少一个标准成功账期、账期 terminal、Research terminal 三个比例，以及每 Key 的 pending Research、待查询 Project ID 和 reconciliation 冷却状态。
 - 系统设置页在“启用 Rebalance MCP”行只在活跃异常 session 数量大于 0 时显示 warning 图标，并跳转到隐藏管理页。
 - 系统状态页始终显示“活跃 `upstream_mcp` session”统计卡；数量大于 0 时使用 warning 语义，数量为 0 时使用 neutral/success 语义。
+- `/api/settings/system/privacy-status` 维持既有诊断字段并可添加 freshness 元数据。服务 ready 后以低优先级
+  预热 immutable last-good；有缓存的读取不得同步重建，在 refresh 或本地 SQLite 压力下直接返回
+  `200 stale`，真冷缓存返回 `503 Retry-After: 1`。请求 deadline 不得取消开放的 SQLite read snapshot。
 
 ## 接口契约（Interfaces & Contracts）
 
@@ -205,6 +208,9 @@
 - Given 多 Key、Research 等待、Retry-After、重启或 HA 接管，When 窗口结算，Then 最终只产生一条幂等 signed adjustment。
 - Given 退款或补扣，When 查询账户或未绑定 Token 的相关额度，Then 原业务窗口统计立即反映差额，S3 不增加次日额度。
 - Given 状态 API 与页面，When secret、官方 key 或 token 存在，Then 任何响应与 UI 都不显示完整敏感值。
+- Given privacy-status last-good 已过 60 秒且 SQLite refresh 受压或正在运行，When 管理员读取该接口，Then
+  在 250ms 内返回 `200 stale`，仅启动一个后台 refresh，且不丢弃 read-session connection；Given 无
+  last-good，Then 在同一预算内返回 `503 Retry-After: 1`。
 - Given reconciliation backlog 中存在 `rate_limited` 窗口，When 管理员查看系统状态页，Then 能区分上游 429、本地 usage 限流与其他重试，并能看到当前时段每个上游 Key 的绑定用户数与待查询 Project ID 数分布。
 - Given 近期窗口与旧 backlog 同时堆积，When reconciliation worker 选择候选窗口，Then 今日+昨日窗口优先进入 recent lane，且不会被老 backlog 长期饿死。
 - Given 同一上游 Key 的多个窗口同时到期且首次 `/usage` 查询收到 429 或本地 usage 限流，When reconciliation worker 执行，Then 该 Key 的到期窗口整体进入同一退避时间，本轮不再反复打同一个 Key，其他 Key 的候选仍可继续结算。

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -177,6 +177,7 @@
 - `/api/settings/system/privacy-status` 维持既有诊断字段并可添加 freshness 元数据。服务 ready 后以低优先级
   预热 immutable last-good；有缓存的读取不得同步重建，在 refresh 或本地 SQLite 压力下直接返回
   `200 stale`，真冷缓存返回 `503 Retry-After: 1`。请求 deadline 不得取消开放的 SQLite read snapshot。
+  优雅停机必须 fence 新 refresh，并等待已开始的 snapshot 显式 close。
 
 ## 接口契约（Interfaces & Contracts）
 

--- a/docs/specs/upstream-privacy-period-reconciliation/contracts/http-apis.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/contracts/http-apis.md
@@ -33,6 +33,8 @@
 immutable last-good 的观测时间，`staleReason` 只使用固定的本地分类。服务启动后异步预热该
 last-good；有缓存时请求不得同步重建，refresh 或本地压力下直接返回 `200 stale`。无缓存时返回
 `503 Retry-After: 1`，且不会因为 HTTP deadline 取消开放 SQLite transaction。
+上述 `200 stale` 与无缓存 `503` 均须在 250ms 内完成；响应只读取 immutable last-good 或在没有
+last-good 时作出有界冷启动判定，不等待完整 SQLite read-model rebuild。
 
 响应不得包含 HMAC secret、官方 API key、完整 Hikari token 或客户端原始 `X-Project-ID`。
 

--- a/docs/specs/upstream-privacy-period-reconciliation/contracts/http-apis.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/contracts/http-apis.md
@@ -29,6 +29,11 @@
 - `dailyReconciliationByKey`：当天每 Key 的 `{ keyIdHint, terminalResearch, pendingResearch, pendingProjectIds, cooldownUntil, cooldownReason }`，仅返回稳定短 hint 与固定原因枚举；
 - 最近 signed adjustments（token 只显示稳定短 id，upstream key 只显示本地短 id）。
 
+响应保留既有字段并可附加读模型 freshness 字段：`coverage` 为 `ok|stale`，`observedAt` 是当前
+immutable last-good 的观测时间，`staleReason` 只使用固定的本地分类。服务启动后异步预热该
+last-good；有缓存时请求不得同步重建，refresh 或本地压力下直接返回 `200 stale`。无缓存时返回
+`503 Retry-After: 1`，且不会因为 HTTP deadline 取消开放 SQLite transaction。
+
 响应不得包含 HMAC secret、官方 API key、完整 Hikari token 或客户端原始 `X-Project-ID`。
 
 phase 当前为：

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -93,6 +93,7 @@
         "store::alert_grouping_tests::",
         "store::sqlite_runtime::tests::",
         "store::tests::",
+        "tavily_proxy::privacy_status_phase_budget_tests::",
         "tavily_proxy::tests::",
         "tests::request_kind_and_core::parse_",
         "tests::proxy_affinity_and_summary::extract_",
@@ -687,6 +688,7 @@
       ],
       "include_prefixes": [
         "server::manual_trigger_tests::",
+        "server::privacy_status_prewarm_logging_tests::",
         "server::db_maintenance_gate_tests::",
         "server::version_detection_tests::",
         "server::tests::api_keys_and_registration::user_",

--- a/src/forward_proxy/tests.rs
+++ b/src/forward_proxy/tests.rs
@@ -200,6 +200,8 @@ rule-providers:
             forced_pending_claim_miss_log_ids: tokio::sync::Mutex::new(std::collections::HashSet::new()),
             #[cfg(test)]
             dashboard_overview_read_pause: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            #[cfg(debug_assertions)]
+            admin_privacy_read_pause: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(
                 std::collections::HashSet::new(),
             ),

--- a/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
+++ b/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
@@ -216,8 +216,16 @@ async fn get_upstream_privacy_status(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<axum::response::Response, axum::response::Response> {
-    if !is_admin_request(state.as_ref(), &headers).await {
-        return Err(StatusCode::FORBIDDEN.into_response());
+    match try_is_admin_request(state.as_ref(), &headers).await {
+        Ok(true) => {}
+        Ok(false) => return Err(StatusCode::FORBIDDEN.into_response()),
+        // Do not reveal a cached administrative read model before the caller
+        // is authenticated. A bounded passkey lookup may defer under SQLite
+        // pressure, so retain the endpoint's retry contract without treating
+        // a valid session as an authorization failure.
+        Err(_) => {
+            return Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response());
+        }
     }
 
     match read_admin_privacy_status(state).await {

--- a/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
+++ b/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
@@ -224,39 +224,16 @@ async fn get_upstream_privacy_status(
         return Ok(Json(status).into_response());
     }
 
-    match tokio::time::timeout(Duration::from_millis(250), state.proxy.upstream_privacy_status()).await {
-        Ok(Ok(status)) => {
-            record_admin_privacy_status_last_good(state.as_ref(), status.clone()).await;
-            Ok(Json(status).into_response())
-        }
-        Ok(Err(error))
-            if tavily_hikari::is_transient_sqlite_write_error(&error) || error.is_deferred() =>
-        {
-            match stale_admin_privacy_status(state.as_ref(), "sqlite_pressure").await {
-                Some(status) => Ok(Json(status).into_response()),
-                None => Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response()),
-            }
-        }
-        Err(_) => match stale_admin_privacy_status(state.as_ref(), "read_timeout").await {
+    let had_cached_value = admin_privacy_status_cached(state.as_ref()).await.is_some();
+    start_admin_privacy_status_refresh(state.clone()).await;
+    if had_cached_value {
+        match stale_admin_privacy_status(state.as_ref()).await {
             Some(status) => Ok(Json(status).into_response()),
             None => Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response()),
-        },
-        Ok(Err(error)) => {
-            eprintln!("get upstream privacy status error: {error}");
-            Err((StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response())
         }
+    } else {
+        Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response())
     }
-}
-
-async fn stale_admin_privacy_status(
-    state: &AppState,
-    reason: &str,
-) -> Option<tavily_hikari::UpstreamPrivacyStatus> {
-    let (mut status, observed_at) = admin_privacy_status_cached(state).await?;
-    status.coverage = "stale".to_string();
-    status.observed_at = Some(observed_at);
-    status.stale_reason = Some(reason.to_string());
-    Some(status)
 }
 
 async fn get_admin_mcp_session_bindings(

--- a/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
+++ b/src/server/handlers/admin_resources/forward_proxy_and_key_validation.rs
@@ -220,19 +220,13 @@ async fn get_upstream_privacy_status(
         return Err(StatusCode::FORBIDDEN.into_response());
     }
 
-    if let Some((status, _observed_at)) = admin_privacy_status_last_good(state.as_ref()).await {
-        return Ok(Json(status).into_response());
-    }
-
-    let had_cached_value = admin_privacy_status_cached(state.as_ref()).await.is_some();
-    start_admin_privacy_status_refresh(state.clone()).await;
-    if had_cached_value {
-        match stale_admin_privacy_status(state.as_ref()).await {
-            Some(status) => Ok(Json(status).into_response()),
-            None => Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response()),
+    match read_admin_privacy_status(state).await {
+        AdminPrivacyStatusResponse::Fresh(status) | AdminPrivacyStatusResponse::Stale(status) => {
+            Ok(Json(status).into_response())
         }
-    } else {
-        Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response())
+        AdminPrivacyStatusResponse::Cold => {
+            Err((StatusCode::SERVICE_UNAVAILABLE, [("retry-after", "1")]).into_response())
+        }
     }
 }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -607,6 +607,7 @@ pub async fn serve(
         shutdown_proxy.nudge_request_stats_flush().await;
     })
     .await?;
+    shutdown_admin_privacy_status_refresh(post_shutdown_state.as_ref()).await;
     if let Err(err) = post_shutdown_state
         .proxy
         .shutdown_request_stats_coalescer(Duration::from_secs(20))

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2401,19 +2401,23 @@ mod serve_tests {
                 .await
                 .expect("session is valid before pressure")
         );
+        prime_admin_privacy_status_for_test(state.clone()).await;
+        assert!(
+            admin_privacy_status_cached(state.as_ref()).await.is_some(),
+            "the pressure path must prove a populated immutable last-good cannot leak"
+        );
 
-        let lock_pool = sqlx::SqlitePool::connect(&format!("sqlite://{db_str}"))
+        let release_pool = Arc::new(tokio::sync::Notify::new());
+        let (pool_held_tx, pool_held_rx) = tokio::sync::oneshot::channel();
+        let pool_holder = {
+            let proxy = state.proxy.clone();
+            let release_pool = release_pool.clone();
+            tokio::spawn(async move { proxy.hold_sqlite_pool_until_for_test(pool_held_tx, release_pool).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), pool_held_rx)
             .await
-            .expect("connect lock pool");
-        let mut writer = lock_pool.acquire().await.expect("acquire lock writer");
-        sqlx::query("BEGIN EXCLUSIVE")
-            .execute(&mut *writer)
-            .await
-            .expect("hold exclusive lock");
-        sqlx::query("CREATE TABLE passkey_privacy_status_pressure_lock (id INTEGER)")
-            .execute(&mut *writer)
-            .await
-            .expect("hold schema lock");
+            .expect("the app SQLite pool should be exhausted")
+            .expect("the pool holder should signal readiness");
 
         let started = std::time::Instant::now();
         let response = get_upstream_privacy_status(State(state), headers)
@@ -2428,11 +2432,22 @@ mod serve_tests {
             Some("1")
         );
         assert!(started.elapsed() < Duration::from_millis(250));
-
-        sqlx::query("ROLLBACK")
-            .execute(&mut *writer)
+        assert!(
+            response.headers().get(CONTENT_TYPE).is_none(),
+            "a retry before authentication must not expose the cached status representation"
+        );
+        let retry_body = body::to_bytes(response.into_body(), BODY_LIMIT)
             .await
-            .expect("release schema lock");
+            .expect("read bounded retry body");
+        assert!(
+            retry_body.is_empty(),
+            "a retry before authentication must not expose cached privacy-status JSON"
+        );
+        release_pool.notify_one();
+        pool_holder
+            .await
+            .expect("pool holder joins")
+            .expect("pool holder releases cleanly");
     }
 
     #[tokio::test]

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -12,6 +12,40 @@ pub async fn serve(
     linuxdo_oauth: LinuxDoOAuthOptions,
     linuxdo_credit: LinuxDoCreditOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    serve_with_shutdown(
+        addr,
+        proxy,
+        static_dir,
+        forward_auth,
+        admin_auth,
+        dev_open_admin,
+        usage_base,
+        api_key_ip_geo_origin,
+        ha_config,
+        linuxdo_oauth,
+        linuxdo_credit,
+        shutdown_signal(),
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_with_shutdown(
+    addr: SocketAddr,
+    proxy: TavilyProxy,
+    static_dir: Option<PathBuf>,
+    forward_auth: ForwardAuthConfig,
+    admin_auth: AdminAuthOptions,
+    dev_open_admin: bool,
+    usage_base: String,
+    api_key_ip_geo_origin: String,
+    ha_config: tavily_hikari::HaConfig,
+    linuxdo_oauth: LinuxDoOAuthOptions,
+    linuxdo_credit: LinuxDoCreditOptions,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+    ready: Option<tokio::sync::oneshot::Sender<Arc<AppState>>>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let AdminAuthOptions {
         forward_auth_enabled,
         builtin_auth_enabled,
@@ -576,6 +610,9 @@ pub async fn serve(
     // last-good after readiness without delaying the listener or competing
     // with foreground work; requests only ever copy the immutable result.
     prewarm_owner_read_models_after_ready(state.clone()).await;
+    if let Some(ready) = ready {
+        let _ = ready.send(state.clone());
+    }
 
     // Always-on HA tasks must stay available on standby/recovery so health, role
     // refresh, and pull-sync keep working even while business traffic is fenced.
@@ -603,7 +640,7 @@ pub async fn serve(
             .into_make_service_with_connect_info::<SocketAddr>(),
     )
     .with_graceful_shutdown(async move {
-        shutdown_signal().await;
+        shutdown.await;
         fence_admin_privacy_status_refresh(shutdown_state.as_ref()).await;
         shutdown_proxy.begin_sqlite_maintenance_run_shutdown();
         shutdown_proxy.nudge_request_stats_flush().await;
@@ -2026,37 +2063,59 @@ mod serve_tests {
         )
         .await
         .expect("proxy created");
-        let state = Arc::new(AppState {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let server = serve_with_shutdown(
+            "127.0.0.1:0".parse().expect("test socket address"),
             proxy,
-            static_dir: None,
-            forward_auth: ForwardAuthConfig::new(None, None, None, None),
-            forward_auth_enabled: false,
-            builtin_admin: BuiltinAdminAuth::new(false, None, None),
-            admin_passkey: AdminPasskeyOptions {
-                enabled: false,
-                rp_id: None,
-                rp_origin: None,
-                scope: None,
-                challenge_ttl_secs: 300,
-                session_max_age_secs: 60 * 60,
+            None,
+            ForwardAuthConfig::new(None, None, None, None),
+            AdminAuthOptions {
+                forward_auth_enabled: false,
+                builtin_auth_enabled: false,
+                builtin_auth_password: None,
+                builtin_auth_password_hash: None,
+                passkey_auth_enabled: false,
+                passkey_rp_id: None,
+                passkey_rp_origin: None,
+                passkey_challenge_ttl_secs: 300,
+                passkey_session_max_age_secs: 60 * 60,
             },
-            linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
-            linuxdo_credit: LinuxDoCreditOptions::disabled(),
-            ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
-            dev_open_admin: false,
-            usage_base: "http://127.0.0.1:58088".to_string(),
-            api_key_ip_geo_origin: "https://api.country.is".to_string(),
-            dashboard_overview_cache: new_dashboard_overview_cache(),
-        });
+            false,
+            "http://127.0.0.1:58088".to_string(),
+            "https://api.country.is".to_string(),
+            tavily_hikari::HaConfig::default(),
+            LinuxDoOAuthOptions::disabled(),
+            LinuxDoCreditOptions::disabled(),
+            async move {
+                let _ = shutdown_rx.await;
+            },
+            Some(ready_tx),
+        );
+        tokio::pin!(server);
+        let state = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::select! {
+                ready = ready_rx => ready.expect("server reported ready state"),
+                result = &mut server => panic!("server exited before listener-ready hook: {result:?}"),
+            }
+        })
+            .await
+            .expect("server reached listener-ready hook");
 
         for _ in 0..100 {
-            prewarm_owner_read_models_after_ready(state.clone()).await;
             wait_for_admin_privacy_status_refresh(state.as_ref()).await;
             if admin_privacy_status_cached(state.as_ref()).await.is_some() {
+                shutdown_tx.send(()).expect("signal server shutdown");
+                tokio::time::timeout(Duration::from_secs(2), &mut server)
+                    .await
+                    .expect("server shuts down")
+                    .expect("server exits cleanly");
                 return;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+        let _ = shutdown_tx.send(());
+        let _ = server.await;
         panic!("listener-ready hook did not publish privacy-status last-good data");
     }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2347,6 +2347,95 @@ mod serve_tests {
     }
 
     #[tokio::test]
+    async fn passkey_auth_pressure_returns_a_bounded_privacy_status_retry() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("passkey-privacy-status-pressure.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let proxy = TavilyProxy::with_endpoint(
+            vec!["tvly-passkey-privacy-status-pressure".to_string()],
+            DEFAULT_UPSTREAM,
+            &db_str,
+        )
+        .await
+        .expect("proxy created");
+        let scope = tavily_hikari::AdminPasskeyScope::new(
+            "node-passkey-privacy-status-pressure",
+            "admin.example.com",
+            "https://admin.example.com",
+        )
+        .expect("passkey scope");
+        let session = proxy
+            .create_admin_passkey_session(&scope, None, 120)
+            .await
+            .expect("create passkey session");
+        let state = Arc::new(AppState {
+            proxy,
+            static_dir: None,
+            forward_auth: ForwardAuthConfig::new(None, None, None, None),
+            forward_auth_enabled: false,
+            builtin_admin: BuiltinAdminAuth::new(false, None, None),
+            admin_passkey: AdminPasskeyOptions {
+                enabled: true,
+                rp_id: Some("admin.example.com".to_string()),
+                rp_origin: Some("https://admin.example.com".to_string()),
+                scope: Some(scope),
+                challenge_ttl_secs: 300,
+                session_max_age_secs: 120,
+            },
+            linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+            linuxdo_credit: LinuxDoCreditOptions::disabled(),
+            ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+            dev_open_admin: false,
+            usage_base: "http://127.0.0.1:58088".to_string(),
+            api_key_ip_geo_origin: "https://api.country.is".to_string(),
+            dashboard_overview_cache: new_dashboard_overview_cache(),
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_str(&format!("{ADMIN_PASSKEY_COOKIE_NAME}={}", session.token))
+                .expect("cookie header should be valid"),
+        );
+        assert!(
+            try_is_admin_request(state.as_ref(), &headers)
+                .await
+                .expect("session is valid before pressure")
+        );
+
+        let lock_pool = sqlx::SqlitePool::connect(&format!("sqlite://{db_str}"))
+            .await
+            .expect("connect lock pool");
+        let mut writer = lock_pool.acquire().await.expect("acquire lock writer");
+        sqlx::query("BEGIN EXCLUSIVE")
+            .execute(&mut *writer)
+            .await
+            .expect("hold exclusive lock");
+        sqlx::query("CREATE TABLE passkey_privacy_status_pressure_lock (id INTEGER)")
+            .execute(&mut *writer)
+            .await
+            .expect("hold schema lock");
+
+        let started = std::time::Instant::now();
+        let response = get_upstream_privacy_status(State(state), headers)
+            .await
+            .expect_err("passkey auth pressure must return a retry response");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response
+                .headers()
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok()),
+            Some("1")
+        );
+        assert!(started.elapsed() < Duration::from_millis(250));
+
+        sqlx::query("ROLLBACK")
+            .execute(&mut *writer)
+            .await
+            .expect("release schema lock");
+    }
+
+    #[tokio::test]
     async fn passkey_authentication_start_is_available_on_standby() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("standby-passkey-auth.db");

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -575,7 +575,7 @@ pub async fn serve(
     // Privacy status is an owner-facing derived read model. It must populate
     // last-good after readiness without delaying the listener or competing
     // with foreground work; requests only ever copy the immutable result.
-    prewarm_admin_privacy_status(state.clone()).await;
+    prewarm_owner_read_models_after_ready(state.clone()).await;
 
     // Always-on HA tasks must stay available on standby/recovery so health, role
     // refresh, and pull-sync keep working even while business traffic is fenced.
@@ -2002,6 +2002,10 @@ async fn shutdown_signal() {
     );
 }
 
+async fn prewarm_owner_read_models_after_ready(state: Arc<AppState>) {
+    prewarm_admin_privacy_status(state).await;
+}
+
 const BODY_LIMIT: usize = 16 * 1024 * 1024; // 16 MiB 默认限制
 const DEFAULT_LOG_LIMIT: usize = 200;
 
@@ -2009,6 +2013,52 @@ const DEFAULT_LOG_LIMIT: usize = 200;
 mod serve_tests {
     use super::*;
     use tavily_hikari::DEFAULT_UPSTREAM;
+
+    #[tokio::test]
+    async fn listener_ready_hook_schedules_privacy_status_prewarm() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("privacy-status-ready-hook.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let proxy = TavilyProxy::with_endpoint(
+            vec!["tvly-privacy-status-ready-hook".to_string()],
+            DEFAULT_UPSTREAM,
+            &db_str,
+        )
+        .await
+        .expect("proxy created");
+        let state = Arc::new(AppState {
+            proxy,
+            static_dir: None,
+            forward_auth: ForwardAuthConfig::new(None, None, None, None),
+            forward_auth_enabled: false,
+            builtin_admin: BuiltinAdminAuth::new(false, None, None),
+            admin_passkey: AdminPasskeyOptions {
+                enabled: false,
+                rp_id: None,
+                rp_origin: None,
+                scope: None,
+                challenge_ttl_secs: 300,
+                session_max_age_secs: 60 * 60,
+            },
+            linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+            linuxdo_credit: LinuxDoCreditOptions::disabled(),
+            ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+            dev_open_admin: false,
+            usage_base: "http://127.0.0.1:58088".to_string(),
+            api_key_ip_geo_origin: "https://api.country.is".to_string(),
+            dashboard_overview_cache: new_dashboard_overview_cache(),
+        });
+
+        for _ in 0..100 {
+            prewarm_owner_read_models_after_ready(state.clone()).await;
+            wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+            if admin_privacy_status_cached(state.as_ref()).await.is_some() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("listener-ready hook did not publish privacy-status last-good data");
+    }
 
     #[tokio::test]
     async fn ha_control_apply_refreshes_in_memory_admin_password_state() {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -572,6 +572,11 @@ pub async fn serve(
         "tavily proxy listening"
     );
 
+    // Privacy status is an owner-facing derived read model. It must populate
+    // last-good after readiness without delaying the listener or competing
+    // with foreground work; requests only ever copy the immutable result.
+    prewarm_admin_privacy_status(state.clone()).await;
+
     // Always-on HA tasks must stay available on standby/recovery so health, role
     // refresh, and pull-sync keep working even while business traffic is fenced.
     // Start them after the dashboard singleflight prewarm: a cold restart must

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -590,6 +590,7 @@ pub async fn serve(
     let _ = spawn_post_ready_serving_tasks_for_status(state.clone(), &startup_ha_status);
 
     let shutdown_proxy = state.proxy.clone();
+    let shutdown_state = state.clone();
     let post_shutdown_state = state.clone();
     axum::serve(
         listener,
@@ -603,6 +604,7 @@ pub async fn serve(
     )
     .with_graceful_shutdown(async move {
         shutdown_signal().await;
+        fence_admin_privacy_status_refresh(shutdown_state.as_ref()).await;
         shutdown_proxy.begin_sqlite_maintenance_run_shutdown();
         shutdown_proxy.nudge_request_stats_flush().await;
     })

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -26,6 +26,8 @@ pub async fn serve(
         linuxdo_credit,
         shutdown_signal(),
         None,
+        #[cfg(test)]
+        None,
     )
     .await
 }
@@ -45,6 +47,10 @@ async fn serve_with_shutdown(
     linuxdo_credit: LinuxDoCreditOptions,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
     ready: Option<tokio::sync::oneshot::Sender<Arc<AppState>>>,
+    #[cfg(test)] prewarm_gate: Option<(
+        tokio::sync::oneshot::Sender<Arc<AppState>>,
+        tokio::sync::oneshot::Receiver<()>,
+    )>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let AdminAuthOptions {
         forward_auth_enabled,
@@ -605,6 +611,12 @@ async fn serve_with_shutdown(
         bind_addr = %bound_addr,
         "tavily proxy listening"
     );
+
+    #[cfg(test)]
+    if let Some((prewarm_blocked, prewarm_gate)) = prewarm_gate {
+        let _ = prewarm_blocked.send(state.clone());
+        let _ = prewarm_gate.await;
+    }
 
     // Privacy status is an owner-facing derived read model. It must populate
     // last-good after readiness without delaying the listener or competing
@@ -2065,6 +2077,8 @@ mod serve_tests {
         .expect("proxy created");
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let (prewarm_blocked_tx, prewarm_blocked_rx) = tokio::sync::oneshot::channel();
+        let (prewarm_gate_tx, prewarm_gate_rx) = tokio::sync::oneshot::channel();
         let server = serve_with_shutdown(
             "127.0.0.1:0".parse().expect("test socket address"),
             proxy,
@@ -2091,8 +2105,25 @@ mod serve_tests {
                 let _ = shutdown_rx.await;
             },
             Some(ready_tx),
+            Some((prewarm_blocked_tx, prewarm_gate_rx)),
         );
         tokio::pin!(server);
+        let state = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::select! {
+                blocked = prewarm_blocked_rx => blocked.expect("server reached prewarm gate"),
+                result = &mut server => panic!("server exited before listener-ready prewarm gate: {result:?}"),
+            }
+        })
+        .await
+        .expect("server reached listener-ready prewarm gate");
+        for _ in 0..6 {
+            state.proxy.record_foreground_activity();
+        }
+        assert!(
+            state.proxy.foreground_activity_rps() > 5,
+            "test must establish foreground pressure before startup prewarm"
+        );
+        prewarm_gate_tx.send(()).expect("release listener-ready prewarm");
         let state = tokio::time::timeout(Duration::from_secs(2), async {
             tokio::select! {
                 ready = ready_rx => ready.expect("server reported ready state"),
@@ -2102,7 +2133,13 @@ mod serve_tests {
             .await
             .expect("server reached listener-ready hook");
 
-        for _ in 0..800 {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            admin_privacy_status_cached(state.as_ref()).await.is_none(),
+            "startup prewarm must defer while foreground pressure is active"
+        );
+
+        for _ in 0..300 {
             if admin_privacy_status_cached(state.as_ref()).await.is_some() {
                 shutdown_tx.send(()).expect("signal server shutdown");
                 tokio::time::timeout(Duration::from_secs(2), &mut server)
@@ -2115,7 +2152,7 @@ mod serve_tests {
         }
         let _ = shutdown_tx.send(());
         let _ = server.await;
-        panic!("listener-ready hook did not publish privacy-status last-good data");
+        panic!("deferred listener-ready prewarm did not publish privacy-status last-good data");
     }
 
     #[tokio::test]

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2102,8 +2102,7 @@ mod serve_tests {
             .await
             .expect("server reached listener-ready hook");
 
-        for _ in 0..100 {
-            wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+        for _ in 0..800 {
             if admin_privacy_status_cached(state.as_ref()).await.is_some() {
                 shutdown_tx.send(()).expect("signal server shutdown");
                 tokio::time::timeout(Duration::from_secs(2), &mut server)

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2139,7 +2139,7 @@ mod serve_tests {
             "startup prewarm must defer while foreground pressure is active"
         );
 
-        for _ in 0..300 {
+        for _ in 0..500 {
             if admin_privacy_status_cached(state.as_ref()).await.is_some() {
                 shutdown_tx.send(()).expect("signal server shutdown");
                 tokio::time::timeout(Duration::from_secs(2), &mut server)

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -64,11 +64,13 @@ struct DashboardOverviewCacheState {
     last_freshness_probe_at: Option<tokio::time::Instant>,
     notify: Arc<tokio::sync::Notify>,
     admin_alerts: AdminAlertsReadCache,
-    admin_privacy_status: Option<AdminPrivacyStatusCacheEntry>,
+    admin_privacy_status: AdminPrivacyStatusController,
     #[cfg(test)]
     build_count: usize,
     #[cfg(test)]
     freshness_probe_count: usize,
+    #[cfg(test)]
+    admin_privacy_refresh_count: usize,
 }
 
 impl Default for DashboardOverviewCacheState {
@@ -85,11 +87,13 @@ impl Default for DashboardOverviewCacheState {
             last_freshness_probe_at: None,
             notify: Arc::new(tokio::sync::Notify::new()),
             admin_alerts: AdminAlertsReadCache::default(),
-            admin_privacy_status: None,
+            admin_privacy_status: AdminPrivacyStatusController::default(),
             #[cfg(test)]
             build_count: 0,
             #[cfg(test)]
             freshness_probe_count: 0,
+            #[cfg(test)]
+            admin_privacy_refresh_count: 0,
         }
     }
 }
@@ -122,6 +126,20 @@ struct AdminPrivacyStatusCacheEntry {
     value: tavily_hikari::UpstreamPrivacyStatus,
     observed_at: i64,
     stored_at: tokio::time::Instant,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AdminPrivacyStatusController {
+    last_good: Option<AdminPrivacyStatusCacheEntry>,
+    refresh_in_flight: bool,
+    last_refresh_reason: Option<&'static str>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AdminPrivacyStatusRefreshStart {
+    Started,
+    InFlight,
+    Deferred { reason: &'static str },
 }
 
 const ADMIN_PRIVACY_STATUS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
@@ -169,7 +187,7 @@ pub(crate) async fn admin_privacy_status_last_good(
 ) -> Option<(tavily_hikari::UpstreamPrivacyStatus, i64)> {
     let cache = dashboard_overview_cache_for_state(state);
     let cache = cache.lock().await;
-    let entry = cache.admin_privacy_status.as_ref()?;
+    let entry = cache.admin_privacy_status.last_good.as_ref()?;
     (entry.stored_at.elapsed() <= ADMIN_PRIVACY_STATUS_CACHE_TTL)
         .then(|| (entry.value.clone(), entry.observed_at))
 }
@@ -179,34 +197,142 @@ pub(crate) async fn admin_privacy_status_cached(
 ) -> Option<(tavily_hikari::UpstreamPrivacyStatus, i64)> {
     let cache = dashboard_overview_cache_for_state(state);
     let cache = cache.lock().await;
-    let entry = cache.admin_privacy_status.as_ref()?;
+    let entry = cache.admin_privacy_status.last_good.as_ref()?;
     Some((entry.value.clone(), entry.observed_at))
+}
+
+pub(crate) async fn stale_admin_privacy_status(
+    state: &AppState,
+) -> Option<tavily_hikari::UpstreamPrivacyStatus> {
+    let cache = dashboard_overview_cache_for_state(state);
+    let cache = cache.lock().await;
+    let controller = &cache.admin_privacy_status;
+    let entry = controller.last_good.as_ref()?;
+    let mut status = entry.value.clone();
+    status.coverage = "stale".to_string();
+    status.observed_at = Some(entry.observed_at);
+    status.stale_reason = Some(
+        controller
+            .last_refresh_reason
+            .unwrap_or("refresh_in_flight")
+            .to_string(),
+    );
+    Some(status)
+}
+
+pub(crate) async fn start_admin_privacy_status_refresh(
+    state: Arc<AppState>,
+) -> AdminPrivacyStatusRefreshStart {
+    let cache = dashboard_overview_cache_for_state(state.as_ref());
+    let mut cache = cache.lock().await;
+    if cache.admin_privacy_status.refresh_in_flight {
+        return AdminPrivacyStatusRefreshStart::InFlight;
+    }
+    if let Some(reason) = state.proxy.admin_privacy_status_refresh_defer_reason() {
+        cache.admin_privacy_status.last_refresh_reason = Some(reason);
+        return AdminPrivacyStatusRefreshStart::Deferred { reason };
+    }
+
+    cache.admin_privacy_status.refresh_in_flight = true;
+    cache.admin_privacy_status.last_refresh_reason = Some("refresh_in_flight");
+    #[cfg(test)]
+    {
+        cache.admin_privacy_refresh_count = cache.admin_privacy_refresh_count.saturating_add(1);
+    }
+    drop(cache);
+
+    tokio::spawn(async move {
+        let result = state.proxy.upstream_privacy_status().await;
+        finish_admin_privacy_status_refresh(state.as_ref(), result).await;
+    });
+    AdminPrivacyStatusRefreshStart::Started
+}
+
+async fn finish_admin_privacy_status_refresh(
+    state: &AppState,
+    result: Result<tavily_hikari::UpstreamPrivacyStatus, tavily_hikari::ProxyError>,
+) {
+    let cache = dashboard_overview_cache_for_state(state);
+    let mut cache = cache.lock().await;
+    cache.admin_privacy_status.refresh_in_flight = false;
+    match result {
+        Ok(mut value) => {
+            let observed_at = state.proxy.backend_time().now_ts();
+            value.coverage = "ok".to_string();
+            value.observed_at = Some(observed_at);
+            value.stale_reason = None;
+            cache.admin_privacy_status.last_good = Some(AdminPrivacyStatusCacheEntry {
+                value,
+                observed_at,
+                stored_at: tokio::time::Instant::now(),
+            });
+            cache.admin_privacy_status.last_refresh_reason = None;
+        }
+        Err(error) => {
+            cache.admin_privacy_status.last_refresh_reason = Some(
+                if tavily_hikari::is_transient_sqlite_write_error(&error) || error.is_deferred() {
+                    "sqlite_pressure"
+                } else {
+                    "refresh_failed"
+                },
+            );
+            tracing::debug!(
+                component = "admin_read",
+                event = "privacy_status_refresh_deferred",
+                reason = cache.admin_privacy_status.last_refresh_reason.unwrap_or("unknown"),
+                "privacy status refresh completed without replacing last-good data"
+            );
+        }
+    }
+}
+
+pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
+    match start_admin_privacy_status_refresh(state).await {
+        AdminPrivacyStatusRefreshStart::Started | AdminPrivacyStatusRefreshStart::InFlight => {
+            tracing::info!(
+                component = "startup",
+                event = "admin_privacy_status_prewarm_started",
+                "scheduled immutable privacy-status last-good prewarm"
+            );
+        }
+        AdminPrivacyStatusRefreshStart::Deferred { reason } => {
+            tracing::debug!(
+                component = "startup",
+                event = "admin_privacy_status_prewarm_deferred",
+                reason,
+                "deferred privacy-status prewarm before SQLite acquisition"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
 pub(crate) async fn expire_admin_privacy_status_last_good_for_test(state: &AppState) {
     let cache = dashboard_overview_cache_for_state(state);
     let mut cache = cache.lock().await;
-    if let Some(entry) = cache.admin_privacy_status.as_mut() {
+    if let Some(entry) = cache.admin_privacy_status.last_good.as_mut() {
         entry.stored_at = tokio::time::Instant::now() - ADMIN_PRIVACY_STATUS_CACHE_TTL;
     }
 }
 
-pub(crate) async fn record_admin_privacy_status_last_good(
-    state: &AppState,
-    mut value: tavily_hikari::UpstreamPrivacyStatus,
-) {
-    let observed_at = state.proxy.backend_time().now_ts();
-    value.coverage = "ok".to_string();
-    value.observed_at = Some(observed_at);
-    value.stale_reason = None;
+#[cfg(test)]
+pub(crate) async fn admin_privacy_refresh_count_for_test(state: &AppState) -> usize {
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_privacy_refresh_count
+}
+
+#[cfg(test)]
+pub(crate) async fn wait_for_admin_privacy_status_refresh(state: &AppState) {
     let cache = dashboard_overview_cache_for_state(state);
-    let mut cache = cache.lock().await;
-    cache.admin_privacy_status = Some(AdminPrivacyStatusCacheEntry {
-        value,
-        observed_at,
-        stored_at: tokio::time::Instant::now(),
-    });
+    for _ in 0..100 {
+        if !cache.lock().await.admin_privacy_status.refresh_in_flight {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("admin privacy status refresh did not finish");
 }
 
 fn new_dashboard_overview_cache() -> Arc<Mutex<DashboardOverviewCacheState>> {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -313,10 +313,10 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
 }
 
 pub(crate) async fn shutdown_admin_privacy_status_refresh(state: &AppState) {
+    fence_admin_privacy_status_refresh(state).await;
     let refresh_task = {
         let cache = dashboard_overview_cache_for_state(state);
         let mut cache = cache.lock().await;
-        cache.admin_privacy_status.shutting_down = true;
         cache.admin_privacy_status.refresh_task.take()
     };
     let Some(refresh_task) = refresh_task else {
@@ -334,6 +334,11 @@ pub(crate) async fn shutdown_admin_privacy_status_refresh(state: &AppState) {
             "privacy-status refresh ended before its cooperative close boundary"
         );
     }
+}
+
+pub(crate) async fn fence_admin_privacy_status_refresh(state: &AppState) {
+    let cache = dashboard_overview_cache_for_state(state);
+    cache.lock().await.admin_privacy_status.shutting_down = true;
 }
 
 #[cfg(test)]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -192,6 +192,7 @@ async fn record_admin_alerts_last_good(
         .truncate(ADMIN_ALERTS_CACHE_CAPACITY);
 }
 
+#[cfg(test)]
 pub(crate) async fn admin_privacy_status_cached(
     state: &AppState,
 ) -> Option<(tavily_hikari::UpstreamPrivacyStatus, i64)> {
@@ -199,6 +200,16 @@ pub(crate) async fn admin_privacy_status_cached(
     let cache = cache.lock().await;
     let entry = cache.admin_privacy_status.last_good.as_ref()?;
     Some((entry.value.clone(), entry.observed_at))
+}
+
+pub(crate) async fn admin_privacy_status_last_good(
+    state: &AppState,
+) -> Option<(tavily_hikari::UpstreamPrivacyStatus, i64)> {
+    let cache = dashboard_overview_cache_for_state(state);
+    let cache = cache.lock().await;
+    let entry = cache.admin_privacy_status.last_good.as_ref()?;
+    (entry.stored_at.elapsed() <= ADMIN_PRIVACY_STATUS_CACHE_TTL)
+        .then(|| (entry.value.clone(), entry.observed_at))
 }
 
 pub(crate) async fn read_admin_privacy_status(
@@ -212,21 +223,25 @@ pub(crate) async fn read_admin_privacy_status(
         return AdminPrivacyStatusResponse::Fresh(entry.value.clone());
     }
 
-    start_admin_privacy_status_refresh_locked(state, &mut cache);
+    start_admin_privacy_status_refresh_locked(state.clone(), &mut cache);
     let controller = &cache.admin_privacy_status;
-    let Some(entry) = controller.last_good.as_ref() else {
-        return AdminPrivacyStatusResponse::Cold;
+    let response = if let Some(entry) = controller.last_good.as_ref() {
+        let mut status = entry.value.clone();
+        status.coverage = "stale".to_string();
+        status.observed_at = Some(entry.observed_at);
+        status.stale_reason = Some(
+            controller
+                .last_refresh_reason
+                .unwrap_or("refresh_in_flight")
+                .to_string(),
+        );
+        AdminPrivacyStatusResponse::Stale(status)
+    } else {
+        AdminPrivacyStatusResponse::Cold
     };
-    let mut status = entry.value.clone();
-    status.coverage = "stale".to_string();
-    status.observed_at = Some(entry.observed_at);
-    status.stale_reason = Some(
-        controller
-            .last_refresh_reason
-            .unwrap_or("refresh_in_flight")
-            .to_string(),
-    );
-    AdminPrivacyStatusResponse::Stale(status)
+    drop(cache);
+    prewarm_admin_privacy_status(state).await;
+    response
 }
 
 pub(crate) async fn start_admin_privacy_status_refresh(
@@ -327,7 +342,7 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
     }
     cache.admin_privacy_status.prewarm_task = Some(tokio::spawn(async move {
         loop {
-            if admin_privacy_status_cached(state.as_ref()).await.is_some() {
+            if admin_privacy_status_last_good(state.as_ref()).await.is_some() {
                 return;
             }
             match start_admin_privacy_status_refresh(state.clone()).await {
@@ -429,16 +444,20 @@ pub(crate) async fn wait_for_admin_privacy_status_refresh(state: &AppState) {
 }
 
 #[cfg(test)]
-pub(crate) async fn prime_admin_privacy_status_for_test(state: Arc<AppState>) {
-    for _ in 0..100 {
-        prewarm_admin_privacy_status(state.clone()).await;
-        wait_for_admin_privacy_status_refresh(state.as_ref()).await;
-        if admin_privacy_status_cached(state.as_ref()).await.is_some() {
+pub(crate) async fn wait_for_admin_privacy_status_last_good(state: &AppState) {
+    for _ in 0..700 {
+        if admin_privacy_status_last_good(state).await.is_some() {
             return;
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    panic!("admin privacy status prewarm did not publish last-good data");
+    panic!("admin privacy status refresh did not publish fresh last-good data");
+}
+
+#[cfg(test)]
+pub(crate) async fn prime_admin_privacy_status_for_test(state: Arc<AppState>) {
+    prewarm_admin_privacy_status(state.clone()).await;
+    wait_for_admin_privacy_status_last_good(state.as_ref()).await;
 }
 
 fn new_dashboard_overview_cache() -> Arc<Mutex<DashboardOverviewCacheState>> {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1450,16 +1450,20 @@ fn wants_secure_cookie(headers: &HeaderMap) -> bool {
 }
 
 async fn is_admin_request(state: &AppState, headers: &HeaderMap) -> bool {
+    try_is_admin_request(state, headers).await.unwrap_or(false)
+}
+
+async fn try_is_admin_request(state: &AppState, headers: &HeaderMap) -> Result<bool, ProxyError> {
     if state.dev_open_admin {
-        return true;
+        return Ok(true);
     }
     if state.forward_auth_enabled && state.forward_auth.is_request_admin(headers) {
-        return true;
+        return Ok(true);
     }
     if state.builtin_admin.is_admin(headers) {
-        return true;
+        return Ok(true);
     }
-    resolve_admin_passkey_session(state, headers).await.is_some()
+    Ok(resolve_admin_passkey_session(state, headers).await?.is_some())
 }
 
 async fn require_full_master_write(state: &AppState) -> Result<(), (StatusCode, String)> {
@@ -1486,16 +1490,17 @@ async fn resolve_user_session(
 async fn resolve_admin_passkey_session(
     state: &AppState,
     headers: &HeaderMap,
-) -> Option<tavily_hikari::AdminPasskeySessionRecord> {
+) -> Result<Option<tavily_hikari::AdminPasskeySessionRecord>, ProxyError> {
     if !state.admin_passkey.is_configured() {
-        return None;
+        return Ok(None);
     }
-    let token = cookie_value(headers, ADMIN_PASSKEY_COOKIE_NAME)?;
-    let scope = state.admin_passkey.scope.as_ref()?;
-    match state.proxy.get_active_admin_passkey_session(scope, &token).await {
-        Ok(Some(session)) => Some(session),
-        _ => None,
-    }
+    let Some(token) = cookie_value(headers, ADMIN_PASSKEY_COOKIE_NAME) else {
+        return Ok(None);
+    };
+    let Some(scope) = state.admin_passkey.scope.as_ref() else {
+        return Ok(None);
+    };
+    state.proxy.get_active_admin_passkey_session(scope, &token).await
 }
 
 async fn admin_maintenance_actor(
@@ -1538,7 +1543,11 @@ async fn admin_maintenance_actor(
         return actor;
     }
 
-    if let Some(session) = resolve_admin_passkey_session(state, headers).await {
+    if let Some(session) = resolve_admin_passkey_session(state, headers)
+        .await
+        .ok()
+        .flatten()
+    {
         actor.actor_display_name = Some(
             session
                 .credential_id
@@ -1720,6 +1729,8 @@ async fn debug_is_admin(
     let builtin_admin = state.builtin_admin.is_admin(&headers);
     let admin_passkey = resolve_admin_passkey_session(state.as_ref(), &headers)
         .await
+        .ok()
+        .flatten()
         .is_some();
     let is_admin = state.dev_open_admin || forward_auth_admin || builtin_admin || admin_passkey;
     Ok(Json(IsAdminDebug {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -51,7 +51,7 @@ struct CachedDashboardOverviewSnapshot {
     freshness: Arc<DashboardOverviewFreshness>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct DashboardOverviewCacheState {
     cached: Option<CachedDashboardOverviewSnapshot>,
     loading: bool,
@@ -128,11 +128,13 @@ struct AdminPrivacyStatusCacheEntry {
     stored_at: tokio::time::Instant,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 struct AdminPrivacyStatusController {
     last_good: Option<AdminPrivacyStatusCacheEntry>,
     refresh_in_flight: bool,
     last_refresh_reason: Option<&'static str>,
+    refresh_task: Option<tokio::task::JoinHandle<()>>,
+    shutting_down: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -228,6 +230,10 @@ pub(crate) async fn start_admin_privacy_status_refresh(
     if cache.admin_privacy_status.refresh_in_flight {
         return AdminPrivacyStatusRefreshStart::InFlight;
     }
+    if cache.admin_privacy_status.shutting_down {
+        cache.admin_privacy_status.last_refresh_reason = Some("shutdown");
+        return AdminPrivacyStatusRefreshStart::Deferred { reason: "shutdown" };
+    }
     if let Some(reason) = state.proxy.admin_privacy_status_refresh_defer_reason() {
         cache.admin_privacy_status.last_refresh_reason = Some(reason);
         return AdminPrivacyStatusRefreshStart::Deferred { reason };
@@ -239,12 +245,12 @@ pub(crate) async fn start_admin_privacy_status_refresh(
     {
         cache.admin_privacy_refresh_count = cache.admin_privacy_refresh_count.saturating_add(1);
     }
-    drop(cache);
-
-    tokio::spawn(async move {
+    let refresh_task = tokio::spawn(async move {
         let result = state.proxy.upstream_privacy_status().await;
         finish_admin_privacy_status_refresh(state.as_ref(), result).await;
     });
+    cache.admin_privacy_status.refresh_task = Some(refresh_task);
+    drop(cache);
     AdminPrivacyStatusRefreshStart::Started
 }
 
@@ -306,6 +312,30 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
     }
 }
 
+pub(crate) async fn shutdown_admin_privacy_status_refresh(state: &AppState) {
+    let refresh_task = {
+        let cache = dashboard_overview_cache_for_state(state);
+        let mut cache = cache.lock().await;
+        cache.admin_privacy_status.shutting_down = true;
+        cache.admin_privacy_status.refresh_task.take()
+    };
+    let Some(refresh_task) = refresh_task else {
+        return;
+    };
+
+    // A refresh owns an open immutable read snapshot until it reaches its
+    // explicit close boundary. Do not abort it during shutdown, because Drop
+    // must remain a fault-containment path rather than normal control flow.
+    if let Err(error) = refresh_task.await {
+        tracing::warn!(
+            component = "shutdown",
+            event = "admin_privacy_status_refresh_join_failed",
+            error = %error,
+            "privacy-status refresh ended before its cooperative close boundary"
+        );
+    }
+}
+
 #[cfg(test)]
 pub(crate) async fn expire_admin_privacy_status_last_good_for_test(state: &AppState) {
     let cache = dashboard_overview_cache_for_state(state);
@@ -333,6 +363,19 @@ pub(crate) async fn wait_for_admin_privacy_status_refresh(state: &AppState) {
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
     panic!("admin privacy status refresh did not finish");
+}
+
+#[cfg(test)]
+pub(crate) async fn prime_admin_privacy_status_for_test(state: Arc<AppState>) {
+    for _ in 0..100 {
+        prewarm_admin_privacy_status(state.clone()).await;
+        wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+        if admin_privacy_status_cached(state.as_ref()).await.is_some() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("admin privacy status prewarm did not publish last-good data");
 }
 
 fn new_dashboard_overview_cache() -> Arc<Mutex<DashboardOverviewCacheState>> {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -328,6 +328,23 @@ async fn finish_admin_privacy_status_refresh(
     }
 }
 
+fn emit_admin_privacy_status_prewarm_started() {
+    tracing::info!(
+        component = "startup",
+        event = "admin_privacy_status_prewarm_started",
+        "scheduled immutable privacy-status last-good prewarm"
+    );
+}
+
+fn emit_admin_privacy_status_prewarm_deferred(reason: &'static str) {
+    tracing::debug!(
+        component = "startup",
+        event = "admin_privacy_status_prewarm_deferred",
+        reason,
+        "deferred privacy-status prewarm before SQLite acquisition"
+    );
+}
+
 pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
     let cache = dashboard_overview_cache_for_state(state.as_ref());
     let mut cache = cache.lock().await;
@@ -347,24 +364,13 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
             }
             match start_admin_privacy_status_refresh(state.clone()).await {
                 AdminPrivacyStatusRefreshStart::Fresh => return,
-                AdminPrivacyStatusRefreshStart::Started => {
-                    tracing::info!(
-                        component = "startup",
-                        event = "admin_privacy_status_prewarm_started",
-                        "scheduled immutable privacy-status last-good prewarm"
-                    );
-                }
+                AdminPrivacyStatusRefreshStart::Started => emit_admin_privacy_status_prewarm_started(),
                 // A prior prewarm iteration owns the singleflight refresh. Keep retrying for
                 // completion, but do not report another start for the same operation.
                 AdminPrivacyStatusRefreshStart::InFlight => {}
                 AdminPrivacyStatusRefreshStart::Deferred { reason: "shutdown" } => return,
                 AdminPrivacyStatusRefreshStart::Deferred { reason } => {
-                    tracing::debug!(
-                        component = "startup",
-                        event = "admin_privacy_status_prewarm_deferred",
-                        reason,
-                        "deferred privacy-status prewarm before SQLite acquisition"
-                    );
+                    emit_admin_privacy_status_prewarm_deferred(reason);
                 }
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -458,6 +464,77 @@ pub(crate) async fn wait_for_admin_privacy_status_last_good(state: &AppState) {
 pub(crate) async fn prime_admin_privacy_status_for_test(state: Arc<AppState>) {
     prewarm_admin_privacy_status(state.clone()).await;
     wait_for_admin_privacy_status_last_good(state.as_ref()).await;
+}
+
+#[cfg(test)]
+mod privacy_status_prewarm_logging_tests {
+    use super::{
+        emit_admin_privacy_status_prewarm_deferred, emit_admin_privacy_status_prewarm_started,
+    };
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
+
+    #[derive(Clone, Default)]
+    struct SharedWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    struct SharedWriterGuard {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for SharedWriterGuard {
+        fn write(&mut self, value: &[u8]) -> io::Result<usize> {
+            self.buffer
+                .lock()
+                .expect("tracing buffer lock")
+                .extend_from_slice(value);
+            Ok(value.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedWriter {
+        type Writer = SharedWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedWriterGuard {
+                buffer: self.buffer.clone(),
+            }
+        }
+    }
+
+    #[test]
+    fn privacy_status_prewarm_events_keep_their_observability_contract() {
+        let writer = SharedWriter::default();
+        let buffer = writer.buffer.clone();
+        let dispatch = tracing::Dispatch::new(
+            tracing_subscriber::fmt()
+                .with_env_filter(EnvFilter::new("debug"))
+                .with_writer(writer)
+                .json()
+                .flatten_event(true)
+                .with_current_span(false)
+                .with_span_list(false)
+                .finish(),
+        );
+        tracing::dispatcher::with_default(&dispatch, || {
+            emit_admin_privacy_status_prewarm_started();
+            emit_admin_privacy_status_prewarm_deferred("foreground_pressure");
+        });
+        let output = String::from_utf8(buffer.lock().expect("tracing buffer lock").clone())
+            .expect("utf8 tracing output");
+
+        assert!(output.contains("\"level\":\"INFO\""));
+        assert!(output.contains("\"event\":\"admin_privacy_status_prewarm_started\""));
+        assert!(output.contains("\"level\":\"DEBUG\""));
+        assert!(output.contains("\"event\":\"admin_privacy_status_prewarm_deferred\""));
+        assert!(output.contains("\"reason\":\"foreground_pressure\""));
+    }
 }
 
 fn new_dashboard_overview_cache() -> Arc<Mutex<DashboardOverviewCacheState>> {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -134,6 +134,7 @@ struct AdminPrivacyStatusController {
     refresh_in_flight: bool,
     last_refresh_reason: Option<&'static str>,
     refresh_task: Option<tokio::task::JoinHandle<()>>,
+    prewarm_task: Option<tokio::task::JoinHandle<()>>,
     shutting_down: bool,
 }
 
@@ -293,32 +294,65 @@ async fn finish_admin_privacy_status_refresh(
 }
 
 pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
-    match start_admin_privacy_status_refresh(state).await {
-        AdminPrivacyStatusRefreshStart::Started | AdminPrivacyStatusRefreshStart::InFlight => {
-            tracing::info!(
-                component = "startup",
-                event = "admin_privacy_status_prewarm_started",
-                "scheduled immutable privacy-status last-good prewarm"
-            );
-        }
-        AdminPrivacyStatusRefreshStart::Deferred { reason } => {
-            tracing::debug!(
-                component = "startup",
-                event = "admin_privacy_status_prewarm_deferred",
-                reason,
-                "deferred privacy-status prewarm before SQLite acquisition"
-            );
-        }
+    let cache = dashboard_overview_cache_for_state(state.as_ref());
+    let mut cache = cache.lock().await;
+    if cache.admin_privacy_status.shutting_down
+        || cache
+            .admin_privacy_status
+            .prewarm_task
+            .as_ref()
+            .is_some_and(|task| !task.is_finished())
+    {
+        return;
     }
+    cache.admin_privacy_status.prewarm_task = Some(tokio::spawn(async move {
+        loop {
+            if admin_privacy_status_cached(state.as_ref()).await.is_some() {
+                return;
+            }
+            match start_admin_privacy_status_refresh(state.clone()).await {
+                AdminPrivacyStatusRefreshStart::Started | AdminPrivacyStatusRefreshStart::InFlight => {
+                    tracing::info!(
+                        component = "startup",
+                        event = "admin_privacy_status_prewarm_started",
+                        "scheduled immutable privacy-status last-good prewarm"
+                    );
+                }
+                AdminPrivacyStatusRefreshStart::Deferred { reason: "shutdown" } => return,
+                AdminPrivacyStatusRefreshStart::Deferred { reason } => {
+                    tracing::debug!(
+                        component = "startup",
+                        event = "admin_privacy_status_prewarm_deferred",
+                        reason,
+                        "deferred privacy-status prewarm before SQLite acquisition"
+                    );
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }));
 }
 
 pub(crate) async fn shutdown_admin_privacy_status_refresh(state: &AppState) {
     fence_admin_privacy_status_refresh(state).await;
-    let refresh_task = {
+    let (prewarm_task, refresh_task) = {
         let cache = dashboard_overview_cache_for_state(state);
         let mut cache = cache.lock().await;
-        cache.admin_privacy_status.refresh_task.take()
+        (
+            cache.admin_privacy_status.prewarm_task.take(),
+            cache.admin_privacy_status.refresh_task.take(),
+        )
     };
+    if let Some(prewarm_task) = prewarm_task
+        && let Err(error) = prewarm_task.await
+    {
+        tracing::warn!(
+            component = "shutdown",
+            event = "admin_privacy_status_prewarm_join_failed",
+            error = %error,
+            "privacy-status prewarm ended before its cooperative boundary"
+        );
+    }
     let Some(refresh_task) = refresh_task else {
         return;
     };

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -440,7 +440,7 @@ pub(crate) async fn admin_privacy_refresh_count_for_test(state: &AppState) -> us
 #[cfg(test)]
 pub(crate) async fn wait_for_admin_privacy_status_refresh(state: &AppState) {
     let cache = dashboard_overview_cache_for_state(state);
-    for _ in 0..100 {
+    for _ in 0..350 {
         if !cache.lock().await.admin_privacy_status.refresh_in_flight {
             return;
         }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -140,9 +140,16 @@ struct AdminPrivacyStatusController {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AdminPrivacyStatusRefreshStart {
+    Fresh,
     Started,
     InFlight,
     Deferred { reason: &'static str },
+}
+
+pub(crate) enum AdminPrivacyStatusResponse {
+    Fresh(tavily_hikari::UpstreamPrivacyStatus),
+    Stale(tavily_hikari::UpstreamPrivacyStatus),
+    Cold,
 }
 
 const ADMIN_PRIVACY_STATUS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
@@ -185,16 +192,6 @@ async fn record_admin_alerts_last_good(
         .truncate(ADMIN_ALERTS_CACHE_CAPACITY);
 }
 
-pub(crate) async fn admin_privacy_status_last_good(
-    state: &AppState,
-) -> Option<(tavily_hikari::UpstreamPrivacyStatus, i64)> {
-    let cache = dashboard_overview_cache_for_state(state);
-    let cache = cache.lock().await;
-    let entry = cache.admin_privacy_status.last_good.as_ref()?;
-    (entry.stored_at.elapsed() <= ADMIN_PRIVACY_STATUS_CACHE_TTL)
-        .then(|| (entry.value.clone(), entry.observed_at))
-}
-
 pub(crate) async fn admin_privacy_status_cached(
     state: &AppState,
 ) -> Option<(tavily_hikari::UpstreamPrivacyStatus, i64)> {
@@ -204,13 +201,22 @@ pub(crate) async fn admin_privacy_status_cached(
     Some((entry.value.clone(), entry.observed_at))
 }
 
-pub(crate) async fn stale_admin_privacy_status(
-    state: &AppState,
-) -> Option<tavily_hikari::UpstreamPrivacyStatus> {
-    let cache = dashboard_overview_cache_for_state(state);
-    let cache = cache.lock().await;
+pub(crate) async fn read_admin_privacy_status(
+    state: Arc<AppState>,
+) -> AdminPrivacyStatusResponse {
+    let cache = dashboard_overview_cache_for_state(state.as_ref());
+    let mut cache = cache.lock().await;
+    if let Some(entry) = cache.admin_privacy_status.last_good.as_ref()
+        && entry.stored_at.elapsed() <= ADMIN_PRIVACY_STATUS_CACHE_TTL
+    {
+        return AdminPrivacyStatusResponse::Fresh(entry.value.clone());
+    }
+
+    start_admin_privacy_status_refresh_locked(state, &mut cache);
     let controller = &cache.admin_privacy_status;
-    let entry = controller.last_good.as_ref()?;
+    let Some(entry) = controller.last_good.as_ref() else {
+        return AdminPrivacyStatusResponse::Cold;
+    };
     let mut status = entry.value.clone();
     status.coverage = "stale".to_string();
     status.observed_at = Some(entry.observed_at);
@@ -220,7 +226,7 @@ pub(crate) async fn stale_admin_privacy_status(
             .unwrap_or("refresh_in_flight")
             .to_string(),
     );
-    Some(status)
+    AdminPrivacyStatusResponse::Stale(status)
 }
 
 pub(crate) async fn start_admin_privacy_status_refresh(
@@ -228,6 +234,21 @@ pub(crate) async fn start_admin_privacy_status_refresh(
 ) -> AdminPrivacyStatusRefreshStart {
     let cache = dashboard_overview_cache_for_state(state.as_ref());
     let mut cache = cache.lock().await;
+    start_admin_privacy_status_refresh_locked(state, &mut cache)
+}
+
+fn start_admin_privacy_status_refresh_locked(
+    state: Arc<AppState>,
+    cache: &mut DashboardOverviewCacheState,
+) -> AdminPrivacyStatusRefreshStart {
+    if cache
+        .admin_privacy_status
+        .last_good
+        .as_ref()
+        .is_some_and(|entry| entry.stored_at.elapsed() <= ADMIN_PRIVACY_STATUS_CACHE_TTL)
+    {
+        return AdminPrivacyStatusRefreshStart::Fresh;
+    }
     if cache.admin_privacy_status.refresh_in_flight {
         return AdminPrivacyStatusRefreshStart::InFlight;
     }
@@ -251,7 +272,6 @@ pub(crate) async fn start_admin_privacy_status_refresh(
         finish_admin_privacy_status_refresh(state.as_ref(), result).await;
     });
     cache.admin_privacy_status.refresh_task = Some(refresh_task);
-    drop(cache);
     AdminPrivacyStatusRefreshStart::Started
 }
 
@@ -311,6 +331,7 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
                 return;
             }
             match start_admin_privacy_status_refresh(state.clone()).await {
+                AdminPrivacyStatusRefreshStart::Fresh => return,
                 AdminPrivacyStatusRefreshStart::Started => {
                     tracing::info!(
                         component = "startup",

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -311,13 +311,16 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
                 return;
             }
             match start_admin_privacy_status_refresh(state.clone()).await {
-                AdminPrivacyStatusRefreshStart::Started | AdminPrivacyStatusRefreshStart::InFlight => {
+                AdminPrivacyStatusRefreshStart::Started => {
                     tracing::info!(
                         component = "startup",
                         event = "admin_privacy_status_prewarm_started",
                         "scheduled immutable privacy-status last-good prewarm"
                     );
                 }
+                // A prior prewarm iteration owns the singleflight refresh. Keep retrying for
+                // completion, but do not report another start for the same operation.
+                AdminPrivacyStatusRefreshStart::InFlight => {}
                 AdminPrivacyStatusRefreshStart::Deferred { reason: "shutdown" } => return,
                 AdminPrivacyStatusRefreshStart::Deferred { reason } => {
                     tracing::debug!(

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -768,8 +768,7 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
     .expect("proxy created");
     let password = "admin-privacy-status-last-good-password";
     let (admin_addr, state) = spawn_builtin_keys_admin_server_with_state(proxy, password).await;
-    prewarm_admin_privacy_status(state.clone()).await;
-    wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+    prime_admin_privacy_status_for_test(state.clone()).await;
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -938,8 +937,7 @@ async fn admin_privacy_status_serves_stale_last_good_without_cancelling_its_read
     .expect("proxy created");
     let password = "admin-privacy-status-singleflight-stale-password";
     let (admin_addr, state) = spawn_builtin_keys_admin_server_with_state(proxy, password).await;
-    prewarm_admin_privacy_status(state.clone()).await;
-    wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+    prime_admin_privacy_status_for_test(state.clone()).await;
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -1016,6 +1014,43 @@ async fn admin_privacy_status_serves_stale_last_good_without_cancelling_its_read
     );
     pause.release();
     wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+
+    expire_admin_privacy_status_last_good_for_test(state.as_ref()).await;
+    let shutdown_pause = state
+        .proxy
+        .install_admin_privacy_read_pause_for_test()
+        .await;
+    let shutdown_stale = client
+        .get(&privacy_status_url)
+        .header(reqwest::header::COOKIE, &cookie)
+        .send()
+        .await
+        .expect("stale privacy status before shutdown");
+    assert_eq!(shutdown_stale.status(), reqwest::StatusCode::OK);
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        shutdown_pause.wait_until_arrived(),
+    )
+    .await
+    .expect("the shutdown refresh reached its controlled read pause");
+    let shutdown = {
+        let state = state.clone();
+        tokio::spawn(async move {
+            shutdown_admin_privacy_status_refresh(state.as_ref()).await;
+        })
+    };
+    tokio::task::yield_now().await;
+    assert!(
+        !shutdown.is_finished(),
+        "shutdown must wait for the refresh close boundary"
+    );
+    assert_eq!(
+        state.proxy.admin_privacy_read_discards_for_test(),
+        0,
+        "shutdown must not discard an open read snapshot"
+    );
+    shutdown_pause.release();
+    shutdown.await.expect("shutdown task joins");
     state
         .proxy
         .verify_admin_privacy_read_connection_clean_for_test()

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -965,7 +965,6 @@ async fn admin_privacy_status_serves_stale_last_good_without_cancelling_its_read
         .proxy
         .install_admin_privacy_read_pause_for_test()
         .await;
-    let started = std::time::Instant::now();
     let first_request = {
         let client = client.clone();
         let cookie = cookie.clone();
@@ -979,17 +978,16 @@ async fn admin_privacy_status_serves_stale_last_good_without_cancelling_its_read
                 .expect("stale privacy status")
         })
     };
+    let stale = tokio::time::timeout(std::time::Duration::from_millis(225), first_request)
+        .await
+        .expect("last-good request must not wait for the refresh")
+        .expect("stale request task joins");
+    assert_eq!(stale.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = stale.json().await.expect("stale privacy status json");
+    assert_eq!(body.get("coverage").and_then(|value| value.as_str()), Some("stale"));
     tokio::time::timeout(std::time::Duration::from_secs(2), pause.wait_until_arrived())
         .await
         .expect("the background refresh reached its controlled read pause");
-    let stale = first_request.await.expect("stale request task joins");
-    assert_eq!(stale.status(), reqwest::StatusCode::OK);
-    assert!(
-        started.elapsed() < std::time::Duration::from_millis(225),
-        "last-good reads must not wait for the refresh"
-    );
-    let body: serde_json::Value = stale.json().await.expect("stale privacy status json");
-    assert_eq!(body.get("coverage").and_then(|value| value.as_str()), Some("stale"));
     let second_started = std::time::Instant::now();
     let second = client
         .get(&privacy_status_url)

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -871,6 +871,7 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         .await
         .expect("hold schema lock for cold privacy status");
     let cold_started = std::time::Instant::now();
+    let cold_errors_before = cold_state.proxy.admin_privacy_read_errors_for_test();
     let cold = client
         .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
         .header(reqwest::header::COOKIE, &cold_cookie)
@@ -895,6 +896,10 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         0,
         "a bounded SQLite BEGIN failure must restore its connection instead of discarding it"
     );
+    assert!(
+        cold_state.proxy.admin_privacy_read_errors_for_test() > cold_errors_before,
+        "a failed cold privacy refresh must enter the runtime workload error metrics"
+    );
     sqlx::query("ROLLBACK")
         .execute(&mut *cold_writer)
         .await
@@ -905,25 +910,13 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         .verify_admin_privacy_read_connection_clean_for_test()
         .await
         .expect("the failed cold refresh must leave the next SQLite transaction clean");
-    let retry = client
+    wait_for_admin_privacy_status_last_good(cold_state.as_ref()).await;
+    let ready = client
         .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
         .header(reqwest::header::COOKIE, &cold_cookie)
         .send()
         .await
-        .expect("retry cold privacy status after pressure drains");
-    if retry.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
-        wait_for_admin_privacy_status_refresh(cold_state.as_ref()).await;
-    }
-    let ready = if retry.status() == reqwest::StatusCode::OK {
-        retry
-    } else {
-        client
-            .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
-            .header(reqwest::header::COOKIE, &cold_cookie)
-            .send()
-            .await
-            .expect("privacy status after cold refresh")
-    };
+        .expect("privacy status after autonomous cold refresh");
     assert_eq!(ready.status(), reqwest::StatusCode::OK);
     let ready_body: serde_json::Value = ready
         .json()

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -793,6 +793,7 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
     let warm_body: serde_json::Value = warm.json().await.expect("warm privacy status json");
     assert!(warm_body.get("dailyReconciliationProgress").is_some());
     assert!(warm_body.get("retryBuckets").is_some());
+    let refresh_count_before = admin_privacy_refresh_count_for_test(state.as_ref()).await;
     expire_admin_privacy_status_last_good_for_test(state.as_ref()).await;
 
     let held = match state.proxy.admit_dashboard_rollup_integrity() {
@@ -815,6 +816,16 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
             .get("staleReason")
             .and_then(|value| value.as_str())
             .is_some()
+    );
+    assert_eq!(
+        stale_body.get("staleReason").and_then(|value| value.as_str()),
+        Some("refresh_in_flight"),
+        "the controller must start the detached read while bulk work is held"
+    );
+    assert_eq!(
+        admin_privacy_refresh_count_for_test(state.as_ref()).await,
+        refresh_count_before + 1,
+        "bulk admission must not defer the privacy-status singleflight refresh"
     );
     drop(held);
     wait_for_admin_privacy_status_refresh(state.as_ref()).await;

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -889,11 +889,22 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         Some("1")
     );
     assert!(cold_started.elapsed() < std::time::Duration::from_millis(250));
+    wait_for_admin_privacy_status_refresh(cold_state.as_ref()).await;
+    assert_eq!(
+        cold_state.proxy.admin_privacy_read_discards_for_test(),
+        0,
+        "a bounded SQLite BEGIN failure must restore its connection instead of discarding it"
+    );
     sqlx::query("ROLLBACK")
         .execute(&mut *cold_writer)
         .await
         .expect("release exclusive cold read lock");
     drop(cold_held);
+    cold_state
+        .proxy
+        .verify_admin_privacy_read_connection_clean_for_test()
+        .await
+        .expect("the failed cold refresh must leave the next SQLite transaction clean");
     let retry = client
         .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
         .header(reqwest::header::COOKIE, &cold_cookie)
@@ -1012,6 +1023,17 @@ async fn admin_privacy_status_serves_stale_last_good_without_cancelling_its_read
     );
     pause.release();
     wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+    let refresh_count_after_completion = admin_privacy_refresh_count_for_test(state.as_ref()).await;
+    assert_eq!(
+        start_admin_privacy_status_refresh(state.clone()).await,
+        AdminPrivacyStatusRefreshStart::Fresh,
+        "a completed refresh must publish fresh last-good before another claim can start"
+    );
+    assert_eq!(
+        admin_privacy_refresh_count_for_test(state.as_ref()).await,
+        refresh_count_after_completion,
+        "a completion-boundary claim must not start a redundant privacy refresh"
+    );
 
     expire_admin_privacy_status_last_good_for_test(state.as_ref()).await;
     let shutdown_pause = state

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -768,6 +768,8 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
     .expect("proxy created");
     let password = "admin-privacy-status-last-good-password";
     let (admin_addr, state) = spawn_builtin_keys_admin_server_with_state(proxy, password).await;
+    prewarm_admin_privacy_status(state.clone()).await;
+    wait_for_admin_privacy_status_refresh(state.as_ref()).await;
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -789,6 +791,9 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         .await
         .expect("warm privacy status");
     assert_eq!(warm.status(), reqwest::StatusCode::OK);
+    let warm_body: serde_json::Value = warm.json().await.expect("warm privacy status json");
+    assert!(warm_body.get("dailyReconciliationProgress").is_some());
+    assert!(warm_body.get("retryBuckets").is_some());
     expire_admin_privacy_status_last_good_for_test(state.as_ref()).await;
 
     let held = match state.proxy.admit_dashboard_rollup_integrity() {
@@ -797,21 +802,38 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
             panic!("test must hold the shared bulk permit, got {reason}")
         }
     };
-    let fresh = client
+    let stale = client
         .get(&privacy_status_url)
         .header(reqwest::header::COOKIE, &cookie)
         .send()
         .await
-        .expect("fresh privacy status");
-    assert_eq!(fresh.status(), reqwest::StatusCode::OK);
-    let fresh_body: serde_json::Value = fresh.json().await.expect("fresh privacy status json");
-    assert_eq!(fresh_body.get("coverage").and_then(|v| v.as_str()), Some("ok"));
+        .expect("stale privacy status");
+    assert_eq!(stale.status(), reqwest::StatusCode::OK);
+    let stale_body: serde_json::Value = stale.json().await.expect("stale privacy status json");
+    assert_eq!(stale_body.get("coverage").and_then(|v| v.as_str()), Some("stale"));
     assert!(
-        fresh_body
+        stale_body
             .get("staleReason")
-            .is_none_or(serde_json::Value::is_null)
+            .and_then(|value| value.as_str())
+            .is_some()
     );
     drop(held);
+    wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+    let refreshed = client
+        .get(&privacy_status_url)
+        .header(reqwest::header::COOKIE, &cookie)
+        .send()
+        .await
+        .expect("refreshed privacy status");
+    assert_eq!(refreshed.status(), reqwest::StatusCode::OK);
+    let refreshed_body: serde_json::Value = refreshed
+        .json()
+        .await
+        .expect("refreshed privacy status json");
+    assert_eq!(
+        refreshed_body.get("coverage").and_then(|value| value.as_str()),
+        Some("ok")
+    );
 
     let cold_db_path = temp_db_path("admin-privacy-status-cold-pressure");
     let cold_db_str = cold_db_path.to_string_lossy().to_string();
@@ -867,7 +889,7 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
             .and_then(|value| value.to_str().ok()),
         Some("1")
     );
-    assert!(cold_started.elapsed() < std::time::Duration::from_millis(350));
+    assert!(cold_started.elapsed() < std::time::Duration::from_millis(250));
     sqlx::query("ROLLBACK")
         .execute(&mut *cold_writer)
         .await
@@ -879,15 +901,128 @@ async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admissi
         .send()
         .await
         .expect("retry cold privacy status after pressure drains");
-    assert_eq!(retry.status(), reqwest::StatusCode::OK);
-    let retry_body: serde_json::Value = retry
+    if retry.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+        wait_for_admin_privacy_status_refresh(cold_state.as_ref()).await;
+    }
+    let ready = if retry.status() == reqwest::StatusCode::OK {
+        retry
+    } else {
+        client
+            .get(format!("http://{cold_addr}/api/settings/system/privacy-status"))
+            .header(reqwest::header::COOKIE, &cold_cookie)
+            .send()
+            .await
+            .expect("privacy status after cold refresh")
+    };
+    assert_eq!(ready.status(), reqwest::StatusCode::OK);
+    let ready_body: serde_json::Value = ready
         .json()
         .await
-        .expect("retry cold privacy status json");
-    assert_eq!(retry_body.get("coverage").and_then(|v| v.as_str()), Some("ok"));
+        .expect("cold refresh privacy status json");
+    assert_eq!(ready_body.get("coverage").and_then(|v| v.as_str()), Some("ok"));
 
     let _ = std::fs::remove_file(db_path);
     let _ = std::fs::remove_file(cold_db_path);
+}
+
+#[tokio::test]
+async fn admin_privacy_status_serves_stale_last_good_without_cancelling_its_read_snapshot() {
+    let db_path = temp_db_path("admin-privacy-status-singleflight-stale");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-admin-privacy-status-singleflight-stale".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let password = "admin-privacy-status-singleflight-stale-password";
+    let (admin_addr, state) = spawn_builtin_keys_admin_server_with_state(proxy, password).await;
+    prewarm_admin_privacy_status(state.clone()).await;
+    wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("build client");
+    let login = client
+        .post(format!("http://{admin_addr}/api/admin/login"))
+        .json(&serde_json::json!({ "password": password }))
+        .send()
+        .await
+        .expect("admin login");
+    let cookie = find_cookie_pair(login.headers(), BUILTIN_ADMIN_COOKIE_NAME)
+        .expect("admin session cookie");
+    let privacy_status_url = format!("http://{admin_addr}/api/settings/system/privacy-status");
+
+    let warm = client
+        .get(&privacy_status_url)
+        .header(reqwest::header::COOKIE, &cookie)
+        .send()
+        .await
+        .expect("warm privacy status");
+    assert_eq!(warm.status(), reqwest::StatusCode::OK);
+    let refresh_count_before = admin_privacy_refresh_count_for_test(state.as_ref()).await;
+    expire_admin_privacy_status_last_good_for_test(state.as_ref()).await;
+    let pause = state
+        .proxy
+        .install_admin_privacy_read_pause_for_test()
+        .await;
+    let started = std::time::Instant::now();
+    let first_request = {
+        let client = client.clone();
+        let cookie = cookie.clone();
+        let privacy_status_url = privacy_status_url.clone();
+        tokio::spawn(async move {
+            client
+                .get(privacy_status_url)
+                .header(reqwest::header::COOKIE, cookie)
+                .send()
+                .await
+                .expect("stale privacy status")
+        })
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(2), pause.wait_until_arrived())
+        .await
+        .expect("the background refresh reached its controlled read pause");
+    let stale = first_request.await.expect("stale request task joins");
+    assert_eq!(stale.status(), reqwest::StatusCode::OK);
+    assert!(
+        started.elapsed() < std::time::Duration::from_millis(225),
+        "last-good reads must not wait for the refresh"
+    );
+    let body: serde_json::Value = stale.json().await.expect("stale privacy status json");
+    assert_eq!(body.get("coverage").and_then(|value| value.as_str()), Some("stale"));
+    let second_started = std::time::Instant::now();
+    let second = client
+        .get(&privacy_status_url)
+        .header(reqwest::header::COOKIE, &cookie)
+        .send()
+        .await
+        .expect("second stale privacy status");
+    assert_eq!(second.status(), reqwest::StatusCode::OK);
+    assert!(
+        second_started.elapsed() < std::time::Duration::from_millis(225),
+        "a refresh already in flight must not delay another stale reader"
+    );
+    assert_eq!(
+        admin_privacy_refresh_count_for_test(state.as_ref()).await,
+        refresh_count_before + 1,
+        "concurrent request refreshes must be singleflight"
+    );
+    assert_eq!(
+        state.proxy.admin_privacy_read_discards_for_test(),
+        0,
+        "the request budget must not discard an open read snapshot"
+    );
+    pause.release();
+    wait_for_admin_privacy_status_refresh(state.as_ref()).await;
+    state
+        .proxy
+        .verify_admin_privacy_read_connection_clean_for_test()
+        .await
+        .expect("the next SQLite transaction must be clean after refresh");
+
+    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]

--- a/src/server/tests/core_support_and_parsing.rs
+++ b/src/server/tests/core_support_and_parsing.rs
@@ -291,7 +291,7 @@
     ) -> reqwest::Response {
         let url = format!("http://{addr}/api/settings/system/status");
         let mut response = client.get(&url).send().await.expect("get cold system status");
-        for _ in 0..100 {
+        for _ in 0..350 {
             if response.status() == StatusCode::OK {
                 return response;
             }

--- a/src/server/tests/core_support_and_parsing.rs
+++ b/src/server/tests/core_support_and_parsing.rs
@@ -285,6 +285,31 @@
         decode_sse_json_text(&text)
     }
 
+    pub(super) async fn get_system_status_after_cold_retry(
+        client: &reqwest::Client,
+        addr: SocketAddr,
+    ) -> reqwest::Response {
+        let url = format!("http://{addr}/api/settings/system/status");
+        let mut response = client.get(&url).send().await.expect("get cold system status");
+        for _ in 0..100 {
+            if response.status() == StatusCode::OK {
+                return response;
+            }
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(
+                response.headers().get("retry-after").and_then(|value| value.to_str().ok()),
+                Some("1")
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            response = client
+                .get(&url)
+                .send()
+                .await
+                .expect("retry system status after privacy refresh");
+        }
+        response
+    }
+
     pub(super) async fn fetch_key_quota_snapshot(
         pool: &sqlx::SqlitePool,
         key_id: &str,

--- a/src/server/tests/system_settings_and_forward_proxy.rs
+++ b/src/server/tests/system_settings_and_forward_proxy.rs
@@ -2754,11 +2754,27 @@ use super::upstream_support_and_manual_jobs::*;
             Some(1)
         );
 
-        let status_response = client
+        let mut status_response = client
             .get(format!("http://{addr}/api/settings/system/status"))
             .send()
             .await
-            .expect("get system status");
+            .expect("get cold system status");
+        for _ in 0..100 {
+            if status_response.status() == StatusCode::OK {
+                break;
+            }
+            assert_eq!(status_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(
+                status_response.headers().get("retry-after").and_then(|value| value.to_str().ok()),
+                Some("1")
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            status_response = client
+                .get(format!("http://{addr}/api/settings/system/status"))
+                .send()
+                .await
+                .expect("retry system status after privacy refresh");
+        }
         assert_eq!(status_response.status(), StatusCode::OK);
         let status_body = status_response
             .json::<serde_json::Value>()

--- a/src/server/tests/system_settings_and_forward_proxy.rs
+++ b/src/server/tests/system_settings_and_forward_proxy.rs
@@ -2754,27 +2754,7 @@ use super::upstream_support_and_manual_jobs::*;
             Some(1)
         );
 
-        let mut status_response = client
-            .get(format!("http://{addr}/api/settings/system/status"))
-            .send()
-            .await
-            .expect("get cold system status");
-        for _ in 0..100 {
-            if status_response.status() == StatusCode::OK {
-                break;
-            }
-            assert_eq!(status_response.status(), StatusCode::SERVICE_UNAVAILABLE);
-            assert_eq!(
-                status_response.headers().get("retry-after").and_then(|value| value.to_str().ok()),
-                Some("1")
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            status_response = client
-                .get(format!("http://{addr}/api/settings/system/status"))
-                .send()
-                .await
-                .expect("retry system status after privacy refresh");
-        }
+        let status_response = get_system_status_after_cold_retry(&client, addr).await;
         assert_eq!(status_response.status(), StatusCode::OK);
         let status_body = status_response
             .json::<serde_json::Value>()

--- a/src/server/tests/system_settings_reconciliation_status.rs
+++ b/src/server/tests/system_settings_reconciliation_status.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::core_support_and_parsing::temp_db_path;
+use super::core_support_and_parsing::*;
 use super::upstream_support_and_manual_jobs::*;
 use tavily_hikari::business_period_for_timestamp;
 
@@ -148,30 +148,7 @@ async fn admin_system_status_reports_reconciliation_diagnostic_timestamps() {
 
     let addr = spawn_admin_forward_proxy_server(proxy, usage_base, true).await;
     let client = Client::new();
-    let mut status_response = client
-        .get(format!("http://{addr}/api/settings/system/status"))
-        .send()
-        .await
-        .expect("get cold system status");
-    for _ in 0..100 {
-        if status_response.status() == StatusCode::OK {
-            break;
-        }
-        assert_eq!(status_response.status(), StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(
-            status_response
-                .headers()
-                .get("retry-after")
-                .and_then(|value| value.to_str().ok()),
-            Some("1")
-        );
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        status_response = client
-            .get(format!("http://{addr}/api/settings/system/status"))
-            .send()
-            .await
-            .expect("retry system status after privacy refresh");
-    }
+    let status_response = get_system_status_after_cold_retry(&client, addr).await;
     assert_eq!(status_response.status(), StatusCode::OK);
     let status_body = status_response
         .json::<serde_json::Value>()

--- a/src/server/tests/system_settings_reconciliation_status.rs
+++ b/src/server/tests/system_settings_reconciliation_status.rs
@@ -147,11 +147,31 @@ async fn admin_system_status_reports_reconciliation_diagnostic_timestamps() {
     }
 
     let addr = spawn_admin_forward_proxy_server(proxy, usage_base, true).await;
-    let status_response = Client::new()
+    let client = Client::new();
+    let mut status_response = client
         .get(format!("http://{addr}/api/settings/system/status"))
         .send()
         .await
-        .expect("get system status");
+        .expect("get cold system status");
+    for _ in 0..100 {
+        if status_response.status() == StatusCode::OK {
+            break;
+        }
+        assert_eq!(status_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            status_response
+                .headers()
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok()),
+            Some("1")
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        status_response = client
+            .get(format!("http://{addr}/api/settings/system/status"))
+            .send()
+            .await
+            .expect("retry system status after privacy refresh");
+    }
     assert_eq!(status_response.status(), StatusCode::OK);
     let status_body = status_response
         .json::<serde_json::Value>()

--- a/src/store/key_store_admin_passkeys.rs
+++ b/src/store/key_store_admin_passkeys.rs
@@ -833,7 +833,11 @@ impl KeyStore {
         token: &str,
     ) -> Result<Option<AdminPasskeySessionRecord>, ProxyError> {
         let now = self.backend_time.now_ts();
-        let row = sqlx::query_as::<_, (String, Option<String>, i64, i64, Option<i64>)>(
+        let mut connection = self
+            .sqlite_runtime
+            .acquire_operation_connection(SqliteOperation::AdminRead)
+            .await?;
+        let row_result = sqlx::query_as::<_, (String, Option<String>, i64, i64, Option<i64>)>(
             r#"SELECT s.token, s.credential_id, s.created_at, s.expires_at, s.revoked_at
                FROM admin_passkey_sessions s
                LEFT JOIN admin_passkey_credentials c
@@ -848,8 +852,9 @@ impl KeyStore {
         .bind(token)
         .bind(&scope.id)
         .bind(now)
-        .fetch_optional(&self.pool)
-        .await?;
+        .fetch_optional(&mut *connection)
+        .await;
+        let row = connection.complete_query(row_result).await?;
 
         Ok(row.map(
             |(token, credential_id, created_at, expires_at, revoked_at)| {
@@ -1242,6 +1247,41 @@ mod admin_passkey_store_tests {
                 .await
                 .expect("expired session")
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn active_passkey_session_lookup_uses_the_bounded_admin_read_connection() {
+        let (_temp, db_path) = temp_db_path("session-bounded-admin-read.db");
+        let store = KeyStore::new_with_time(&db_path, BackendTime::system())
+            .await
+            .expect("create store");
+        let session = store
+            .create_admin_passkey_session(&test_scope(), None, 120)
+            .await
+            .expect("create passkey session");
+
+        let first = store.pool.acquire().await.expect("hold first connection");
+        let second = store.pool.acquire().await.expect("hold second connection");
+        let third = store.pool.acquire().await.expect("hold third connection");
+        let started = std::time::Instant::now();
+        let error = store
+            .get_active_admin_passkey_session(&test_scope(), &session.token)
+            .await
+            .expect_err("pool exhaustion must bound passkey session lookup");
+        assert!(matches!(
+            error,
+            ProxyError::Database(sqlx::Error::PoolTimedOut)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(150));
+        drop((third, second, first));
+
+        assert!(
+            store
+                .get_active_admin_passkey_session(&test_scope(), &session.token)
+                .await
+                .expect("connection must remain reusable after bounded lookup")
+                .is_some()
         );
     }
 

--- a/src/store/key_store_admin_passkeys.rs
+++ b/src/store/key_store_admin_passkeys.rs
@@ -869,6 +869,22 @@ impl KeyStore {
         ))
     }
 
+    #[cfg(debug_assertions)]
+    pub(crate) async fn hold_sqlite_pool_until_for_test(
+        &self,
+        ready: tokio::sync::oneshot::Sender<()>,
+        release: std::sync::Arc<tokio::sync::Notify>,
+    ) -> Result<(), ProxyError> {
+        let mut connections = Vec::with_capacity(crate::SQLITE_POOL_MAX_CONNECTIONS_DEFAULT as usize);
+        for _ in 0..crate::SQLITE_POOL_MAX_CONNECTIONS_DEFAULT {
+            connections.push(self.pool.acquire().await?);
+        }
+        let _ = ready.send(());
+        release.notified().await;
+        drop(connections);
+        Ok(())
+    }
+
     pub async fn revoke_admin_passkey_session(
         &self,
         scope: &AdminPasskeyScope,

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -5,11 +5,15 @@ async fn admin_privacy_meta_values(
     snapshot: &mut SqliteReadSnapshot,
 ) -> Result<StdHashMap<String, String>, ProxyError> {
     snapshot.ensure_cooperative_run_budget()?;
-    Ok(sqlx::query_as::<_, (String, String)>("SELECT key, value FROM meta")
+    let rows = sqlx::query_as::<_, (String, String)>("SELECT key, value FROM meta")
         .fetch_all(&mut **snapshot)
-        .await?
-        .into_iter()
-        .collect())
+        .await?;
+    let mut values = StdHashMap::with_capacity(rows.len());
+    for (key, value) in rows {
+        snapshot.ensure_cooperative_run_budget()?;
+        values.insert(key, value);
+    }
+    Ok(values)
 }
 
 fn admin_privacy_meta_i64(values: &StdHashMap<String, String>, key: &str) -> Option<i64> {
@@ -328,6 +332,7 @@ impl KeyStore {
             other: 0,
         };
         for (reason, count) in retry_rows {
+            snapshot.ensure_cooperative_run_budget()?;
             match classify_reconciliation_retry_reason(reason.as_deref()) {
                 RECONCILIATION_RETRY_REASON_UPSTREAM_429 => retry_buckets.upstream_429 += count,
                 RECONCILIATION_RETRY_REASON_LOCAL_USAGE_RATE_LIMIT => {
@@ -433,17 +438,19 @@ impl KeyStore {
         .fetch_all(&mut **snapshot)
         .await?;
         snapshot.ensure_cooperative_run_budget()?;
-        let backoffs = sqlx::query_as::<_, (String, i64, Option<String>)>(
+        let backoff_rows = sqlx::query_as::<_, (String, i64, Option<String>)>(
             r#"SELECT key_id, cooldown_until, reason_code
                  FROM api_key_transient_backoffs
                 WHERE scope = 'period_reconciliation' AND cooldown_until > ?"#,
         )
         .bind(now)
         .fetch_all(&mut **snapshot)
-        .await?
-        .into_iter()
-        .map(|(key_id, cooldown_until, reason)| (key_id, (cooldown_until, reason)))
-        .collect::<StdHashMap<_, _>>();
+        .await?;
+        let mut backoffs = StdHashMap::with_capacity(backoff_rows.len());
+        for (key_id, cooldown_until, reason) in backoff_rows {
+            snapshot.ensure_cooperative_run_budget()?;
+            backoffs.insert(key_id, (cooldown_until, reason));
+        }
         let daily_reconciliation_progress = DailyReconciliationProgress {
             observed_accounts,
             accounts_with_settled_period,
@@ -504,20 +511,19 @@ impl KeyStore {
                 && last_window_pending_delta <= 0,
             complete: complete_research_window.is_some(),
         };
-        let daily_reconciliation_by_key = key_rows
-            .into_iter()
-            .map(|(key_id, terminal_research, pending_research, pending_project_ids)| {
-                let cooldown = backoffs.get(&key_id);
-                DailyReconciliationKeyProgress {
-                    key_id_hint: key_id.chars().take(12).collect(),
-                    terminal_research,
-                    pending_research,
-                    pending_project_ids,
-                    cooldown_until: cooldown.map(|(until, _)| *until),
-                    cooldown_reason: cooldown.and_then(|(_, reason)| reason.clone()),
-                }
-            })
-            .collect();
+        let mut daily_reconciliation_by_key = Vec::with_capacity(key_rows.len());
+        for (key_id, terminal_research, pending_research, pending_project_ids) in key_rows {
+            snapshot.ensure_cooperative_run_budget()?;
+            let cooldown = backoffs.get(&key_id);
+            daily_reconciliation_by_key.push(DailyReconciliationKeyProgress {
+                key_id_hint: key_id.chars().take(12).collect(),
+                terminal_research,
+                pending_research,
+                pending_project_ids,
+                cooldown_until: cooldown.map(|(until, _)| *until),
+                cooldown_reason: cooldown.and_then(|(_, reason)| reason.clone()),
+            });
+        }
         snapshot.ensure_cooperative_run_budget()?;
         let degraded_observed: i64 = sqlx::query_scalar(&format!(
             "SELECT COUNT(*) FROM (SELECT 1 FROM upstream_reconciliation_settlements \
@@ -604,7 +610,7 @@ impl KeyStore {
         })?;
         let dashboard_alert_projection = admin_privacy_alert_projection_status(snapshot, now).await?;
         snapshot.ensure_cooperative_run_budget()?;
-        let recent_adjustments = sqlx::query_as::<_, (String, String, String, String, i64, Option<String>, i64)>(
+        let recent_adjustment_rows = sqlx::query_as::<_, (String, String, String, String, i64, Option<String>, i64)>(
             r#"SELECT settlement_key, token_id, billing_subject, period_code, delta_credits,
                       degraded_reason, created_at
                  FROM billing_reconciliation_adjustments
@@ -612,10 +618,20 @@ impl KeyStore {
                 LIMIT 10"#,
         )
         .fetch_all(&mut **snapshot)
-        .await?
-        .into_iter()
-        .map(|(settlement_key, token_id, billing_subject, period_code, delta_credits, degraded_reason, created_at)| {
-            UpstreamReconciliationAdjustment {
+        .await?;
+        let mut recent_adjustments = Vec::with_capacity(recent_adjustment_rows.len());
+        for (
+            settlement_key,
+            token_id,
+            billing_subject,
+            period_code,
+            delta_credits,
+            degraded_reason,
+            created_at,
+        ) in recent_adjustment_rows
+        {
+            snapshot.ensure_cooperative_run_budget()?;
+            recent_adjustments.push(UpstreamReconciliationAdjustment {
                 settlement_key,
                 token_id_hint: token_id.chars().take(8).collect(),
                 billing_subject_kind: billing_subject.split(':').next().unwrap_or("unknown").to_string(),
@@ -623,9 +639,8 @@ impl KeyStore {
                 delta_credits,
                 degraded_reason,
                 created_at,
-            }
-        })
-        .collect();
+            });
+        }
         let value_i64 = |key| meta_i64(key).unwrap_or(0);
         let shadow_ready = mode_ready && api_rebalance_enabled && rebalance_mcp_enabled;
         let next_epoch_at = if legacy_active != 0
@@ -637,6 +652,23 @@ impl KeyStore {
         } else {
             activation_period_start
         };
+        let mut current_period_bound_users_by_key = Vec::with_capacity(bound_rows.len());
+        for (key_id, count) in bound_rows {
+            snapshot.ensure_cooperative_run_budget()?;
+            current_period_bound_users_by_key.push(UpstreamKeyActivityPoint {
+                key_id_hint: key_id.chars().take(12).collect(),
+                count,
+            });
+        }
+        let mut current_period_pending_project_ids_by_key =
+            Vec::with_capacity(pending_project_rows.len());
+        for (key_id, count) in pending_project_rows {
+            snapshot.ensure_cooperative_run_budget()?;
+            current_period_pending_project_ids_by_key.push(UpstreamKeyActivityPoint {
+                key_id_hint: key_id.chars().take(12).collect(),
+                count,
+            });
+        }
         snapshot.ensure_cooperative_run_budget()?;
         Ok(UpstreamPrivacyStatus {
             phase: controller_mode.as_str().to_string(),
@@ -696,8 +728,8 @@ impl KeyStore {
                 stale_reason: dashboard_alert_projection.stale_reason,
             },
             retry_buckets,
-            current_period_bound_users_by_key: bound_rows.into_iter().map(|(key_id, count)| UpstreamKeyActivityPoint { key_id_hint: key_id.chars().take(12).collect(), count }).collect(),
-            current_period_pending_project_ids_by_key: pending_project_rows.into_iter().map(|(key_id, count)| UpstreamKeyActivityPoint { key_id_hint: key_id.chars().take(12).collect(), count }).collect(),
+            current_period_bound_users_by_key,
+            current_period_pending_project_ids_by_key,
             daily_reconciliation_progress,
             daily_reconciliation_by_key,
             recent_adjustments,

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -158,6 +158,8 @@ impl KeyStore {
         &self,
         snapshot: &mut SqliteReadSnapshot,
     ) -> Result<UpstreamPrivacyStatus, ProxyError> {
+        #[cfg(debug_assertions)]
+        self.wait_for_admin_privacy_read_pause_if_installed().await;
         let now = self.backend_time.now_ts();
         let period = business_period_for_timestamp(now);
         let day_window = server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&Local));

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -4,6 +4,7 @@
 async fn admin_privacy_meta_values(
     snapshot: &mut SqliteReadSnapshot,
 ) -> Result<StdHashMap<String, String>, ProxyError> {
+    snapshot.ensure_cooperative_run_budget()?;
     Ok(sqlx::query_as::<_, (String, String)>("SELECT key, value FROM meta")
         .fetch_all(&mut **snapshot)
         .await?
@@ -19,6 +20,7 @@ async fn admin_privacy_alert_source_fence(
     snapshot: &mut SqliteReadSnapshot,
     source_kind: &str,
 ) -> Result<Option<(i64, String)>, ProxyError> {
+    snapshot.ensure_cooperative_run_budget()?;
     let row = match source_kind {
         ALERT_SOURCE_AUTH_TOKEN_LOG => sqlx::query_as::<_, (i64, i64)>(
             r#"SELECT created_at, id
@@ -73,6 +75,7 @@ async fn admin_privacy_alert_projection_status(
     snapshot: &mut SqliteReadSnapshot,
     now: i64,
 ) -> Result<AlertProjectionStatus, ProxyError> {
+    snapshot.ensure_cooperative_run_budget()?;
     let (
         sources,
         observed_at,
@@ -109,6 +112,7 @@ async fn admin_privacy_alert_projection_status(
         "projecting"
     };
     if recent_coverage == "projecting" && stale_reason.is_none() {
+        snapshot.ensure_cooperative_run_budget()?;
         let incomplete_sources = sqlx::query_scalar::<_, String>(
             r#"SELECT source_kind
                  FROM observability.dashboard_alert_projection_state
@@ -188,6 +192,7 @@ impl KeyStore {
         )
         .unwrap_or(0)
             != 0;
+        snapshot.ensure_cooperative_run_budget()?;
         let active_upstream_mcp_sessions: i64 = sqlx::query_scalar(
             r#"SELECT COUNT(*)
                  FROM mcp_sessions
@@ -226,6 +231,7 @@ impl KeyStore {
         ];
 
         let observed_at = meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LAST_RUN_AT_V1);
+        snapshot.ensure_cooperative_run_budget()?;
         let has_eligible: bool = sqlx::query_scalar(
             r#"SELECT EXISTS(
                 SELECT 1
@@ -247,6 +253,7 @@ impl KeyStore {
         .bind(now)
         .fetch_one(&mut **snapshot)
         .await?;
+        snapshot.ensure_cooperative_run_budget()?;
         let oldest_period_end: Option<i64> = sqlx::query_scalar(
             r#"SELECT w.period_end
                  FROM upstream_reconciliation_work w
@@ -269,6 +276,7 @@ impl KeyStore {
         .fetch_optional(&mut **snapshot)
         .await?;
         let queue_estimate = if observed_at.is_some() {
+            snapshot.ensure_cooperative_run_budget()?;
             Some(
                 sqlx::query_scalar::<_, i64>(&format!(
                     r#"SELECT COUNT(*) FROM (
@@ -304,6 +312,7 @@ impl KeyStore {
                 .map(|period_end| now.saturating_sub(period_end).max(0)),
         };
 
+        snapshot.ensure_cooperative_run_budget()?;
         let retry_rows = sqlx::query_as::<_, (Option<String>, i64)>(
             r#"SELECT degraded_reason, COUNT(*)
                  FROM upstream_reconciliation_settlements
@@ -328,6 +337,7 @@ impl KeyStore {
             }
         }
 
+        snapshot.ensure_cooperative_run_budget()?;
         let bound_rows = sqlx::query_as::<_, (String, i64)>(
             r#"SELECT u.key_id, COUNT(DISTINCT CASE
                       WHEN u.billing_subject LIKE 'account:%' THEN SUBSTR(u.billing_subject, 9)
@@ -341,6 +351,7 @@ impl KeyStore {
         .bind(&period.code)
         .fetch_all(&mut **snapshot)
         .await?;
+        snapshot.ensure_cooperative_run_budget()?;
         let pending_project_rows = sqlx::query_as::<_, (String, i64)>(
             r#"SELECT u.key_id, COUNT(DISTINCT u.project_id) AS pending_project_ids
                  FROM upstream_reconciliation_usage u
@@ -356,6 +367,7 @@ impl KeyStore {
         .fetch_all(&mut **snapshot)
         .await?;
 
+        snapshot.ensure_cooperative_run_budget()?;
         let (observed_accounts, accounts_with_settled_period, fully_terminal_accounts, observed_periods, settled_periods, degraded_periods, pending_periods) =
             sqlx::query_as::<_, (i64, i64, i64, i64, i64, i64, i64)>(
                 r#"WITH windows AS (
@@ -383,6 +395,7 @@ impl KeyStore {
             .bind(day_window.end)
             .fetch_one(&mut **snapshot)
             .await?;
+        snapshot.ensure_cooperative_run_budget()?;
         let (research_total, research_terminal, research_pending) = sqlx::query_as::<_, (i64, i64, i64)>(
             r#"SELECT COUNT(DISTINCT r.request_id),
                        COUNT(DISTINCT CASE WHEN r.terminal_at IS NOT NULL THEN r.request_id END),
@@ -396,6 +409,7 @@ impl KeyStore {
         .bind(day_window.end)
         .fetch_one(&mut **snapshot)
         .await?;
+        snapshot.ensure_cooperative_run_budget()?;
         let key_rows = sqlx::query_as::<_, (String, i64, i64, i64)>(
             r#"SELECT u.key_id,
                        COUNT(DISTINCT CASE WHEN r.terminal_at IS NOT NULL THEN r.request_id END),
@@ -418,6 +432,7 @@ impl KeyStore {
         .bind(day_window.end)
         .fetch_all(&mut **snapshot)
         .await?;
+        snapshot.ensure_cooperative_run_budget()?;
         let backoffs = sqlx::query_as::<_, (String, i64, Option<String>)>(
             r#"SELECT key_id, cooldown_until, reason_code
                  FROM api_key_transient_backoffs
@@ -447,14 +462,17 @@ impl KeyStore {
             last_window_ended_at,
             last_window_terminal_delta,
             last_window_pending_delta,
-        ) = sqlx::query_as::<_, (i64, Option<i64>, Option<i64>, i64, i64)>(
+        ) = {
+            snapshot.ensure_cooperative_run_budget()?;
+            sqlx::query_as::<_, (i64, Option<i64>, Option<i64>, i64, i64)>(
             r#"SELECT active_started_at, last_window_started_at, last_window_ended_at,
                        last_window_terminal_delta, last_window_pending_delta
                   FROM upstream_reconciliation_research_progress_window
                  WHERE id = 'local'"#,
         )
         .fetch_one(&mut **snapshot)
-        .await?;
+        .await?
+        };
         let complete_research_window = last_window_started_at.zip(last_window_ended_at);
         let (research_window_started_at, research_window_ended_at, research_window_seconds) =
             if let Some((started_at, ended_at)) = complete_research_window {
@@ -500,6 +518,7 @@ impl KeyStore {
                 }
             })
             .collect();
+        snapshot.ensure_cooperative_run_budget()?;
         let degraded_observed: i64 = sqlx::query_scalar(&format!(
             "SELECT COUNT(*) FROM (SELECT 1 FROM upstream_reconciliation_settlements \
              WHERE status IN ('degraded', 'shadow_degraded') LIMIT {})",
@@ -517,6 +536,7 @@ impl KeyStore {
             meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1).unwrap_or(0),
             meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1).unwrap_or(0),
         );
+        snapshot.ensure_cooperative_run_budget()?;
         let run_row = sqlx::query_as::<_, ReconciliationRunObservationRow>(
             r#"SELECT o.mode,
                       CASE WHEN p.completed != 0 THEN 'complete'
@@ -569,6 +589,7 @@ impl KeyStore {
             next_retry_at: run_row.next_retry_at,
             observed_at: (run_row.observed_at > 0).then_some(run_row.observed_at),
         };
+        snapshot.ensure_cooperative_run_budget()?;
         let (mode, activation_period_code, activation_period_start, legacy_active, paused_reason, transitioned_at) =
             sqlx::query_as::<_, (String, Option<String>, Option<i64>, i64, Option<String>, i64)>(
                 r#"SELECT mode, activation_period_code, activation_period_start, legacy_active,
@@ -582,6 +603,7 @@ impl KeyStore {
             ProxyError::Other("invalid persisted upstream reconciliation mode".to_string())
         })?;
         let dashboard_alert_projection = admin_privacy_alert_projection_status(snapshot, now).await?;
+        snapshot.ensure_cooperative_run_budget()?;
         let recent_adjustments = sqlx::query_as::<_, (String, String, String, String, i64, Option<String>, i64)>(
             r#"SELECT settlement_key, token_id, billing_subject, period_code, delta_credits,
                       degraded_reason, created_at
@@ -615,6 +637,7 @@ impl KeyStore {
         } else {
             activation_period_start
         };
+        snapshot.ensure_cooperative_run_budget()?;
         Ok(UpstreamPrivacyStatus {
             phase: controller_mode.as_str().to_string(),
             configured_project_id_mode: upstream_project_id_mode,

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -680,6 +680,8 @@ impl KeyStore {
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             #[cfg(debug_assertions)]
             dashboard_overview_read_pause: Arc::new(Mutex::new(None)),
+            #[cfg(debug_assertions)]
+            admin_privacy_read_pause: Arc::new(Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
         // Existing deployments may predate newly added observability control
@@ -782,6 +784,8 @@ impl KeyStore {
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             #[cfg(debug_assertions)]
             dashboard_overview_read_pause: Arc::new(Mutex::new(None)),
+            #[cfg(debug_assertions)]
+            admin_privacy_read_pause: Arc::new(Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
         instrument_db_operation(

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -1339,6 +1339,8 @@ impl KeyStore {
             forced_pending_claim_miss_log_ids: Mutex::new(HashSet::new()),
             #[cfg(debug_assertions)]
             dashboard_overview_read_pause: Arc::new(Mutex::new(None)),
+            #[cfg(debug_assertions)]
+            admin_privacy_read_pause: Arc::new(Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
         store.ensure_meta_schema().await?;

--- a/src/store/key_store_request_stats_coalescer.rs
+++ b/src/store/key_store_request_stats_coalescer.rs
@@ -57,6 +57,7 @@ pub(crate) struct RequestLogRollupInput<'a> {
 #[derive(Debug, Clone)]
 pub struct RequestStatsPostFlushPause {
     pub(crate) arrived: Arc<Notify>,
+    pub(crate) arrival_observed: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) release: Arc<Notify>,
     pub(crate) released: Arc<std::sync::atomic::AtomicBool>,
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2664,6 +2664,9 @@ pub(crate) struct KeyStore {
     #[cfg(debug_assertions)]
     #[allow(dead_code)]
     pub(crate) dashboard_overview_read_pause: Arc<Mutex<Option<RequestStatsPostFlushPause>>>,
+    #[cfg(debug_assertions)]
+    #[allow(dead_code)]
+    pub(crate) admin_privacy_read_pause: Arc<Mutex<Option<RequestStatsPostFlushPause>>>,
     // Lightweight failpoint registry used by integration tests to simulate a lost quota
     // subject lease after precheck but before settlement.
     pub(crate) forced_quota_subject_lock_loss_subjects: std::sync::Mutex<HashSet<String>>,
@@ -2704,6 +2707,21 @@ impl KeyStore {
     #[allow(dead_code)]
     pub(crate) async fn wait_for_dashboard_overview_read_pause_if_installed(&self) {
         wait_for_request_stats_test_pause_if_installed(&self.dashboard_overview_read_pause).await;
+    }
+
+    #[cfg(debug_assertions)]
+    #[allow(dead_code)]
+    pub(crate) async fn install_admin_privacy_read_pause(&self) -> RequestStatsPostFlushPause {
+        let pause = new_request_stats_test_pause();
+        let mut slot = self.admin_privacy_read_pause.lock().await;
+        *slot = Some(pause.clone());
+        pause
+    }
+
+    #[cfg(debug_assertions)]
+    #[allow(dead_code)]
+    pub(crate) async fn wait_for_admin_privacy_read_pause_if_installed(&self) {
+        wait_for_request_stats_test_pause_if_installed(&self.admin_privacy_read_pause).await;
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2686,7 +2686,8 @@ async fn wait_for_request_stats_test_pause_if_installed(
     slot: &Arc<Mutex<Option<RequestStatsPostFlushPause>>>,
 ) {
     if let Some(pause) = slot.lock().await.take() {
-        pause.arrived.notify_waiters();
+        // Retain the arrival signal when the request returns before the test waits.
+        pause.arrived.notify_one();
         while !pause.released.load(std::sync::atomic::Ordering::SeqCst) {
             pause.release.notified().await;
         }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2676,6 +2676,7 @@ pub(crate) struct KeyStore {
 fn new_request_stats_test_pause() -> RequestStatsPostFlushPause {
     RequestStatsPostFlushPause {
         arrived: Arc::new(Notify::new()),
+        arrival_observed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         release: Arc::new(Notify::new()),
         released: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
@@ -2687,6 +2688,9 @@ async fn wait_for_request_stats_test_pause_if_installed(
 ) {
     if let Some(pause) = slot.lock().await.take() {
         // Retain the arrival signal when the request returns before the test waits.
+        pause
+            .arrival_observed
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         pause.arrived.notify_one();
         while !pause.released.load(std::sync::atomic::Ordering::SeqCst) {
             pause.release.notified().await;
@@ -2820,7 +2824,19 @@ mod tests {
     #[tokio::test]
     async fn request_stats_test_pause_retains_one_arrival_permit() {
         let pause = new_request_stats_test_pause();
-        pause.arrived.notify_one();
+        let slot = Arc::new(tokio::sync::Mutex::new(Some(pause.clone())));
+        let paused_task = {
+            let slot = Arc::clone(&slot);
+            tokio::spawn(async move {
+                wait_for_request_stats_test_pause_if_installed(&slot).await;
+            })
+        };
+        while !pause
+            .arrival_observed
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            tokio::task::yield_now().await;
+        }
 
         tokio::time::timeout(Duration::from_millis(10), pause.wait_until_arrived())
             .await
@@ -2831,6 +2847,8 @@ mod tests {
                 .is_err(),
             "the pause must retain only one arrival permit"
         );
+        pause.release();
+        paused_task.await.expect("paused task joins after release");
     }
 
     #[test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2817,6 +2817,22 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn request_stats_test_pause_retains_one_arrival_permit() {
+        let pause = new_request_stats_test_pause();
+        pause.arrived.notify_one();
+
+        tokio::time::timeout(Duration::from_millis(10), pause.wait_until_arrived())
+            .await
+            .expect("a late single waiter must consume the retained arrival permit");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), pause.wait_until_arrived())
+                .await
+                .is_err(),
+            "the pause must retain only one arrival permit"
+        );
+    }
+
     #[test]
     fn fold_request_rollup_rows_preserves_day_buckets_across_shared_five_minute_bucket() {
         let rows = vec![

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -367,7 +367,7 @@ pub(crate) struct SqliteRuntime {
 }
 
 impl SqliteRuntime {
-    #[cfg(test)]
+    #[cfg(debug_assertions)]
     pub(crate) fn discarded_connections_for_test(&self, operation: SqliteOperation) -> u64 {
         self.inner
             .workload
@@ -634,6 +634,20 @@ impl SqliteRuntime {
         } else if self.recent_contention_active() {
             Some(SqliteAdmissionDeferReason::RecentContention)
         } else if self.inner.pool.num_idle() == 0
+            || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
+        {
+            Some(SqliteAdmissionDeferReason::PoolPressure)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn admin_privacy_read_defer_reason(&self) -> Option<SqliteAdmissionDeferReason> {
+        if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS {
+            Some(SqliteAdmissionDeferReason::ForegroundPressure)
+        } else if self.recent_contention_active() {
+            Some(SqliteAdmissionDeferReason::RecentContention)
+        } else if !self.has_foreground_pool_capacity()
             || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
         {
             Some(SqliteAdmissionDeferReason::PoolPressure)
@@ -1178,6 +1192,13 @@ impl SqliteRuntime {
 }
 
 impl KeyStore {
+    pub(crate) fn admin_privacy_read_refresh_defer_reason(&self) -> Option<&'static str> {
+        let reason = self.sqlite_runtime.admin_privacy_read_defer_reason()?;
+        self.sqlite_runtime
+            .record_deferred(SqliteOperation::AdminPrivacyRead, reason);
+        Some(reason.as_str())
+    }
+
     pub(crate) async fn begin_admin_privacy_read_session(
         &self,
     ) -> Result<SqliteReadSnapshot, ProxyError> {

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -11,6 +11,8 @@ use tracing::{debug, error, info, warn};
 
 const SQLITE_WORKLOAD_LOG_INTERVAL: Duration = Duration::from_secs(60);
 const DEFAULT_BUSY_TIMEOUT_MS: i64 = 5_000;
+const ADMIN_PRIVACY_READ_RUN_BUDGET: Duration = Duration::from_secs(2);
+const ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS: i32 = 1_000;
 
 const MAINTENANCE_BULK_MAX_FOREGROUND_RPS: i64 = 5;
 const MAINTENANCE_BULK_CONTENTION_COOLDOWN: Duration = Duration::from_secs(5);
@@ -376,6 +378,18 @@ impl SqliteRuntime {
             .operations
             .get(&operation)
             .map(|metrics| metrics.discarded_connections)
+            .unwrap_or_default()
+    }
+
+    #[cfg(debug_assertions)]
+    pub(crate) fn operation_errors_for_test(&self, operation: SqliteOperation) -> u64 {
+        self.inner
+            .workload
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .operations
+            .get(&operation)
+            .map(|metrics| metrics.errors)
             .unwrap_or_default()
     }
 
@@ -846,6 +860,17 @@ impl SqliteRuntime {
         }
         snapshot.begin_wait = begin_started.elapsed();
         snapshot.started_at = Instant::now();
+        if matches!(operation, SqliteOperation::AdminPrivacyRead)
+            && let Err(error) = snapshot
+                .arm_cooperative_run_budget(ADMIN_PRIVACY_READ_RUN_BUDGET)
+                .await
+        {
+            let close = snapshot.close_after_query(Some(&error)).await;
+            return match close {
+                Ok(()) => Err(error),
+                Err(close_error) => Err(close_error),
+            };
+        }
         Ok(snapshot)
     }
 
@@ -1446,6 +1471,24 @@ impl Drop for SqliteOperationConnection {
 }
 
 impl SqliteReadSnapshot {
+    pub(crate) async fn arm_cooperative_run_budget(
+        &mut self,
+        run_budget: Duration,
+    ) -> Result<(), ProxyError> {
+        let deadline = Instant::now() + run_budget;
+        let mut handle = self.lock_handle().await.map_err(ProxyError::Database)?;
+        handle.set_progress_handler(ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS, move || {
+            Instant::now() < deadline
+        });
+        Ok(())
+    }
+
+    async fn clear_cooperative_run_budget(&mut self) -> Result<(), ProxyError> {
+        let mut handle = self.lock_handle().await.map_err(ProxyError::Database)?;
+        handle.remove_progress_handler();
+        Ok(())
+    }
+
     pub(crate) async fn complete_query<T>(
         mut self,
         query_result: Result<T, sqlx::Error>,
@@ -1494,7 +1537,17 @@ impl SqliteReadSnapshot {
         }
     }
 
-    pub(crate) async fn close(mut self) -> Result<(), ProxyError> {
+    pub(crate) async fn close_after_query(
+        mut self,
+        query_error: Option<&ProxyError>,
+    ) -> Result<(), ProxyError> {
+        if let Err(error) = self.clear_cooperative_run_budget().await {
+            let conn = self.conn.take().expect("SQLite read snapshot connection");
+            conn.detach().close().await.ok();
+            self.runtime
+                .record_error(self.operation, self.pool_wait, self.begin_wait, &error);
+            return Err(error);
+        }
         let result = sqlx::query("ROLLBACK").execute(&mut *self).await;
         match result {
             Ok(_) => {
@@ -1511,13 +1564,22 @@ impl SqliteReadSnapshot {
                     );
                     return Err(err);
                 }
-                self.runtime.record_success(
-                    self.operation,
-                    self.pool_wait,
-                    self.begin_wait,
-                    self.started_at.elapsed(),
-                    0,
-                );
+                if let Some(error) = query_error {
+                    self.runtime.record_error(
+                        self.operation,
+                        self.pool_wait,
+                        self.begin_wait,
+                        error,
+                    );
+                } else {
+                    self.runtime.record_success(
+                        self.operation,
+                        self.pool_wait,
+                        self.begin_wait,
+                        self.started_at.elapsed(),
+                        0,
+                    );
+                }
                 Ok(())
             }
             Err(err) => {
@@ -1529,6 +1591,10 @@ impl SqliteReadSnapshot {
                 Err(err)
             }
         }
+    }
+
+    pub(crate) async fn close(self) -> Result<(), ProxyError> {
+        self.close_after_query(None).await
     }
 }
 
@@ -2354,6 +2420,47 @@ mod tests {
         ));
         assert!(started.elapsed() < Duration::from_millis(150));
         drop((third, second, first));
+    }
+
+    #[tokio::test]
+    async fn admin_privacy_read_run_budget_interrupts_before_discarding_its_session() {
+        let runtime = single_connection_runtime().await;
+        let mut session = runtime
+            .begin_read_snapshot(SqliteOperation::AdminPrivacyRead)
+            .await
+            .expect("privacy read session");
+        session
+            .arm_cooperative_run_budget(Duration::ZERO)
+            .await
+            .expect("install immediate read budget");
+        let query_error = sqlx::query_scalar::<_, i64>(
+            "WITH RECURSIVE counter(value) AS (VALUES(1) UNION ALL SELECT value + 1 FROM counter WHERE value < 1000000) SELECT SUM(value) FROM counter",
+        )
+        .fetch_one(&mut *session)
+        .await
+        .expect_err("the SQLite progress handler must interrupt an expired read budget");
+        let query_error = ProxyError::Database(query_error);
+        session
+            .close_after_query(Some(&query_error))
+            .await
+            .expect("interrupted session closes explicitly");
+        assert_eq!(
+            runtime.discarded_connections_for_test(SqliteOperation::AdminPrivacyRead),
+            0,
+            "cooperative interruption must not discard the SQLite connection"
+        );
+        assert_eq!(
+            runtime.operation_errors_for_test(SqliteOperation::AdminPrivacyRead),
+            1,
+            "an interrupted query must enter runtime workload error metrics"
+        );
+        runtime
+            .begin_read_snapshot(SqliteOperation::AdminPrivacyRead)
+            .await
+            .expect("next privacy session is clean")
+            .close()
+            .await
+            .expect("close next privacy session");
     }
 
     #[tokio::test]

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -802,19 +802,33 @@ impl SqliteRuntime {
             started_at: Instant::now(),
             restore_busy_timeout,
         };
-        match tokio::time::timeout(
-            operation.begin_budget(),
-            sqlx::query("BEGIN").execute(&mut *snapshot),
-        )
-        .await
-        {
+        let begin_result = if matches!(operation, SqliteOperation::AdminPrivacyRead) {
+            // Admin privacy refreshes are detached from the HTTP budget. Its
+            // connection-local busy timeout is the bounded defer mechanism;
+            // cancelling this future would leave a physical connection in an
+            // unknown transaction state and turn discard into normal flow.
+            Ok(sqlx::query("BEGIN").execute(&mut *snapshot).await)
+        } else {
+            tokio::time::timeout(
+                operation.begin_budget(),
+                sqlx::query("BEGIN").execute(&mut *snapshot),
+            )
+            .await
+        };
+        match begin_result {
             Ok(Ok(_)) => {}
             Ok(Err(err)) => {
                 let conn = snapshot
                     .conn
                     .take()
                     .expect("SQLite read snapshot connection");
-                conn.detach().close().await.ok();
+                if let Err(restore_err) =
+                    restore_operation_connection(conn, snapshot.restore_busy_timeout).await
+                {
+                    let err = ProxyError::Database(restore_err);
+                    self.record_error(operation, pool_wait, begin_started.elapsed(), &err);
+                    return Err(err);
+                }
                 let err = ProxyError::Database(err);
                 self.record_error(operation, pool_wait, begin_started.elapsed(), &err);
                 return Err(err);

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -815,6 +815,8 @@ impl SqliteRuntime {
             begin_wait: Duration::ZERO,
             started_at: Instant::now(),
             restore_busy_timeout,
+            #[cfg(test)]
+            cooperative_run_budget_for_test: None,
         };
         let begin_result = if matches!(operation, SqliteOperation::AdminPrivacyRead) {
             // Admin privacy refreshes are detached from the HTTP budget. Its
@@ -1273,6 +1275,8 @@ pub(crate) struct SqliteReadSnapshot {
     begin_wait: Duration,
     started_at: Instant,
     restore_busy_timeout: bool,
+    #[cfg(test)]
+    cooperative_run_budget_for_test: Option<Duration>,
 }
 
 #[derive(Debug)]
@@ -1480,7 +1484,17 @@ impl SqliteReadSnapshot {
         handle.set_progress_handler(ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS, move || {
             Instant::now() < deadline
         });
+        drop(handle);
+        #[cfg(test)]
+        {
+            self.cooperative_run_budget_for_test = Some(run_budget);
+        }
         Ok(())
+    }
+
+    #[cfg(test)]
+    fn cooperative_run_budget_for_test(&self) -> Option<Duration> {
+        self.cooperative_run_budget_for_test
     }
 
     async fn clear_cooperative_run_budget(&mut self) -> Result<(), ProxyError> {
@@ -2429,6 +2443,11 @@ mod tests {
             .begin_read_snapshot(SqliteOperation::AdminPrivacyRead)
             .await
             .expect("privacy read session");
+        assert_eq!(
+            session.cooperative_run_budget_for_test(),
+            Some(ADMIN_PRIVACY_READ_RUN_BUDGET),
+            "admin privacy snapshots install the production two-second run budget"
+        );
         session
             .arm_cooperative_run_budget(Duration::ZERO)
             .await

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -815,8 +815,11 @@ impl SqliteRuntime {
             begin_wait: Duration::ZERO,
             started_at: Instant::now(),
             restore_busy_timeout,
+            cooperative_run_deadline: None,
             #[cfg(test)]
             cooperative_run_budget_for_test: None,
+            #[cfg(test)]
+            cooperative_run_budget_checks_remaining_for_test: None,
         };
         let begin_result = if matches!(operation, SqliteOperation::AdminPrivacyRead) {
             // Admin privacy refreshes are detached from the HTTP budget. Its
@@ -1275,8 +1278,11 @@ pub(crate) struct SqliteReadSnapshot {
     begin_wait: Duration,
     started_at: Instant,
     restore_busy_timeout: bool,
+    cooperative_run_deadline: Option<Instant>,
     #[cfg(test)]
     cooperative_run_budget_for_test: Option<Duration>,
+    #[cfg(test)]
+    cooperative_run_budget_checks_remaining_for_test: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -1485,6 +1491,7 @@ impl SqliteReadSnapshot {
             Instant::now() < deadline
         });
         drop(handle);
+        self.cooperative_run_deadline = Some(deadline);
         #[cfg(test)]
         {
             self.cooperative_run_budget_for_test = Some(run_budget);
@@ -1497,9 +1504,39 @@ impl SqliteReadSnapshot {
         self.cooperative_run_budget_for_test
     }
 
+    pub(crate) fn ensure_cooperative_run_budget(&mut self) -> Result<(), ProxyError> {
+        #[cfg(test)]
+        if let Some(checks_remaining) = self
+            .cooperative_run_budget_checks_remaining_for_test
+            .as_mut()
+        {
+            if *checks_remaining == 0 {
+                return Err(ProxyError::Database(sqlx::Error::PoolTimedOut));
+            }
+            *checks_remaining = checks_remaining.saturating_sub(1);
+        }
+        if self
+            .cooperative_run_deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return Err(ProxyError::Database(sqlx::Error::PoolTimedOut));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn expire_cooperative_run_budget_after_check_for_test(
+        &mut self,
+        checks_remaining: usize,
+    ) {
+        self.cooperative_run_budget_checks_remaining_for_test = Some(checks_remaining);
+    }
+
     async fn clear_cooperative_run_budget(&mut self) -> Result<(), ProxyError> {
         let mut handle = self.lock_handle().await.map_err(ProxyError::Database)?;
         handle.remove_progress_handler();
+        drop(handle);
+        self.cooperative_run_deadline = None;
         Ok(())
     }
 

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -1,4 +1,9 @@
 impl TavilyProxy {
+    #[doc(hidden)]
+    pub fn admin_privacy_status_refresh_defer_reason(&self) -> Option<&'static str> {
+        self.key_store.admin_privacy_read_refresh_defer_reason()
+    }
+
     pub fn admit_admin_privacy_status(&self) -> SqliteAdmissionOutcome {
         // Compatibility surface only: privacy status owns its bounded read
         // session and must never re-enter maintenance-bulk admission.

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -71,6 +71,34 @@ impl TavilyProxy {
         }
     }
 
+    #[cfg(test)]
+    #[doc(hidden)]
+    pub async fn upstream_privacy_status_after_one_safe_boundary_for_test(
+        &self,
+    ) -> Result<UpstreamPrivacyStatus, ProxyError> {
+        let mut session = self.key_store.begin_admin_privacy_read_session().await?;
+        session.expire_cooperative_run_budget_after_check_for_test(1);
+        let result = self
+            .key_store
+            .upstream_privacy_status_from_snapshot(&mut session)
+            .await;
+        let close = session.close_after_query(result.as_ref().err()).await;
+        match (result, close) {
+            (Ok(status), Ok(())) => Ok(status),
+            (Err(error), _) | (_, Err(error)) => Err(error),
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn hold_sqlite_pool_until_for_test(
+        &self,
+        ready: tokio::sync::oneshot::Sender<()>,
+        release: std::sync::Arc<tokio::sync::Notify>,
+    ) -> Result<(), ProxyError> {
+        self.key_store.hold_sqlite_pool_until_for_test(ready, release).await
+    }
+
     #[cfg(debug_assertions)]
     #[doc(hidden)]
     pub async fn install_admin_privacy_read_pause_for_test(
@@ -2880,5 +2908,42 @@ fn normalize_quota_sync_fetch_error(err: ProxyError) -> ProxyError {
             QUOTA_SYNC_FETCH_TIMEOUT_SECS
         )),
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod privacy_status_phase_budget_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn privacy_status_stops_at_a_safe_boundary_and_closes_its_snapshot() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("privacy-status-phase-budget.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let proxy = TavilyProxy::with_endpoint(
+            vec!["tvly-privacy-status-phase-budget".to_string()],
+            crate::DEFAULT_UPSTREAM,
+            &db_str,
+        )
+        .await
+        .expect("proxy created");
+
+        let error = proxy
+            .upstream_privacy_status_after_one_safe_boundary_for_test()
+            .await
+            .expect_err("the real status builder must stop before its second SQLite phase");
+        assert!(matches!(
+            error,
+            ProxyError::Database(sqlx::Error::PoolTimedOut)
+        ));
+        assert_eq!(
+            proxy.admin_privacy_read_discards_for_test(),
+            0,
+            "phase-bound refresh aborts must close the snapshot without discarding it"
+        );
+        proxy
+            .verify_admin_privacy_read_connection_clean_for_test()
+            .await
+            .expect("the next privacy transaction is clean after a phase-bound refresh abort");
     }
 }

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -64,7 +64,7 @@ impl TavilyProxy {
             .key_store
             .upstream_privacy_status_from_snapshot(&mut session)
             .await;
-        let close = session.close().await;
+        let close = session.close_after_query(result.as_ref().err()).await;
         match (result, close) {
             (Ok(status), Ok(())) => Ok(status),
             (Err(error), _) | (_, Err(error)) => Err(error),
@@ -85,6 +85,14 @@ impl TavilyProxy {
         self.key_store
             .sqlite_runtime
             .discarded_connections_for_test(crate::store::SqliteOperation::AdminPrivacyRead)
+    }
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn admin_privacy_read_errors_for_test(&self) -> u64 {
+        self.key_store
+            .sqlite_runtime
+            .operation_errors_for_test(crate::store::SqliteOperation::AdminPrivacyRead)
     }
 
     #[cfg(debug_assertions)]

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -71,6 +71,33 @@ impl TavilyProxy {
         }
     }
 
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn install_admin_privacy_read_pause_for_test(
+        &self,
+    ) -> crate::store::RequestStatsPostFlushPause {
+        self.key_store.install_admin_privacy_read_pause().await
+    }
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn admin_privacy_read_discards_for_test(&self) -> u64 {
+        self.key_store
+            .sqlite_runtime
+            .discarded_connections_for_test(crate::store::SqliteOperation::AdminPrivacyRead)
+    }
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub async fn verify_admin_privacy_read_connection_clean_for_test(&self) -> Result<(), ProxyError> {
+        self.key_store
+            .sqlite_runtime
+            .begin_immediate(crate::store::SqliteOperation::AdminPrivacyRead)
+            .await?
+            .rollback()
+            .await
+    }
+
     pub async fn record_upstream_reconciliation_usage(
         &self,
         token_id: &str,

--- a/src/tests/jobs_and_request_log_retention.rs
+++ b/src/tests/jobs_and_request_log_retention.rs
@@ -36,6 +36,8 @@ async fn quota_subject_lock_retries_transient_sqlite_write_lock() {
         forced_pending_claim_miss_log_ids: Mutex::new(std::collections::HashSet::new()),
         #[cfg(test)]
         dashboard_overview_read_pause: Arc::new(Mutex::new(None)),
+        #[cfg(debug_assertions)]
+        admin_privacy_read_pause: Arc::new(Mutex::new(None)),
         forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(
             std::collections::HashSet::new(),
         ),

--- a/src/tests/request_kind_and_core.rs
+++ b/src/tests/request_kind_and_core.rs
@@ -2304,6 +2304,8 @@ async fn request_kind_database_migration_retries_after_transient_write_lock() {
         forced_pending_claim_miss_log_ids: Mutex::new(std::collections::HashSet::new()),
         #[cfg(test)]
         dashboard_overview_read_pause: Arc::new(Mutex::new(None)),
+        #[cfg(debug_assertions)]
+        admin_privacy_read_pause: Arc::new(Mutex::new(None)),
         forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(
             std::collections::HashSet::new(),
         ),


### PR DESCRIPTION
## Summary

- Serve immutable privacy-status last-good data from an AppState controller and refresh it in one pressure-aware flight.
- Prewarm the owner-facing read model after listener readiness; stale cache reads no longer cancel open SQLite snapshots.
- Fence new refreshes immediately on shutdown and cooperatively drain the owned refresh before process exit.
- Keep `AdminPrivacyRead BEGIN` bounded by its connection-local busy timeout, returning the connection to the pool on contention.
- Preserve diagnostic fields, document the read-isolation contract, and add regressions for stale, cold, singleflight, ready, shutdown, clean-connection, and deferred-start prewarm behavior.

## Validation

- `cargo test --bin tavily-hikari listener_ready_hook_schedules_privacy_status_prewarm -- --nocapture`
- `cargo test --bin tavily-hikari admin_privacy_status -- --nocapture`
- `cargo test --bin tavily-hikari admin_system_status_reports_reconciliation_diagnostic_timestamps -- --nocapture`
- `cargo test --lib admin_privacy_read_session_is_bounded_and_independent_of_bulk_admission -- --nocapture`
- `cargo fmt --check && cargo clippy --locked -j 2 -- -D warnings`
- `python3 scripts/ci_backend_tests.py run-shard --id bin-admin-api-lifecycle`

## Baseline

- Implementation began with `origin/main` locked at `e559ab868f60ac6c197143f24a38f103d3b7a4f0`.
- During final convergence, `origin/main` advanced to `b5caf4b8b7cc4ef3e2ea087336916376662a5f83`; the PR branch was rebased onto that current base and all SHA-bound validation, CI, and review evidence was refreshed.

No production endpoint, deployment, pool-size, WAL, timeout, or reconciliation-billing configuration was changed.
