### PR TITLE
test(ci): synchronize async lifecycle tests

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -82,6 +82,8 @@ use tavily_hikari::{
 use tokio::signal;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal as unix_signal};
+#[cfg(test)]
+use tokio::sync::Notify;
 use tokio::sync::{Mutex, OwnedMutexGuard, RwLock, Semaphore};
 use tokio_util::io::{ReaderStream, StreamReader};
 include!("state.rs");

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2123,6 +2123,15 @@ mod serve_tests {
             state.proxy.foreground_activity_rps() > 5,
             "test must establish foreground pressure before startup prewarm"
         );
+        let prewarm_deferred = admin_privacy_status_prewarm_deferred_signal_for_test(
+            state.as_ref(),
+        )
+        .await
+        .notified_owned();
+        let last_good_published =
+            admin_privacy_status_last_good_published_signal_for_test(state.as_ref())
+                .await
+                .notified_owned();
         prewarm_gate_tx.send(()).expect("release listener-ready prewarm");
         let state = tokio::time::timeout(Duration::from_secs(2), async {
             tokio::select! {
@@ -2133,26 +2142,25 @@ mod serve_tests {
             .await
             .expect("server reached listener-ready hook");
 
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::timeout(Duration::from_secs(1), prewarm_deferred)
+            .await
+            .expect("startup prewarm observed foreground pressure");
         assert!(
             admin_privacy_status_cached(state.as_ref()).await.is_none(),
             "startup prewarm must defer while foreground pressure is active"
         );
-
-        for _ in 0..500 {
-            if admin_privacy_status_cached(state.as_ref()).await.is_some() {
-                shutdown_tx.send(()).expect("signal server shutdown");
-                tokio::time::timeout(Duration::from_secs(2), &mut server)
-                    .await
-                    .expect("server shuts down")
-                    .expect("server exits cleanly");
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        let _ = shutdown_tx.send(());
-        let _ = server.await;
-        panic!("deferred listener-ready prewarm did not publish privacy-status last-good data");
+        tokio::time::timeout(Duration::from_secs(2), last_good_published)
+            .await
+            .expect("deferred listener-ready prewarm published privacy-status last-good data");
+        assert!(
+            admin_privacy_status_cached(state.as_ref()).await.is_some(),
+            "deferred listener-ready prewarm must publish privacy-status last-good data"
+        );
+        shutdown_tx.send(()).expect("signal server shutdown");
+        tokio::time::timeout(Duration::from_secs(2), &mut server)
+            .await
+            .expect("server shuts down")
+            .expect("server exits cleanly");
     }
 
     #[tokio::test]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -136,6 +136,10 @@ struct AdminPrivacyStatusController {
     refresh_task: Option<tokio::task::JoinHandle<()>>,
     prewarm_task: Option<tokio::task::JoinHandle<()>>,
     shutting_down: bool,
+    #[cfg(test)]
+    prewarm_deferred: Arc<Notify>,
+    #[cfg(test)]
+    last_good_published: Arc<Notify>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -200,6 +204,30 @@ pub(crate) async fn admin_privacy_status_cached(
     let cache = cache.lock().await;
     let entry = cache.admin_privacy_status.last_good.as_ref()?;
     Some((entry.value.clone(), entry.observed_at))
+}
+
+#[cfg(test)]
+pub(crate) async fn admin_privacy_status_prewarm_deferred_signal_for_test(
+    state: &AppState,
+) -> Arc<Notify> {
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_privacy_status
+        .prewarm_deferred
+        .clone()
+}
+
+#[cfg(test)]
+pub(crate) async fn admin_privacy_status_last_good_published_signal_for_test(
+    state: &AppState,
+) -> Arc<Notify> {
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_privacy_status
+        .last_good_published
+        .clone()
 }
 
 pub(crate) async fn admin_privacy_status_last_good(
@@ -309,6 +337,11 @@ async fn finish_admin_privacy_status_refresh(
                 stored_at: tokio::time::Instant::now(),
             });
             cache.admin_privacy_status.last_refresh_reason = None;
+            #[cfg(test)]
+            cache
+                .admin_privacy_status
+                .last_good_published
+                .notify_waiters();
         }
         Err(error) => {
             cache.admin_privacy_status.last_refresh_reason = Some(
@@ -370,6 +403,13 @@ pub(crate) async fn prewarm_admin_privacy_status(state: Arc<AppState>) {
                 AdminPrivacyStatusRefreshStart::InFlight => {}
                 AdminPrivacyStatusRefreshStart::Deferred { reason: "shutdown" } => return,
                 AdminPrivacyStatusRefreshStart::Deferred { reason } => {
+                    #[cfg(test)]
+                    dashboard_overview_cache_for_state(state.as_ref())
+                        .lock()
+                        .await
+                        .admin_privacy_status
+                        .prewarm_deferred
+                        .notify_waiters();
                     emit_admin_privacy_status_prewarm_deferred(reason);
                 }
             }

--- a/src/store/key_store_request_stats_flush_and_public_metrics.rs
+++ b/src/store/key_store_request_stats_flush_and_public_metrics.rs
@@ -404,6 +404,12 @@ impl KeyStore {
             }
         };
 
+        if flush_result.is_ok() {
+            #[cfg(test)]
+            request_stats_coalescer
+                .wait_for_post_flush_pause_if_installed()
+                .await;
+        }
         {
             let mut state = request_stats_coalescer.state.lock().await;
             state.flushing = false;
@@ -430,10 +436,6 @@ impl KeyStore {
             }
             request_stats_coalescer.flushed.notify_waiters();
         }
-        #[cfg(test)]
-        request_stats_coalescer
-            .wait_for_post_flush_pause_if_installed()
-            .await;
         Ok(())
     }
 

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -798,25 +798,59 @@ async fn admin_summary_does_not_start_a_slow_background_flush() {
 
     let flush_arrived = pause.arrived.clone().notified_owned();
     proxy.nudge_request_stats_flush().await;
-    // The worker's production slice remains wall-clock bounded to 50ms, but
-    // CI can spend more than one scheduler second starting a fresh SQLite
-    // worker after this test is launched alongside the neighboring admin cases.
+    // This bounds worker startup only. Completion is synchronized below with
+    // the coalescer's owned lifecycle state rather than this arrival deadline.
     tokio::time::timeout(Duration::from_secs(5), flush_arrived)
         .await
         .expect("explicit background flush reached post-flush pause");
+    assert!(
+        proxy
+            .key_store
+            .request_stats_coalescer
+            .state
+            .lock()
+            .await
+            .flushing,
+        "post-flush pause must retain flush ownership until the worker is released"
+    );
+    let summary_while_flush_paused = proxy
+        .summary()
+        .await
+        .expect("summary during background flush");
+    assert_eq!(
+        summary_while_flush_paused.total_requests, 1,
+        "summary reads must observe the durable data committed by the explicit flush"
+    );
+    assert!(
+        proxy
+            .key_store
+            .request_stats_coalescer
+            .state
+            .lock()
+            .await
+            .flushing,
+        "summary reads must not complete or replace the paused background flush"
+    );
 
-    pause
-        .released
-        .store(true, std::sync::atomic::Ordering::SeqCst);
-    pause.release.notify_waiters();
+    pause.release();
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        proxy.wait_until_request_stats_flush_finishes_for_test(),
+    )
+    .await
+    .expect("explicit background flush leaves its owned lifecycle state");
 
     let summary_after = proxy
-        .summary()
+        .summary_without_flush()
         .await
         .expect("summary after background flush");
     assert_eq!(summary_after.total_requests, 1);
     assert_eq!(summary_after.success_count, 1);
 
+    proxy
+        .shutdown_request_stats_coalescer(Duration::from_secs(2))
+        .await
+        .expect("stop request-stats worker before test cleanup");
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));


### PR DESCRIPTION
## Summary

- synchronize the privacy prewarm test with explicit deferred and published lifecycle signals
- keep request-stats flush ownership through the test pause and await worker completion before cleanup

## Delivery

- Delivery role: direct
- Spec: -
- Spec Disposition: link (existing SQLite lifecycle contracts unchanged)
- Solutions: -
- Project Docs: -

## Validation

- `cargo clippy --locked -j 2 -- -D warnings`
- `cargo test --locked --bin tavily-hikari server::serve_tests::listener_ready_hook_schedules_privacy_status_prewarm -- --exact --nocapture`
- `cargo test --locked --lib tests::request_rollup_public_metrics::admin_summary_does_not_start_a_slow_background_flush -- --exact --nocapture`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-request-rollup-reporting`
- `python3 scripts/ci_backend_tests.py run-shard --id bin-admin-api-lifecycle`

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->
