### PR TITLE
test(pressure): wait for deferred tail flush

### DIFF
--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -1632,6 +1632,10 @@ async fn analysis_pressure_rebuild_drains_events_arriving_during_tail_replay() {
     )
     .await
     .expect("rebuild should enter the tail replay before the live producer starts");
+    let pressure_flush_complete = proxy
+        .server_pressure_flush_completed_notifier_for_test()
+        .await
+        .notified_owned();
     let producer = {
         let proxy = proxy.clone();
         tokio::spawn(async move {
@@ -1654,7 +1658,9 @@ async fn analysis_pressure_rebuild_drains_events_arriving_during_tail_replay() {
     .await
     .expect("pressure rebuild drains its live tail");
 
-    wait_for_server_pressure_totals(&proxy, 250, 100).await;
+    tokio::time::timeout(Duration::from_secs(3), pressure_flush_complete)
+        .await
+        .expect("deferred pressure writer drains events recorded during tail replay");
 
     let (success_count, failure_count): (i64, i64) = sqlx::query_as(
         r#"


### PR DESCRIPTION
## Summary
- Replace SQLite polling in the live tail-replay test with the existing in-memory deferred-writer completion signal.
- Preserve the final bucket-total assertion without competing with the writer under CI concurrency.

## Delivery
- Delivery role: direct
- Spec: -
- Spec Disposition: not_needed
- Solutions: -
- Project Docs: -
- Visual evidence: not applicable; no owner-visible surface changed.

## Validation
- `cargo fmt --all -- --check`
- `python3 scripts/ci_backend_tests.py verify`
- `cargo test --locked --lib tests::user_pressure_analysis::analysis_pressure_rebuild_drains_events_arriving_during_tail_replay -- --exact --test-threads=2 --nocapture`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-account-user-lifecycle`
- `cargo test --locked --test rust_source_line_budgets`
- pre-commit `cargo clippy --locked -j 2 -- -D warnings`