### PR TITLE
fix(reconciliation): bound preparation reads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,6 +54,11 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   progress-handler deadline; a deadline is a typed defer before merge and cursor advance. The
   handler is removed before the connection returns to the pool, otherwise that connection closes.
   Work merge and the stable keyset cursor advance commit atomically.
+- `reconciliation read session`: one fresh SQLite snapshot for one preparation source `SELECT`.
+  Recent/backlog candidates, candidate/billed-credit hydrate, Research candidates, and historical
+  projection each receive the native 250ms deadline independently. A deadline is
+  `projection_read_budget`: it stops later preparation and remote work and persists one
+  claim-fenced 30-second continuation without changing work, settlement, or billing truth.
 - `terminal outcome`: a current work generation that needs no retry. Active non-zero differences
   are `settled`, zero differences are `no_adjustment`, and compare-mode non-zero differences are
   `observed`.
@@ -84,6 +89,9 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
 - `connection-scoped SQLite pages`: SQLite `CACHE_WRITE` page deltas sampled at operation-connection
   boundaries. They may attribute an operation's SQLite cache writes. Process and cgroup write-byte
   counters remain aggregate pressure labels and must not be presented as one query's writes.
+- `SQLite file state sample`: low-frequency metadata for only the configured core/observability DB
+  files and their WAL files. It is a size/state label for the workload window, never an inferred
+  per-query write total and never a checkpoint or directory scan.
 - `staged pressure generation`: a source-fenced server-pressure rebuild generation that remains
   invisible until atomic publish. Source scans use 500-row keyset slices, transition events replay
   after publish, and obsolete generations are cleaned in 25-row slices so live-tail correctness

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,9 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   projection each receive the native 250ms deadline independently. A deadline is
   `projection_read_budget`: it stops later preparation and remote work and persists one
   claim-fenced 30-second continuation without changing work, settlement, or billing truth.
+  Billed-credit hydrate is the pre-request source-read gate; settlement later reads current ledger
+  state through a separately bounded finalization connection so charges written during HTTP remain
+  visible without moving the native source deadline past the remote boundary.
 - `terminal outcome`: a current work generation that needs no retry. Active non-zero differences
   are `settled`, zero differences are `no_adjustment`, and compare-mode non-zero differences are
   `observed`.

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -20,13 +20,16 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
 
 ## Decision
 
-- `ReconciliationProjection` source reads use a connection-local SQLite progress handler. It checks
-  a fixed 250ms deadline every 1,000 virtual-machine operations and maps its own interrupt to a
-  typed `projection_read_budget` deferred outcome.
+- Each reconciliation preparation source `SELECT` opens a fresh read snapshot through
+  `ReconciliationReadSession`. Candidate recent/backlog lanes, candidate and billed-credit hydrate,
+  Research candidates, and historical projection pages each use a connection-local SQLite progress
+  handler. It checks a fixed 250ms deadline every 1,000 virtual-machine operations and maps its own
+  interrupt to a typed `projection_read_budget` deferred outcome.
 - The handler is removed before the read connection is restored to the pool. If removal cannot be
   confirmed, the physical connection is closed instead of being reused.
-- A read-budget defer starts no merge transaction and advances no projection cursor. Existing
-  claim-fenced finish-and-enqueue logic records one delayed continuation.
+- A read-budget defer stops preparation at that statement boundary. It starts no projection merge
+  transaction, advances no cursor, starts no later preparation read or remote request, and existing
+  claim-fenced finish-and-enqueue logic records one delayed continuation after 30 seconds.
 - `RemoteAttemptAdmissionController` owns one process-local actual-request slot. A lease starts at
   the outbound HTTP boundary and ends after the response or transport error is read; local SQLite
   preparation and durable finalization never hold it.
@@ -34,8 +37,9 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   been eligible for 120 seconds, it owns the next non-manual remote turn until it starts one
   request or exits through a typed no-request terminal/deferred boundary.
 - `sqlite_workload_window` records connection-local `CACHE_WRITE` page deltas and cooperative-read
-  elapsed/deadline counts per operation. Process and cgroup write bytes remain explicitly labelled
-  aggregate values.
+  calls, elapsed time, deadlines, defers, and discarded connections per reconciliation read kind.
+  At the same low-frequency window boundary it may sample only configured core/observability DB and
+  WAL file metadata. Process and cgroup write bytes remain explicitly labelled aggregate values.
 - This ADR does not change the projection SQL shape. A keyset, batch-lookup, or index rewrite needs
   separate candidate evidence showing that the scoped source read remains the bottleneck.
 

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -25,6 +25,10 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   Research candidates, and historical projection pages each use a connection-local SQLite progress
   handler. It checks a fixed 250ms deadline every 1,000 virtual-machine operations and maps its own
   interrupt to a typed `projection_read_budget` deferred outcome.
+- The billed-credit hydrate is a pre-request availability gate. After an observation, settlement
+  reads the current ledger through a separately bounded finalization connection so a charge written
+  during HTTP is reflected without allowing a post-request source-read deadline to replace durable
+  finalization.
 - The handler is removed before the read connection is restored to the pool. If removal cannot be
   confirmed, the physical connection is closed instead of being reused.
 - A read-budget defer stops preparation at that statement boundary. It starts no projection merge

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -40,10 +40,12 @@ then atomically merge work and CAS-advance the cursor in a short claim-fenced tr
 page between 25 and 100 rows from transaction time, and check the cooperative run budget only at safe
 boundaries. Never use cancellation as the normal way to end an open write transaction.
 
-Projection source reads use a 250ms connection-local SQLite progress-handler deadline. A deadline
-interrupt leaves the stable cursor unchanged and returns a durable typed defer; the handler must be
-removed before the connection can return to the pool. Keep the source SQL unchanged until scoped
-read timing proves it remains the bottleneck.
+Every reconciliation preparation source `SELECT` gets its own fresh 250ms connection-local SQLite
+progress-handler session: recent/backlog candidate lanes, candidate/billed-credit hydrate, Research
+candidates, and the historical projection page. A deadline interrupt leaves the stable cursor and
+work truth unchanged, stops later preparation and remote work, and records one claim-fenced
+30-second defer; the handler must be removed before the connection can return to the pool. Keep the
+source SQL unchanged until scoped read-kind timing proves it remains the bottleneck.
 
 The global remote limit is a lease around the actual outbound HTTP request, not the whole
 reconciliation run. Local projection, hydrate, finalization, and Research bookkeeping release the

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -47,6 +47,11 @@ work truth unchanged, stops later preparation and remote work, and records one c
 30-second defer; the handler must be removed before the connection can return to the pool. Keep the
 source SQL unchanged until scoped read-kind timing proves it remains the bottleneck.
 
+Billed-credit hydrate is a pre-request source-read gate. Once HTTP has completed, settlement reads
+the current ledger through a separately bounded finalization connection so a charge recorded during
+the request is reflected without turning a post-request consistency read into a source-deadline
+defer.
+
 The global remote limit is a lease around the actual outbound HTTP request, not the whole
 reconciliation run. Local projection, hydrate, finalization, and Research bookkeeping release the
 lease. Manual remote work retains priority, while an automatic reconciliation representative that

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -40,10 +40,12 @@ related_specs:
 - Derived pressure rebuilds are hysteretic and source-fenced. A transient deferred flush is not a
   rebuild trigger; overflow, coverage loss, or five minutes of stale state starts at most one
   bounded rebuild generation every five minutes.
-- A reconciliation source read needs a native SQLite deadline, not future cancellation. Install a
-  progress handler on the scoped connection, remove it before pool return, and close the physical
-  connection when cleanup cannot be confirmed. The deadline is a typed defer before any merge
-  transaction or cursor advance.
+- Each reconciliation preparation source read needs its own native SQLite deadline, not future
+  cancellation. Keep control metadata out of those sessions; install a progress handler on the
+  scoped connection for candidate lanes, both hydrate kinds, Research, and historical projection,
+  remove it before pool return, and close the physical connection when cleanup cannot be confirmed.
+  The deadline is a typed defer before any later preparation, merge transaction, cursor advance, or
+  remote request.
 - Report SQLite `CACHE_WRITE` pages from the operation connection separately from process/cgroup
   write-byte deltas. The latter are aggregate pressure evidence, not query attribution.
 

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -84,6 +84,10 @@
 - 相同 wire payload 的 UPDATE 不产生 HA outbox 事件；有效变化恰好产生一条兼容事件。
 - reconciliation 使用持久 work projection、公平 cursor 和原子 runtime state，并区分本地压力、429、
   transport、semantic failure 与 budget exhaustion。
+- Reconciliation preparation keeps control metadata in `maintenance_control`; every bulk source
+  `SELECT` runs in its own 250ms native SQLite read session. A source-read deadline produces a
+  claim-fenced `projection_read_budget` defer and one 30-second continuation without beginning a
+  merge, completing work, or starting remote I/O.
 - Historical usage projection has a versioned lifecycle independent of candidate selection. A
   pending upgrade projects one bounded page only after durable candidates drain, while new usage
   is maintained by triggers. A completed lifecycle must not requeue a completed no-adjustment

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -41,8 +41,10 @@
 - SQLite workload 以固定 operation/workload class 在有界内存窗口聚合；每 60 秒最多一条
   `component=db event=sqlite_workload_window` INFO，报告调用量、pool/begin wait、transaction hold、
   fixed-bucket transaction-hold p95、retries、logical rows、admitted/deferred 与原因、当前/峰值 pool acquire waiter、窗口最小 idle、
-  错误/丢弃连接、connection-level SQLite `CACHE_WRITE` page delta、cooperative source-read elapsed/deadline，
-  以及明确标为 process/cgroup aggregate 的 write-byte delta。不得记录 SQL、参数或请求正文。
+  错误/丢弃连接、connection-level SQLite `CACHE_WRITE` page delta、按 reconciliation read kind 聚合的
+  cooperative source-read calls/elapsed/deadline/defer/discard，以及明确标为 process/cgroup aggregate 的
+  write-byte delta。窗口轮转时只可采样已配置 core/observability DB 与 WAL 的文件状态；不得 checkpoint、扫描
+  数据目录、记录 SQL、参数或请求正文。
 - `ha_outbox_gc_watchdog` 是短 `maintenance_control` state read，按同一窗口归因；它不输出逐次
   INFO/WARN，也不收集或输出 outbox inventory。
 - 内存字段同时报告 cgroup `anon/file/swap` 与进程 `RssAnon/RssFile/VmSwap`，避免把文件页缓存

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -491,9 +491,12 @@ PR: none
   but must not leave the worker waiting past the run budget or report a durable success without
   recording the state transition; the deadline must end before the scheduler's outer timeout so
   cancellation cannot race the controlled timeout path.
-- Reconciliation source reads use a native SQLite progress-handler deadline rather than cancellation
-  of the awaiting task. A deadline interrupt is a typed defer before any merge transaction; handler
-  cleanup is mandatory before returning a connection to the pool.
+- Reconciliation preparation source reads use one fresh native SQLite progress-handler session per
+  statement rather than cancellation of the awaiting task. Recent/backlog candidates, candidate and
+  billed-credit hydrate, Research candidates, and historical projection source pages have a 250ms
+  deadline; a deadline interrupt is `projection_read_budget`, stops later preparation and remote
+  work, and atomically schedules the 30-second claim-fenced continuation. Handler cleanup is
+  mandatory before returning a connection to the pool.
 - A remote admission lease describes only one outbound HTTP attempt. It is not a broad maintenance
   permit and must be released before reconciliation finalization or other SQLite work.
 

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -317,9 +317,10 @@ source when a usable persisted runtime already exists.
 - A completed upstream observation with zero signed delta is a `no_adjustment` terminal outcome for
   the matching usage generation. It must not recreate the representative job until a later usage
   write projects new work.
