### PR TITLE
fix(rollup): recover canonicalized rebalance audits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,12 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
 - `best-effort audit`: rebalance audit records are capped in memory and may report stale coverage
   when contention or capacity prevents persistence. A missing audit record never changes MCP
   response semantics, billing truth, or durable business work.
+- `rebalance audit`: an observational record of a rebalance MCP request. It is not billing truth
+  or durable business work, and its presence does not prove that a derived dashboard projection is
+  complete.
+- `dashboard rollup recovery`: automatic reconciliation of the dashboard's derived request
+  projection from retained rebalance audit records. It may correct the projection without changing
+  the original audit records or request outcome.
 - `staged pressure generation`: a source-fenced server-pressure rebuild generation that remains
   invisible until atomic publish. Source scans use 500-row keyset slices, transition events replay
   after publish, and obsolete generations are cleaned in 25-row slices so live-tail correctness

--- a/docs/adr/0003-rebalance-audit-rollup-recovery.md
+++ b/docs/adr/0003-rebalance-audit-rollup-recovery.md
@@ -1,0 +1,3 @@
+# Rebalance audit rollup recovery
+
+Dashboard rollup recovery identifies retained rebalance audit records by their durable gateway, experiment, and upstream-operation markers, not by request classification fields that canonicalization may fill during insertion. Advancing the recovery semantic version reopens a previously completed operation so the existing fenced, bounded, zero-maintenance worker can replace affected minute buckets and re-audit their sealed days without modifying the source logs or request semantics.

--- a/docs/specs/admin-dashboard-hourly-request-charts/HISTORY.md
+++ b/docs/specs/admin-dashboard-hourly-request-charts/HISTORY.md
@@ -1,5 +1,6 @@
 # Admin 仪表盘请求趋势图表演进历史（#h2698）
 
+- 2026-08-25: 修复 rebalance 异步审计漏记后的历史 recovery 资格。canonicalization 会补全请求分类字段，恢复因此改用持久 gateway/variant/upstream 标识，并通过 recovery 版本升级重新扫描此前错误完成的状态；分钟与日桶仍由既有有界 integrity worker 自动修复。
 - 2026-07-24: 两张自然日较昨日差值图被积分柱图与积分面积图替换。积分视图同时展示本地
   估算和上游实扣；前者来自请求 rollup，后者来自 quota 样本差分。未采样上游桶保持未知，
   避免将缺失数据误报为零。

--- a/docs/specs/admin-dashboard-hourly-request-charts/IMPLEMENTATION.md
+++ b/docs/specs/admin-dashboard-hourly-request-charts/IMPLEMENTATION.md
@@ -27,6 +27,7 @@
 - 已验证本地日封存 JSON seal。保留期内的迟到数据修复会刷新 daily rollup 与 seal；GC 删除原始日志前
   检查最早可见候选日的 seal 及分钟、日级 rollup 一致性，已过期日的 daily rollup 可以由 seal 校验并恢复。
   仅含被抑制 retry shadow 的日期不属于 dashboard 事实源，不会无故阻塞日志 GC。
+- rebalance recovery 使用持久三字段标识发现历史审计行；恢复版本升级会重新打开此前错误标记为完成的单例，继续沿用 source fence、5 分钟分片和日级复核。
 - 请求统计 coalescer 现在有可等待的关闭协议；服务在 graceful shutdown 返回后最多等待 20 秒 drain，
   Compose 给出 30 秒容器终止宽限。
 

--- a/docs/specs/admin-dashboard-hourly-request-charts/SPEC.md
+++ b/docs/specs/admin-dashboard-hourly-request-charts/SPEC.md
@@ -63,6 +63,10 @@
 - `request_logs` 是保留期内本地请求统计的事实源。审计必须使用既有
   `(visibility, created_at, id)` 索引分页读取，固定每个工作项的源数据 fence；不得在请求热路径新增
   写入，也不得在启动阶段重建原始日志。
+- rebalance 历史 recovery 的资格必须使用持久的
+  `visibility + gateway_mode=rebalance + experiment_variant=rebalance + upstream_operation=mcp`
+  标识；`request_kind_key` 等会被 canonicalization 触发器补全的字段不能作为“是否漏记”的证据。
+  recovery 语义版本落后时，必须重新建立单例的源范围、source fence 和 cursor，从保留源重新替换派生桶。
 - 审计工作项最多读取 500 条日志或消耗 150ms 读取预算。高密度时间片必须将游标和累计结果持久化，未
   完成前不得写入任何部分 rollup。
 - 聚合完成后才允许打开短写事务，精确替换受影响的分钟 rollup。写入目标为 100ms；超过 250ms 必须记

