### PR TITLE
test(pressure): allow deferred tail flush recovery

### DIFF
--- a/src/tests/user_pressure_analysis.rs
+++ b/src/tests/user_pressure_analysis.rs
@@ -1658,7 +1658,9 @@ async fn analysis_pressure_rebuild_drains_events_arriving_during_tail_replay() {
     .await
     .expect("pressure rebuild drains its live tail");
 
-    tokio::time::timeout(Duration::from_secs(3), pressure_flush_complete)
+    // The deferred writer may yield for the five-second contention cooldown
+    // before its one-second retry cadence can observe the completed replay.
+    tokio::time::timeout(Duration::from_secs(8), pressure_flush_complete)
         .await
         .expect("deferred pressure writer drains events recorded during tail replay");
 


### PR DESCRIPTION
## Summary
- Align the tail-replay deferred writer assertion with the configured five-second contention cooldown and one-second retry cadence.
- Keep the existing in-memory completion signal and final bucket-total assertion; production pressure writer behavior is unchanged.

## Delivery
- Delivery role: direct
- Spec: -
- Spec Disposition: not_needed
- Solutions: -
- Project Docs: -

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked --lib tests::user_pressure_analysis::analysis_pressure_rebuild_drains_events_arriving_during_tail_replay -- --exact --test-threads=2 --nocapture`
- `cargo test --locked --lib tests::user_pressure_analysis::analysis_ -- --test-threads=2 --nocapture`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-account-user-lifecycle`
- `python3 scripts/ci_backend_tests.py verify`
- pre-commit `cargo clippy --locked -j 2 -- -D warnings`