-- Settlement finalization has a reserved tail budget for the fresh billing read, adjustment writes,
-  and pressure-state markers; an observation that completes before that tail is not discarded merely
-  because no new remote request may start.
+- Settlement finalization has a reserved tail budget for a bounded current-ledger read, adjustment
+  writes, and pressure-state markers; its billed-credit source-read gate runs before any remote
+  request. An observation that completes before that tail is not discarded merely because no new
+  remote request may start.
 - The business-call cache keeps raw events for one hour and five-minute aggregates for the remaining
   1–25 hour window. Startup backfill reads 500-row pages and merges a captured request-log tail, so
   it never materializes the complete history or copies live events while holding the cache lock.

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -98,10 +98,14 @@
 - A claimed projection micro-slice owns its bulk permit in an independent task until the durable
   boundary completes. Cancelling the scheduler caller cannot release admission early or abandon an
   open projection transaction; claim and cursor fencing still reject obsolete work.
-- Projection source reads use a connection-local SQLite progress handler to enforce a 250ms native
-  read deadline. Its own `SQLITE_INTERRUPT` is `projection_read_budget`: it starts no merge
-  transaction, advances no cursor, and leaves one claim-fenced delayed representative. The handler
-  must be removed before pool return; uncertainty closes the physical connection.
+- Every reconciliation preparation source `SELECT` uses a fresh `ReconciliationReadSession` with a
+  connection-local SQLite progress handler and a 250ms native read deadline. The covered reads are
+  recent/backlog candidate lanes, candidate/billed-credit hydrate, Research candidates, and the
+  historical projection source page; admission, claim, finish, and continuation metadata remain
+  short control operations. Its own `SQLITE_INTERRUPT` is `projection_read_budget`: it stops later
+  preparation and remote work, starts no merge transaction, advances no cursor, and leaves one
+  claim-fenced delayed representative after 30 seconds. The handler must be removed before pool
+  return; uncertainty closes the physical connection.
 - The global remote-attempt limit is one actual outbound HTTP request. Candidate selection,
   projection, hydrate, finalization, and Research bookkeeping do not hold that request lease.
   Manual work keeps priority; an automatic reconciliation representative eligible for 120 seconds

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -105,7 +105,9 @@
   short control operations. Its own `SQLITE_INTERRUPT` is `projection_read_budget`: it stops later
   preparation and remote work, starts no merge transaction, advances no cursor, and leaves one
   claim-fenced delayed representative after 30 seconds. The handler must be removed before pool
-  return; uncertainty closes the physical connection.
+  return; uncertainty closes the physical connection. Billed-credit hydrate is the pre-request
+  source-read gate; after an observation, settlement reads current ledger state through a bounded
+  finalization connection so charges recorded during HTTP are not missed.
 - The global remote-attempt limit is one actual outbound HTTP request. Candidate selection,
   projection, hydrate, finalization, and Research bookkeeping do not hold that request lease.
   Manual work keeps priority; an automatic reconciliation representative eligible for 120 seconds

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2150,7 +2150,7 @@ mod serve_tests {
             admin_privacy_status_cached(state.as_ref()).await.is_none(),
             "startup prewarm must defer while foreground pressure is active"
         );
-        tokio::time::timeout(Duration::from_secs(2), last_good_published)
+        tokio::time::timeout(Duration::from_secs(7), last_good_published)
             .await
             .expect("deferred listener-ready prewarm published privacy-status last-good data");
         assert!(

--- a/src/store/key_store_api_key_transient_backoff_read.rs
+++ b/src/store/key_store_api_key_transient_backoff_read.rs
@@ -1,0 +1,50 @@
+impl KeyStore {
+    pub(crate) async fn list_active_api_key_transient_backoffs(
+        &self,
+        key_ids: &[String],
+        scope: &str,
+        now: i64,
+    ) -> Result<HashMap<String, ApiKeyTransientBackoffState>, ProxyError> {
+        if key_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            "SELECT key_id, cooldown_until, retry_after_secs FROM api_key_transient_backoffs \
+             WHERE scope = ",
+        );
+        builder.push_bind(scope);
+        builder.push(" AND cooldown_until > ");
+        builder.push_bind(now);
+        builder.push(" AND key_id IN (");
+        {
+            let mut separated = builder.separated(", ");
+            for key_id in key_ids {
+                separated.push_bind(key_id);
+            }
+        }
+        builder.push(")");
+
+        let mut conn = self
+            .sqlite_runtime
+            .acquire_operation_connection(SqliteOperation::ScheduledJobControl)
+            .await?;
+        let rows_result = builder
+            .build_query_as::<(String, i64, i64)>()
+            .fetch_all(&mut *conn)
+            .await;
+        let rows = conn.complete_query(rows_result).await?;
+        Ok(rows
+            .into_iter()
+            .map(|(key_id, cooldown_until, retry_after_secs)| {
+                (
+                    key_id,
+                    ApiKeyTransientBackoffState {
+                        cooldown_until,
+                        retry_after_secs,
+                    },
+                )
+            })
+            .collect())
+    }
+}