--- a/src/store/key_store_dashboard_rollup_integrity.rs
+++ b/src/store/key_store_dashboard_rollup_integrity.rs
@@ -8,7 +8,8 @@ const DASHBOARD_ROLLUP_INTEGRITY_WRITE_TARGET: Duration = Duration::from_millis(
 const DASHBOARD_ROLLUP_INTEGRITY_WRITE_WARN: Duration = Duration::from_millis(250);
 const DASHBOARD_ROLLUP_INTEGRITY_HOT_WINDOW_SECS: i64 = SECS_PER_DAY;
 const DASHBOARD_ROLLUP_INTEGRITY_STALLED_SECS: i64 = 2 * SECS_PER_HOUR;
-const DASHBOARD_ROLLUP_REBALANCE_RECOVERY_VERSION: i64 = 1;
+// Reopen v1 states: canonicalization made the old NULL selector unreachable.
+const DASHBOARD_ROLLUP_REBALANCE_RECOVERY_VERSION: i64 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DashboardRollupIntegritySlice {
@@ -311,7 +312,6 @@ impl KeyStore {
               AND gateway_mode = 'rebalance'
               AND experiment_variant = 'rebalance'
               AND upstream_operation = 'mcp'
-              AND request_kind_key IS NULL
             "#,
         )
         .bind(REQUEST_LOG_VISIBILITY_VISIBLE)

--- a/src/store/key_store_dashboard_rollup_integrity.rs
+++ b/src/store/key_store_dashboard_rollup_integrity.rs
@@ -309,12 +309,13 @@ impl KeyStore {
             SELECT MIN(created_at), MAX(created_at)
             FROM request_logs
             WHERE visibility = ?
-              AND gateway_mode = 'rebalance'
+              AND gateway_mode = ?
               AND experiment_variant = 'rebalance'
               AND upstream_operation = 'mcp'
             "#,
         )
         .bind(REQUEST_LOG_VISIBILITY_VISIBLE)
+        .bind(MCP_GATEWAY_MODE_REBALANCE)
         .fetch_one(&self.pool)
         .await?;
         let source_fence: i64 = sqlx::query_scalar("SELECT COALESCE(MAX(id), 0) FROM request_logs")

--- a/src/tests/dashboard_rollup_integrity.rs
+++ b/src/tests/dashboard_rollup_integrity.rs
@@ -560,12 +560,6 @@ async fn rebalance_rollup_recovery_is_fenced_and_resumable() {
     let proxy = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
         .await
         .expect("create proxy");
-    sqlx::query(
-        "DROP TRIGGER IF EXISTS observability.trg_request_logs_canonical_request_kind_insert",
-    )
-    .execute(&proxy.key_store.pool)
-    .await
-    .expect("disable canonical trigger for legacy recovery fixture");
     let now = proxy.backend_time().now_ts();
     let range_start = local_day_bucket_start_utc_ts(now - 2 * SECS_PER_DAY);
     let recovery_start = range_start + SECS_PER_FIVE_MINUTES;
@@ -577,8 +571,21 @@ async fn rebalance_rollup_recovery_is_fenced_and_resumable() {
         .await;
     }
     pin_integrity_after_hot_window(&proxy, now, range_start).await;
+    sqlx::query(
+        r#"
+        INSERT INTO dashboard_rollup_rebalance_recovery (
+            id, version, status, range_start, range_end, source_fence, cursor,
+            last_error, completed_at, updated_at
+        ) VALUES (1, 1, 'complete', NULL, NULL, 0, NULL, NULL, ?, ?)
+        "#,
+    )
+    .bind(now)
+    .bind(now)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed the previously false-complete recovery state");
     let matched: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM request_logs WHERE gateway_mode = 'rebalance' AND experiment_variant = 'rebalance' AND upstream_operation = 'mcp' AND request_kind_key IS NULL",
+        "SELECT COUNT(*) FROM request_logs WHERE gateway_mode = 'rebalance' AND experiment_variant = 'rebalance' AND upstream_operation = 'mcp' AND request_kind_key IS NOT NULL",
     )
     .fetch_one(&proxy.key_store.pool)
     .await
@@ -597,11 +604,23 @@ async fn rebalance_rollup_recovery_is_fenced_and_resumable() {
         .expect("read recovery integrity status");
     assert_eq!(integrity_status.state, "repairing");
     assert!(integrity_status.unverified_bucket_count > 0);
+    let recovery_version: i64 =
+        sqlx::query_scalar("SELECT version FROM dashboard_rollup_rebalance_recovery WHERE id = 1")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read recovery version");
+    assert_eq!(recovery_version, 2);
     let second = proxy
         .run_dashboard_rollup_integrity_slice()
         .await
         .expect("resume fenced recovery slice");
     assert_eq!(second.state, "repaired");
+    let recovery_status_after_minute_repair: String =
+        sqlx::query_scalar("SELECT status FROM dashboard_rollup_rebalance_recovery WHERE id = 1")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read recovery status before day re-audit");
+    assert_eq!(recovery_status_after_minute_repair, "pending");
     let third = proxy
         .run_dashboard_rollup_integrity_slice()
         .await
@@ -637,6 +656,24 @@ async fn rebalance_rollup_recovery_is_fenced_and_resumable() {
     .await
     .expect("read idempotent recovery rollup");
     assert_eq!(idempotent_total, 501);
+
+    drop(proxy);
+    let restarted = TavilyProxy::with_endpoint(Vec::<String>::new(), DEFAULT_UPSTREAM, &db_str)
+        .await
+        .expect("restart proxy after recovery completion");
+    restarted
+        .run_dashboard_rollup_integrity_slice()
+        .await
+        .expect("verify completed recovery remains resumable after restart");
+    let restarted_total: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(total_requests), 0) FROM dashboard_request_rollup_buckets WHERE bucket_secs = 60 AND bucket_start >= ? AND bucket_start < ?",
+    )
+    .bind(recovery_start)
+    .bind(recovery_start + SECS_PER_FIVE_MINUTES)
+    .fetch_one(&restarted.key_store.pool)
+    .await
+    .expect("read restarted recovery rollup");
+    assert_eq!(restarted_total, 501);
 }
 
 async fn pin_integrity_hot_work(proxy: &TavilyProxy, range_start: i64, range_end: i64) {

--- a/src/tests/dashboard_rollup_integrity.rs
+++ b/src/tests/dashboard_rollup_integrity.rs
@@ -507,12 +507,13 @@ async fn insert_rebalance_recovery_log(proxy: &TavilyProxy, created_at: i64) {
         ) VALUES (
             NULL, 'POST', '/mcp', NULL, 200, 200,
             NULL, 'success', NULL, NULL,
-            NULL, 'rebalance', 'rebalance', 'mcp',
+            NULL, ?, 'rebalance', 'mcp',
             '{"jsonrpc":"2.0","method":"tools/call"}', '{"result":{}}', '[]', '[]',
             'visible', ?
         )
         "#,
     )
+    .bind(MCP_GATEWAY_MODE_REBALANCE)
     .bind(created_at)
     .execute(&proxy.key_store.pool)
     .await
@@ -585,8 +586,9 @@ async fn rebalance_rollup_recovery_is_fenced_and_resumable() {
     .await
     .expect("seed the previously false-complete recovery state");
     let matched: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM request_logs WHERE gateway_mode = 'rebalance' AND experiment_variant = 'rebalance' AND upstream_operation = 'mcp' AND request_kind_key IS NOT NULL",
+        "SELECT COUNT(*) FROM request_logs WHERE gateway_mode = ? AND experiment_variant = 'rebalance' AND upstream_operation = 'mcp' AND request_kind_key IS NOT NULL",
     )
+    .bind(MCP_GATEWAY_MODE_REBALANCE)
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("count matching recovery source logs");


### PR DESCRIPTION
## Delivery role
Direct fast-track PR. Stop condition: merge-ready / Step 5C Ready.

## Summary
The canonical request-kind trigger fills `request_kind_key` on legacy rebalance audit rows, so the v1 recovery selector requiring `request_kind_key IS NULL` could never find the rows it was intended to repair. This change advances the recovery semantic version to v2 and selects retained rows by durable rebalance markers instead. Existing source fences, bounded five-minute work items, SQLite admission, short writes, lock deferral, and sealed-day re-audit behavior remain unchanged.

No request classification, neutral/unknown semantics, dashboard UI, API, manual endpoint, CLI, SQL maintenance path, or synchronous rebuild was changed.

## Spec and docs
- Spec: `docs/specs/admin-dashboard-hourly-request-charts/`
- Spec disposition: synced `SPEC.md`, `IMPLEMENTATION.md`, and `HISTORY.md`.
- Solutions: none.
- Project Docs: `CONTEXT.md` updated with the audit/projection boundary.
- ADR: `docs/adr/0003-rebalance-audit-rollup-recovery.md`.

## Validation
- `python3 scripts/ci_backend_tests.py run-shard --id lib-request-rollup-integrity` (19 passed)
- `cargo test --lib tests::dashboard_rollup_integrity::rebalance_rollup_recovery_is_fenced_and_resumable -- --exact` (passed)
- pre-commit: clippy, fmt, Markdown format, commitlint (passed)
- Read-only SQLite backup from machine 101 to an isolated `/srv/codex` testbox run: both databases passed `PRAGMA integrity_check` and SHA-256 verification.
- Candidate container on the testbox automatically reopened v1 `complete` as v2 `pending`, repaired the first historical five-minute slice, advanced the cursor, and verified `raw=272` equals `rollup=272`. Test containers, network, snapshot copies, and run directory were removed.

Production was not modified or restarted. A normal version update remains separately authorized and does not require a maintenance window.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
