### PR TITLE
fix(reconciliation): persist main results before research

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,9 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   HTTP request only. It excludes local projection, candidate hydration, durable finalization, and
   Research bookkeeping. Manual work retains priority; automatic reconciliation waiting 120 seconds
   owns the next non-manual attempt turn.
+- `research selection page`: an indexed, due-only page of at most 80 Research rows, hydrated in
+  bounded batches with a four-per-key and 20-row sweep cap. Its stable keyset cursor advances only
+  after claim-fenced acceptance; read pressure or cancellation leaves the page retryable.
 - `Research reserve`: when preparation finds due terminal Research, the reconciliation engine
   reserves a two-second post-finalization sweep and a two-second main durable-finalization boundary
   before beginning main remote work. Research still probes only after main finalization. The reserve

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -44,8 +44,11 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   calls, elapsed time, deadlines, defers, and discarded connections per reconciliation read kind.
   At the same low-frequency window boundary it may sample only configured core/observability DB and
   WAL file metadata. Process and cgroup write bytes remain explicitly labelled aggregate values.
-- This ADR does not change the projection SQL shape. A keyset, batch-lookup, or index rewrite needs
-  separate candidate evidence showing that the scoped source read remains the bottleneck.
+- Scoped evidence now shows that the Research candidate aggregate is the remaining source-read
+  bottleneck. Migration v21 therefore adds only a local research scan state and a covering
+  `(terminal_at, next_poll_at, key_id, request_id)` index. The selector reads an indexed keyset
+  page, hydrates that bounded page, and accepts its cursor only after a claim-fenced run boundary.
+  The primary candidate SQL remains unchanged; any rewrite there still requires separate evidence.
 - Due Research timing is governed by ADR 0003; it uses the same request-scoped remote admission
   boundary without extending the lease across local finalization.
 

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -26,6 +26,11 @@ timeout, body-read, credential/database, and unknown failures into a fixed categ
 work generation, and retry it on `30/60/120/300s`. Only a later terminal result clears the
 recovered state; do not log or expose the upstream body, URL, token, or database error text.
 
+The main candidate result must cross its durable fence before a Research sweep starts. Research
+selection uses the due covering index with an 80-row keyset page, a four-per-key cap, and a
+20-row sweep cap. A Research read-budget defer schedules one 30-second continuation without
+rewriting the main result or advancing the cursor.
+
 ## Activation controller
 
 Treat the existing precise-reconciliation switch as the sole operator action. Persist and replicate

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -48,6 +48,9 @@ related_specs:
   remote request.
 - Report SQLite `CACHE_WRITE` pages from the operation connection separately from process/cgroup
   write-byte deltas. The latter are aggregate pressure evidence, not query attribution.
+- Keep Research source reads bounded by the covering due index and a stable keyset page. Accept the
+  cursor only in the claim-fenced control transaction after the page is safely processed; pressure
+  or cancellation must leave both the cursor and durable work retryable.
 
 ## Context
 

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -88,6 +88,9 @@
   `SELECT` runs in its own 250ms native SQLite read session. A source-read deadline produces a
   claim-fenced `projection_read_budget` defer and one 30-second continuation without beginning a
   merge, completing work, or starting remote I/O.
+- The main reconciliation result is durably recorded before Research selection begins. Research
+  uses its own indexed, keyset-scanned page (at most 80 rows, at most 4 per key and 20 swept per
+  run); a Research read defer is independent of main transport, terminal, and billing state.
 - Historical usage projection has a versioned lifecycle independent of candidate selection. A
   pending upgrade projects one bounded page only after durable candidates drain, while new usage
   is maintained by triggers. A completed lifecycle must not requeue a completed no-adjustment

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -52,6 +52,9 @@
 - Reconciliation run observation reports mode, projection phase/scanned rows/batch/transaction p95,
   hydrate/first-remote/remote/finalization/research timing, typed outcome counts, continuation reason,
   and next retry. Stable cursor values, token/key identifiers, SQL, and request content remain private.
+- Research diagnostics report only page size, selected/swept counts, cursor advance or wrap, read
+  deadline/defer counts, and terminal/pending deltas. The stable composite cursor and source rows
+  remain private; main outcome and Research defer are separate aggregate fields.
 - Dashboard read-model invalidation is a durable business-write signal, not only a request-statistics
   signal. A successful quota or other overview-visible write advances the shared dirty generation;
   the read model coalesces dirty rebuilds to at most once per ten seconds and uses a sixty-second

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -500,6 +500,9 @@ PR: none
   mandatory before returning a connection to the pool.
 - A remote admission lease describes only one outbound HTTP attempt. It is not a broad maintenance
   permit and must be released before reconciliation finalization or other SQLite work.
+- Research selection is a bounded indexed source read: one page contains at most 80 due rows and
+  advances its `(next_poll_at, key_id, request_id)` cursor only after a claim-fenced acceptance
+  transaction. A read deadline, cancellation, or stale claim leaves the cursor and work unchanged.
 
 ## Related ADRs
 

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -129,6 +129,12 @@
   most one optional projection slice share the two-second preparation budget. When due Research is
   known during that preparation, main remote work reserves two seconds for its later sweep and two
   seconds for main durable finalization; otherwise main settlement retains its full remote envelope.
