### PR TITLE
fix(reconciliation): reserve due research budget

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,11 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   HTTP request only. It excludes local projection, candidate hydration, durable finalization, and
   Research bookkeeping. Manual work retains priority; automatic reconciliation waiting 120 seconds
   owns the next non-manual attempt turn.
+- `Research reserve`: when preparation finds due terminal Research, the reconciliation engine
+  reserves a two-second post-finalization sweep and a two-second main durable-finalization boundary
+  before beginning main remote work. Research still probes only after main finalization. The reserve
+  may forego a second slow main-key request; no due Research leaves the normal main remote envelope
+  unchanged.
 
 ## Observability Boundaries
 

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -46,6 +46,8 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   WAL file metadata. Process and cgroup write bytes remain explicitly labelled aggregate values.
 - This ADR does not change the projection SQL shape. A keyset, batch-lookup, or index rewrite needs
   separate candidate evidence showing that the scoped source read remains the bottleneck.
+- Due Research timing is governed by ADR 0003; it uses the same request-scoped remote admission
+  boundary without extending the lease across local finalization.
 
 ## Consequences
 

--- a/docs/adr/0003-reconciliation-research-reserve.md
+++ b/docs/adr/0003-reconciliation-research-reserve.md
@@ -1,0 +1,39 @@
+# ADR 0003: Due Research Reserves a Reconciliation Window
+
+## Status
+
+Accepted
+
+## Context
+
+Reconciliation starts main `/usage` work before terminal Research polling. A slow main request can
+consume the former Research start threshold and leave due Research unprobed forever while the same
+main work keeps retrying. Treating Research as only leftover time therefore does not provide a
+progress guarantee.
+
+Research must not run before main settlement, and the engine may issue at most two serial remote
+requests per run. The decision must preserve compare-mode billing truth and the durable
+claim-fenced continuation boundary.
+
+## Decision
+
+- Preparation reads due Research eligibility without issuing a Research request.
+- When due Research exists, main remote work reserves two seconds for the later Research sweep and
+  two seconds for the main result's durable finalization boundary before it starts a main request.
+  A second slow main-key request may therefore be skipped.
+- Research probes still start only after main observation retry/finalization reaches its durable
+  boundary. The sweep uses at most its reserved two seconds.
+- When no Research is due, main remote work retains its existing request envelope and can use both
+  serial main attempts.
+- If the protected durable boundary cannot be reached, the run returns the existing typed deferred
+  outcome and claim-fenced delayed representative. It does not start Research early, complete work,
+  or change billing truth.
+- Run diagnostics include the logical main remote request count and whether the Research reserve
+  was required. These counters do not expose keys, tokens, request IDs, URLs, or response bodies.
+
+## Consequences
+
+- Due Research becomes independently progressable under recurring slow main `/usage` work.
+- A run with due Research may complete fewer main-key requests than an otherwise identical run.
+- The existing remote-attempt admission, two-attempt cap, mode semantics, and billing rules remain
+  unchanged.

--- a/docs/adr/0003-reconciliation-research-reserve.md
+++ b/docs/adr/0003-reconciliation-research-reserve.md
@@ -11,9 +11,10 @@ consume the former Research start threshold and leave due Research unprobed fore
 main work keeps retrying. Treating Research as only leftover time therefore does not provide a
 progress guarantee.
 
-Research must not run before main settlement, and the engine may issue at most two serial remote
-requests per run. The decision must preserve compare-mode billing truth and the durable
-claim-fenced continuation boundary.
+Research must not run before main settlement. The engine may issue at most two serial main
+settlement requests per run; Research remains an independent, globally single-concurrent sweep.
+The decision must preserve compare-mode billing truth and the durable claim-fenced continuation
+boundary.
 
 ## Decision
 
@@ -35,5 +36,5 @@ claim-fenced continuation boundary.
 
 - Due Research becomes independently progressable under recurring slow main `/usage` work.
 - A run with due Research may complete fewer main-key requests than an otherwise identical run.
-- The existing remote-attempt admission, two-attempt cap, mode semantics, and billing rules remain
-  unchanged.
+- The existing remote-attempt admission, two-main-attempt cap, mode semantics, and billing rules
+  remain unchanged. Research retains its independent two-second sweep budget.

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -3,8 +3,9 @@
 ## Current scheduling contract
 
 Candidate windows are maintained in an indexed durable work projection. The engine hydrates a bounded page,
-starts primary settlement before research polling, and permits at most two serial remote attempts per run. When
-due Research is known during preparation, it reserves two seconds for the later Research sweep and two seconds
+starts primary settlement before research polling, and permits at most two serial main settlement requests per
+run. Research remains an independent, globally single-concurrent sweep. When due Research is known during
+preparation, it reserves two seconds for the later Research sweep and two seconds
 for main durable finalization before it starts main remote work; the reserve may preclude a second slow main
 request. Without due Research, main settlement retains its normal remote envelope. Research exhaustion is
 diagnostic follow-up, not primary local pressure. Local-pressure backoff (`30/60/120/300s`) is separate from upstream-429 backoff

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -3,9 +3,11 @@
 ## Current scheduling contract
 
 Candidate windows are maintained in an indexed durable work projection. The engine hydrates a bounded page,
-starts primary settlement before research polling, permits at most two serial remote attempts per run, and gives
-research at most two seconds of the remaining time. Research exhaustion is diagnostic follow-up, not primary
-local pressure. Local-pressure backoff (`30/60/120/300s`) is separate from upstream-429 backoff
+starts primary settlement before research polling, and permits at most two serial remote attempts per run. When
+due Research is known during preparation, it reserves two seconds for the later Research sweep and two seconds
+for main durable finalization before it starts main remote work; the reserve may preclude a second slow main
+request. Without due Research, main settlement retains its normal remote envelope. Research exhaustion is
+diagnostic follow-up, not primary local pressure. Local-pressure backoff (`30/60/120/300s`) is separate from upstream-429 backoff
 (`2/5/10/30m`); non-429 failures do not reset the remote circuit. A current claim that reaches a
 low-foreground recovery window clears only its local-pressure state before trying the engine again;
 if SQLite is still pressured, that attempt durably defers again. This preserves foreground yielding
@@ -215,9 +217,11 @@ remote attempt and exhausted local budget, persist a short local backoff without
 a later Retry-After; a real remote attempt or successful settlement clears the relevant state. Keep
 normal per-key 429 logs at DEBUG and reserve state-transition logs for enter, escalation, and recovery.
 