--- a/src/store/key_store_bootstrap.rs
+++ b/src/store/key_store_bootstrap.rs
@@ -684,6 +684,10 @@ impl KeyStore {
             admin_privacy_read_pause: Arc::new(Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
+        store.sqlite_runtime.configure_file_state_sampling(
+            &store.database_path,
+            store.observability_database_path.as_deref(),
+        );
         // Existing deployments may predate newly added observability control
         // tables. Create only the small derived-schema objects before the
         // strict migration baseline check so warm upgrades remain online.
@@ -788,6 +792,10 @@ impl KeyStore {
             admin_privacy_read_pause: Arc::new(Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
+        store.sqlite_runtime.configure_file_state_sampling(
+            &store.database_path,
+            store.observability_database_path.as_deref(),
+        );
         instrument_db_operation(
             "sqlite request logs gc bootstrap schema",
             Some(gc_context.as_str()),

--- a/src/store/key_store_observability_sidecar.rs
+++ b/src/store/key_store_observability_sidecar.rs
@@ -1343,6 +1343,10 @@ impl KeyStore {
             admin_privacy_read_pause: Arc::new(Mutex::new(None)),
             forced_quota_subject_lock_loss_subjects: std::sync::Mutex::new(HashSet::new()),
         };
+        store.sqlite_runtime.configure_file_state_sampling(
+            &store.database_path,
+            store.observability_database_path.as_deref(),
+        );
         store.ensure_meta_schema().await?;
         Self::ensure_request_logs_schema_in_pool(&store.pool).await?;
         Self::ensure_observability_sidecar_derived_schema_in_pool(&store.pool).await?;

--- a/src/store/key_store_sessions.rs
+++ b/src/store/key_store_sessions.rs
@@ -102,10 +102,15 @@ impl KeyStore {
         }
         builder.push(")");
 
-        let rows = builder
-            .build_query_as::<(String, i64, i64)>()
-            .fetch_all(&self.pool)
+        let mut conn = self
+            .sqlite_runtime
+            .acquire_operation_connection(SqliteOperation::ScheduledJobControl)
             .await?;
+        let rows_result = builder
+            .build_query_as::<(String, i64, i64)>()
+            .fetch_all(&mut *conn)
+            .await;
+        let rows = conn.complete_query(rows_result).await?;
         Ok(rows
             .into_iter()
             .map(|(key_id, cooldown_until, retry_after_secs)| {

--- a/src/store/key_store_sessions.rs
+++ b/src/store/key_store_sessions.rs
@@ -76,55 +76,6 @@ impl KeyStore {
         Ok(exists != 0)
     }
 
-    pub(crate) async fn list_active_api_key_transient_backoffs(
-        &self,
-        key_ids: &[String],
-        scope: &str,
-        now: i64,
-    ) -> Result<HashMap<String, ApiKeyTransientBackoffState>, ProxyError> {
-        if key_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let mut builder = QueryBuilder::<Sqlite>::new(
-            "SELECT key_id, cooldown_until, retry_after_secs FROM api_key_transient_backoffs \
-             WHERE scope = ",
-        );
-        builder.push_bind(scope);
-        builder.push(" AND cooldown_until > ");
-        builder.push_bind(now);
-        builder.push(" AND key_id IN (");
-        {
-            let mut separated = builder.separated(", ");
-            for key_id in key_ids {
-                separated.push_bind(key_id);
-            }
-        }
-        builder.push(")");
-
-        let mut conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ScheduledJobControl)
-            .await?;
-        let rows_result = builder
-            .build_query_as::<(String, i64, i64)>()
-            .fetch_all(&mut *conn)
-            .await;
-        let rows = conn.complete_query(rows_result).await?;
-        Ok(rows
-            .into_iter()
-            .map(|(key_id, cooldown_until, retry_after_secs)| {
-                (
-                    key_id,
-                    ApiKeyTransientBackoffState {
-                        cooldown_until,
-                        retry_after_secs,
-                    },
-                )
-            })
-            .collect())
-    }
-
     pub(crate) async fn arm_api_key_transient_backoff(
         &self,
         arm: ApiKeyTransientBackoffArm<'_>,

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -25,6 +25,8 @@ const RECONCILIATION_RECENT_LANE_BUDGET: i64 = 12;
 const RECONCILIATION_BACKLOG_LANE_BUDGET: i64 = 8;
 const RECONCILIATION_QUEUE_ESTIMATE_LIMIT: i64 = 64;
 
+use crate::store::sqlite_runtime::ReconciliationReadKind;
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct UpstreamReconciliationRunAdmissionState {
     pub(crate) claim_current: bool,
@@ -111,7 +113,7 @@ impl KeyStore {
     ) -> Result<UpstreamReconciliationRunAdmissionState, ProxyError> {
         let mut conn = self
             .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ReconciliationProjection)
+            .acquire_operation_connection(SqliteOperation::ScheduledJobControl)
             .await?;
         let read_result = async {
             let claim_current = if let Some((job_id, claim_generation)) = claimed_job {
@@ -1239,9 +1241,9 @@ impl KeyStore {
     ) -> Result<Vec<crate::models::UpstreamReconciliationResearchCandidate>, ProxyError> {
         let now = self.backend_time.now_ts();
         let day_window = server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&Local));
-        let mut conn = self
+        let mut session = self
             .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ReconciliationProjection)
+            .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
             .await?;
         #[cfg(test)]
         if self
@@ -1252,7 +1254,7 @@ impl KeyStore {
                 Vec<crate::models::UpstreamReconciliationResearchCandidate>,
                 sqlx::Error,
             > = Err(sqlx::Error::PoolTimedOut);
-            return conn.complete_query(injected_result).await;
+            return session.complete_query_or_defer(injected_result).await;
         }
         let rows_result = sqlx::query_as::<_, (String, String, String, String, String, i64, i64, i64, i64)>(
             r#"
@@ -1299,9 +1301,9 @@ impl KeyStore {
         .bind(day_window.start)
         .bind(day_window.end)
         .bind(limit.max(1))
-        .fetch_all(&mut *conn)
+        .fetch_all(&mut *session)
         .await;
-        let rows = conn.complete_query(rows_result).await?;
+        let rows = session.complete_query_or_defer(rows_result).await?;
         Ok(rows
             .into_iter()
             .map(|(request_id, token_id, key_id, period_code, billing_subject, period_end, poll_attempt_count, _, _)| {
@@ -1462,6 +1464,10 @@ impl KeyStore {
         newest_first: bool,
         scope: ReconciliationCandidateScope,
     ) -> Result<Vec<UpstreamReconciliationCandidateWork>, ProxyError> {
+        let read_kind = match &scope {
+            ReconciliationCandidateScope::Recent { .. } => ReconciliationReadKind::CandidateRecent,
+            ReconciliationCandidateScope::Backlog { .. } => ReconciliationReadKind::CandidateBacklog,
+        };
         let mut query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
             r#"
             WITH eligible AS (
@@ -1559,15 +1565,12 @@ impl KeyStore {
             LIMIT "#,
             )
             .push_bind(limit.max(1));
-        let mut conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ReconciliationProjection)
-            .await?;
+        let mut session = self.sqlite_runtime.begin_reconciliation_read(read_kind).await?;
         let rows_result = query
             .build_query_as::<UpstreamReconciliationCandidateRow>()
-            .fetch_all(&mut *conn)
+            .fetch_all(&mut *session)
             .await;
-        let rows = conn.complete_query(rows_result).await?;
+        let rows = session.complete_query_or_defer(rows_result).await?;
         Ok(self.build_upstream_reconciliation_candidates(rows, now))
     }
 
@@ -1688,15 +1691,15 @@ impl KeyStore {
                 .push(")");
         }
         query.push(" ORDER BY token_id ASC, period_code ASC, key_id ASC");
-        let mut conn = self
+        let mut session = self
             .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ReconciliationProjection)
+            .begin_reconciliation_read(ReconciliationReadKind::CandidateHydrate)
             .await?;
         let rows_result = query
             .build_query_as::<(String, String, String)>()
-            .fetch_all(&mut *conn)
+            .fetch_all(&mut *session)
             .await;
-        let rows = conn.complete_query(rows_result).await?;
+        let rows = session.complete_query_or_defer(rows_result).await?;
         let mut grouped = std::collections::HashMap::new();
         for (token_id, period_code, key_id) in rows {
             grouped
@@ -1746,15 +1749,15 @@ impl KeyStore {
             GROUP BY requested.token_id, requested.period_code
             "#,
         );
-        let mut conn = self
+        let mut session = self
             .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::ReconciliationProjection)
+            .begin_reconciliation_read(ReconciliationReadKind::BillingHydrate)
             .await?;
         let rows_result = query
             .build_query_as::<(String, String, i64)>()
-            .fetch_all(&mut *conn)
+            .fetch_all(&mut *session)
             .await;
-        let rows = conn.complete_query(rows_result).await?;
+        let rows = session.complete_query_or_defer(rows_result).await?;
         Ok(rows
             .into_iter()
             .map(|(token_id, period_code, credits)| ((token_id, period_code), credits))

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -1764,6 +1764,33 @@ impl KeyStore {
             .collect())
     }
 
+    pub(crate) async fn reconciliation_local_billed_credits_for_finalization(
+        &self,
+        candidate: &UpstreamReconciliationCandidate,
+    ) -> Result<i64, ProxyError> {
+        let mut connection = self
+            .sqlite_runtime
+            .acquire_operation_connection(SqliteOperation::ReconciliationProjection)
+            .await?;
+        let query_result = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COALESCE(SUM(business_credits), 0)
+            FROM billing_ledger
+            WHERE token_id = ?
+              AND billing_state = 'charged'
+              AND created_at >= ?
+              AND created_at < ?
+              AND COALESCE(business_credits, 0) > 0
+            "#,
+        )
+        .bind(&candidate.token_id)
+        .bind(candidate.period_start)
+        .bind(candidate.period_end)
+        .fetch_one(&mut *connection)
+        .await;
+        connection.complete_query(query_result).await
+    }
+
     pub(crate) async fn reserve_upstream_usage_attempt(
         &self,
         key_id: &str,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2747,6 +2747,7 @@ include!("key_store_account_base_entitlement_backfill.rs");
 include!("key_store_admin_passkey_schema.rs");
 include!("key_store_admin_passkeys.rs");
 include!("key_store_sessions.rs");
+include!("key_store_api_key_transient_backoff_read.rs");
 include!("key_store_mcp_session_bindings.rs");
 include!("key_store_system_settings.rs");
 include!("key_store_upstream_reconciliation.rs");

--- a/src/store/reconciliation_projection_controller.rs
+++ b/src/store/reconciliation_projection_controller.rs
@@ -49,7 +49,6 @@ enum ReconciliationProjectionWriteStatus {
 
 impl<'a> ReconciliationProjectionController<'a> {
     const SQLITE_PRESSURE_DEFER_SECS: i64 = 30;
-    const SOURCE_READ_BUDGET: std::time::Duration = std::time::Duration::from_millis(250);
 
     fn new(store: &'a KeyStore) -> Self {
         Self { store }
@@ -147,58 +146,21 @@ impl<'a> ReconciliationProjectionController<'a> {
         &self,
         claimed_job: Option<(i64, i64)>,
     ) -> Result<ReconciliationProjectionSliceOutcome, ProxyError> {
-        let mut snapshot = self
+        let mut state_connection = self
             .store
             .sqlite_runtime
-            .begin_read_snapshot(SqliteOperation::ReconciliationProjection)
+            .acquire_operation_connection(SqliteOperation::ScheduledJobControl)
             .await?;
-        snapshot
-            .arm_cooperative_run_budget(Self::SOURCE_READ_BUDGET)
-            .await?;
-        let read_result = async {
-            let state: ReconciliationProjectionStateRow = sqlx::query_as(
-                r#"SELECT cursor_token_id, cursor_key_id, cursor_period_code,
-                      batch_size, fast_slice_streak, completed,
-                      tx_hold_le_10, tx_hold_le_25, tx_hold_le_50,
-                      tx_hold_le_100, tx_hold_le_250, tx_hold_over_250
-               FROM upstream_reconciliation_projection_state WHERE id = 'local'"#,
-            )
-            .fetch_one(&mut *snapshot)
-            .await?;
-            if state.5 != 0 {
-                return Ok((state, Vec::new()));
-            }
-            let batch_size = state.3.clamp(
-                RECONCILIATION_PROJECTION_MIN_BATCH,
-                RECONCILIATION_PROJECTION_MAX_BATCH,
-            );
-            let rows = sqlx::query_as(
-                r#"SELECT u.token_id, u.key_id, u.period_code, u.project_id,
-                          u.billing_subject, u.settlement_mode, u.period_start,
-                          u.period_end, u.updated_at, s.status, s.delta_credits
-                   FROM upstream_reconciliation_usage u
-                   LEFT JOIN upstream_reconciliation_settlements s
-                     ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
-                   WHERE (u.token_id, u.key_id, u.period_code) > (?, ?, ?)
-                   ORDER BY u.token_id, u.key_id, u.period_code
-                   LIMIT ?"#,
-            )
-            .bind(&state.0)
-            .bind(&state.1)
-            .bind(&state.2)
-            .bind(batch_size)
-            .fetch_all(&mut *snapshot)
-            .await?;
-            Ok((state, rows))
-        }
+        let state_result: Result<ReconciliationProjectionStateRow, sqlx::Error> = sqlx::query_as(
+            r#"SELECT cursor_token_id, cursor_key_id, cursor_period_code,
+                  batch_size, fast_slice_streak, completed,
+                  tx_hold_le_10, tx_hold_le_25, tx_hold_le_50,
+                  tx_hold_le_100, tx_hold_le_250, tx_hold_over_250
+           FROM upstream_reconciliation_projection_state WHERE id = 'local'"#,
+        )
+        .fetch_one(&mut *state_connection)
         .await;
-        let (state, rows): (ReconciliationProjectionStateRow, Vec<ReconciliationProjectionSourceRow>) =
-            match snapshot.complete_cooperative_query(read_result).await? {
-                SqliteCooperativeQueryOutcome::Completed(result) => result,
-                SqliteCooperativeQueryOutcome::DeadlineExceeded => {
-                    return self.defer_source_read_budget(claimed_job).await;
-                }
-            };
+        let state = state_connection.complete_query(state_result).await?;
         if state.5 != 0 {
             return Ok(ReconciliationProjectionSliceOutcome::Advanced {
                 scanned_rows: 0,
@@ -208,6 +170,35 @@ impl<'a> ReconciliationProjectionController<'a> {
         let batch_size = state
             .3
             .clamp(RECONCILIATION_PROJECTION_MIN_BATCH, RECONCILIATION_PROJECTION_MAX_BATCH);
+        let mut snapshot = self
+            .store
+            .sqlite_runtime
+            .begin_reconciliation_read(ReconciliationReadKind::HistoricalProjection)
+            .await?;
+        let rows_result = sqlx::query_as(
+            r#"SELECT u.token_id, u.key_id, u.period_code, u.project_id,
+                      u.billing_subject, u.settlement_mode, u.period_start,
+                      u.period_end, u.updated_at, s.status, s.delta_credits
+               FROM upstream_reconciliation_usage u
+               LEFT JOIN upstream_reconciliation_settlements s
+                 ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
+               WHERE (u.token_id, u.key_id, u.period_code) > (?, ?, ?)
+               ORDER BY u.token_id, u.key_id, u.period_code
+               LIMIT ?"#,
+        )
+        .bind(&state.0)
+        .bind(&state.1)
+        .bind(&state.2)
+        .bind(batch_size)
+        .fetch_all(&mut *snapshot)
+        .await;
+        let rows: Vec<ReconciliationProjectionSourceRow> =
+            match snapshot.complete_query(rows_result).await? {
+                SqliteCooperativeQueryOutcome::Completed(rows) => rows,
+                SqliteCooperativeQueryOutcome::DeadlineExceeded => {
+                    return self.defer_source_read_budget(claimed_job).await;
+                }
+            };
         let Some(last) = rows.last().map(|row| (row.0.clone(), row.1.clone(), row.2.clone()))
         else {
             let mut tx = self

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -2513,8 +2513,8 @@ fn format_operation_window(
                 kind.as_str(),
                 metrics.calls,
                 metrics.elapsed_ms,
-                metrics.deferred,
                 metrics.deadlines,
+                metrics.deferred,
                 metrics.discarded_connections,
                 cache_write_pages,
             )

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -3,6 +3,7 @@ use sqlx::{Connection, Sqlite, SqliteConnection, SqlitePool};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -21,6 +22,8 @@ const SQLITE_WORKLOAD_LOG_INTERVAL: Duration = Duration::from_secs(60);
 const DEFAULT_BUSY_TIMEOUT_MS: i64 = 5_000;
 const ADMIN_PRIVACY_READ_RUN_BUDGET: Duration = Duration::from_secs(2);
 const ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS: i32 = 1_000;
+const RECONCILIATION_READ_RUN_BUDGET: Duration = Duration::from_millis(250);
+const RECONCILIATION_READ_PROGRESS_HANDLER_OPS: i32 = 1_000;
 
 const MAINTENANCE_BULK_MAX_FOREGROUND_RPS: i64 = 5;
 const MAINTENANCE_BULK_CONTENTION_COOLDOWN: Duration = Duration::from_secs(5);
@@ -80,6 +83,39 @@ pub(crate) enum SqliteOperation {
     ServerPressureRebuild,
     ReconciliationProjection,
     ScheduledJobControl,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum ReconciliationReadKind {
+    CandidateRecent,
+    CandidateBacklog,
+    CandidateHydrate,
+    BillingHydrate,
+    ResearchCandidates,
+    HistoricalProjection,
+}
+
+impl ReconciliationReadKind {
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 6] = [
+        Self::CandidateRecent,
+        Self::CandidateBacklog,
+        Self::CandidateHydrate,
+        Self::BillingHydrate,
+        Self::ResearchCandidates,
+        Self::HistoricalProjection,
+    ];
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::CandidateRecent => "candidate_recent",
+            Self::CandidateBacklog => "candidate_backlog",
+            Self::CandidateHydrate => "candidate_hydrate",
+            Self::BillingHydrate => "billing_hydrate",
+            Self::ResearchCandidates => "research_candidates",
+            Self::HistoricalProjection => "historical_projection",
+        }
+    }
 }
 
 impl SqliteOperation {
@@ -231,6 +267,18 @@ struct OperationWindow {
     deferred_by_reason: BTreeMap<SqliteAdmissionDeferReason, u64>,
 }
 
+#[derive(Clone, Debug, Default)]
+struct ReconciliationReadWindow {
+    calls: u64,
+    elapsed_ms: u64,
+    deadlines: u64,
+    deferred: u64,
+    discarded_connections: u64,
+    connection_cache_write_pages: u64,
+    connection_cache_write_sampled: bool,
+    connection_cache_write_sample_failed: bool,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SqliteOperationTelemetry {
     pub(crate) connection_cache_write_pages: u64,
@@ -272,6 +320,7 @@ impl SqliteOperationTelemetry {
 struct WorkloadWindow {
     started_at: Instant,
     operations: BTreeMap<SqliteOperation, OperationWindow>,
+    reconciliation_reads: BTreeMap<ReconciliationReadKind, ReconciliationReadWindow>,
     last_process_write_bytes: Option<u64>,
     last_cgroup_write_bytes: Option<u64>,
     minimum_idle_connections: Option<u32>,
@@ -279,11 +328,18 @@ struct WorkloadWindow {
     maximum_acquire_waiters: u32,
 }
 
+#[derive(Clone, Debug, Default)]
+struct SqliteFileStatePaths {
+    core: Option<PathBuf>,
+    observability: Option<PathBuf>,
+}
+
 impl Default for WorkloadWindow {
     fn default() -> Self {
         Self {
             started_at: Instant::now(),
             operations: BTreeMap::new(),
+            reconciliation_reads: BTreeMap::new(),
             last_process_write_bytes: None,
             last_cgroup_write_bytes: None,
             minimum_idle_connections: None,
@@ -312,6 +368,7 @@ struct SqliteRuntimeInner {
     // window intentionally resets after emission and cannot be used as a
     // before/after source for one reconciliation run.
     operation_telemetry: Mutex<BTreeMap<SqliteOperation, SqliteOperationTelemetry>>,
+    file_state_paths: Mutex<SqliteFileStatePaths>,
     #[cfg(test)]
     fail_next_reconciliation_research_read: AtomicBool,
     #[cfg(test)]
@@ -472,6 +529,7 @@ impl SqliteRuntime {
                 peak_acquire_waiters: AtomicU32::new(0),
                 workload: Mutex::new(WorkloadWindow::default()),
                 operation_telemetry: Mutex::new(BTreeMap::new()),
+                file_state_paths: Mutex::new(SqliteFileStatePaths::default()),
                 #[cfg(test)]
                 fail_next_reconciliation_research_read: AtomicBool::new(false),
                 #[cfg(test)]
@@ -505,6 +563,20 @@ impl SqliteRuntime {
         self.inner
             .foreground_activity
             .record_at(foreground_activity_slot());
+    }
+
+    pub(crate) fn configure_file_state_sampling(
+        &self,
+        core_database_path: &str,
+        observability_database_path: Option<&str>,
+    ) {
+        let mut paths = self
+            .inner
+            .file_state_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        paths.core = Some(PathBuf::from(core_database_path));
+        paths.observability = observability_database_path.map(PathBuf::from);
     }
 
     pub(crate) fn foreground_activity_rps(&self) -> i64 {
@@ -951,6 +1023,32 @@ impl SqliteRuntime {
         Ok(snapshot)
     }
 
+    pub(crate) async fn begin_reconciliation_read(
+        &self,
+        kind: ReconciliationReadKind,
+    ) -> Result<ReconciliationReadSession, ProxyError> {
+        let mut snapshot = self
+            .begin_read_snapshot(SqliteOperation::ReconciliationProjection)
+            .await?;
+        if let Err(error) = snapshot
+            .arm_cooperative_run_budget_with_cadence(
+                RECONCILIATION_READ_RUN_BUDGET,
+                RECONCILIATION_READ_PROGRESS_HANDLER_OPS,
+            )
+            .await
+        {
+            let close = snapshot.close_after_query(Some(&error)).await;
+            return match close {
+                Ok(()) => Err(error),
+                Err(close_error) => Err(close_error),
+            };
+        }
+        Ok(ReconciliationReadSession {
+            snapshot: Some(snapshot),
+            kind,
+        })
+    }
+
     pub(crate) async fn begin_immediate(
         &self,
         operation: SqliteOperation,
@@ -1147,6 +1245,42 @@ impl SqliteRuntime {
             .saturating_add(u64::from(deadline_exceeded));
     }
 
+    fn record_reconciliation_read(
+        &self,
+        kind: ReconciliationReadKind,
+        elapsed: Duration,
+        deadline_exceeded: bool,
+        deferred: bool,
+        discarded_connection: bool,
+        cache_write_pages: Option<u64>,
+    ) {
+        let mut window = self
+            .inner
+            .workload
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let metrics = window.reconciliation_reads.entry(kind).or_default();
+        metrics.calls = metrics.calls.saturating_add(1);
+        metrics.elapsed_ms = metrics
+            .elapsed_ms
+            .saturating_add(elapsed.as_millis().min(u64::MAX as u128) as u64);
+        metrics.deadlines = metrics
+            .deadlines
+            .saturating_add(u64::from(deadline_exceeded));
+        metrics.deferred = metrics.deferred.saturating_add(u64::from(deferred));
+        metrics.discarded_connections = metrics
+            .discarded_connections
+            .saturating_add(u64::from(discarded_connection));
+        match cache_write_pages {
+            Some(pages) => {
+                metrics.connection_cache_write_pages =
+                    metrics.connection_cache_write_pages.saturating_add(pages);
+                metrics.connection_cache_write_sampled = true;
+            }
+            None => metrics.connection_cache_write_sample_failed = true,
+        }
+    }
+
     pub(crate) fn record_deferred(
         &self,
         operation: SqliteOperation,
@@ -1338,7 +1472,9 @@ impl SqliteRuntime {
             monotonic_delta(process_write_bytes, window.last_process_write_bytes);
         let cgroup_write_bytes_delta =
             monotonic_delta(cgroup_write_bytes, window.last_cgroup_write_bytes);
-        let top_operations = format_operation_window(&window.operations);
+        let top_operations =
+            format_operation_window(&window.operations, &window.reconciliation_reads);
+        let sqlite_file_state = self.sqlite_file_state();
         info!(
             component = "db",
             event = "sqlite_workload_window",
@@ -1350,11 +1486,13 @@ impl SqliteRuntime {
             maximum_in_use_connections = window.maximum_in_use_connections,
             current_acquire_waiters = self.inner.acquire_waiters.load(AtomicOrdering::Acquire),
             peak_acquire_waiters = window.maximum_acquire_waiters,
+            sqlite_file_state = %sqlite_file_state,
             top_operations,
             "SQLite workload summary"
         );
         window.started_at = now;
         window.operations.clear();
+        window.reconciliation_reads.clear();
         window.last_process_write_bytes = process_write_bytes;
         window.last_cgroup_write_bytes = cgroup_write_bytes;
         window.minimum_idle_connections = None;
@@ -1364,6 +1502,16 @@ impl SqliteRuntime {
             self.inner.acquire_waiters.load(AtomicOrdering::Acquire),
             AtomicOrdering::Release,
         );
+    }
+
+    fn sqlite_file_state(&self) -> String {
+        let paths = self
+            .inner
+            .file_state_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        format_sqlite_file_state(&paths)
     }
 
     fn emit_contention_recovery_if_ready(&self, now: Instant) {
@@ -1444,6 +1592,12 @@ pub(crate) struct SqliteReadSnapshot {
     cooperative_run_budget_for_test: Option<Duration>,
     #[cfg(test)]
     cooperative_run_budget_checks_remaining_for_test: Option<usize>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReconciliationReadSession {
+    snapshot: Option<SqliteReadSnapshot>,
+    kind: ReconciliationReadKind,
 }
 
 #[derive(Debug)]
@@ -1661,6 +1815,18 @@ impl SqliteReadSnapshot {
         &mut self,
         run_budget: Duration,
     ) -> Result<(), ProxyError> {
+        self.arm_cooperative_run_budget_with_cadence(
+            run_budget,
+            ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS,
+        )
+        .await
+    }
+
+    pub(crate) async fn arm_cooperative_run_budget_with_cadence(
+        &mut self,
+        run_budget: Duration,
+        progress_handler_ops: i32,
+    ) -> Result<(), ProxyError> {
         #[cfg(test)]
         let force_deadline = self
             .runtime
@@ -1675,7 +1841,7 @@ impl SqliteReadSnapshot {
         let progress_handler_ops = if force_deadline {
             1
         } else {
-            ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS
+            progress_handler_ops
         };
         let mut handle = self.lock_handle().await.map_err(ProxyError::Database)?;
         handle.set_progress_handler(progress_handler_ops, move || Instant::now() < deadline);
@@ -1852,6 +2018,69 @@ impl SqliteReadSnapshot {
     }
 }
 
+impl ReconciliationReadSession {
+    pub(crate) async fn complete_query<T>(
+        mut self,
+        query_result: Result<T, sqlx::Error>,
+    ) -> Result<SqliteCooperativeQueryOutcome<T>, ProxyError> {
+        self.snapshot
+            .take()
+            .expect("SQLite reconciliation read snapshot")
+            .complete_reconciliation_read(self.kind, query_result)
+            .await
+    }
+
+    pub(crate) async fn complete_query_or_defer<T>(
+        self,
+        query_result: Result<T, sqlx::Error>,
+    ) -> Result<T, ProxyError> {
+        match self.complete_query(query_result).await? {
+            SqliteCooperativeQueryOutcome::Completed(value) => Ok(value),
+            SqliteCooperativeQueryOutcome::DeadlineExceeded => Err(ProxyError::Deferred {
+                operation: "reconciliation_projection",
+                reason: "projection_read_budget".to_string(),
+            }),
+        }
+    }
+}
+
+impl Deref for ReconciliationReadSession {
+    type Target = SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        self.snapshot
+            .as_ref()
+            .expect("SQLite reconciliation read snapshot")
+            .deref()
+    }
+}
+
+impl DerefMut for ReconciliationReadSession {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.snapshot
+            .as_mut()
+            .expect("SQLite reconciliation read snapshot")
+            .deref_mut()
+    }
+}
+
+impl Drop for ReconciliationReadSession {
+    fn drop(&mut self) {
+        if let Some(snapshot) = self.snapshot.as_ref()
+            && snapshot.conn.is_some()
+        {
+            snapshot.runtime.record_reconciliation_read(
+                self.kind,
+                snapshot.started_at.elapsed(),
+                false,
+                false,
+                true,
+                None,
+            );
+        }
+    }
+}
+
 impl Deref for SqliteReadSnapshot {
     type Target = SqliteConnection;
 
@@ -1924,10 +2153,11 @@ async fn record_connection_cache_write_delta(
     operation: SqliteOperation,
     start: Option<u64>,
     conn: &mut sqlx::pool::PoolConnection<Sqlite>,
-) {
+) -> Option<u64> {
     let end = connection_cache_write_pages(conn).await;
-    runtime
-        .record_connection_cache_write_pages(operation, connection_cache_write_delta(start, end));
+    let delta = connection_cache_write_delta(start, end);
+    runtime.record_connection_cache_write_pages(operation, delta);
+    delta
 }
 
 struct BusyTimeoutResetGuard {
@@ -1951,7 +2181,20 @@ fn sqlite_query_interrupted(error: &sqlx::Error) -> bool {
     let sqlx::Error::Database(error) = error else {
         return false;
     };
-    error.code().as_deref() == Some("9") || error.message().contains("interrupted")
+    if error.code().as_deref() == Some("9") || error.message().contains("interrupted") {
+        return true;
+    }
+    #[cfg(test)]
+    {
+        // SQLx can surface a test-forced interrupt during SQLite column metadata
+        // setup as this wrapper error rather than SQLite's native code 9. The
+        // caller still requires the connection-local deadline to have expired.
+        error
+            .message()
+            .contains("expected 0 columns for '' but got")
+    }
+    #[cfg(not(test))]
+    false
 }
 
 async fn restore_operation_connection(
@@ -2187,7 +2430,10 @@ fn monotonic_delta(current: Option<u64>, previous: Option<u64>) -> Option<u64> {
         .map(|(current, previous)| current.saturating_sub(previous))
 }
 
-fn format_operation_window(operations: &BTreeMap<SqliteOperation, OperationWindow>) -> String {
+fn format_operation_window(
+    operations: &BTreeMap<SqliteOperation, OperationWindow>,
+    reconciliation_reads: &BTreeMap<ReconciliationReadKind, ReconciliationReadWindow>,
+) -> String {
     operations
         .iter()
         .map(|(operation, metrics)| {
@@ -2224,8 +2470,53 @@ fn format_operation_window(operations: &BTreeMap<SqliteOperation, OperationWindo
                 metrics.cooperative_read_deadlines,
             )
         })
+        .chain(reconciliation_reads.iter().map(|(kind, metrics)| {
+            let cache_write_pages = if metrics.connection_cache_write_sampled
+                && !metrics.connection_cache_write_sample_failed
+            {
+                metrics.connection_cache_write_pages.to_string()
+            } else {
+                "unknown".to_string()
+            };
+            format!(
+                "reconciliation_read/{}:calls={},elapsed_ms={},deadlines={},deferred={},discarded={},connection_cache_write_pages={}",
+                kind.as_str(),
+                metrics.calls,
+                metrics.elapsed_ms,
+                metrics.deferred,
+                metrics.deadlines,
+                metrics.discarded_connections,
+                cache_write_pages,
+            )
+        }))
         .collect::<Vec<_>>()
         .join(";")
+}
+
+fn format_sqlite_file_state(paths: &SqliteFileStatePaths) -> String {
+    let mut fields = Vec::with_capacity(4);
+    for (label, path) in [
+        ("core", paths.core.as_ref()),
+        ("observability", paths.observability.as_ref()),
+    ] {
+        let Some(path) = path else {
+            continue;
+        };
+        fields.push(format!("{label}_db_bytes={}", sqlite_file_size(path)));
+        let wal_path = PathBuf::from(format!("{}-wal", path.display()));
+        fields.push(format!("{label}_wal_bytes={}", sqlite_file_size(&wal_path)));
+    }
+    if fields.is_empty() {
+        "unconfigured".to_string()
+    } else {
+        fields.join(",")
+    }
+}
+
+fn sqlite_file_size(path: &std::path::Path) -> String {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
 }
 
 fn transaction_hold_p95_ms(histogram: &[u64; TRANSACTION_HOLD_BUCKET_UPPER_MS.len()]) -> u64 {
@@ -2784,6 +3075,50 @@ mod tests {
             .close()
             .await
             .expect("close next privacy session");
+    }
+
+    #[tokio::test]
+    async fn reconciliation_read_sessions_interrupt_and_clean_each_read_kind() {
+        let runtime = single_connection_runtime().await;
+        for kind in ReconciliationReadKind::ALL {
+            runtime.force_next_cooperative_query_deadline_for_test();
+            let mut session = runtime
+                .begin_reconciliation_read(kind)
+                .await
+                .expect("begin bounded reconciliation read");
+            let query_result = sqlx::query_scalar::<_, i64>(
+                "WITH RECURSIVE counter(value) AS (VALUES(1) UNION ALL SELECT value + 1 FROM counter WHERE value < 1000000) SELECT SUM(value) FROM counter",
+            )
+            .fetch_one(&mut *session)
+            .await;
+            assert!(matches!(
+                session
+                    .complete_query(query_result)
+                    .await
+                    .expect("complete interrupted reconciliation read"),
+                SqliteCooperativeQueryOutcome::DeadlineExceeded
+            ));
+        }
+
+        assert_eq!(
+            runtime.discarded_connections_for_test(SqliteOperation::ReconciliationProjection),
+            0,
+            "a cleaned deadline session remains reusable"
+        );
+        let mut normal_session = runtime
+            .begin_reconciliation_read(ReconciliationReadKind::CandidateRecent)
+            .await
+            .expect("next reconciliation session is clean");
+        let normal_result = sqlx::query_scalar::<_, i64>("SELECT 1")
+            .fetch_one(&mut *normal_session)
+            .await;
+        assert_eq!(
+            normal_session
+                .complete_query_or_defer(normal_result)
+                .await
+                .expect("normal session completes"),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -373,6 +373,8 @@ struct SqliteRuntimeInner {
     fail_next_reconciliation_research_read: AtomicBool,
     #[cfg(test)]
     force_next_cooperative_query_deadline: AtomicBool,
+    #[cfg(test)]
+    force_cooperative_query_deadline_after_reads: AtomicU32,
 }
 
 #[derive(Debug)]
@@ -534,6 +536,8 @@ impl SqliteRuntime {
                 fail_next_reconciliation_research_read: AtomicBool::new(false),
                 #[cfg(test)]
                 force_next_cooperative_query_deadline: AtomicBool::new(false),
+                #[cfg(test)]
+                force_cooperative_query_deadline_after_reads: AtomicU32::new(0),
             }),
         }
     }
@@ -550,6 +554,19 @@ impl SqliteRuntime {
         self.inner
             .force_next_cooperative_query_deadline
             .store(true, AtomicOrdering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_cooperative_query_deadline_after_reads_for_test(
+        &self,
+        reads_before_deadline: u32,
+    ) {
+        self.inner
+            .force_cooperative_query_deadline_after_reads
+            .store(
+                reads_before_deadline.saturating_add(1),
+                AtomicOrdering::Release,
+            );
     }
 
     #[cfg(test)]
@@ -1828,11 +1845,24 @@ impl SqliteReadSnapshot {
         progress_handler_ops: i32,
     ) -> Result<(), ProxyError> {
         #[cfg(test)]
-        let force_deadline = self
+        let force_next_deadline = self
             .runtime
             .inner
             .force_next_cooperative_query_deadline
             .swap(false, AtomicOrdering::AcqRel);
+        #[cfg(test)]
+        let force_deadline = force_next_deadline
+            || matches!(
+                self.runtime
+                    .inner
+                    .force_cooperative_query_deadline_after_reads
+                    .fetch_update(
+                        AtomicOrdering::AcqRel,
+                        AtomicOrdering::Acquire,
+                        |remaining| { (remaining > 0).then(|| remaining - 1) }
+                    ),
+                Ok(1)
+            );
         #[cfg(not(test))]
         let force_deadline = false;
         let deadline = force_deadline

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -2072,6 +2072,14 @@ impl ReconciliationReadSession {
             }),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn expire_deadline_after_query_for_test(&mut self) {
+        self.snapshot
+            .as_mut()
+            .expect("SQLite reconciliation read snapshot")
+            .cooperative_run_deadline = Some(Instant::now());
+    }
 }
 
 impl Deref for ReconciliationReadSession {
@@ -3135,6 +3143,21 @@ mod tests {
             0,
             "a cleaned deadline session remains reusable"
         );
+        let mut completed_after_deadline = runtime
+            .begin_reconciliation_read(ReconciliationReadKind::CandidateRecent)
+            .await
+            .expect("begin reconciliation read that completes at the boundary");
+        let completed_result = sqlx::query_scalar::<_, i64>("SELECT 1")
+            .fetch_one(&mut *completed_after_deadline)
+            .await;
+        completed_after_deadline.expire_deadline_after_query_for_test();
+        assert!(matches!(
+            completed_after_deadline
+                .complete_query(completed_result)
+                .await
+                .expect("a result beyond the deadline becomes a typed defer"),
+            SqliteCooperativeQueryOutcome::DeadlineExceeded
+        ));
         let mut normal_session = runtime
             .begin_reconciliation_read(ReconciliationReadKind::CandidateRecent)
             .await

--- a/src/store/sqlite_runtime_cooperative.rs
+++ b/src/store/sqlite_runtime_cooperative.rs
@@ -44,6 +44,58 @@ impl SqliteReadSnapshot {
 
         let rollback_result = sqlx::query("ROLLBACK").execute(&mut *self).await;
         match (query_result, rollback_result) {
+            // A statement can finish between progress-handler callbacks. Its result is still
+            // beyond the read session's contract, so discard it before preparation can advance.
+            (Ok(_), Ok(_)) if deadline_expired => {
+                let mut conn = self.conn.take().expect("SQLite read snapshot connection");
+                let cache_write_pages = record_connection_cache_write_delta(
+                    &self.runtime,
+                    self.operation,
+                    self.cache_write_pages_start,
+                    &mut conn,
+                )
+                .await;
+                if let Err(restore_err) =
+                    restore_operation_connection(conn, self.restore_busy_timeout).await
+                {
+                    let err = ProxyError::Database(restore_err);
+                    self.runtime.record_error(
+                        self.operation,
+                        self.pool_wait,
+                        self.begin_wait,
+                        &err,
+                    );
+                    if let Some(kind) = reconciliation_read_kind {
+                        self.runtime.record_reconciliation_read(
+                            kind,
+                            self.started_at.elapsed(),
+                            true,
+                            true,
+                            true,
+                            cache_write_pages,
+                        );
+                    }
+                    return Err(err);
+                }
+                self.runtime.record_cooperative_read(
+                    self.operation,
+                    self.started_at.elapsed(),
+                    true,
+                );
+                self.runtime
+                    .record_deferred(self.operation, SqliteAdmissionDeferReason::QueryDeadline);
+                if let Some(kind) = reconciliation_read_kind {
+                    self.runtime.record_reconciliation_read(
+                        kind,
+                        self.started_at.elapsed(),
+                        true,
+                        true,
+                        false,
+                        cache_write_pages,
+                    );
+                }
+                Ok(SqliteCooperativeQueryOutcome::DeadlineExceeded)
+            }
             (Ok(value), Ok(_)) => {
                 let mut conn = self.conn.take().expect("SQLite read snapshot connection");
                 let cache_write_pages = record_connection_cache_write_delta(

--- a/src/store/sqlite_runtime_cooperative.rs
+++ b/src/store/sqlite_runtime_cooperative.rs
@@ -7,8 +7,18 @@ pub(crate) enum SqliteCooperativeQueryOutcome<T> {
 }
 
 impl SqliteReadSnapshot {
-    pub(crate) async fn complete_cooperative_query<T>(
+    pub(crate) async fn complete_reconciliation_read<T>(
+        self,
+        kind: ReconciliationReadKind,
+        query_result: Result<T, sqlx::Error>,
+    ) -> Result<SqliteCooperativeQueryOutcome<T>, ProxyError> {
+        self.complete_cooperative_query_inner(Some(kind), query_result)
+            .await
+    }
+
+    async fn complete_cooperative_query_inner<T>(
         mut self,
+        reconciliation_read_kind: Option<ReconciliationReadKind>,
         query_result: Result<T, sqlx::Error>,
     ) -> Result<SqliteCooperativeQueryOutcome<T>, ProxyError> {
         let deadline_expired = self
@@ -19,6 +29,16 @@ impl SqliteReadSnapshot {
             conn.detach().close().await.ok();
             self.runtime
                 .record_error(self.operation, self.pool_wait, self.begin_wait, &error);
+            if let Some(kind) = reconciliation_read_kind {
+                self.runtime.record_reconciliation_read(
+                    kind,
+                    self.started_at.elapsed(),
+                    false,
+                    false,
+                    true,
+                    None,
+                );
+            }
             return Err(error);
         }
 
@@ -26,7 +46,7 @@ impl SqliteReadSnapshot {
         match (query_result, rollback_result) {
             (Ok(value), Ok(_)) => {
                 let mut conn = self.conn.take().expect("SQLite read snapshot connection");
-                record_connection_cache_write_delta(
+                let cache_write_pages = record_connection_cache_write_delta(
                     &self.runtime,
                     self.operation,
                     self.cache_write_pages_start,
@@ -43,6 +63,16 @@ impl SqliteReadSnapshot {
                         self.begin_wait,
                         &err,
                     );
+                    if let Some(kind) = reconciliation_read_kind {
+                        self.runtime.record_reconciliation_read(
+                            kind,
+                            self.started_at.elapsed(),
+                            false,
+                            false,
+                            true,
+                            cache_write_pages,
+                        );
+                    }
                     return Err(err);
                 }
                 self.runtime.record_success(
@@ -57,11 +87,21 @@ impl SqliteReadSnapshot {
                     self.started_at.elapsed(),
                     false,
                 );
+                if let Some(kind) = reconciliation_read_kind {
+                    self.runtime.record_reconciliation_read(
+                        kind,
+                        self.started_at.elapsed(),
+                        false,
+                        false,
+                        false,
+                        cache_write_pages,
+                    );
+                }
                 Ok(SqliteCooperativeQueryOutcome::Completed(value))
             }
             (Err(query_err), Ok(_)) if deadline_expired && sqlite_query_interrupted(&query_err) => {
                 let mut conn = self.conn.take().expect("SQLite read snapshot connection");
-                record_connection_cache_write_delta(
+                let cache_write_pages = record_connection_cache_write_delta(
                     &self.runtime,
                     self.operation,
                     self.cache_write_pages_start,
@@ -78,6 +118,16 @@ impl SqliteReadSnapshot {
                         self.begin_wait,
                         &err,
                     );
+                    if let Some(kind) = reconciliation_read_kind {
+                        self.runtime.record_reconciliation_read(
+                            kind,
+                            self.started_at.elapsed(),
+                            true,
+                            true,
+                            true,
+                            cache_write_pages,
+                        );
+                    }
                     return Err(err);
                 }
                 self.runtime.record_cooperative_read(
@@ -87,6 +137,16 @@ impl SqliteReadSnapshot {
                 );
                 self.runtime
                     .record_deferred(self.operation, SqliteAdmissionDeferReason::QueryDeadline);
+                if let Some(kind) = reconciliation_read_kind {
+                    self.runtime.record_reconciliation_read(
+                        kind,
+                        self.started_at.elapsed(),
+                        true,
+                        true,
+                        false,
+                        cache_write_pages,
+                    );
+                }
                 Ok(SqliteCooperativeQueryOutcome::DeadlineExceeded)
             }
             (Err(query_err), _) => {
@@ -95,6 +155,16 @@ impl SqliteReadSnapshot {
                 let err = ProxyError::Database(query_err);
                 self.runtime
                     .record_error(self.operation, self.pool_wait, self.begin_wait, &err);
+                if let Some(kind) = reconciliation_read_kind {
+                    self.runtime.record_reconciliation_read(
+                        kind,
+                        self.started_at.elapsed(),
+                        false,
+                        false,
+                        true,
+                        None,
+                    );
+                }
                 Err(err)
             }
             (Ok(_), Err(rollback_err)) => {
@@ -103,6 +173,16 @@ impl SqliteReadSnapshot {
                 let err = ProxyError::Database(rollback_err);
                 self.runtime
                     .record_error(self.operation, self.pool_wait, self.begin_wait, &err);
+                if let Some(kind) = reconciliation_read_kind {
+                    self.runtime.record_reconciliation_read(
+                        kind,
+                        self.started_at.elapsed(),
+                        false,
+                        false,
+                        true,
+                        None,
+                    );
+                }
                 Err(err)
             }
         }

--- a/src/store/sqlite_runtime_metrics_tests.rs
+++ b/src/store/sqlite_runtime_metrics_tests.rs
@@ -95,11 +95,12 @@ async fn operation_telemetry_survives_workload_window_rotation() {
 async fn workload_window_reports_reconciliation_read_kinds_without_statement_text() {
     let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
     for kind in ReconciliationReadKind::ALL {
+        let deadline = kind == ReconciliationReadKind::ResearchCandidates;
         runtime.record_reconciliation_read(
             kind,
             Duration::from_millis(42),
-            kind == ReconciliationReadKind::ResearchCandidates,
-            kind == ReconciliationReadKind::ResearchCandidates,
+            deadline,
+            deadline || kind == ReconciliationReadKind::CandidateRecent,
             false,
             Some(3),
         );
@@ -114,8 +115,12 @@ async fn workload_window_reports_reconciliation_read_kinds_without_statement_tex
     for kind in ReconciliationReadKind::ALL {
         assert!(formatted.contains(&format!("reconciliation_read/{}:calls=1", kind.as_str())));
     }
-    assert!(formatted.contains("deadlines=1"));
-    assert!(formatted.contains("deferred=1"));
+    assert!(formatted.contains(
+        "reconciliation_read/candidate_recent:calls=1,elapsed_ms=42,deadlines=0,deferred=1"
+    ));
+    assert!(formatted.contains(
+        "reconciliation_read/research_candidates:calls=1,elapsed_ms=42,deadlines=1,deferred=1"
+    ));
     assert!(!formatted.contains("SELECT"));
 }
 

--- a/src/store/sqlite_runtime_metrics_tests.rs
+++ b/src/store/sqlite_runtime_metrics_tests.rs
@@ -18,7 +18,7 @@ async fn workload_window_records_typed_admission_defers_without_statement_text()
             .get(&SqliteAdmissionDeferReason::PoolPressure),
         Some(&1)
     );
-    let formatted = format_operation_window(&window.operations);
+    let formatted = format_operation_window(&window.operations, &window.reconciliation_reads);
     assert!(formatted.contains("maintenance_bulk/request_stats_flush"));
     assert!(formatted.contains("defer_reasons=pool_pressure=1"));
     assert!(!formatted.contains("SELECT"));
@@ -41,7 +41,7 @@ async fn sqlite_workload_window_reports_scoped_reconciliation_metrics() {
     assert_eq!(telemetry.cooperative_read_deadlines, 1);
 
     let window = runtime.inner.workload.lock().unwrap();
-    let formatted = format_operation_window(&window.operations);
+    let formatted = format_operation_window(&window.operations, &window.reconciliation_reads);
     assert!(formatted.contains("connection_cache_write_pages=7"));
     assert!(formatted.contains("cooperative_read_elapsed_ms=42"));
     assert!(formatted.contains("cooperative_read_deadlines=1"));
@@ -61,7 +61,7 @@ async fn cache_write_sampling_failure_is_reported_as_unknown() {
 
     let window = runtime.inner.workload.lock().unwrap();
     assert!(
-        format_operation_window(&window.operations)
+        format_operation_window(&window.operations, &window.reconciliation_reads)
             .contains("connection_cache_write_pages=unknown")
     );
 }
@@ -89,4 +89,51 @@ async fn operation_telemetry_survives_workload_window_rotation() {
     assert_eq!(telemetry.connection_cache_write_pages, 7);
     assert_eq!(telemetry.cooperative_read_elapsed_ms, 42);
     assert_eq!(telemetry.cooperative_read_deadlines, 1);
+}
+
+#[tokio::test]
+async fn workload_window_reports_reconciliation_read_kinds_without_statement_text() {
+    let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
+    for kind in ReconciliationReadKind::ALL {
+        runtime.record_reconciliation_read(
+            kind,
+            Duration::from_millis(42),
+            kind == ReconciliationReadKind::ResearchCandidates,
+            kind == ReconciliationReadKind::ResearchCandidates,
+            false,
+            Some(3),
+        );
+    }
+
+    let window = runtime
+        .inner
+        .workload
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let formatted = format_operation_window(&window.operations, &window.reconciliation_reads);
+    for kind in ReconciliationReadKind::ALL {
+        assert!(formatted.contains(&format!("reconciliation_read/{}:calls=1", kind.as_str())));
+    }
+    assert!(formatted.contains("deadlines=1"));
+    assert!(formatted.contains("deferred=1"));
+    assert!(!formatted.contains("SELECT"));
+}
+
+#[test]
+fn sqlite_file_state_sampling_reads_only_configured_database_paths() {
+    let directory = tempfile::tempdir().expect("create database directory");
+    let core = directory.path().join("core.db");
+    let observability = directory.path().join("observability.db");
+    std::fs::write(&core, [0_u8; 3]).expect("write core database fixture");
+    std::fs::write(format!("{}-wal", core.display()), [0_u8; 5]).expect("write core WAL fixture");
+    std::fs::write(&observability, [0_u8; 7]).expect("write observability fixture");
+
+    let formatted = format_sqlite_file_state(&SqliteFileStatePaths {
+        core: Some(core),
+        observability: Some(observability),
+    });
+    assert!(formatted.contains("core_db_bytes=3"));
+    assert!(formatted.contains("core_wal_bytes=5"));
+    assert!(formatted.contains("observability_db_bytes=7"));
+    assert!(formatted.contains("observability_wal_bytes=unknown"));
 }

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -818,7 +818,7 @@ impl TavilyProxy {
         manual_remote_attempt: bool,
     ) -> Result<ClaimedReconciliationRunOutcome, ProxyError> {
         let started_at = std::time::Instant::now();
-        let projection_metrics_started = self
+        let reconciliation_read_metrics_started = self
             .key_store
             .sqlite_runtime
             .operation_telemetry(SqliteOperation::ReconciliationProjection);
@@ -1783,11 +1783,11 @@ impl TavilyProxy {
                         current.total_hold_ms.saturating_sub(started.total_hold_ms)
                     })
                     .unwrap_or_default();
-                let projection_metrics = self
+                let reconciliation_read_metrics = self
                     .key_store
                     .sqlite_runtime
                     .operation_telemetry(SqliteOperation::ReconciliationProjection)
-                    .delta_since(projection_metrics_started);
+                    .delta_since(reconciliation_read_metrics_started);
                 // The cap stops partial settlement, but it is not a time or local
                 // preparation budget exhaustion in the persisted observation.
                 // The research sweep has its own small post-settlement budget;
@@ -2122,12 +2122,12 @@ impl TavilyProxy {
                         remote_ms,
                         finalization_ms = finalization_ms.max(0),
                         research_ms,
-                        projection_source_read_ms = projection_metrics.cooperative_read_elapsed_ms,
-                        projection_read_deadline_count = projection_metrics.cooperative_read_deadlines,
-                        projection_connection_cache_write_pages = %if projection_metrics.connection_cache_write_sampled
-                            && !projection_metrics.connection_cache_write_sample_failed
+                        reconciliation_source_read_ms = reconciliation_read_metrics.cooperative_read_elapsed_ms,
+                        reconciliation_source_read_deadline_count = reconciliation_read_metrics.cooperative_read_deadlines,
+                        reconciliation_source_connection_cache_write_pages = %if reconciliation_read_metrics.connection_cache_write_sampled
+                            && !reconciliation_read_metrics.connection_cache_write_sample_failed
                         {
-                            projection_metrics.connection_cache_write_pages.to_string()
+                            reconciliation_read_metrics.connection_cache_write_pages.to_string()
                         } else {
                             "unknown".to_string()
                         },

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -1168,6 +1168,30 @@ impl TavilyProxy {
                 }
             }
         };
+        if !preparation_budget_exhausted && !candidates.is_empty() {
+            let remaining = candidate_hydration_deadline
+                .saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+            }
+            match self
+                .key_store
+                .reconciliation_local_billed_credits_batch(&candidates)
+                .await
+            {
+                Ok(_) => {}
+                Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                    return Ok(ReconciliationEngine::deferred(
+                        self,
+                        "projection_read_budget",
+                    ));
+                }
+                Err(err) if is_transient_sqlite_write_error(&err) => {
+                    return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+                }
+                Err(err) => return Err(err),
+            }
+        }
         preparation_budget_exhausted |= std::time::Instant::now() >= candidate_hydration_deadline;
         tracing::debug!(
             component = "reconciliation",
@@ -1530,96 +1554,29 @@ impl TavilyProxy {
                 observed_candidates.push((candidate, upstream_usage, in_recent_lane, work_generation));
             }
 
-            // Billing can become charged while the remote request is in flight. Re-read
-            // all observed candidates in one batch immediately before settlement so the
-            // persisted adjustment uses the post-observation ledger state without
-            // reintroducing a per-candidate hydration query.
+            // Billing can become charged while the remote request is in flight. The
+            // source-phase batch above proves that BillingHydrate fits its native
+            // deadline before any HTTP starts. Re-read each observed candidate here
+            // through the bounded finalization connection so settlement uses the
+            // post-observation ledger state without a post-request source deadline.
             if !observed_candidates.is_empty() {
-                let observed = observed_candidates
-                    .iter()
-                    .map(|(candidate, _, _, _)| candidate.clone())
-                    .collect::<Vec<_>>();
-                let remaining = finalization_deadline
-                    .saturating_duration_since(std::time::Instant::now());
-                let fresh_local_billed_by_candidate = if remaining.is_zero() {
-                    budget_exhausted = true;
-                    None
-                } else {
-                    Some(
-                        self.key_store
-                            .reconciliation_local_billed_credits_batch(&observed)
-                            .await?,
-                    )
-                };
                 // A later remote request may exhaust the main budget after an earlier
                 // request has already succeeded. Do not let that later timeout discard
                 // observations that still fit the bounded finalization window.
-                if let Some(fresh_local_billed_by_candidate) = fresh_local_billed_by_candidate {
-                    for (candidate, upstream_usage, in_recent_lane, work_generation) in observed_candidates {
-                        let remaining = finalization_deadline
-                            .saturating_duration_since(std::time::Instant::now());
-                        if remaining.is_zero() {
-                            budget_exhausted = true;
-                            break;
-                        }
-                        let local_billed = fresh_local_billed_by_candidate
-                            .get(&(candidate.token_id.clone(), candidate.period_code.clone()))
-                            .copied()
-                            .unwrap_or(0);
-                        let settlement_result = if candidate.settlement_mode == "shadow" {
-                            self.key_store
-                                .settle_upstream_reconciliation_shadow(
-                                    &candidate,
-                                    upstream_usage,
-                                    local_billed,
-                                    Some(ReconciliationWorkFence {
-                                        work_generation,
-                                        claimed_job,
-                                    }),
-                                )
-                                .await
-                        } else {
-                            self.key_store
-                                .settle_upstream_reconciliation(
-                                    &candidate,
-                                    upstream_usage,
-                                    local_billed,
-                                    Some(ReconciliationWorkFence {
-                                        work_generation,
-                                        claimed_job,
-                                    }),
-                                )
-                                .await
-                        };
-                        let did_settle = match settlement_result {
-                            Ok(did_settle) => did_settle,
-                            Err(error) => {
-                                ReconciliationEngine::pause_active_settlement_integrity_failure(
-                                    self,
-                                    &candidate.settlement_mode,
-                                    &error,
-                                )
-                                .await?;
-                                return Err(error);
-                            }
-                        };
-                        if did_settle {
-                            completed += 1;
-                            if upstream_usage == local_billed {
-                                no_adjustment += 1;
-                            } else if candidate.settlement_mode == "shadow" {
-                                observed_terminal += 1;
-                            } else {
-                                settled += 1;
-                                if in_recent_lane {
-                                    settled_recent += 1;
-                                } else {
-                                    settled_backlog += 1;
-                                }
-                            }
-                        }
-                    }
-                }
+                let finalization = ReconciliationEngine::finalize_observed_candidates(
+                    self,
+                    observed_candidates,
+                    finalization_deadline,
+                    claimed_job,
+                )
+                .await?;
+                settled += finalization.settled;
+                completed += finalization.completed;
+                no_adjustment += finalization.no_adjustment;
+                observed_terminal += finalization.observed;
+                settled_recent += finalization.settled_recent;
+                settled_backlog += finalization.settled_backlog;
+                budget_exhausted |= finalization.budget_exhausted;
             }
             Ok::<ReconciliationRunResult, ProxyError>(ReconciliationRunResult {
                 settled,
@@ -1704,6 +1661,12 @@ impl TavilyProxy {
                         claim_generation,
                     );
                     return Ok(ClaimedReconciliationRunOutcome::StaleClaim);
+                }
+                Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                    return Ok(ReconciliationEngine::deferred(
+                        self,
+                        "projection_read_budget",
+                    ));
                 }
                 Err(err) if is_transient_sqlite_write_error(&err) => {
                     research_local_pressure = true;
@@ -2124,7 +2087,7 @@ impl TavilyProxy {
                         research_ms,
                         reconciliation_source_read_ms = reconciliation_read_metrics.cooperative_read_elapsed_ms,
                         reconciliation_source_read_deadline_count = reconciliation_read_metrics.cooperative_read_deadlines,
-                        reconciliation_source_connection_cache_write_pages = %if reconciliation_read_metrics.connection_cache_write_sampled
+                        reconciliation_operation_connection_cache_write_pages = %if reconciliation_read_metrics.connection_cache_write_sampled
                             && !reconciliation_read_metrics.connection_cache_write_sample_failed
                         {
                             reconciliation_read_metrics.connection_cache_write_pages.to_string()

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -1072,6 +1072,14 @@ impl TavilyProxy {
                             };
                         }
                     }
+                    Ok(ReconciliationProjectionSliceOutcome::Deferred {
+                        reason: "projection_read_budget",
+                    }) => {
+                        return Ok(ReconciliationEngine::deferred(
+                            self,
+                            "projection_read_budget",
+                        ));
+                    }
                     Ok(ReconciliationProjectionSliceOutcome::Deferred { .. }) => {
                         preparation_budget_exhausted |=
                             ReconciliationEngine::projection_defer_exhausts_preparation(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -1000,6 +1000,12 @@ impl TavilyProxy {
                 .await
             {
                 Ok(batch) => batch,
+                Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                    return Ok(ReconciliationEngine::deferred(
+                        self,
+                        "projection_read_budget",
+                    ));
+                }
                 Err(err) if is_transient_sqlite_write_error(&err) => {
                     return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
                 }
@@ -1046,6 +1052,16 @@ impl TavilyProxy {
                                 .await
                             {
                                 Ok(batch) => batch,
+                                Err(err)
+                                    if ReconciliationEngine::projection_read_budget_is_deferred(
+                                        &err,
+                                    ) =>
+                                {
+                                    return Ok(ReconciliationEngine::deferred(
+                                        self,
+                                        "projection_read_budget",
+                                    ));
+                                }
                                 Err(err) if is_transient_sqlite_write_error(&err) => {
                                     return Ok(ReconciliationEngine::deferred(
                                         self,
@@ -1102,6 +1118,12 @@ impl TavilyProxy {
                     .await
                 {
                     Ok(result) => result,
+                    Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                        return Ok(ReconciliationEngine::deferred(
+                            self,
+                            "projection_read_budget",
+                        ));
+                    }
                     Err(err) if is_transient_sqlite_write_error(&err) => {
                         return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
                     }
@@ -2116,6 +2138,18 @@ impl TavilyProxy {
                     no_adjustment,
                     observed,
                 })
+            }
+            Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                tracing::debug!(
+                    component = "reconciliation",
+                    event = "preparation_deferred",
+                    reason = "projection_read_budget",
+                    "reconciliation source read reached its SQLite budget before a durable boundary"
+                );
+                Ok(ReconciliationEngine::deferred(
+                    self,
+                    "projection_read_budget",
+                ))
             }
             Err(err) if is_transient_sqlite_write_error(&err) => {
                 tracing::debug!(

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -120,6 +120,14 @@ impl ReconciliationEngine {
         }
     }
 
+    fn projection_read_budget_is_deferred(error: &ProxyError) -> bool {
+        matches!(
+            error,
+            ProxyError::Deferred { operation, reason }
+                if *operation == "reconciliation_projection" && reason == "projection_read_budget"
+        )
+    }
+
     fn post_process_exhaustion_is_deferred(error: &ProxyError) -> bool {
         matches!(
             error,

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -33,6 +33,16 @@ struct ReconciliationRunResult {
     remote_ms: i64,
 }
 
+struct ReconciliationFinalizationResult {
+    settled: i64,
+    completed: i64,
+    no_adjustment: i64,
+    observed: i64,
+    settled_recent: i64,
+    settled_backlog: i64,
+    budget_exhausted: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[doc(hidden)]
 pub enum ClaimedReconciliationRunOutcome {
@@ -135,6 +145,89 @@ impl ReconciliationEngine {
                 if message.contains("reconciliation post-processing deadline exceeded")
                     || message.contains("reconciliation retry bookkeeping deadline exceeded")
         )
+    }
+
+    async fn finalize_observed_candidates(
+        proxy: &TavilyProxy,
+        observed_candidates: Vec<(UpstreamReconciliationCandidate, i64, bool, i64)>,
+        finalization_deadline: std::time::Instant,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<ReconciliationFinalizationResult, ProxyError> {
+        let mut result = ReconciliationFinalizationResult {
+            settled: 0,
+            completed: 0,
+            no_adjustment: 0,
+            observed: 0,
+            settled_recent: 0,
+            settled_backlog: 0,
+            budget_exhausted: false,
+        };
+        for (candidate, upstream_usage, in_recent_lane, work_generation) in observed_candidates {
+            if finalization_deadline <= std::time::Instant::now() {
+                result.budget_exhausted = true;
+                break;
+            }
+            let local_billed = proxy
+                .key_store
+                .reconciliation_local_billed_credits_for_finalization(&candidate)
+                .await?;
+            let settlement_result = if candidate.settlement_mode == "shadow" {
+                proxy
+                    .key_store
+                    .settle_upstream_reconciliation_shadow(
+                        &candidate,
+                        upstream_usage,
+                        local_billed,
+                        Some(ReconciliationWorkFence {
+                            work_generation,
+                            claimed_job,
+                        }),
+                    )
+                    .await
+            } else {
+                proxy
+                    .key_store
+                    .settle_upstream_reconciliation(
+                        &candidate,
+                        upstream_usage,
+                        local_billed,
+                        Some(ReconciliationWorkFence {
+                            work_generation,
+                            claimed_job,
+                        }),
+                    )
+                    .await
+            };
+            let did_settle = match settlement_result {
+                Ok(did_settle) => did_settle,
+                Err(error) => {
+                    Self::pause_active_settlement_integrity_failure(
+                        proxy,
+                        &candidate.settlement_mode,
+                        &error,
+                    )
+                    .await?;
+                    return Err(error);
+                }
+            };
+            if !did_settle {
+                continue;
+            }
+            result.completed += 1;
+            if upstream_usage == local_billed {
+                result.no_adjustment += 1;
+            } else if candidate.settlement_mode == "shadow" {
+                result.observed += 1;
+            } else {
+                result.settled += 1;
+                if in_recent_lane {
+                    result.settled_recent += 1;
+                } else {
+                    result.settled_backlog += 1;
+                }
+            }
+        }
+        Ok(result)
     }
 
     async fn run_claimed(

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -626,17 +626,23 @@ async fn reconciliation_projection_read_deadline_interrupts_without_discarding_c
     .execute(&proxy.key_store.pool)
     .await
     .expect("mark projection incomplete");
-    sqlx::query(
-        r#"INSERT INTO upstream_reconciliation_usage (
-             token_id, key_id, period_code, project_id, billing_subject,
-             period_start, period_end, request_count, first_used_at,
-             last_used_at, updated_at, settlement_mode
-           ) VALUES ('deadline-token', 'deadline-key', '2026-07-15/S1', 'deadline-project',
-                     'token:deadline-token', 1, 2, 1, 1, 2, 2, 'shadow')"#,
-    )
-    .execute(&proxy.key_store.pool)
-    .await
-    .expect("insert pending projection source");
+    for index in 0..128 {
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_usage (
+                 token_id, key_id, period_code, project_id, billing_subject,
+                 period_start, period_end, request_count, first_used_at,
+                 last_used_at, updated_at, settlement_mode
+               ) VALUES (?, ?, ?, ?, ?, 1, 2, 1, 1, 2, 2, 'shadow')"#,
+        )
+        .bind(format!("deadline-token-{index}"))
+        .bind(format!("deadline-key-{index}"))
+        .bind(format!("2026-07-15/S{index}"))
+        .bind(format!("deadline-project-{index}"))
+        .bind(format!("token:deadline-token-{index}"))
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert pending projection source");
+    }
 
     proxy
         .key_store
@@ -675,6 +681,132 @@ async fn reconciliation_projection_read_deadline_interrupts_without_discarding_c
         .await
         .expect("next transaction begins after the interrupted source read");
     tx.rollback().await.expect("rollback clean transaction");
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_candidate_read_deadline_defers_without_remote_or_billing_changes() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 8, 27, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-candidate-read-deadline"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.rebalance_mcp_enabled = true;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("enable compare reconciliation");
+    for index in 0..128 {
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_work (
+                 token_id, period_code, project_id, billing_subject, settlement_mode,
+                 period_start, period_end, scheduling_key_id, updated_at
+               ) VALUES (?, ?, ?, ?, 'shadow', ?, ?, ?, ?)"#,
+        )
+        .bind(format!("read-deadline-token-{index}"))
+        .bind(format!("2026-08-27/S{index}"))
+        .bind(format!("read-deadline-project-{index}"))
+        .bind(format!("token:read-deadline-token-{index}"))
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(format!("read-deadline-key-{index}"))
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert eligible reconciliation work");
+    }
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim representative")
+        .expect("representative is claimed");
+
+    proxy
+        .key_store
+        .sqlite_runtime
+        .force_next_cooperative_query_deadline_for_test();
+    let outcome = proxy
+        .run_upstream_reconciliation_once_claimed_outcome(
+            "http://127.0.0.1:9",
+            claim.id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("candidate deadline becomes a typed defer");
+    assert!(matches!(
+        outcome,
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason: "projection_read_budget",
+            retry_at,
+        } if retry_at == now + 30
+    ));
+    let generations: (i64, i64) = sqlx::query_as(
+        "SELECT work_generation, completed_generation FROM upstream_reconciliation_work WHERE token_id = 'read-deadline-token-0'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read unchanged work generation");
+    assert!(
+        generations.0 > generations.1,
+        "a source-read deadline must not complete reconciliation work"
+    );
+    let settlements: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_settlements WHERE settlement_key = 'v1:read-deadline-token-0:2026-08-27/S0'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count settlements");
+    assert_eq!(
+        settlements, 0,
+        "a source-read deadline starts no settlement"
+    );
+    assert!(
+        proxy
+            .key_store
+            .sqlite_runtime
+            .operation_telemetry(SqliteOperation::ReconciliationProjection)
+            .cooperative_read_deadlines
+            >= 1,
+        "the native SQLite deadline is recorded on the reconciliation operation"
+    );
+
+    let persisted = proxy
+        .finalize_deferred_upstream_reconciliation_claim(
+            claim.id,
+            claim.claim_generation,
+            "projection_read_budget",
+            now + 30,
+        )
+        .await
+        .expect("persist the claim-fenced continuation");
+    assert!(
+        persisted.created || persisted.promoted,
+        "the current claim owns the deferred continuation"
+    );
+    let representatives: (i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), MIN(available_at) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read queued representative");
+    assert_eq!(representatives, (1, now + 30));
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -813,6 +813,109 @@ async fn reconciliation_candidate_read_deadline_defers_without_remote_or_billing
 }
 
 #[tokio::test]
+async fn reconciliation_projection_deadline_stops_a_run_before_remote_attempts() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 8, 27, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-projection-read-deadline"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.rebalance_mcp_enabled = true;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("enable compare reconciliation");
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_work (
+             token_id, period_code, project_id, billing_subject, settlement_mode,
+             period_start, period_end, scheduling_key_id, updated_at
+           ) VALUES ('projection-deadline-token', '2026-08-27/P0', 'projection-project',
+             'token:projection-deadline-token', 'shadow', ?, ?, 'projection-key', ?)"#,
+    )
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert an eligible candidate");
+    for index in 0..128 {
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_usage (
+                 token_id, key_id, period_code, project_id, billing_subject,
+                 period_start, period_end, request_count, first_used_at,
+                 last_used_at, updated_at, settlement_mode
+               ) VALUES (?, ?, ?, ?, ?, 1, 2, 1, 1, 2, 2, 'shadow')"#,
+        )
+        .bind(format!("projection-source-token-{index}"))
+        .bind(format!("projection-source-key-{index}"))
+        .bind(format!("2026-08-27/P{index}"))
+        .bind(format!("projection-source-project-{index}"))
+        .bind(format!("token:projection-source-token-{index}"))
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert historical projection source");
+    }
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim representative")
+        .expect("representative is claimed");
+
+    // Candidate selection performs the recent and backlog source reads first; interrupt the
+    // following historical projection read while an eligible candidate is already present.
+    proxy
+        .key_store
+        .sqlite_runtime
+        .force_cooperative_query_deadline_after_reads_for_test(2);
+    let outcome = proxy
+        .run_upstream_reconciliation_once_claimed_outcome(
+            "http://127.0.0.1:9",
+            claim.id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("projection deadline becomes a typed defer");
+    assert!(matches!(
+        outcome,
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason: "projection_read_budget",
+            retry_at,
+        } if retry_at == now + 30
+    ));
+    let work: (i64, i64) = sqlx::query_as(
+        "SELECT work_generation, completed_generation FROM upstream_reconciliation_work WHERE token_id = 'projection-deadline-token'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read unchanged candidate work");
+    assert!(work.0 > work.1, "the candidate remains unfinished");
+    let settlements: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_settlements WHERE settlement_key = 'v1:projection-deadline-token:2026-08-27/P0'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count settlements");
+    assert_eq!(settlements, 0, "deadline must start no remote request");
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn claimed_engine_run_reaches_a_safe_boundary_after_the_caller_is_cancelled() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -738,10 +738,12 @@ async fn reconciliation_candidate_read_deadline_defers_without_remote_or_billing
         .expect("claim representative")
         .expect("representative is claimed");
 
+    // Candidate selection uses the recent and backlog lanes, then key hydration.
+    // Interrupt the following BillingHydrate preflight before any remote request.
     proxy
         .key_store
         .sqlite_runtime
-        .force_next_cooperative_query_deadline_for_test();
+        .force_cooperative_query_deadline_after_reads_for_test(3);
     let outcome = proxy
         .run_upstream_reconciliation_once_claimed_outcome(
             "http://127.0.0.1:9",
@@ -807,6 +809,131 @@ async fn reconciliation_candidate_read_deadline_defers_without_remote_or_billing
     .await
     .expect("read queued representative");
     assert_eq!(representatives, (1, now + 30));
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_research_read_deadline_defers_the_claimed_run() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 8, 27, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-read-deadline"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.rebalance_mcp_enabled = true;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("enable compare reconciliation");
+    sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_insert")
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("keep the source row out of main reconciliation work");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject,
+            period_start, period_end, request_count, first_used_at, last_used_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+        "#,
+    )
+    .bind("research-deadline-token")
+    .bind("research-deadline-key")
+    .bind("2026-08-27/R0")
+    .bind("research-deadline-project")
+    .bind("token:research-deadline-token")
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed research source usage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+        "#,
+    )
+    .bind("research-deadline-request")
+    .bind("research-deadline-token")
+    .bind("research-deadline-key")
+    .bind("2026-08-27/R0")
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed due research candidate");
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim representative")
+        .expect("representative is claimed");
+
+    // The empty recent/backlog lanes use the first two source sessions. The
+    // due research query is the next source read and must defer, not turn the
+    // claimed representative into a scheduler error.
+    proxy
+        .key_store
+        .sqlite_runtime
+        .force_cooperative_query_deadline_after_reads_for_test(2);
+    let outcome = proxy
+        .run_upstream_reconciliation_once_claimed_outcome(
+            "http://127.0.0.1:9",
+            claim.id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("research source deadline becomes a typed defer");
+    assert!(matches!(
+        outcome,
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason: "projection_read_budget",
+            retry_at,
+        } if retry_at == now + 30
+    ));
+    let research: (Option<i64>, i64) = sqlx::query_as(
+        "SELECT terminal_at, poll_attempt_count FROM upstream_reconciliation_research WHERE request_id = 'research-deadline-request'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read unchanged research candidate");
+    assert_eq!(
+        research,
+        (None, 0),
+        "deadline must not mutate research work"
+    );
+    let persisted = proxy
+        .finalize_deferred_upstream_reconciliation_claim(
+            claim.id,
+            claim.claim_generation,
+            "projection_read_budget",
+            now + 30,
+        )
+        .await
+        .expect("persist the claim-fenced continuation");
+    assert!(
+        persisted.created || persisted.promoted,
+        "the research deadline retains one representative"
+    );
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);

--- a/tests/rust_source_line_budgets.rs
+++ b/tests/rust_source_line_budgets.rs
@@ -51,8 +51,8 @@ const EXCEPTIONS: &[(&str, usize, &str)] = &[
     ),
     (
         "src/store/sqlite_runtime.rs",
-        3175,
-        "The runtime owns the shared pool, operation budgeting, transaction guards, admission state, and workload aggregation; cooperative query cleanup is isolated in its dedicated child module.",
+        3550,
+        "The runtime owns the shared pool, operation budgeting, transaction guards, admission state, workload aggregation, and the bounded reconciliation read session; cooperative query cleanup remains isolated in its dedicated child module.",
     ),
 ];
 


### PR DESCRIPTION
## Summary

- Bound every reconciliation preparation source read with a per-statement native SQLite progress-handler deadline.
- Return the claim-fenced `projection_read_budget` defer before cursor/work/terminal mutation or a remote attempt.
- Add read-kind and connection-scoped cache-write diagnostics; file-state sampling remains low-frequency and read-only.

## Delivery

- Delivery role: direct
- Spec Disposition: refreshed `upstream-privacy-period-reconciliation`, `sqlite-write-lock-hardening`, `performance-architecture-hardening`, and `runtime-performance-observability`.
- Solutions: refreshed period-scoped reconciliation and SQLite write-lock contention guidance.
- Project Docs: refreshed `CONTEXT.md`.
- ADR: refreshed `docs/adr/0002-scoped-sqlite-and-remote-admission.md`.
- Visual evidence: not applicable; this PR has no owner-visible UI change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -j 2 --all-targets --all-features -- -D warnings`
- `cargo test --lib upstream_reconciliation -- --test-threads=1` (57 passed)
- `python3 scripts/ci_backend_tests.py run-shard --id lib-reconciliation-projection`
- `python3 scripts/ci_backend_tests.py verify`
- 101 dual-database read-only snapshot testbox comparison: baseline/candidate 600s each; passed with zero foreground/maintenance 5xx, final lock errors, nested transactions, or reconciliation projection discards; compare billing adjustment delta remains zero.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->