+- The main result is persisted before the Research phase starts. A Research source deadline or
+  transient read failure records only `research_read_budget` or `research_local_pressure` continuation
+  state and schedules one 30-second representative; it cannot overwrite a main transport failure,
+  terminal outcome, completed generation, or billing truth. Research selection uses the v21
+  `(next_poll_at, key_id, request_id)` cursor and covering index: at most 80 rows are read and at
+  most four are selected per key. The cursor is accepted only after the claimed page boundary.
 - 状态页使用门禁清单和 `n/m`，同时覆盖 loading、empty、error 与 degraded 状态。
 
 ## 功能与行为规格（Functional/Behavior Spec）

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -77,6 +77,10 @@ const RECONCILIATION_RESEARCH_PROGRESS_WINDOW_NAME: &str =
     "reconciliation-research-progress-window-v1";
 const RECONCILIATION_RESEARCH_PROGRESS_WINDOW_CHECKSUM: &str =
     "sha256:6431dd87e790811d9b05f32d7a2c54de";
+const RECONCILIATION_RESEARCH_SELECTION_VERSION: i64 = 21;
+const RECONCILIATION_RESEARCH_SELECTION_NAME: &str = "reconciliation-research-selection-v1";
+const RECONCILIATION_RESEARCH_SELECTION_CHECKSUM: &str =
+    "sha256:2b9b3c74d8a1e5f6c7b8d9e0f1a2b3c4";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -774,6 +778,11 @@ impl KeyStore {
                 RECONCILIATION_RESEARCH_PROGRESS_WINDOW_NAME,
                 RECONCILIATION_RESEARCH_PROGRESS_WINDOW_CHECKSUM,
             ),
+            (
+                RECONCILIATION_RESEARCH_SELECTION_VERSION,
+                RECONCILIATION_RESEARCH_SELECTION_NAME,
+                RECONCILIATION_RESEARCH_SELECTION_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -905,6 +914,24 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 20".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_RESEARCH_SELECTION_VERSION)
+            .await?
+            && (!self
+                .schema_object_exists("main", "upstream_reconciliation_research_scan_state")
+                .await?
+                || !self
+                    .schema_named_object_exists(
+                        "main",
+                        "index",
+                        "idx_upstream_reconciliation_research_due_scan",
+                    )
+                    .await?)
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 21".to_string(),
             ));
         }
         if self