-Main settlement must start before terminal-research polling. Hydrate the bounded candidate page and
-key/cooldown state in one indexed batch, reserve the first eligible key within the two-second local
-preparation budget, then use the remaining 20-second job budget for the research sweep.
+Main settlement must start before terminal-research polling. Hydrate the bounded candidate page,
+key/cooldown state, and Research eligibility in the two-second local preparation budget. If Research is due,
+reserve its two-second post-finalization sweep before starting main HTTP, along with the two-second main
+durable-finalization boundary. This is a progress guarantee for due Research, not permission to poll before
+main settlement; with no due Research, do not reduce main remote capacity.
 
 ## Claim-fenced deferred finalization
 

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -255,6 +255,7 @@ PR: none
 
 - [ADR 0001: HA Planned Cutover Control Plane](../../adr/0001-ha-planned-cutover-control-plane.md)
 - [ADR 0002: Scoped SQLite and Remote Admission](../../adr/0002-scoped-sqlite-and-remote-admission.md)
+- [ADR 0003: Due Research Reserves a Reconciliation Window](../../adr/0003-reconciliation-research-reserve.md)
 
 ## 参考（References）
 

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -192,3 +192,4 @@ PR: none
 ## Related ADRs
 
 - [ADR 0002: Scoped SQLite and Remote Admission](../../adr/0002-scoped-sqlite-and-remote-admission.md)
+- [ADR 0003: Due Research Reserves a Reconciliation Window](../../adr/0003-reconciliation-research-reserve.md)

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -504,3 +504,4 @@ PR: none
 ## Related ADRs
 
 - [ADR 0002: Scoped SQLite and Remote Admission](../../adr/0002-scoped-sqlite-and-remote-admission.md)
+- [ADR 0003: Due Research Reserves a Reconciliation Window](../../adr/0003-reconciliation-research-reserve.md)

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -91,7 +91,7 @@
 
 ## Current performance contract
 
-- Main settlement now hydrates the bounded candidate page and all referenced key/cooldown state before starting the first `/usage` request; the research terminal sweep runs only after main settlement and may use at most two seconds of the remaining job time. Its timeout is not primary budget exhaustion.
+- Main settlement hydrates the bounded candidate page, referenced key/cooldown state, and Research eligibility before starting the first `/usage` request. The terminal sweep still runs only after main durable finalization. When due Research exists, the run reserves two seconds for the later sweep and two seconds for main finalization before it starts main remote work; without due Research, it retains the existing main request envelope. A sweep timeout is not primary budget exhaustion.
 - Local budget exhaustion is persisted separately from the upstream-429 backoff. Only observed upstream 429 attempts advance the 2/5/10/30-minute global state; local pressure uses a short independent delay and never fabricates a remote rate-limit signal.
 - Remote request start, observation, settlement finalization, and research bookkeeping use nested
   deadlines with reserved post-processing headroom. The four local-pressure meta keys are included

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -71,7 +71,7 @@
 - `429` 只对 `period_reconciliation` scope 中的对应 Key 建立持久化冷却，使用 `Retry-After` 或 `5/10/20/30` 分钟退避；不得批量把同 Key 的其他窗口写为 rate-limited，也不得影响正常 API/MCP 流量。
 - 候选观测必须使用有界索引页：`queueEstimate` 可为空且最多统计 64 个候选，`hasEligible` 与最老候选年龄必须单独表达，首次观测前 coverage 为 `unknown`，不得以零伪装未观测状态。历史 degraded 状态必须由独立的索引化 `EXISTS` 探测保留，不能用当天计数替代。
 - 连续三轮存在候选、未产生远端尝试且本地预算耗尽时，持久化独立的本地短退避；它不得增加 upstream 429 全局退避。只有真实远端 429 才按 `2/5/10/30` 分钟升级，并以更晚的 `Retry-After` 为准；退避期间只保留一个 delayed representative job，真实远端尝试或成功结算后立即复位。
-- 主结算候选页、key/cooldown hydrate 与 reservation 的本地准备预算最多 2 秒，主结算优先启动；terminal-research sweep 仅在主结算之后使用同一轮剩余预算，且最多占用 2 秒。Research 超时不代表主结算本地预算耗尽，单轮总预算保持 20 秒。
+- 主结算候选页、key/cooldown hydrate 与 Research eligibility read 的本地准备预算最多 2 秒，主结算优先启动；terminal-research sweep 仅在主结算的 durable finalization 之后启动。存在 due Research 时，在发起主结算 HTTP 前预留 2 秒给 sweep，并预留 2 秒给主结果的 durable finalization；该 reserve 可以阻止第二个慢主 Key 请求。没有 due Research 时保留原有主结算远端窗口。Research 超时不代表主结算本地预算耗尽，单轮总预算保持 20 秒。
 - 远端请求启动、观察结果、结算写入和 Research 状态落盘均受同一轮截止时间约束；最后的持久化收尾预算不得被新一轮远端请求抢占。
 - 在发起远端请求前必须保留两秒给持久化收尾。收尾预算、post-processing 或 retry bookkeeping
   不足时，claimed run 只能返回 `Deferred { reason, retry_at }`，不得写 terminal job error。
@@ -126,8 +126,9 @@
 - Compare-mode non-zero differences write only the shadow observation and complete as `observed`;
   they do not create an actual billing adjustment and are not included in settled totals.
 - Main settlement work always precedes the terminal Research sweep. Candidate preparation and at
-  most one optional projection slice share the two-second preparation budget; Research uses at most
-  two seconds of the remaining run budget after main finalization.
+  most one optional projection slice share the two-second preparation budget. When due Research is
+  known during that preparation, main remote work reserves two seconds for its later sweep and two
+  seconds for main durable finalization; otherwise main settlement retains its full remote envelope.
 - 状态页使用门禁清单和 `n/m`，同时覆盖 loading、empty、error 与 degraded 状态。
 
 ## 功能与行为规格（Functional/Behavior Spec）
@@ -392,3 +393,4 @@ PR: include
 ## Related ADRs
 
 - [ADR 0002: Scoped SQLite and Remote Admission](../../adr/0002-scoped-sqlite-and-remote-admission.md)
+- [ADR 0003: Due Research Reserves a Reconciliation Window](../../adr/0003-reconciliation-research-reserve.md)

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -1332,12 +1332,17 @@ impl KeyStore {
             r#"
             SELECT EXISTS(
                 SELECT 1
-                FROM upstream_reconciliation_research
-                WHERE terminal_at IS NULL AND next_poll_at <= ?
+                FROM upstream_reconciliation_research r
+                JOIN upstream_reconciliation_usage u
+                  ON u.token_id = r.token_id AND u.period_code = r.period_code
+                WHERE r.terminal_at IS NULL AND COALESCE(r.next_poll_at, 0) <= ?
+                GROUP BY r.request_id
+                HAVING MAX(u.period_end) <= ?
                 LIMIT 1
             )
             "#,
         )