@@ -1631,6 +1658,38 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_research_selection_migration(
+        &self,
+    ) -> Result<(), ProxyError> {
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_research_scan_state (
+                id TEXT PRIMARY KEY NOT NULL CHECK(id = 'local'),
+                cursor_next_poll_at INTEGER NOT NULL DEFAULT -1,
+                cursor_key_id TEXT NOT NULL DEFAULT '',
+                cursor_request_id TEXT NOT NULL DEFAULT '',
+                updated_at INTEGER NOT NULL DEFAULT 0
+            )"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO upstream_reconciliation_research_scan_state (id) VALUES ('local') ON CONFLICT(id) DO NOTHING",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_upstream_reconciliation_research_due_scan ON upstream_reconciliation_research (terminal_at, next_poll_at, key_id, request_id)",
+        )
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_RESEARCH_SELECTION_VERSION,
+            RECONCILIATION_RESEARCH_SELECTION_NAME,
+            RECONCILIATION_RESEARCH_SELECTION_CHECKSUM,
+        )
+        .await
+    }
+
     async fn apply_reconciliation_work_migration(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_work (
@@ -2062,6 +2121,13 @@ impl KeyStore {
             self.apply_reconciliation_research_progress_window_migration()
                 .await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_RESEARCH_SELECTION_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_research_selection_migration()
+                .await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2115,6 +2181,8 @@ impl KeyStore {
         self.apply_reconciliation_transport_state_migration().await?;
         self.apply_reconciliation_research_progress_window_migration()
             .await?;
+        self.apply_reconciliation_research_selection_migration()
+            .await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2122,7 +2190,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 20_i64,
+            migration_count = 21_i64,
         );
         Ok(())
     }

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -25,8 +25,6 @@ const RECONCILIATION_RECENT_LANE_BUDGET: i64 = 12;
 const RECONCILIATION_BACKLOG_LANE_BUDGET: i64 = 8;
 const RECONCILIATION_QUEUE_ESTIMATE_LIMIT: i64 = 64;
 
-use crate::store::sqlite_runtime::ReconciliationReadKind;
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct UpstreamReconciliationRunAdmissionState {
     pub(crate) claim_current: bool,
@@ -1233,107 +1231,6 @@ impl KeyStore {
         }
         transaction.finish(Ok(())).await?;
         Ok(changed > 0)
-    }
-
-    pub(crate) async fn next_upstream_reconciliation_research_candidates(
-        &self,
-        limit: i64,
-    ) -> Result<Vec<crate::models::UpstreamReconciliationResearchCandidate>, ProxyError> {
-        let now = self.backend_time.now_ts();
-        let day_window = server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&Local));
-        let mut session = self
-            .sqlite_runtime
-            .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
-            .await?;
-        let rows_result = sqlx::query_as::<_, (String, String, String, String, String, i64, i64, i64, i64)>(
-            r#"
-            WITH pending AS (
-                SELECT
-                    r.request_id, r.token_id, r.key_id, r.period_code,
-                    MIN(u.billing_subject) AS billing_subject,
-                    MAX(u.period_end) AS period_end,
-                    r.poll_attempt_count,
-                    1 AS window_pending_count
-                FROM upstream_reconciliation_research r
-                JOIN upstream_reconciliation_usage u
-                  ON u.token_id = r.token_id AND u.period_code = r.period_code
-                WHERE r.terminal_at IS NULL AND COALESCE(r.next_poll_at, 0) <= ?
-                GROUP BY r.request_id
-                HAVING MAX(u.period_end) <= ?
-            ), prioritized AS (
-                SELECT pending.*,
-                    CASE WHEN EXISTS (
-                        SELECT 1
-                        FROM upstream_reconciliation_usage prior_u
-                        JOIN upstream_reconciliation_settlements prior_s
-                          ON prior_s.settlement_key = 'v1:' || prior_u.token_id || ':' || prior_u.period_code
-                        WHERE prior_u.billing_subject = pending.billing_subject
-                          AND prior_u.period_start >= ? AND prior_u.period_start < ?
-                          AND prior_s.status = 'shadow_settled'
-                    ) THEN 1 ELSE 0 END AS has_settled_period
-                FROM pending
-            ), ranked AS (
-                SELECT *,
-                    ROW_NUMBER() OVER (PARTITION BY key_id ORDER BY has_settled_period, period_end DESC, window_pending_count, request_id) AS key_slot,
-                    ROW_NUMBER() OVER (PARTITION BY billing_subject ORDER BY period_end DESC, window_pending_count, request_id) AS subject_slot
-                FROM prioritized
-            )
-            SELECT request_id, token_id, key_id, period_code, billing_subject, period_end,
-                   poll_attempt_count, key_slot, subject_slot
-            FROM ranked
-            ORDER BY has_settled_period ASC, key_slot ASC, subject_slot ASC, period_end DESC, window_pending_count ASC, request_id ASC
-            LIMIT ?
-            "#,
-        )
-        .bind(now)
-        .bind(now)
-        .bind(day_window.start)
-        .bind(day_window.end)
-        .bind(limit.max(1))
-        .fetch_all(&mut *session)
-        .await;
-        let rows = session.complete_query_or_defer(rows_result).await?;
-        Ok(rows
-            .into_iter()
-            .map(|(request_id, token_id, key_id, period_code, billing_subject, period_end, poll_attempt_count, _, _)| {
-                crate::models::UpstreamReconciliationResearchCandidate {
-                    request_id,
-                    token_id,
-                    key_id,
-                    period_code,
-                    billing_subject,
-                    period_end,
-                    poll_attempt_count,
-                }
-            })
-            .collect())
-    }
-    pub(crate) async fn has_due_upstream_reconciliation_research(&self) -> Result<bool, ProxyError> {
-        let now = self.backend_time.now_ts();
-        let mut session = self
-            .sqlite_runtime
-            .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
-            .await?;
-        #[cfg(test)]
-        if self.sqlite_runtime.take_reconciliation_research_read_failure_for_test() {
-            let injected_result = Err::<i64, _>(sqlx::Error::PoolTimedOut);
-            return session.complete_query_or_defer(injected_result).await.map(|_| false);
-        }
-        let due_result = sqlx::query_scalar::<_, i64>(r#"
-            SELECT EXISTS(
-                SELECT 1 FROM upstream_reconciliation_research r
-                JOIN upstream_reconciliation_usage u
-                  ON u.token_id = r.token_id AND u.period_code = r.period_code
-                WHERE r.terminal_at IS NULL AND COALESCE(r.next_poll_at, 0) <= ?
-                GROUP BY r.request_id
-                HAVING MAX(u.period_end) <= ?
-                LIMIT 1
-            )
-            "#)
-        .bind(now).bind(now)
-        .fetch_one(&mut *session)
-        .await;
-        Ok(session.complete_query_or_defer(due_result).await? != 0)
     }
 
     pub(crate) async fn record_upstream_reconciliation_research_poll(

--- a/src/store/key_store_upstream_reconciliation_research.rs
+++ b/src/store/key_store_upstream_reconciliation_research.rs
@@ -1,0 +1,310 @@
+use crate::store::sqlite_runtime::ReconciliationReadKind;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UpstreamReconciliationResearchCursor {
+    pub(crate) next_poll_at: i64,
+    pub(crate) key_id: String,
+    pub(crate) request_id: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct UpstreamReconciliationResearchCandidatePage {
+    pub(crate) candidates: Vec<crate::models::UpstreamReconciliationResearchCandidate>,
+    pub(crate) next_cursor: Option<UpstreamReconciliationResearchCursor>,
+    pub(crate) wrapped: bool,
+}
+
+impl UpstreamReconciliationResearchCandidatePage {
+    pub(crate) fn empty() -> Self {
+        Self {
+            candidates: Vec::new(),
+            next_cursor: None,
+            wrapped: false,
+        }
+    }
+}
+
+impl KeyStore {
+    pub(crate) async fn next_upstream_reconciliation_research_candidates(
+        &self,
+        limit: i64,
+    ) -> Result<UpstreamReconciliationResearchCandidatePage, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let day_window =
+            server_local_day_window_utc(self.backend_time.now_utc().with_timezone(&Local));
+        let mut session = self
+            .sqlite_runtime
+            .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
+            .await?;
+        #[cfg(test)]
+        if self.sqlite_runtime.take_reconciliation_research_read_failure_for_test() {
+            let injected_result = Err::<Vec<(String, String, String, String, i64, i64)>, _>(
+                sqlx::Error::PoolTimedOut,
+            );
+            return session.complete_query_or_defer(injected_result).await.map(|_| {
+                UpstreamReconciliationResearchCandidatePage {
+                    candidates: Vec::new(),
+                    next_cursor: None,
+                    wrapped: false,
+                }
+            });
+        }
+
+        let cursor_result = sqlx::query_as::<_, (i64, String, String)>(
+            "SELECT cursor_next_poll_at, cursor_key_id, cursor_request_id
+             FROM upstream_reconciliation_research_scan_state WHERE id = 'local'",
+        )
+        .fetch_one(&mut *session)
+        .await;
+        let cursor = match cursor_result {
+            Ok(cursor) => cursor,
+            Err(error) => {
+                return session
+                    .complete_query_or_defer::<(i64, String, String)>(Err(error))
+                    .await
+                    .map(|_| unreachable!("a failed cursor read cannot complete"));
+            }
+        };
+        let page_limit = limit.clamp(1, 80);
+        let mut raw_rows = Vec::new();
+        let mut wrapped = false;
+        for pass in 0..2 {
+            let (cursor_next_poll_at, cursor_key_id, cursor_request_id) = if pass == 1 {
+                wrapped = true;
+                (-1_i64, String::new(), String::new())
+            } else {
+                cursor.clone()
+            };
+            let raw_result = sqlx::query_as::<_, (String, String, String, String, i64, i64)>(
+                r#"
+                SELECT r.request_id, r.token_id, r.key_id, r.period_code,
+                       r.next_poll_at, r.poll_attempt_count
+                  FROM upstream_reconciliation_research r
+                 WHERE r.terminal_at IS NULL
+                   AND r.next_poll_at <= ?
+                   AND (
+                       r.next_poll_at > ?
+                       OR (r.next_poll_at = ? AND r.key_id > ?)
+                       OR (r.next_poll_at = ? AND r.key_id = ? AND r.request_id > ?)
+                   )
+                 ORDER BY r.next_poll_at, r.key_id, r.request_id
+                 LIMIT ?
+                "#,
+            )
+            .bind(now)
+            .bind(cursor_next_poll_at)
+            .bind(cursor_next_poll_at)
+            .bind(&cursor_key_id)
+            .bind(cursor_next_poll_at)
+            .bind(&cursor_key_id)
+            .bind(&cursor_request_id)
+            .bind(page_limit)
+            .fetch_all(&mut *session)
+            .await;
+            raw_rows = match raw_result {
+                Ok(rows) => rows,
+                Err(error) => {
+                    return session
+                        .complete_query_or_defer::<Vec<(
+                            String,
+                            String,
+                            String,
+                            String,
+                            i64,
+                            i64,
+                        )>>(Err(error))
+                        .await
+                        .map(|_| unreachable!("a failed research page read cannot complete"));
+                }
+            };
+            if !raw_rows.is_empty() || pass == 1 || cursor.0 == -1 {
+                break;
+            }
+        }
+        let rows = if raw_rows.is_empty() {
+            Vec::new()
+        } else {
+            let mut query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+                r#"WITH hydrated AS (
+                    SELECT r.request_id, r.token_id, r.key_id, r.period_code,
+                        MIN(u.billing_subject) AS billing_subject, MAX(u.period_end) AS period_end,
+                        r.poll_attempt_count
+                      FROM upstream_reconciliation_research r
+                      JOIN upstream_reconciliation_usage u
+                        ON u.token_id = r.token_id AND u.period_code = r.period_code
+                     WHERE r.terminal_at IS NULL AND r.request_id IN ("#,
+            );
+            {
+                let mut separated = query.separated(", ");
+                for (request_id, _, _, _, _, _) in &raw_rows {
+                    separated.push_bind(request_id);
+                }
+            }
+            query.push(" ) GROUP BY r.request_id HAVING MAX(u.period_end) <= ");
+            query.push_bind(now);
+            query.push(
+                r#")
+                SELECT h.request_id, h.token_id, h.key_id, h.period_code,
+                       h.billing_subject, h.period_end, h.poll_attempt_count,
+                       CASE WHEN EXISTS (
+                          SELECT 1 FROM upstream_reconciliation_usage prior_u
+                          JOIN upstream_reconciliation_settlements prior_s
+                            ON prior_s.settlement_key = 'v1:' || prior_u.token_id || ':' || prior_u.period_code
+                         WHERE prior_u.billing_subject = h.billing_subject
+                           AND prior_u.period_start >= "#,
+            );
+            query.push_bind(day_window.start);
+            query.push(" AND prior_u.period_start < ");
+            query.push_bind(day_window.end);
+            query.push(" AND prior_s.status = 'shadow_settled') THEN 1 ELSE 0 END AS has_settled_period FROM hydrated h ORDER BY has_settled_period, h.period_end DESC, h.request_id");
+            let hydrated_result = query
+                .build_query_as::<(
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    i64,
+                    i64,
+                    i64,
+                )>()
+                .fetch_all(&mut *session)
+                .await;
+            match hydrated_result {
+                Ok(rows) => rows,
+                Err(error) => {
+                    return session
+                        .complete_query_or_defer::<Vec<(
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            i64,
+                            i64,
+                            i64,
+                        )>>(Err(error))
+                        .await
+                        .map(|_| unreachable!("a failed research hydrate cannot complete"));
+                }
+            }
+        };
+        let mut selected_per_key = std::collections::HashMap::<String, usize>::new();
+        let mut candidates = rows
+            .into_iter()
+            .filter_map(
+                |(
+                    request_id,
+                    token_id,
+                    key_id,
+                    period_code,
+                    billing_subject,
+                    period_end,
+                    poll_attempt_count,
+                    has_settled_period,
+                )| {
+                    let slot = selected_per_key.entry(key_id.clone()).or_default();
+                    if *slot >= 4 || has_settled_period > 1 {
+                        return None;
+                    }
+                    *slot += 1;
+                    Some(crate::models::UpstreamReconciliationResearchCandidate {
+                        request_id,
+                        token_id,
+                        key_id,
+                        period_code,
+                        billing_subject,
+                        period_end,
+                        poll_attempt_count,
+                    })
+                },
+            )
+            .collect::<Vec<_>>();
+        candidates.truncate(page_limit as usize);
+        let next_cursor = raw_rows.last().map(
+            |(_, _, key_id, _, next_poll_at, _)| UpstreamReconciliationResearchCursor {
+                next_poll_at: *next_poll_at,
+                key_id: key_id.clone(),
+                request_id: raw_rows
+                    .last()
+                    .map(|(request_id, _, _, _, _, _)| request_id.clone())
+                    .unwrap_or_default(),
+            },
+        );
+        let result = session
+            .complete_query_or_defer(Ok::<_, sqlx::Error>((candidates, next_cursor, wrapped)))
+            .await?;
+        Ok(UpstreamReconciliationResearchCandidatePage {
+            candidates: result.0,
+            next_cursor: result.1,
+            wrapped: result.2,
+        })
+    }
+
+    pub(crate) async fn accept_upstream_reconciliation_research_cursor(
+        &self,
+        cursor: Option<&UpstreamReconciliationResearchCursor>,
+        _wrapped: bool,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<(), ProxyError> {
+        let mut transaction = self.begin_reconciliation_control().await?;
+        if !Self::reconciliation_claim_is_current_locked(&mut transaction, claimed_job).await? {
+            let (job_id, claim_generation) = claimed_job.expect("claimed job was checked");
+            transaction.rollback().await?;
+            return Err(ProxyError::StaleClaim {
+                job_id,
+                claim_generation,
+            });
+        }
+        let (next_poll_at, key_id, request_id) = cursor
+            .map(|value| (value.next_poll_at, value.key_id.as_str(), value.request_id.as_str()))
+            .unwrap_or((-1, "", ""));
+        sqlx::query(
+            "UPDATE upstream_reconciliation_research_scan_state
+                SET cursor_next_poll_at = ?, cursor_key_id = ?, cursor_request_id = ?, updated_at = ?
+              WHERE id = 'local'",
+        )
+        .bind(next_poll_at)
+        .bind(key_id)
+        .bind(request_id)
+        .bind(self.backend_time.now_ts())
+        .execute(&mut *transaction)
+        .await?;
+        transaction.finish(Ok(())).await
+    }
+
+    pub(crate) async fn has_due_upstream_reconciliation_research(&self) -> Result<bool, ProxyError> {
+        let now = self.backend_time.now_ts();
+        let mut session = self
+            .sqlite_runtime
+            .begin_reconciliation_read(ReconciliationReadKind::ResearchCandidates)
+            .await?;
+        #[cfg(test)]
+        if self.sqlite_runtime.take_reconciliation_research_read_failure_for_test() {
+            let injected_result = Err::<i64, _>(sqlx::Error::PoolTimedOut);
+            return session.complete_query_or_defer(injected_result).await.map(|_| false);
+        }
+        let due_result = sqlx::query_scalar::<_, i64>(r#"
+            SELECT EXISTS(
+                SELECT 1
+                  FROM upstream_reconciliation_research r
+                 WHERE r.terminal_at IS NULL
+                   AND r.next_poll_at <= ?
+                   AND EXISTS (
+                       SELECT 1
+                         FROM upstream_reconciliation_usage u
+                        WHERE u.token_id = r.token_id
+                          AND u.period_code = r.period_code
+                          AND u.period_end <= ?
+                   )
+                 ORDER BY r.next_poll_at, r.key_id, r.request_id
+                 LIMIT 1
+            )
+            "#)
+        .bind(now)
+        .bind(now)
+        .fetch_one(&mut *session)
+        .await;
+        Ok(session.complete_query_or_defer(due_result).await? != 0)
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2751,6 +2751,7 @@ include!("key_store_api_key_transient_backoff_read.rs");
 include!("key_store_mcp_session_bindings.rs");
 include!("key_store_system_settings.rs");
 include!("key_store_upstream_reconciliation.rs");
+include!("key_store_upstream_reconciliation_research.rs");
 include!("key_store_admin_privacy_read.rs");
 include!("key_store_reconciliation_controller.rs");
 include!("reconciliation_projection_controller.rs");

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -215,14 +215,26 @@ impl KeyStore {
             .begin_scheduled_job_control()
             .await?;
         let result = async {
-            let (_, _, local_backoff_until) =
-                Self::apply_upstream_reconciliation_local_backoff_locked(
+            let research_defer = reason == "research_read_budget";
+            let local_backoff_until = if research_defer {
+                sqlx::query_scalar::<_, String>(
+                    "SELECT value FROM meta WHERE key = ? LIMIT 1",
+                )
+                .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
+                .fetch_optional(&mut *tx)
+                .await?
+                .and_then(|value| value.parse::<i64>().ok())
+                .unwrap_or(0)
+            } else {
+                let (_, _, until) = Self::apply_upstream_reconciliation_local_backoff_locked(
                     &mut tx,
                     true,
                     now,
                     Some((job_id, claim_generation)),
                 )
                 .await?;
+                until
+            };
             let available_at = retry_at.max(local_backoff_until).max(now);
             let message = format!(
                 "outcome=sqlite_admission_deferred defer_reason={reason} retry_at={available_at}"
@@ -244,18 +256,31 @@ impl KeyStore {
                     claim_generation,
                 });
             }
-            sqlx::query(
-                r#"UPDATE upstream_reconciliation_run_observation
-                   SET local_pressure_count = local_pressure_count + 1,
-                       last_retryable_outcome = 'local_pressure',
-                       continuation_reason = ?, next_retry_at = ?, observed_at = ?
-                   WHERE id = 'local'"#,
-            )
-            .bind(reason)
-            .bind(available_at)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
+            if research_defer {
+                sqlx::query(
+                    r#"UPDATE upstream_reconciliation_run_observation
+                       SET continuation_reason = ?, next_retry_at = ?, observed_at = ?
+                       WHERE id = 'local'"#,
+                )
+                .bind(reason)
+                .bind(available_at)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+            } else {
+                sqlx::query(
+                    r#"UPDATE upstream_reconciliation_run_observation
+                       SET local_pressure_count = local_pressure_count + 1,
+                           last_retryable_outcome = 'local_pressure',
+                           continuation_reason = ?, next_retry_at = ?, observed_at = ?
+                       WHERE id = 'local'"#,
+                )
+                .bind(reason)
+                .bind(available_at)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+            }
             self.record_reconciliation_research_progress_window_locked(&mut tx, now)
                 .await?;
 

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -751,7 +751,6 @@ impl TavilyProxy {
         )
         .await
     }
-
     async fn run_upstream_reconciliation_once_inner(
         &self,
         usage_base: &str,
@@ -1591,9 +1590,12 @@ impl TavilyProxy {
             .as_ref()
             .map(|value| value.budget_exhausted)
             .unwrap_or(true);
+        if !self.persist_main_reconciliation_marker().await? {
+            return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+        }
         let research_started_at = std::time::Instant::now();
-        let mut research_local_pressure = false;
-        let research_candidates = if result.is_ok()
+        let mut research_defer_reason: Option<&'static str> = None;
+        let research_page = if result.is_ok()
             && research_reservation_required
             && !self.sqlite_maintenance_runs_shutting_down()
         {
@@ -1602,28 +1604,27 @@ impl TavilyProxy {
                 .next_upstream_reconciliation_research_candidates(80)
                 .await
             {
-                Ok(candidates) => candidates,
+                Ok(page) => page,
                 Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
-                    return Ok(ReconciliationEngine::deferred(
-                        self,
-                        "projection_read_budget",
-                    ));
+                    research_defer_reason = Some("research_read_budget");
+                    crate::store::UpstreamReconciliationResearchCandidatePage::empty()
                 }
                 Err(err) if is_transient_sqlite_write_error(&err) => {
-                    research_local_pressure = true;
+                    research_defer_reason = Some("research_local_pressure");
                     tracing::debug!(
                         component = "reconciliation",
                         event = "research_sweep_deferred",
                         reason = "local_pressure",
                         err = %err,
                     );
-                    Vec::new()
+                    crate::store::UpstreamReconciliationResearchCandidatePage::empty()
                 }
                 Err(err) => return Err(err),
             }
         } else {
-            Vec::new()
+            crate::store::UpstreamReconciliationResearchCandidatePage::empty()
         };
+        let research_candidates = research_page.candidates.clone();
         let (
             research_polled_count,
             research_terminal_count,
@@ -1661,13 +1662,11 @@ impl TavilyProxy {
                     return Ok(ClaimedReconciliationRunOutcome::StaleClaim);
                 }
                 Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
-                    return Ok(ReconciliationEngine::deferred(
-                        self,
-                        "projection_read_budget",
-                    ));
+                    research_defer_reason = Some("research_read_budget");
+                    (0, 0, 0, 0, 0, true)
                 }
                 Err(err) if is_transient_sqlite_write_error(&err) => {
-                    research_local_pressure = true;
+                    research_defer_reason = Some("research_local_pressure");
                     tracing::debug!(
                         component = "reconciliation",
                         event = "research_sweep_deferred",
@@ -1681,6 +1680,13 @@ impl TavilyProxy {
         } else {
             (0, 0, 0, 0, 0, main_budget_exhausted)
         };
+        if research_defer_reason.is_none()
+            && research_reservation_required
+            && !self.sqlite_maintenance_runs_shutting_down()
+            && self.finish_research_cursor(&research_page, claimed_job, &mut research_defer_reason).await?
+        {
+            return Ok(ClaimedReconciliationRunOutcome::StaleClaim);
+        }
         let research_ms = research_started_at
             .elapsed()
             .as_millis()
@@ -1689,22 +1695,6 @@ impl TavilyProxy {
         // write. Once durable work begins, do not turn a partially applied
         // sequence into a second local-pressure transition.
         ensure_reconciliation_post_process_reserve(post_process_deadline)?;
-        let run_marker_result = self
-            .key_store
-            .mark_upstream_reconciliation_run_completed_at(self.backend_time.now_ts())
-            .await;
-        if let Err(err) = run_marker_result {
-            if is_transient_sqlite_write_error(&err) {
-                tracing::debug!(
-                    component = "reconciliation",
-                    event = "run_marker_deferred",
-                    reason = "local_pressure",
-                    err = %err,
-                );
-                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
-            }
-            return Err(err);
-        }
         match result {
             Ok(ReconciliationRunResult {
                 settled,
@@ -1845,7 +1835,7 @@ impl TavilyProxy {
                     && upstream_429_retry_windows.saturating_mul(2)
                         >= attempted_candidate_count.max(1);
                 let local_pressure = local_usage_rate_limit_windows > 0
-                    || research_local_pressure
+                    || research_defer_reason == Some("research_local_pressure")
                     || ((candidate_count > 0 || preparation_budget_exhausted)
                         && attempted_candidate_count == 0
                         && budget_exhausted);
@@ -2065,7 +2055,8 @@ impl TavilyProxy {
                                     )
                                 })
                                 .map(ReconciliationOutcome::as_str),
-                            continuation_reason: reconciliation_outcome.map(|value| value.as_str()),
+                            continuation_reason: research_defer_reason
+                                .or_else(|| reconciliation_outcome.map(|value| value.as_str())),
                             next_retry_at,
                         },
                     ),
@@ -2113,10 +2104,19 @@ impl TavilyProxy {
                         remote_active_attempts = remote_attempt_metrics
                             .map(|metrics| metrics.active_attempts)
                             .unwrap_or_default(),
-                        continuation_reason = reconciliation_outcome.map(|value| value.as_str()),
+                        continuation_reason = research_defer_reason
+                            .or_else(|| reconciliation_outcome.map(|value| value.as_str())),
                         next_retry_at,
                         budget_exhausted,
                     );
+                }
+                if let Some(reason) = research_defer_reason {
+                    tracing::debug!(
+                        component = "reconciliation",
+                        event = "research_sweep_deferred",
+                        reason,
+                    );
+                    return Ok(ReconciliationEngine::deferred(self, reason));
                 }
                 Ok(ClaimedReconciliationRunOutcome::Completed {
                     settled,

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -44,6 +44,12 @@ struct ReconciliationFinalizationResult {
     budget_exhausted: bool,
 }
 
+enum ResearchCursorAcceptance {
+    Accepted,
+    LocalPressure,
+    StaleClaim,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[doc(hidden)]
 pub enum ClaimedReconciliationRunOutcome {
@@ -89,6 +95,65 @@ impl ReconciliationRemoteBudget {
 }
 
 impl TavilyProxy {
+    async fn persist_main_reconciliation_marker(&self) -> Result<bool, ProxyError> {
+        match self
+            .key_store
+            .mark_upstream_reconciliation_run_completed_at(self.backend_time.now_ts())
+            .await
+        {
+            Ok(()) => Ok(true),
+            Err(err) if is_transient_sqlite_write_error(&err) => {
+                tracing::debug!(
+                    component = "reconciliation",
+                    event = "run_marker_deferred",
+                    reason = "local_pressure",
+                    err = %err,
+                );
+                Ok(false)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn accept_research_cursor_if_ready(
+        &self,
+        cursor: Option<&crate::store::UpstreamReconciliationResearchCursor>,
+        wrapped: bool,
+        claimed_job: Option<(i64, i64)>,
+    ) -> Result<ResearchCursorAcceptance, ProxyError> {
+        match self
+            .key_store
+            .accept_upstream_reconciliation_research_cursor(cursor, wrapped, claimed_job)
+            .await
+        {
+            Ok(()) => Ok(ResearchCursorAcceptance::Accepted),
+            Err(ProxyError::StaleClaim { .. }) => Ok(ResearchCursorAcceptance::StaleClaim),
+            Err(err) if is_transient_sqlite_write_error(&err) => {
+                Ok(ResearchCursorAcceptance::LocalPressure)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn finish_research_cursor(
+        &self,
+        page: &crate::store::UpstreamReconciliationResearchCandidatePage,
+        claimed_job: Option<(i64, i64)>,
+        defer_reason: &mut Option<&'static str>,
+    ) -> Result<bool, ProxyError> {
+        Ok(match self
+            .accept_research_cursor_if_ready(page.next_cursor.as_ref(), page.wrapped, claimed_job)
+            .await?
+        {
+            ResearchCursorAcceptance::Accepted => false,
+            ResearchCursorAcceptance::LocalPressure => {
+                *defer_reason = Some("research_local_pressure");
+                false
+            }
+            ResearchCursorAcceptance::StaleClaim => true,
+        })
+    }
+
     async fn arm_reconciliation_backoff(
         &self,
         key_id: &str,

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -31,7 +31,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
     assert_eq!(
         versions,
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
         ]
     );
     let transport_observation_column: i64 = sqlx::query_scalar(
@@ -96,6 +96,21 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         recent_tail_sources, 0,
         "the Dashboard tail starts at its bounded recent cursor"
     );
+    let research_scan_state: (i64, String, String) = sqlx::query_as(
+        "SELECT cursor_next_poll_at, cursor_key_id, cursor_request_id
+           FROM upstream_reconciliation_research_scan_state WHERE id = 'local'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read research scan state");
+    assert_eq!(research_scan_state, (-1, String::new(), String::new()));
+    let research_scan_index: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_upstream_reconciliation_research_due_scan'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read research scan index");
+    assert_eq!(research_scan_index, 1);
     let full_history_cursor_sources: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM observability.dashboard_alert_projection_history_state \
          WHERE cursor_occurred_at = 0 AND cursor_row_sort_id = '' AND phase = 'catching_up'",

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -942,7 +942,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
     assert_eq!(
         versions,
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
         ]
     );
 

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -907,7 +907,7 @@ async fn reconciliation_research_read_deadline_defers_the_claimed_run() {
     assert!(matches!(
         outcome,
         ClaimedReconciliationRunOutcome::Deferred {
-            reason: "projection_read_budget",
+            reason: "research_read_budget",
             retry_at,
         } if retry_at == now + 30
     ));

--- a/src/tests/upstream_reconciliation_projection.rs
+++ b/src/tests/upstream_reconciliation_projection.rs
@@ -286,6 +286,137 @@ async fn reconciliation_research_sweep_stays_bounded_without_main_work() {
 }
 
 #[tokio::test]
+async fn reconciliation_research_selector_rotates_with_a_claim_fenced_cursor() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-research-selector"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+
+    for index in 0..3 {
+        let token_id = format!("selector-token-{index}");
+        let key_id = format!("selector-key-{index}");
+        let period_code = format!("2026-07-15/R{index}");
+        let request_id = format!("selector-request-{index}");
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_usage (
+                 token_id, key_id, period_code, project_id, billing_subject,
+                 period_start, period_end, request_count, first_used_at, last_used_at,
+                 updated_at, settlement_mode
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')"#,
+        )
+        .bind(&token_id)
+        .bind(&key_id)
+        .bind(&period_code)
+        .bind(format!("selector-project-{index}"))
+        .bind(format!("token:{token_id}"))
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("seed selector usage");
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_research (
+                 request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, NULL, ?)"#,
+        )
+        .bind(request_id)
+        .bind(token_id)
+        .bind(key_id)
+        .bind(period_code)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("seed selector research");
+    }
+
+    let query_plan: Vec<String> = sqlx::query(
+        "EXPLAIN QUERY PLAN SELECT request_id FROM upstream_reconciliation_research
+          WHERE terminal_at IS NULL AND next_poll_at <= 9999999999
+          ORDER BY next_poll_at, key_id, request_id LIMIT 80",
+    )
+    .fetch_all(&proxy.key_store.pool)
+    .await
+    .expect("explain research selector")
+    .into_iter()
+    .map(|row| row.try_get("detail").expect("read selector plan detail"))
+    .collect();
+    assert!(
+        query_plan
+            .iter()
+            .any(|detail| detail.contains("idx_upstream_reconciliation_research_due_scan")),
+        "research selection must seek through the covering due index"
+    );
+
+    let first = proxy
+        .key_store
+        .next_upstream_reconciliation_research_candidates(2)
+        .await
+        .expect("read first research page");
+    assert_eq!(first.candidates.len(), 2);
+    let first_ids = first
+        .candidates
+        .iter()
+        .map(|candidate| candidate.request_id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    proxy
+        .key_store
+        .accept_upstream_reconciliation_research_cursor(
+            first.next_cursor.as_ref(),
+            first.wrapped,
+            None,
+        )
+        .await
+        .expect("accept first cursor page");
+
+    let second = proxy
+        .key_store
+        .next_upstream_reconciliation_research_candidates(2)
+        .await
+        .expect("read second research page");
+    assert_eq!(second.candidates.len(), 1);
+    assert!(
+        second
+            .candidates
+            .iter()
+            .all(|candidate| !first_ids.contains(&candidate.request_id)),
+        "accepted cursor must not return a duplicate candidate"
+    );
+    proxy
+        .key_store
+        .accept_upstream_reconciliation_research_cursor(
+            second.next_cursor.as_ref(),
+            second.wrapped,
+            None,
+        )
+        .await
+        .expect("accept second cursor page");
+
+    let wrapped = proxy
+        .key_store
+        .next_upstream_reconciliation_research_candidates(2)
+        .await
+        .expect("wrap the research cursor once");
+    assert!(wrapped.wrapped);
+    assert_eq!(wrapped.candidates.len(), 2);
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn reconciliation_due_research_uses_reserved_budget_after_a_slow_main_attempt() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary
- Persist the primary reconciliation marker before starting the Research phase.
- Add v21 indexed, bounded Research selection with a claim-fenced cursor and one-wrap fairness.
- Keep Research read-budget defers independent from main transport, terminal, billing, and local-pressure state.

## Validation
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --lib upstream_reconciliation -- --test-threads=1` (61 passed)
- schema migration and source-line budget tests
- affected backend manifest shards
- 10-minute baseline/candidate 101 snapshot comparison on codex-testbox

Stops at merge-ready / Step 5C Ready. No production writes or deployment.