+        .bind(now)
         .bind(now)
         .fetch_one(&mut *session)
         .await;

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -1308,31 +1308,20 @@ impl KeyStore {
             })
             .collect())
     }
-
-    pub(crate) async fn has_due_upstream_reconciliation_research(
-        &self,
-    ) -> Result<bool, ProxyError> {
+    pub(crate) async fn has_due_upstream_reconciliation_research(&self) -> Result<bool, ProxyError> {
         let now = self.backend_time.now_ts();
         let mut session = self
             .sqlite_runtime
             .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
             .await?;
         #[cfg(test)]
-        if self
-            .sqlite_runtime
-            .take_reconciliation_research_read_failure_for_test()
-        {
-            let injected_result: Result<i64, sqlx::Error> = Err(sqlx::Error::PoolTimedOut);
-            return session
-                .complete_query_or_defer(injected_result)
-                .await
-                .map(|_| false);
+        if self.sqlite_runtime.take_reconciliation_research_read_failure_for_test() {
+            let injected_result = Err::<i64, _>(sqlx::Error::PoolTimedOut);
+            return session.complete_query_or_defer(injected_result).await.map(|_| false);
         }
-        let due_result = sqlx::query_scalar::<_, i64>(
-            r#"
+        let due_result = sqlx::query_scalar::<_, i64>(r#"
             SELECT EXISTS(
-                SELECT 1
-                FROM upstream_reconciliation_research r
+                SELECT 1 FROM upstream_reconciliation_research r
                 JOIN upstream_reconciliation_usage u
                   ON u.token_id = r.token_id AND u.period_code = r.period_code
                 WHERE r.terminal_at IS NULL AND COALESCE(r.next_poll_at, 0) <= ?
@@ -1340,10 +1329,8 @@ impl KeyStore {
                 HAVING MAX(u.period_end) <= ?
                 LIMIT 1
             )
-            "#,
-        )
-        .bind(now)
-        .bind(now)
+            "#)
+        .bind(now).bind(now)
         .fetch_one(&mut *session)
         .await;
         Ok(session.complete_query_or_defer(due_result).await? != 0)

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -1245,17 +1245,6 @@ impl KeyStore {
             .sqlite_runtime
             .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
             .await?;
-        #[cfg(test)]
-        if self
-            .sqlite_runtime
-            .take_reconciliation_research_read_failure_for_test()
-        {
-            let injected_result: Result<
-                Vec<crate::models::UpstreamReconciliationResearchCandidate>,
-                sqlx::Error,
-            > = Err(sqlx::Error::PoolTimedOut);
-            return session.complete_query_or_defer(injected_result).await;
-        }
         let rows_result = sqlx::query_as::<_, (String, String, String, String, String, i64, i64, i64, i64)>(
             r#"
             WITH pending AS (
@@ -1318,6 +1307,41 @@ impl KeyStore {
                 }
             })
             .collect())
+    }
+
+    pub(crate) async fn has_due_upstream_reconciliation_research(
+        &self,
+    ) -> Result<bool, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let mut session = self
+            .sqlite_runtime
+            .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
+            .await?;
+        #[cfg(test)]
+        if self
+            .sqlite_runtime
+            .take_reconciliation_research_read_failure_for_test()
+        {
+            let injected_result: Result<i64, sqlx::Error> = Err(sqlx::Error::PoolTimedOut);
+            return session
+                .complete_query_or_defer(injected_result)
+                .await
+                .map(|_| false);
+        }
+        let due_result = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM upstream_reconciliation_research
+                WHERE terminal_at IS NULL AND next_poll_at <= ?
+                LIMIT 1
+            )
+            "#,
+        )
+        .bind(now)
+        .fetch_one(&mut *session)
+        .await;
+        Ok(session.complete_query_or_defer(due_result).await? != 0)
     }
 
     pub(crate) async fn record_upstream_reconciliation_research_poll(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -1131,27 +1131,30 @@ impl TavilyProxy {
             }
         }
         preparation_budget_exhausted |= std::time::Instant::now() >= candidate_hydration_deadline;
-        // This is only an eligibility read. The terminal probes remain after
-        // main candidate finalization, but knowing that Research is due lets
-        // us reserve its bounded request window before main HTTP begins.
-        let research_candidates = match self
+        // This indexed eligibility probe is deliberately smaller than the
+        // prioritized Research sweep. A deadline here must not turn due
+        // Research into a precondition for main settlement: reserve
+        // conservatively and select the full sweep only after main durable
+        // finalization.
+        let research_reservation_required = match self
             .key_store
-            .next_upstream_reconciliation_research_candidates(80)
+            .has_due_upstream_reconciliation_research()
             .await
         {
-            Ok(candidates) => candidates,
-            Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
-                return Ok(ReconciliationEngine::deferred(
-                    self,
-                    "projection_read_budget",
-                ));
-            }
-            Err(err) if is_transient_sqlite_write_error(&err) => {
-                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+            Ok(due) => due,
+            Err(err)
+                if ReconciliationEngine::projection_read_budget_is_deferred(&err)
+                    || is_transient_sqlite_write_error(&err) =>
+            {
+                tracing::debug!(
+                    component = "reconciliation",
+                    event = "research_reservation_unknown",
+                    "Research eligibility could not be read before main settlement; retaining the bounded reserve"
+                );
+                true
             }
             Err(err) => return Err(err),
         };
-        let research_reservation_required = !research_candidates.is_empty();
         let ReconciliationRemoteBudget {
             main_remote_deadline,
             main_finalization_deadline,
@@ -1590,6 +1593,37 @@ impl TavilyProxy {
             .unwrap_or(true);
         let research_started_at = std::time::Instant::now();
         let mut research_local_pressure = false;
+        let research_candidates = if result.is_ok()
+            && research_reservation_required
+            && !self.sqlite_maintenance_runs_shutting_down()
+        {
+            match self
+                .key_store
+                .next_upstream_reconciliation_research_candidates(80)
+                .await
+            {
+                Ok(candidates) => candidates,
+                Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                    return Ok(ReconciliationEngine::deferred(
+                        self,
+                        "projection_read_budget",
+                    ));
+                }
+                Err(err) if is_transient_sqlite_write_error(&err) => {
+                    research_local_pressure = true;
+                    tracing::debug!(
+                        component = "reconciliation",
+                        event = "research_sweep_deferred",
+                        reason = "local_pressure",
+                        err = %err,
+                    );
+                    Vec::new()
+                }
+                Err(err) => return Err(err),
+            }
+        } else {
+            Vec::new()
+        };
         let (
             research_polled_count,
             research_terminal_count,
@@ -1597,10 +1631,7 @@ impl TavilyProxy {
             research_retry_count,
             research_skipped_cooldown_count,
             research_budget_exhausted,
-        ) = if result.is_ok()
-            && !research_candidates.is_empty()
-            && !self.sqlite_maintenance_runs_shutting_down()
-        {
+        ) = if result.is_ok() && !research_candidates.is_empty() {
             let research_deadline = remote_request_deadline.min(
                 std::time::Instant::now()
                     + std::time::Duration::from_secs(Self::RECONCILIATION_RESEARCH_SWEEP_BUDGET_SECS),

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -27,8 +27,9 @@ fn should_emit_reconciliation_summary(now: i64) -> bool {
 impl TavilyProxy {
     const RECONCILIATION_BACKOFF_SCOPE: &'static str = "period_reconciliation";
     // Candidate hydration is deliberately bounded so the first main settlement
-    // request cannot be displaced by the terminal-research sweep. Research is
-    // allowed to use the remainder of the scheduler's 20 second budget.
+    // request cannot be displaced by the terminal-research sweep. When due
+    // Research exists, its two-second request window is reserved before main
+    // remote work starts.
     const RECONCILIATION_MAIN_PREP_BUDGET_SECS: u64 = 2;
     const RECONCILIATION_TOTAL_BUDGET_SECS: u64 = 20;
     const RECONCILIATION_FINALIZATION_HEADROOM_SECS: u64 = 2;
@@ -345,58 +346,12 @@ impl TavilyProxy {
             .map(|state| state.cooldown_until))
     }
 
-    async fn arm_reconciliation_backoff(
-        &self,
-        key_id: &str,
-        requested_until: Option<i64>,
-        reason: &str,
-        claimed_job: Option<(i64, i64)>,
-    ) -> Result<i64, ProxyError> {
-        let now = self.backend_time.now_ts();
-        let prior_retry_after_secs = self
-            .reconciliation_cooldown_until(key_id, now)
-            .await?
-            .map(|until| until.saturating_sub(now))
-            .or(self
-                .key_store
-                .api_key_transient_backoff_state(key_id, Self::RECONCILIATION_BACKOFF_SCOPE)
-                .await?
-                .map(|state| state.retry_after_secs));
-        let retry_after_secs = requested_until
-            .map(|until| until.saturating_sub(now).max(1))
-            .unwrap_or_else(|| match prior_retry_after_secs {
-                None | Some(0) => 300,
-                Some(1..=300) => 600,
-                Some(301..=600) => 1200,
-                _ => 1800,
-            });
-        let cooldown_until = now.saturating_add(retry_after_secs);
-        let arm = ApiKeyTransientBackoffArm {
-            key_id,
-            scope: Self::RECONCILIATION_BACKOFF_SCOPE,
-            cooldown_until,
-            retry_after_secs,
-            reason_code: Some(classify_reconciliation_retry_reason(Some(reason))),
-            source_request_log_id: None,
-            now,
-        };
-        let armed = match claimed_job {
-            Some((job_id, claim_generation)) => {
-                self.key_store
-                    .arm_api_key_transient_backoff_claimed(arm, job_id, claim_generation)
-                    .await?
-            }
-            None => self.key_store.arm_api_key_transient_backoff(arm).await?,
-        };
-        Ok(armed.map(|state| state.cooldown_until).unwrap_or(cooldown_until))
-    }
-
     async fn run_research_terminal_sweep(
         &self,
         usage_base: &str,
         started_at: &std::time::Instant,
-        request_start_budget_secs: u64,
         request_deadline: std::time::Instant,
+        candidates: Vec<crate::models::UpstreamReconciliationResearchCandidate>,
         claimed_job: Option<(i64, i64)>,
         remote_attempt: ReconciliationRemoteAttemptContext<'_>,
     ) -> Result<(i64, i64, i64, i64, i64, bool), ProxyError> {
@@ -405,10 +360,6 @@ impl TavilyProxy {
         if remaining.is_zero() {
             return Ok((0, 0, 0, 0, 0, true));
         }
-        let candidates = self
-            .key_store
-            .next_upstream_reconciliation_research_candidates(80)
-            .await?;
         let candidate_count = candidates.len() as i64;
         tracing::debug!(
             component = "reconciliation",
@@ -427,10 +378,6 @@ impl TavilyProxy {
         let mut budget_exhausted = false;
         for candidate in candidates {
             if polled as usize >= Self::RESEARCH_SWEEP_LIMIT {
-                break;
-            }
-            if started_at.elapsed() >= std::time::Duration::from_secs(request_start_budget_secs) {
-                budget_exhausted = true;
                 break;
             }
             let cooldown_remaining = request_deadline.saturating_duration_since(std::time::Instant::now());
@@ -453,10 +400,6 @@ impl TavilyProxy {
             if cooling_keys.contains(&candidate.key_id) || cooldown_active {
                 skipped_cooldown += 1;
                 continue;
-            }
-            if started_at.elapsed() >= std::time::Duration::from_secs(request_start_budget_secs) {
-                budget_exhausted = true;
-                break;
             }
             let selected = selected_per_key.entry(candidate.key_id.clone()).or_default();
             if *selected >= Self::RESEARCH_SWEEP_PER_KEY_LIMIT {
@@ -984,11 +927,6 @@ impl TavilyProxy {
                 Self::RECONCILIATION_TOTAL_BUDGET_SECS
                     .saturating_sub(Self::RECONCILIATION_OUTER_TIMEOUT_MARGIN_SECS),
             );
-        let research_start_budget_secs = Self::RECONCILIATION_TOTAL_BUDGET_SECS
-            .saturating_sub(QUOTA_SYNC_FETCH_TIMEOUT_SECS)
-            .saturating_sub(Self::RECONCILIATION_FINALIZATION_HEADROOM_SECS)
-            .saturating_sub(Self::RECONCILIATION_POST_PROCESS_HEADROOM_SECS);
-        let remote_request_start_budget_secs = research_start_budget_secs;
         let mut preparation_budget_exhausted = false;
         let mut candidate_batch;
         if preparation_deadline <= std::time::Instant::now() {
@@ -1193,6 +1131,37 @@ impl TavilyProxy {
             }
         }
         preparation_budget_exhausted |= std::time::Instant::now() >= candidate_hydration_deadline;
+        // This is only an eligibility read. The terminal probes remain after
+        // main candidate finalization, but knowing that Research is due lets
+        // us reserve its bounded request window before main HTTP begins.
+        let research_candidates = match self
+            .key_store
+            .next_upstream_reconciliation_research_candidates(80)
+            .await
+        {
+            Ok(candidates) => candidates,
+            Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                return Ok(ReconciliationEngine::deferred(
+                    self,
+                    "projection_read_budget",
+                ));
+            }
+            Err(err) if is_transient_sqlite_write_error(&err) => {
+                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+            }
+            Err(err) => return Err(err),
+        };
+        let research_reservation_required = !research_candidates.is_empty();
+        let ReconciliationRemoteBudget {
+            main_remote_deadline,
+            main_finalization_deadline,
+        } = ReconciliationRemoteBudget::with_due_research_reserve(
+            research_reservation_required,
+            remote_request_deadline,
+            finalization_deadline,
+            std::time::Duration::from_secs(Self::RECONCILIATION_RESEARCH_SWEEP_BUDGET_SECS),
+            std::time::Duration::from_secs(Self::RECONCILIATION_FINALIZATION_HEADROOM_SECS),
+        );
         tracing::debug!(
             component = "reconciliation",
             event = "run_started",
@@ -1208,6 +1177,7 @@ impl TavilyProxy {
             research_pending_count = 0_i64,
             research_retry_count = 0_i64,
             research_skipped_cooldown_count = 0_i64,
+            research_reservation_required,
         );
         let hydrate_ms = started_at.elapsed().as_millis().min(i64::MAX as u128) as i64;
         // Remote I/O and durable settlement must never retain the local bulk
@@ -1248,9 +1218,7 @@ impl TavilyProxy {
                 if budget_exhausted {
                     break;
                 }
-                if started_at.elapsed()
-                    >= std::time::Duration::from_secs(remote_request_start_budget_secs)
-                {
+                if std::time::Instant::now() >= main_remote_deadline {
                     budget_exhausted = true;
                     break;
                 }
@@ -1345,11 +1313,11 @@ impl TavilyProxy {
                     // the bounded request timeout to finish and use the
                     // separate total-budget deadline for subsequent requests.
                     let reservation_deadline = if candidate_attempted || remote_request_started {
-                        remote_request_deadline
+                        main_remote_deadline
                     } else {
                         preparation_deadline
                     };
-                    let remote_remaining = remote_request_deadline
+                    let remote_remaining = main_remote_deadline
                         .saturating_duration_since(std::time::Instant::now());
                     let request_timeout = Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS);
                     if remote_remaining < request_timeout {
@@ -1382,7 +1350,7 @@ impl TavilyProxy {
                         attempted_candidate_count += 1;
                         candidate_attempted = true;
                     }
-                    let remaining = remote_request_deadline
+                    let remaining = main_remote_deadline
                         .saturating_duration_since(std::time::Instant::now());
                     remote_request_started = true;
                     if remote_request_count == 0 {
@@ -1482,12 +1450,7 @@ impl TavilyProxy {
                                     .max(retry_after_until),
                             );
                         }
-                        let retry_bookkeeping_deadline = started_at
-                            + std::time::Duration::from_secs(
-                                Self::RECONCILIATION_TOTAL_BUDGET_SECS
-                                    .saturating_sub(Self::RECONCILIATION_POST_PROCESS_HEADROOM_SECS),
-                            );
-                        ensure_reconciliation_post_process_reserve(retry_bookkeeping_deadline)?;
+                        ensure_reconciliation_post_process_reserve(main_finalization_deadline)?;
                         let cooldown_until = if reason_kind
                             == RECONCILIATION_RETRY_REASON_UPSTREAM_429
                         {
@@ -1566,7 +1529,7 @@ impl TavilyProxy {
                 let finalization = ReconciliationEngine::finalize_observed_candidates(
                     self,
                     observed_candidates,
-                    finalization_deadline,
+                    main_finalization_deadline,
                     claimed_job,
                 )
                 .await?;
@@ -1594,6 +1557,7 @@ impl TavilyProxy {
                 key_backoff_window_count,
                 skipped_by_key_backoff,
                 attempted_candidate_count,
+                main_remote_request_count: remote_request_count,
                 budget_exhausted,
                 remote_attempt_limit_reached,
                 max_retry_after_until,
@@ -1633,7 +1597,10 @@ impl TavilyProxy {
             research_retry_count,
             research_skipped_cooldown_count,
             research_budget_exhausted,
-        ) = if result.is_ok() && !self.sqlite_maintenance_runs_shutting_down() {
+        ) = if result.is_ok()
+            && !research_candidates.is_empty()
+            && !self.sqlite_maintenance_runs_shutting_down()
+        {
             let research_deadline = remote_request_deadline.min(
                 std::time::Instant::now()
                     + std::time::Duration::from_secs(Self::RECONCILIATION_RESEARCH_SWEEP_BUDGET_SECS),
@@ -1642,8 +1609,8 @@ impl TavilyProxy {
                 .run_research_terminal_sweep(
                     usage_base,
                     &started_at,
-                    research_start_budget_secs,
                     research_deadline,
+                    research_candidates,
                     claimed_job,
                     remote_attempt_context,
                 )
@@ -1724,6 +1691,7 @@ impl TavilyProxy {
                 key_backoff_window_count,
                 skipped_by_key_backoff,
                 attempted_candidate_count,
+                main_remote_request_count,
                 mut budget_exhausted,
                 remote_attempt_limit_reached,
                 max_retry_after_until,
@@ -1762,6 +1730,8 @@ impl TavilyProxy {
                     elapsed_ms = started_at.elapsed().as_millis() as u64,
                     job_type = "upstream_reconciliation",
                     candidate_count,
+                    attempted_candidate_count,
+                    main_remote_request_count,
                     settled_count = settled,
                     recent_lane_budget,
                     backlog_lane_budget,
@@ -1780,6 +1750,12 @@ impl TavilyProxy {
                     research_retry_count,
                     research_skipped_cooldown_count,
                     research_budget_exhausted,
+                    research_reservation_required,
+                    research_reserved_ms = if research_reservation_required {
+                        Self::RECONCILIATION_RESEARCH_SWEEP_BUDGET_SECS * 1_000
+                    } else {
+                        0
+                    },
                     budget_exhausted,
                     remote_wait_ms,
                     remote_hold_ms,
@@ -2072,6 +2048,7 @@ impl TavilyProxy {
                         elapsed_ms = started_at.elapsed().as_millis() as u64,
                         candidate_count,
                         attempted_candidate_count,
+                        main_remote_request_count,
                         settled_count = settled,
                         completed_count = completed,
                         no_adjustment_count = no_adjustment,
@@ -2085,6 +2062,12 @@ impl TavilyProxy {
                         remote_ms,
                         finalization_ms = finalization_ms.max(0),
                         research_ms,
+                        research_reservation_required,
+                        research_reserved_ms = if research_reservation_required {
+                            Self::RECONCILIATION_RESEARCH_SWEEP_BUDGET_SECS * 1_000
+                        } else {
+                            0
+                        },
                         reconciliation_source_read_ms = reconciliation_read_metrics.cooperative_read_elapsed_ms,
                         reconciliation_source_read_deadline_count = reconciliation_read_metrics.cooperative_read_deadlines,
                         reconciliation_operation_connection_cache_write_pages = %if reconciliation_read_metrics.connection_cache_write_sampled

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -25,6 +25,7 @@ struct ReconciliationRunResult {
     key_backoff_window_count: i64,
     skipped_by_key_backoff: i64,
     attempted_candidate_count: i64,
+    main_remote_request_count: i64,
     budget_exhausted: bool,
     remote_attempt_limit_reached: bool,
     max_retry_after_until: Option<i64>,
@@ -56,6 +57,84 @@ pub enum ClaimedReconciliationRunOutcome {
 }
 
 pub(crate) struct ReconciliationEngine;
+
+#[derive(Clone, Copy)]
+struct ReconciliationRemoteBudget {
+    main_remote_deadline: std::time::Instant,
+    main_finalization_deadline: std::time::Instant,
+}
+
+impl ReconciliationRemoteBudget {
+    fn with_due_research_reserve(
+        research_reservation_required: bool,
+        remote_request_deadline: std::time::Instant,
+        finalization_deadline: std::time::Instant,
+        research_sweep_budget: std::time::Duration,
+        finalization_headroom: std::time::Duration,
+    ) -> Self {
+        if research_reservation_required {
+            Self {
+                main_remote_deadline: remote_request_deadline
+                    - research_sweep_budget
+                    - finalization_headroom,
+                main_finalization_deadline: remote_request_deadline - research_sweep_budget,
+            }
+        } else {
+            Self {
+                main_remote_deadline: remote_request_deadline,
+                main_finalization_deadline: finalization_deadline,
+            }
+        }
+    }
+}
+
+impl TavilyProxy {
+    async fn arm_reconciliation_backoff(
+        &self,
+        key_id: &str,
+        requested_until: Option<i64>,
+        reason: &str,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<i64, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let prior_retry_after_secs = self
+            .reconciliation_cooldown_until(key_id, now)
+            .await?
+            .map(|until| until.saturating_sub(now))
+            .or(self
+                .key_store
+                .api_key_transient_backoff_state(key_id, Self::RECONCILIATION_BACKOFF_SCOPE)
+                .await?
+                .map(|state| state.retry_after_secs));
+        let retry_after_secs = requested_until
+            .map(|until| until.saturating_sub(now).max(1))
+            .unwrap_or_else(|| match prior_retry_after_secs {
+                None | Some(0) => 300,
+                Some(1..=300) => 600,
+                Some(301..=600) => 1200,
+                _ => 1800,
+            });
+        let cooldown_until = now.saturating_add(retry_after_secs);
+        let arm = ApiKeyTransientBackoffArm {
+            key_id,
+            scope: Self::RECONCILIATION_BACKOFF_SCOPE,
+            cooldown_until,
+            retry_after_secs,
+            reason_code: Some(classify_reconciliation_retry_reason(Some(reason))),
+            source_request_log_id: None,
+            now,
+        };
+        let armed = match claimed_job {
+            Some((job_id, claim_generation)) => {
+                self.key_store
+                    .arm_api_key_transient_backoff_claimed(arm, job_id, claim_generation)
+                    .await?
+            }
+            None => self.key_store.arm_api_key_transient_backoff(arm).await?,
+        };
+        Ok(armed.map(|state| state.cooldown_until).unwrap_or(cooldown_until))
+    }
+}
 
 #[derive(Clone, Copy)]
 struct ReconciliationRemoteAttemptContext<'a> {

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -888,13 +888,14 @@ async fn reconciliation_research_read_deadline_defers_the_claimed_run() {
         .expect("claim representative")
         .expect("representative is claimed");
 
-    // The empty recent/backlog lanes use the first two source sessions. The
-    // due research query is the next source read and must defer, not turn the
-    // claimed representative into a scheduler error.
+    // The empty recent/backlog lanes and the bounded Research eligibility
+    // probe use the first three source sessions. Interrupt the following
+    // full Research candidate query: it must defer, not turn the claimed
+    // representative into a scheduler error.
     proxy
         .key_store
         .sqlite_runtime
-        .force_cooperative_query_deadline_after_reads_for_test(2);
+        .force_cooperative_query_deadline_after_reads_for_test(3);
     let outcome = proxy
         .run_upstream_reconciliation_once_claimed_outcome(
             "http://127.0.0.1:9",

--- a/src/tests/upstream_reconciliation_projection.rs
+++ b/src/tests/upstream_reconciliation_projection.rs
@@ -82,7 +82,7 @@ async fn reconciliation_projection_micro_slices_resume() {
 }
 
 #[tokio::test]
-async fn reconciliation_research_sweep_does_not_hold_an_empty_main_run() {
+async fn reconciliation_research_sweep_stays_bounded_without_main_work() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
     let now = local_ts(2026, 7, 15, 12, 0);
@@ -162,12 +162,18 @@ async fn reconciliation_research_sweep_does_not_hold_an_empty_main_run() {
 
     let research_started = Arc::new(AtomicBool::new(false));
     let research_started_for_route = Arc::clone(&research_started);
+    let research_request_started_at = Arc::new(std::sync::Mutex::new(None));
+    let research_request_started_at_for_route = Arc::clone(&research_request_started_at);
     let app = Router::new().route(
         "/research/research-budget-slow",
         get(move || {
             let research_started = Arc::clone(&research_started_for_route);
+            let research_request_started_at = Arc::clone(&research_request_started_at_for_route);
             async move {
                 research_started.store(true, Ordering::SeqCst);
+                *research_request_started_at
+                    .lock()
+                    .expect("record research request start") = Some(std::time::Instant::now());
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 Json(serde_json::json!({ "status": "completed" }))
             }
@@ -185,16 +191,39 @@ async fn reconciliation_research_sweep_does_not_hold_an_empty_main_run() {
             .expect("serve research upstream");
     });
 
-    let started_at = std::time::Instant::now();
-    let settled = proxy
-        .run_upstream_reconciliation_once(&format!("http://{addr}"))
-        .await
-        .expect("run reconciliation with research-only work");
+    // This direct helper has a short foreground-safe admission wait. Under a
+    // loaded shard, retry only its documented transient admission result; the
+    // test's subject is the bounded Research request, not pool arbitration.
+    let settled = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match proxy
+                .run_upstream_reconciliation_once(&format!("http://{addr}"))
+                .await
+            {
+                Ok(settled) => break settled,
+                Err(ProxyError::Other(message))
+                    if message.starts_with(
+                        "upstream reconciliation local preparation remained deferred",
+                    ) =>
+                {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                Err(err) => panic!("run reconciliation with research-only work: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("admit research-only reconciliation within a bounded retry window");
     assert_eq!(settled, 0);
     assert!(research_started.load(Ordering::SeqCst));
     assert!(
-        started_at.elapsed() < Duration::from_secs(5),
-        "a slow research probe must not consume the 20-second main settlement budget"
+        research_request_started_at
+            .lock()
+            .expect("read research request start")
+            .expect("research request started")
+            .elapsed()
+            < Duration::from_secs(3),
+        "a slow research probe must finish within its two-second sweep after it starts"
     );
     let (_, attempted, _, _, _, budget_exhausted) = proxy
         .key_store
@@ -207,31 +236,25 @@ async fn reconciliation_research_sweep_does_not_hold_an_empty_main_run() {
         "research's independent budget must not report primary local pressure"
     );
 
-    for _ in 0..3 {
-        proxy.fail_next_reconciliation_research_read_for_test();
-        assert_eq!(
-            proxy
-                .run_upstream_reconciliation_once(&format!("http://{addr}"))
-                .await
-                .expect("defer transient research pressure"),
-            0
-        );
-    }
-    let (streak, level, backoff_until) = proxy
+    proxy.fail_next_reconciliation_research_read_for_test();
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("defer a transient research eligibility read"),
+        0
+    );
+    let (streak, level, _) = proxy
         .key_store
         .upstream_reconciliation_local_backoff_state()
         .await
-        .expect("read research pressure backoff");
-    assert_eq!((streak, level), (3, 1));
-    assert!(backoff_until >= now + 30);
-    assert!(
-        proxy
-            .key_store
-            .upstream_reconciliation_continuation_at()
-            .await
-            .expect("read durable continuation")
-            .is_some_and(|continuation_at| continuation_at >= backoff_until)
+        .expect("read local pressure state after a preparation defer");
+    assert_eq!(
+        (streak, level),
+        (0, 0),
+        "an unclaimed preparation defer must not fabricate a durable local-pressure backoff"
     );
+
     let (work_generation, completed_generation): (i64, i64) = sqlx::query_as(
         "SELECT work_generation, completed_generation FROM upstream_reconciliation_work \
          WHERE token_id = 'research-budget-token' AND period_code = '2026-07-15/R1'",
@@ -252,11 +275,319 @@ async fn reconciliation_research_sweep_does_not_hold_an_empty_main_run() {
         .sqlite_runtime
         .begin_immediate(SqliteOperation::ReconciliationProjection)
         .await
-        .expect("begin transaction after transient research read");
+        .expect("begin transaction after bounded research read");
     transaction
         .rollback()
         .await
         .expect("rollback reusable projection connection");
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_due_research_uses_reserved_budget_after_a_slow_main_attempt() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-reserve"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save compare-only settings");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-research-reserve")
+        .await
+        .expect("create reconciliation key");
+
+    for (token_id, period_code, project_id, billing_subject) in [
+        (
+            "slow-main-token",
+            "2026-07-15/S1",
+            "project-slow-main",
+            "token:slow-main-token",
+        ),
+        (
+            "reserved-research-token",
+            "2026-07-15/R1",
+            "project-reserved-research",
+            "token:reserved-research-token",
+        ),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_usage (
+                token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+                request_count, first_used_at, last_used_at, updated_at, settlement_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+            "#,
+        )
+        .bind(token_id)
+        .bind(&key_id)
+        .bind(period_code)
+        .bind(project_id)
+        .bind(billing_subject)
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 1_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("seed reconciliation usage");
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+        "#,
+    )
+    .bind("reserved-research-request")
+    .bind("reserved-research-token")
+    .bind(&key_id)
+    .bind("2026-07-15/R1")
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed due research");
+    sqlx::query(
+        r#"
+        UPDATE upstream_reconciliation_work
+        SET completed_generation = work_generation
+        WHERE token_id = 'reserved-research-token' AND period_code = '2026-07-15/R1'
+        "#,
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("keep pending research out of main settlement work");
+
+    let usage_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let usage_hits_for_route = Arc::clone(&usage_hits);
+    let research_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let research_hits_for_route = Arc::clone(&research_hits);
+    let app = Router::new()
+        .route(
+            "/usage",
+            get(move || {
+                let usage_hits = Arc::clone(&usage_hits_for_route);
+                async move {
+                    usage_hits.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(8_500)).await;
+                    Json(serde_json::json!({ "key": { "usage": 0 } }))
+                }
+            }),
+        )
+        .route(
+            "/research/reserved-research-request",
+            get(move || {
+                let research_hits = Arc::clone(&research_hits_for_route);
+                async move {
+                    research_hits.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({ "status": "completed" }))
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind reconciliation upstream");
+    let addr = listener
+        .local_addr()
+        .expect("read reconciliation upstream address");
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve reconciliation upstream");
+    });
+
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("run reconciliation with a slow main attempt"),
+        0
+    );
+    assert!(
+        (1..=2).contains(&usage_hits.load(Ordering::SeqCst)),
+        "one eligible main candidate may use the existing bounded HTTP retry path"
+    );
+    assert_eq!(
+        research_hits.load(Ordering::SeqCst),
+        1,
+        "a due research item must receive its reserved request window after the durable main retry"
+    );
+    let main_work: (i64, i64, String) = sqlx::query_as(
+        r#"
+        SELECT work_generation, completed_generation, last_outcome
+        FROM upstream_reconciliation_work
+        WHERE token_id = 'slow-main-token' AND period_code = '2026-07-15/S1'
+        "#,
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read retryable main work");
+    assert!(main_work.1 < main_work.0);
+    assert_eq!(main_work.2, "transport_failure");
+    let research_terminal_at: Option<i64> = sqlx::query_scalar(
+        "SELECT terminal_at FROM upstream_reconciliation_research WHERE request_id = 'reserved-research-request'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read research terminal state");
+    assert_eq!(research_terminal_at, Some(now));
+    let (_, attempted_candidate_count, _, _, _, _) = proxy
+        .key_store
+        .upstream_reconciliation_last_run_stats()
+        .await
+        .expect("read reconciliation run stats");
+    assert_eq!(
+        attempted_candidate_count, 1,
+        "the due research reservation must not turn one main work item into another candidate"
+    );
+    let actual_adjustments: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM billing_reconciliation_adjustments")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("count actual billing adjustments");
+    assert_eq!(actual_adjustments, 0);
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_without_due_research_retains_two_main_remote_attempts() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec![
+            "tvly-reconciliation-main-capacity-one",
+            "tvly-reconciliation-main-capacity-two",
+        ],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save compare-only settings");
+    let first_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-main-capacity-one")
+        .await
+        .expect("create first reconciliation key");
+    let second_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-main-capacity-two")
+        .await
+        .expect("create second reconciliation key");
+    for key_id in [&first_key_id, &second_key_id] {
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_usage (
+                token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+                request_count, first_used_at, last_used_at, updated_at, settlement_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+            "#,
+        )
+        .bind("two-main-attempts-token")
+        .bind(key_id)
+        .bind("2026-07-15/S1")
+        .bind("project-two-main-attempts")
+        .bind("token:two-main-attempts-token")
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 1_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("seed two-key reconciliation usage");
+    }
+
+    let usage_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let usage_hits_for_route = Arc::clone(&usage_hits);
+    let app = Router::new().route(
+        "/usage",
+        get(move || {
+            let usage_hits = Arc::clone(&usage_hits_for_route);
+            async move {
+                usage_hits.fetch_add(1, Ordering::SeqCst);
+                Json(serde_json::json!({ "key": { "usage": 0 } }))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind reconciliation upstream");
+    let addr = listener
+        .local_addr()
+        .expect("read reconciliation upstream address");
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve reconciliation upstream");
+    });
+
+    assert_eq!(
+        proxy
+            .run_upstream_reconciliation_once(&format!("http://{addr}"))
+            .await
+            .expect("run reconciliation without due research"),
+        1
+    );
+    assert_eq!(
+        usage_hits.load(Ordering::SeqCst),
+        2,
+        "without due Research, reconciliation retains both bounded main remote attempts"
+    );
+    let (_, attempted_candidate_count, _, _, _, _) = proxy
+        .key_store
+        .upstream_reconciliation_last_run_stats()
+        .await
+        .expect("read reconciliation run stats");
+    assert_eq!(attempted_candidate_count, 1);
+    let research_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_research WHERE terminal_at IS NULL",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count due research");
+    assert_eq!(research_count, 0);
+    let actual_adjustments: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM billing_reconciliation_adjustments")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("count actual billing adjustments");
+    assert_eq!(actual_adjustments, 0);
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);

--- a/src/tests/upstream_reconciliation_projection.rs
+++ b/src/tests/upstream_reconciliation_projection.rs
@@ -532,6 +532,61 @@ async fn reconciliation_unknown_research_eligibility_preserves_two_main_remote_a
         .await
         .expect("seed two-key reconciliation usage");
     }
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind("current-period-research-token")
+    .bind(&first_key_id)
+    .bind("2026-07-15/S2")
+    .bind("project-current-period-research")
+    .bind("token:current-period-research-token")
+    .bind(now - 900)
+    .bind(now + 3_600)
+    .bind(now - 900)
+    .bind(now)
+    .bind(now)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed current-period research usage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+        "#,
+    )
+    .bind("current-period-research-request")
+    .bind("current-period-research-token")
+    .bind(&first_key_id)
+    .bind("2026-07-15/S2")
+    .bind(now)
+    .bind(now)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed current-period research");
+    sqlx::query(
+        r#"
+        UPDATE upstream_reconciliation_work
+        SET completed_generation = work_generation
+        WHERE token_id = 'current-period-research-token' AND period_code = '2026-07-15/S2'
+        "#,
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("keep current-period research out of main settlement work");
+    assert!(
+        !proxy
+            .key_store
+            .has_due_upstream_reconciliation_research()
+            .await
+            .expect("read Research eligibility"),
+        "current-period Research must not reserve main settlement capacity"
+    );
 
     let usage_hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let usage_hits_for_route = Arc::clone(&usage_hits);
@@ -581,8 +636,11 @@ async fn reconciliation_unknown_research_eligibility_preserves_two_main_remote_a
     )
     .fetch_one(&proxy.key_store.pool)
     .await
-    .expect("count due research");
-    assert_eq!(research_count, 0);
+    .expect("count current-period research");
+    assert_eq!(
+        research_count, 1,
+        "current-period Research must remain unpolled"
+    );
     let actual_adjustments: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM billing_reconciliation_adjustments")
             .fetch_one(&proxy.key_store.pool)

--- a/src/tests/upstream_reconciliation_projection.rs
+++ b/src/tests/upstream_reconciliation_projection.rs
@@ -473,7 +473,7 @@ async fn reconciliation_due_research_uses_reserved_budget_after_a_slow_main_atte
 }
 
 #[tokio::test]
-async fn reconciliation_without_due_research_retains_two_main_remote_attempts() {
+async fn reconciliation_unknown_research_eligibility_preserves_two_main_remote_attempts() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
     let now = local_ts(2026, 7, 15, 12, 0);
@@ -557,17 +557,18 @@ async fn reconciliation_without_due_research_retains_two_main_remote_attempts() 
             .expect("serve reconciliation upstream");
     });
 
+    proxy.fail_next_reconciliation_research_read_for_test();
     assert_eq!(
         proxy
             .run_upstream_reconciliation_once(&format!("http://{addr}"))
             .await
-            .expect("run reconciliation without due research"),
+            .expect("run reconciliation with an unavailable Research eligibility probe"),
         1
     );
     assert_eq!(
         usage_hits.load(Ordering::SeqCst),
         2,
-        "without due Research, reconciliation retains both bounded main remote attempts"
+        "an unavailable Research eligibility probe must not defer main settlement"
     );
     let (_, attempted_candidate_count, _, _, _, _) = proxy
         .key_store


### PR DESCRIPTION
## Summary

- Move the expensive Research candidate sweep after main durable settlement so a bounded preflight cannot suppress primary reconciliation progress.
- Reserve Research capacity from a small ended-period eligibility probe; unavailable eligibility conservatively reserves capacity without deferring main settlement.
- Keep current-period Research out of the reserve and retain existing compare-mode billing semantics.

## Delivery

- Delivery role: direct
- Spec: upstream-privacy-period-reconciliation, performance-architecture-hardening, sqlite-write-lock-hardening, runtime-performance-observability
- Spec Disposition: refresh
- Solutions: period-scoped-upstream-usage-reconciliation
- Project Docs: CONTEXT.md updated

## Validation

- Reconciliation projection and upstream reconciliation backend shards passed.
- Source line budget and backend manifest verification passed.
- cargo clippy --locked --all-targets --all-features -- -D warnings passed.
- 101 read-only dual-database testbox comparison ran baseline/candidate for 10 minutes each: candidate terminalDelta=5, fixture terminal completed, zero projection discards, zero final lock errors, zero 5xx, and zero billing adjustments.
- Independent review found no unresolved P0/P1/P2.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->