### PR TITLE
fix(reconciliation): scope cooldown per upstream key

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,10 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
 - `retryable outcome`: `upstream_429`, `transport_failure`, `semantic_failure`, or
   `local_pressure`. It preserves the current work generation and its independent retry state until
   a later terminal outcome.
+- `Key cooldown`: a `period_reconciliation`-scoped retry window written only for the upstream Key
+  that returned `429`, using the `5/10/20/30` minute ladder and `Retry-After`. Non-cooling Keys keep
+  progressing; if every eligible Key is cooling, the representative defers to the earliest expiry.
+  Legacy global-backoff meta is compatibility data, not a live gate or wake source.
 - `missing eligible upstream key`: a durable nonterminal input condition. It records a fixed
   fifteen-minute retry without incrementing semantic or transport failure state, and administrators
   see only its aggregate count.

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -57,6 +57,11 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   migration creates this derived table and index without scanning usage or emitting HA events;
   terminal completion removes the rows. Exhausting the request cap is a typed
   `remote_attempt_budget` continuation at 30 seconds, never a semantic failure.
+- An upstream `429` writes cooldown only for the affected `period_reconciliation` Key. The existing
+  `5/10/20/30` minute ladder and `Retry-After` determine its next attempt; non-cooling Keys remain
+  eligible, and an all-Key cooldown schedules the claim-fenced representative at the earliest
+  expiry. Legacy global-backoff metadata remains readable for rolling compatibility but is not a
+  reconciliation gate or representative wake source.
 
 ## Consequences
 

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -8,8 +8,9 @@ run. Research remains an independent, globally single-concurrent sweep. When due
 preparation, it reserves two seconds for the later Research sweep and two seconds
 for main durable finalization before it starts main remote work; the reserve may preclude a second slow main
 request. Without due Research, main settlement retains its normal remote envelope. Research exhaustion is
-diagnostic follow-up, not primary local pressure. Local-pressure backoff (`30/60/120/300s`) is separate from upstream-429 backoff
-(`2/5/10/30m`); non-429 failures do not reset the remote circuit. A current claim that reaches a
+diagnostic follow-up, not primary local pressure. Local-pressure backoff (`30/60/120/300s`) is separate from the
+per-key upstream-429 cooldown (`5/10/20/30m`); a 429 only cools the affected `period_reconciliation` key,
+and non-429 failures do not reset that key's cooldown. A current claim that reaches a
 low-foreground recovery window clears only its local-pressure state before trying the engine again;
 if SQLite is still pressured, that attempt durably defers again. This preserves foreground yielding
 without letting a stale local backoff consume the whole recovery tail.

--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -219,14 +219,17 @@ Operators need to know whether exact reconciliation is active or merely configur
 This is why Tavily Hikari ships a dedicated `System Status` admin page instead of hiding the state
 inside logs.
 
-## Global upstream pressure backoff
+## Key-scoped upstream cooldown
 
-When candidates exist but a run settles none and at least half of its attempts are upstream 429s,
-preserve the per-key cooldown records but also persist a run-level pressure streak. After three
-consecutive pressure runs, skip further candidate work for 2, 5, 10, then 30 minutes; successful
-settlement or a lower pressure ratio clears the state. Emit per-key cooldowns at DEBUG and reserve
-WARN for entering, escalating, or recovering the global state so diagnosis does not become the
-dominant write or log workload.
+An upstream `429` belongs to the `period_reconciliation` Key that returned it. Persist one cooldown
+for that Key using the existing `5/10/20/30` minute ladder, honoring a later `Retry-After`, and
+leave other Keys eligible. A run that finds every otherwise eligible Key cooling down does no HTTP
+work and returns a claim-fenced deferred outcome at the earliest cooldown expiry; it does not turn
+the condition into a run-wide circuit or a semantic failure.
+
+The legacy global-backoff meta remains readable for rolling compatibility, but it is not a live
+engine gate, representative wake source, or administrator blocker. Keep per-Key cooldown events at
+DEBUG and reserve state-transition logs for entering, escalating, and recovering the affected Key.
 
 Run reconciliation in a remote-I/O concurrency class with a total wall-clock budget. Before each
 new upstream request, verify that enough budget remains for the request deadline; a timeout around
@@ -239,10 +242,11 @@ page, an exact `hasEligible` existence check, and the oldest candidate age. The 
 uses nullable, explicitly bounded estimates so an unobserved queue is not reported as zero and a
 multi-item queue is not collapsed into a boolean. Keep historical degraded visibility as a separate
 indexed existence probe instead of deriving it from a current-day metric. After three rounds with no
-remote attempt and exhausted local budget, persist a short local backoff without changing remote
-429 state. Only actual upstream 429 attempts advance the global `2/5/10/30` minute backoff and honor
-a later Retry-After; a real remote attempt or successful settlement clears the relevant state. Keep
-normal per-key 429 logs at DEBUG and reserve state-transition logs for enter, escalation, and recovery.
+remote attempt and exhausted local budget, persist a short local backoff without changing any Key
+cooldown. Only an actual upstream 429 attempt advances the affected Key's `5/10/20/30` minute
+cooldown and honors a later Retry-After; a real remote attempt or successful settlement clears only
+the recovered Key state. Keep normal per-Key 429 logs at DEBUG and reserve state-transition logs for
+enter, escalation, and recovery.
 
 Main settlement must start before terminal-research polling. Hydrate the bounded candidate page,
 key/cooldown state, and Research eligibility in the two-second local preparation budget. If Research is due,

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -281,9 +281,10 @@ reads:
   first observation. Never render an unknown queue as zero.
 - When three rounds have candidates but no remote attempt and local budget exhaustion, persist one
   representative delayed job and apply a short local backoff. Keep that state separate from the
-  `2/5/10/30` minute upstream-429 backoff, which only changes after real remote 429 attempts and
-  honors the maximum Retry-After. This protects the SQLite worker from a one-minute no-op loop
-  without hiding real progress.
+  per-key upstream-429 cooldown (`5/10/20/30` minutes), which only changes after a real remote 429
+  attempt for that `period_reconciliation` key and honors the maximum Retry-After. Legacy
+  global-backoff metadata is readable for compatibility but is not a live gate. This protects the
+  SQLite worker from a one-minute no-op loop without hiding progress on healthy keys.
 - For in-memory owner-facing usage windows, retain only the last hour as events and aggregate older
   1–25 hour history into five-minute buckets. Backfill with 500-row pages and merge the captured live
   tail so a lock-held full-history copy is never required.

--- a/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
+++ b/docs/specs/runtime-performance-observability/IMPLEMENTATION.md
@@ -141,11 +141,11 @@
 
 ## Reconciliation pressure telemetry
 
-- Reconciliation persists a global pressure streak and backoff level. Three consecutive runs with
-  zero settlements and predominantly upstream 429 responses enter a 2/5/10/30 minute backoff;
-  per-key cooldown remains authoritative, while normal per-key backoff logs are DEBUG and the
-  state transition is summarized once at WARN. The administrative system-status surface exposes the
-  current pressure streak, level, and retry time.
+- Reconciliation persists cooldown state per `period_reconciliation` Key. A real upstream 429 uses
+  the `5/10/20/30` minute ladder (honoring `Retry-After`) only for the affected Key; other Keys
+  remain eligible, and an all-Key cooldown defers to the earliest retry time. Legacy global-backoff
+  meta remains readable for rolling compatibility but is not a live gate or representative wake
+  source. Normal per-Key cooldown logs are DEBUG; only Key state transitions are summarized at WARN.
 
 ## Low-cost memory and transition telemetry
 
@@ -173,12 +173,12 @@
 
 PR: include
 
-![System status global reconciliation backoff](./assets/system-status-global-reconciliation-backoff.png)
+![Historical system status reconciliation pressure fixture](./assets/system-status-global-reconciliation-backoff.png)
 
 - Storybook canvas: `Admin/Modules/SystemStatusModule/GlobalBackoff`
-- evidence_note: Mock-only system-status state showing the persisted global reconciliation backoff
-  after three pressure runs. Bound to `525c07d305537a6c60cf176d28f8ec9788895424`; it must be
-  recaptured after any UI or fixture change.
+- evidence_note: Historical mock-only system-status fixture retained for compatibility documentation;
+  it is not a live reconciliation gate. Current runtime status uses per-Key cooldown and an earliest
+  retry time.
 
 ## 状态
 

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -73,7 +73,7 @@
   state unchanged; a separately throttled observation heartbeat maintains recent-tail liveness.
   Sidecar Dashboard aggregation returns only scalar counts and the bounded top-group page, never an
   unbounded payload collection.
-- 事务污染、stale claim recovery、连续零进展、预算耗尽和全局退避只在进入、升级或恢复时告警。
+- 事务污染、stale claim recovery、连续零进展、预算耗尽和逐 Key cooldown 只在进入、升级或恢复时告警；遗留 global-backoff meta 不作为 live 状态。
 - HA GC 低压恢复、SLO deadline、最老可删事件年龄与真实删除率必须可从管理员状态和聚合日志
   还原；sequence span 仅作趋势估算，不作为库存或 ETA。
 - Request-log GC admission and an unsealed-day retention guard are DEBUG-level typed outcomes. They

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -82,6 +82,9 @@
 - 对账主结算必须先于 Research sweep；本地预算压力与 upstream 429 必须分开记录，且最终
   远端观察、结算和状态落盘都必须受同一轮预算约束。HA GC 正常进展继续按通道 60 秒聚合，
   不能恢复逐片 WARN。
+- Reconciliation 429 state is scoped to the affected `period_reconciliation` Key. Non-cooling Keys
+  remain eligible; an all-Key cooldown reports the earliest retry time. Legacy global-backoff meta
+  is compatibility data only and cannot gate work or representative wake.
 - Privacy status owns an AppState-owned immutable last-good controller. After ready it starts one
   low-priority prewarm; deferred prewarm retries in the background until last-good is published or
   shutdown fences it, without delaying readiness or competing with foreground work.

--- a/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -582,8 +582,10 @@
 - `scheduled_jobs.claim_generation` fences stale finish/error/continuation writes. HA continuation
   enqueue is atomic with finish; failed persistence is left for stale reaper recovery instead of an
   unbounded retry task.
-- Reconciliation candidate selection is an indexed bounded page, and the persisted local pressure
-  state applies `2/5/10/30` minute backoff with the maximum upstream `Retry-After`.
+- Reconciliation candidate selection is an indexed bounded page. Local pressure has its own short
+  backoff; an observed upstream 429 applies the `5/10/20/30` minute cooldown only to the triggering
+  `period_reconciliation` key and honors the maximum `Retry-After`. Legacy global-backoff metadata
+  remains diagnostic-only and never gates reconciliation.
 - Business-call usage keeps only the last hour as events, stores older history in five-minute buckets,
   and backfills in 500-row pages while preserving a request-log tail captured at the start.
 - Normal GC/reconciliation phases and per-key 429 diagnostics are DEBUG. INFO is aggregated at a

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -493,11 +493,12 @@ PR: none
 - Reconciliation candidate-query timeouts are recorded as local pressure rather than an empty
   queue, and successful remote observations are finalized within the reserved write tail even when
   a later candidate exhausts the request budget.
-- Reconciliation completion markers, run statistics, and local/global pressure state share one
-  bounded post-processing deadline. SQLite contention may produce an explicit persistence timeout,
-  but must not leave the worker waiting past the run budget or report a durable success without
-  recording the state transition; the deadline must end before the scheduler's outer timeout so
-  cancellation cannot race the controlled timeout path.
+- Reconciliation completion markers, run statistics, local-pressure state, and affected-Key cooldown
+  state share one bounded post-processing deadline. SQLite contention may produce an explicit
+  persistence timeout, but must not leave the worker waiting past the run budget or report a durable
+  success without recording the state transition; the deadline must end before the scheduler's outer
+  timeout so cancellation cannot race the controlled timeout path. Legacy global-backoff metadata is
+  compatibility-only and is never a live reconciliation gate.
 - Reconciliation preparation source reads use one fresh native SQLite progress-handler session per
   statement rather than cancellation of the awaiting task. Recent/backlog candidates, candidate and
   billed-credit hydrate, Research candidates, and historical projection source pages have a 250ms

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -507,6 +507,8 @@ PR: none
   mandatory before returning a connection to the pool.
 - A remote admission lease describes only one outbound HTTP attempt. It is not a broad maintenance
   permit and must be released before reconciliation finalization or other SQLite work.
+- A reconciliation 429 records only the affected Key cooldown and its claim-fenced continuation;
+  the legacy global-backoff metadata is never consulted as a SQLite or scheduler gate.
 - Research selection is a bounded indexed source read: one page contains at most 80 due rows and
   advances its `(next_poll_at, key_id, request_id)` cursor only after a claim-fenced acceptance
   transaction. A read deadline, cancellation, or stale claim leaves the cursor and work unchanged.

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -316,7 +316,8 @@ source when a usable persisted runtime already exists.
   any remote request; they must acquire admission and release it before remote I/O. Three consecutive
   rounds with eligible candidates but no remote attempt and exhausted local budget enter a persisted
   short local backoff with one delayed representative job. Only actual upstream 429 attempts enter
-  the persisted `2/5/10/30` minute remote backoff and honor `Retry-After`.
+  the persisted `5/10/20/30` minute cooldown for the affected `period_reconciliation` key and honor
+  `Retry-After`; a cooldown never gates healthy keys.
 - Reconciliation's main settlement pass owns the first remote-attempt budget. Research terminal
   polling is permitted only after the main pass (or when no eligible main candidate exists), and
   all remote requests plus their durable bookkeeping are bounded by the same per-run deadline.

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -31,14 +31,16 @@
 - reconciliation keeps a one-at-a-time remote attempt lease only while an outbound HTTP request is
   active and remains under the 20-second total budget. Local projection, hydrate, finalization, and
   Research bookkeeping do not hold that lease; a 120-second eligible automatic representative owns
-  the next non-manual request turn. Global 429 pressure state and the delayed representative remain
-  durable, avoiding minute-by-minute empty work.
+  the next non-manual request turn. The per-key 429 cooldown and delayed representative remain
+  durable, avoiding minute-by-minute empty work; legacy global-backoff metadata is diagnostic-only
+  and never gates execution or representative wake.
 - 候选页先以 period/settlement 索引限制扫描，再做有界 hydrate 与 Research `EXISTS` 判断；执行
   前后不再运行精确队列聚合。系统状态读取 bounded observation，未首次观测时保留 unknown/null
   语义。
-- 本地压力连续三轮触发 `30/60/120/300` 秒退避；真实 upstream 429 独立触发
-  `2/5/10/30` 分钟退避并尊重更晚的 `Retry-After`。transport、semantic failure 与本地预算耗尽
-  不会清空已有 429 状态。
+- 本地压力连续三轮触发 `30/60/120/300` 秒退避；真实 upstream 429 仅对触发它的
+  `period_reconciliation` Key 独立触发 `5/10/20/30` 分钟退避并尊重更晚的 `Retry-After`。
+  transport、semantic failure 与本地预算耗尽不会清空已有逐 Key 429 状态；遗留 global-backoff
+  meta 只为滚动兼容保留。
 - `upstream_reconciliation_work` 由 usage 写入增量维护。升级前历史行由
   `ReconciliationProjectionController` 使用稳定复合 keyset 和 `25..100` 行自适应微片吸收：读扫描
   在事务外完成，work merge、claim fence、cursor CAS 和进度在同一短事务提交。低压续跑最快一秒，
@@ -102,7 +104,11 @@
 ## Current performance contract
 
 - Main settlement hydrates the bounded candidate page, referenced key/cooldown state, and Research eligibility before starting the first `/usage` request. The terminal sweep still runs only after main durable finalization. When due Research exists, the run reserves two seconds for the later sweep and two seconds for main finalization before it starts main remote work; without due Research, it retains the existing main request envelope. A sweep timeout is not primary budget exhaustion.
-- Local budget exhaustion is persisted separately from the upstream-429 backoff. Only observed upstream 429 attempts advance the 2/5/10/30-minute global state; local pressure uses a short independent delay and never fabricates a remote rate-limit signal.
+- Local budget exhaustion is persisted separately from the per-key upstream-429 backoff. Only an
+  observed upstream 429 advances the cooldown for that `period_reconciliation` key, using the
+  existing `5/10/20/30`-minute ladder and `Retry-After`; local pressure uses a short independent
+  delay and never fabricates a remote rate-limit signal. Legacy global-backoff metadata remains
+  readable for compatibility but is not a live gate or wake source.
 - Remote request start, observation, settlement finalization, and research bookkeeping use nested
   deadlines with reserved post-processing headroom. The four local-pressure meta keys are included
   in HA incremental and baseline replication so failover retains the same recovery state.

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -192,6 +192,8 @@
   representative job。所有可选 Key 都冷却时，continuation 使用最早的 Key 到期时间。
 - 遗留 global-backoff meta 仅为滚动升级兼容保留，不参与 reconciliation engine、代表任务唤醒或
   管理员 live blocker。逐 Key 429 为采样 DEBUG，只有 Key cooldown 的进入、升级和恢复产生状态跃迁日志。
+- 单 Key 429 不得阻断其他未冷却 Key；仅当本轮所有可选 Key 都在 cooldown 时，才以最早到期时间
+  安排 `key_cooldown` continuation，且不推进 completed generation。
 - 管理员状态同时返回 `reconciliationObservation` 与 `reconciliationLocalBackoff`；未观测时
   coverage 为 `unknown`，`queueEstimate=null`，页面显示“未知”而不是“0”。
 - 历史 degraded 相位由独立索引化 `EXISTS` 决定；管理员 `degradedSettlements` 为最多 64 条的

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -70,7 +70,7 @@
 - reconciliation 在每轮结算前主动轮询已关闭窗口中未终态的 Research；轮询最多 20 条、每个 Key 最多 4 条，并优先补足当天尚无标准成功账期的账号覆盖。
 - `429` 只对 `period_reconciliation` scope 中的对应 Key 建立持久化冷却，使用 `Retry-After` 或 `5/10/20/30` 分钟退避；不得批量把同 Key 的其他窗口写为 rate-limited，也不得影响正常 API/MCP 流量。
 - 候选观测必须使用有界索引页：`queueEstimate` 可为空且最多统计 64 个候选，`hasEligible` 与最老候选年龄必须单独表达，首次观测前 coverage 为 `unknown`，不得以零伪装未观测状态。历史 degraded 状态必须由独立的索引化 `EXISTS` 探测保留，不能用当天计数替代。
-- 连续三轮存在候选、未产生远端尝试且本地预算耗尽时，持久化独立的本地短退避；它不得增加 upstream 429 全局退避。只有真实远端 429 才按 `2/5/10/30` 分钟升级，并以更晚的 `Retry-After` 为准；退避期间只保留一个 delayed representative job，真实远端尝试或成功结算后立即复位。
+- 连续三轮存在候选、未产生远端尝试且本地预算耗尽时，持久化独立的本地短退避；它不得改变任何 Key 的 429 冷却。真实远端 429 只对触发它的 `period_reconciliation` Key 按 `5/10/20/30` 分钟阶梯冷却，并以更晚的 `Retry-After` 为准；所有可选 Key 都在冷却时，使用最早到期时间保留一个 delayed representative job，非冷却 Key 不受影响。
 - 主结算候选页、key/cooldown hydrate 与 Research eligibility read 的本地准备预算最多 2 秒，主结算优先启动；terminal-research sweep 仅在主结算的 durable finalization 之后启动。存在 due Research 时，在发起主结算 HTTP 前预留 2 秒给 sweep，并预留 2 秒给主结果的 durable finalization；该 reserve 可以阻止第二个慢主 Key 请求。没有 due Research 时保留原有主结算远端窗口。Research 超时不代表主结算本地预算耗尽，单轮总预算保持 20 秒。
 - 远端请求启动、观察结果、结算写入和 Research 状态落盘均受同一轮截止时间约束；最后的持久化收尾预算不得被新一轮远端请求抢占。
 - 在发起远端请求前必须保留两秒给持久化收尾。收尾预算、post-processing 或 retry bookkeeping
@@ -187,11 +187,11 @@
   lease，并具有 20 秒单轮总预算；剩余预算不足时不得发起新的上游请求。candidate、projection、
   hydrate、finalization 与 Research bookkeeping 不占该 lease，因此本地 HA GC 等维护任务不被长时间
   远程 I/O 占用。
-- 全局 429 压力状态与 job continuation 原子持久化。连续三轮零结算且 429 占比至少一半后，按
-  `2/5/10/30` 分钟退避，并采用 `max(退避, Retry-After)`；退避期间只保留一个 delayed
-  representative job。
-- 成功结算或压力比例恢复后清零全局压力状态。逐 key 429 为采样 DEBUG，进入、升级和恢复全局
-  退避才产生状态跃迁日志。
+- `period_reconciliation` Key 的 429 cooldown 与 job continuation 原子持久化。单 Key 使用
+  `5/10/20/30` 分钟阶梯并采用 `max(阶梯, Retry-After)`；退避期间只保留一个 delayed
+  representative job。所有可选 Key 都冷却时，continuation 使用最早的 Key 到期时间。
+- 遗留 global-backoff meta 仅为滚动升级兼容保留，不参与 reconciliation engine、代表任务唤醒或
+  管理员 live blocker。逐 Key 429 为采样 DEBUG，只有 Key cooldown 的进入、升级和恢复产生状态跃迁日志。
 - 管理员状态同时返回 `reconciliationObservation` 与 `reconciliationLocalBackoff`；未观测时
   coverage 为 `unknown`，`queueEstimate=null`，页面显示“未知”而不是“0”。
 - 历史 degraded 相位由独立索引化 `EXISTS` 决定；管理员 `degradedSettlements` 为最多 64 条的
@@ -262,7 +262,7 @@
   last-good，Then 在同一预算内返回 `503 Retry-After: 1`。
 - Given reconciliation backlog 中存在 `rate_limited` 窗口，When 管理员查看系统状态页，Then 能区分上游 429、本地 usage 限流与其他重试，并能看到当前时段每个上游 Key 的绑定用户数与待查询 Project ID 数分布。
 - Given 近期窗口与旧 backlog 同时堆积，When reconciliation worker 选择候选窗口，Then 今日+昨日窗口优先进入 recent lane，且不会被老 backlog 长期饿死。
-- Given 同一上游 Key 的多个窗口同时到期且首次 `/usage` 查询收到 429 或本地 usage 限流，When reconciliation worker 执行，Then 该 Key 的到期窗口整体进入同一退避时间，本轮不再反复打同一个 Key，其他 Key 的候选仍可继续结算。
+- Given 同一上游 Key 的多个窗口同时到期且首次 `/usage` 查询收到 429 或本地 usage 限流，When reconciliation worker 执行，Then 该 Key 的到期窗口整体进入同一 `period_reconciliation` cooldown，本轮不再反复打同一个 Key，其他非冷却 Key 的候选仍可继续结算；只有全部可选 Key 冷却时才按最早到期时间 deferred。
 - Given a claimed run reaches its finalization reserve or post-processing deadline, When the scheduler
   persists the outcome, Then the job finish, local-backoff state, local-pressure observation, retry deadline, and one
   delayed representative commit in one claim-fenced control transaction; a control-acquire failure

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -535,6 +535,8 @@
         "tests::upstream_reconciliation::next_upstream_reconciliation_candidates_skip_pending_recent_rows_before_limiting",
         "tests::upstream_reconciliation::next_upstream_reconciliation_candidates_treat_midnight_closing_s3_as_recent",
         "tests::upstream_reconciliation::reconciliation_global_backoff_counts_only_attempted_candidates",
+        "tests::upstream_reconciliation::reconciliation_key_429_does_not_stop_other_key_research",
+        "tests::upstream_reconciliation::reconciliation_all_key_cooldowns_defer_to_earliest_retry",
         "tests::upstream_reconciliation::reconciliation_no_adjustment_completes_only_the_current_usage_generation",
         "tests::upstream_reconciliation::reconciliation_observation_reports_due_window_without_queue_count",
         "tests::upstream_reconciliation::reconciliation_rejects_reclaimed_claim_after_remote_fetch",

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -537,6 +537,7 @@
         "tests::upstream_reconciliation::reconciliation_global_backoff_counts_only_attempted_candidates",
         "tests::upstream_reconciliation::reconciliation_key_429_does_not_stop_other_key_research",
         "tests::upstream_reconciliation::reconciliation_all_key_cooldowns_defer_to_earliest_retry",
+        "tests::upstream_reconciliation::reconciliation_mixed_key_cooldown_allows_healthy_sibling",
         "tests::upstream_reconciliation::reconciliation_no_adjustment_completes_only_the_current_usage_generation",
         "tests::upstream_reconciliation::reconciliation_observation_reports_due_window_without_queue_count",
         "tests::upstream_reconciliation::reconciliation_rejects_reclaimed_claim_after_remote_fetch",

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -537,7 +537,7 @@
         "tests::upstream_reconciliation::reconciliation_global_backoff_counts_only_attempted_candidates",
         "tests::upstream_reconciliation::reconciliation_key_429_does_not_stop_other_key_research",
         "tests::upstream_reconciliation::reconciliation_all_key_cooldowns_defer_to_earliest_retry",
-        "tests::upstream_reconciliation::reconciliation_mixed_key_cooldown_allows_healthy_sibling",
+        "tests::upstream_reconciliation::reconciliation_fresh_429_mixed_key_allows_healthy_sibling",
         "tests::upstream_reconciliation::reconciliation_no_adjustment_completes_only_the_current_usage_generation",
         "tests::upstream_reconciliation::reconciliation_observation_reports_due_window_without_queue_count",
         "tests::upstream_reconciliation::reconciliation_rejects_reclaimed_claim_after_remote_fetch",

--- a/scripts/test_ci_backend_tests.py
+++ b/scripts/test_ci_backend_tests.py
@@ -160,7 +160,7 @@ class BackendTestRunnerContractTests(unittest.TestCase):
         )
         upstream = reconciliation_shards["lib-upstream-reconciliation"]
         self.assertEqual(RUNNER.shard_resource_limits(upstream, 4, 2), (4, 1))
-        self.assertEqual(len(upstream["include_prefixes"]), 26)
+        self.assertEqual(len(upstream["include_prefixes"]), 28)
         self.assertEqual(len(upstream["include_prefixes"]), len(set(upstream["include_prefixes"])))
         self.assertTrue(
             all(
@@ -181,6 +181,7 @@ class BackendTestRunnerContractTests(unittest.TestCase):
         self.assertEqual(
             set(prefixes),
             {
+                "remote_attempt_admission::tests::",
                 "tests::maintenance_queue_performance::",
                 "tests::schema_migrations::",
                 "tests::reconciliation_controller::",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1433,12 +1433,16 @@ const META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_SWEEP_AT_V1: &str =
     "upstream_reconciliation_last_research_sweep_at_v1";
 const META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_TERMINAL_AT_V1: &str =
     "upstream_reconciliation_last_research_terminal_at_v1";
+#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_PRESSURE_STREAK_V1: &str =
     "upstream_reconciliation_pressure_streak_v1";
+#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1: &str =
     "upstream_reconciliation_backoff_level_v1";
+#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1: &str =
     "upstream_reconciliation_backoff_until_v1";
+#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_LAST_RECOVERED_AT_V1: &str =
     "upstream_reconciliation_last_recovered_at_v1";
 const META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1: &str =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1433,13 +1433,10 @@ const META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_SWEEP_AT_V1: &str =
     "upstream_reconciliation_last_research_sweep_at_v1";
 const META_KEY_UPSTREAM_RECONCILIATION_LAST_RESEARCH_TERMINAL_AT_V1: &str =
     "upstream_reconciliation_last_research_terminal_at_v1";
-#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_PRESSURE_STREAK_V1: &str =
     "upstream_reconciliation_pressure_streak_v1";
-#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1: &str =
     "upstream_reconciliation_backoff_level_v1";
-#[cfg(test)]
 const META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1: &str =
     "upstream_reconciliation_backoff_until_v1";
 #[cfg(test)]

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -544,11 +544,10 @@ impl KeyStore {
         ))
         .fetch_one(&mut **snapshot)
         .await?;
-        let (global_pressure_streak, global_backoff_level, global_backoff_until) = (
-            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_PRESSURE_STREAK_V1).unwrap_or(0),
-            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1).unwrap_or(0),
-            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1).unwrap_or(0),
-        );
+        // The legacy global 429 fields remain in the response for rolling
+        // compatibility, but they are no longer live reconciliation gates.
+        // Per-key cooldowns below are the only actionable retry state.
+        let (global_pressure_streak, global_backoff_level, global_backoff_until) = (0, 0, 0);
         let (local_pressure_streak, local_backoff_level, local_backoff_until) = (
             meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1).unwrap_or(0),
             meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1).unwrap_or(0),

--- a/src/store/key_store_admin_privacy_read.rs
+++ b/src/store/key_store_admin_privacy_read.rs
@@ -544,10 +544,14 @@ impl KeyStore {
         ))
         .fetch_one(&mut **snapshot)
         .await?;
-        // The legacy global 429 fields remain in the response for rolling
-        // compatibility, but they are no longer live reconciliation gates.
-        // Per-key cooldowns below are the only actionable retry state.
-        let (global_pressure_streak, global_backoff_level, global_backoff_until) = (0, 0, 0);
+        // Keep the legacy global 429 fields readable for rolling compatibility,
+        // but they are diagnostic history only. Per-key cooldowns below remain
+        // the only actionable reconciliation retry state.
+        let (global_pressure_streak, global_backoff_level, global_backoff_until) = (
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_PRESSURE_STREAK_V1).unwrap_or(0),
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1).unwrap_or(0),
+            meta_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1).unwrap_or(0),
+        );
         let (local_pressure_streak, local_backoff_level, local_backoff_until) = (
             meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1).unwrap_or(0),
             meta_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1).unwrap_or(0),

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -611,7 +611,20 @@ impl KeyStore {
                 w.next_attempt_at,
                 w.period_end + 600,
                 CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
-                     THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+                     THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END,
+                COALESCE((
+                    SELECT MIN(b.cooldown_until)
+                    FROM api_key_transient_backoffs b
+                    WHERE b.scope = 'period_reconciliation'
+                      AND b.cooldown_until > ?
+                      AND EXISTS (
+                          SELECT 1
+                          FROM upstream_reconciliation_usage u
+                          WHERE u.token_id = w.token_id
+                            AND u.period_code = w.period_code
+                            AND u.key_id = b.key_id
+                      )
+                ), 0)
             ))
             FROM upstream_reconciliation_work w
             LEFT JOIN upstream_reconciliation_settlements s
@@ -629,6 +642,7 @@ impl KeyStore {
               )
             "#,
         )
+        .bind(now)
         .bind(now)
         .fetch_one(&mut *conn)
         .await?;

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -15,6 +15,7 @@ pub(crate) const RECONCILIATION_OUTCOME_SETTLED: &str = "settled";
 pub(crate) const RECONCILIATION_OUTCOME_NO_ADJUSTMENT: &str = "no_adjustment";
 pub(crate) const RECONCILIATION_OUTCOME_OBSERVED: &str = "observed";
 pub(crate) const RECONCILIATION_OUTCOME_UPSTREAM_429: &str = "upstream_429";
+pub(crate) const RECONCILIATION_OUTCOME_KEY_COOLDOWN: &str = "key_cooldown";
 pub(crate) const RECONCILIATION_OUTCOME_TRANSPORT_FAILURE: &str = "transport_failure";
 pub(crate) const RECONCILIATION_OUTCOME_SEMANTIC_FAILURE: &str = "semantic_failure";
 pub(crate) const RECONCILIATION_OUTCOME_MISSING_ELIGIBLE_UPSTREAM_KEY: &str =
@@ -1409,13 +1410,34 @@ impl KeyStore {
             .push_bind(now)
             .push(r#"
               AND w.work_generation > w.completed_generation
-              AND MAX(
-                  w.next_attempt_at,
-                  CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
-                       THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
-              ) <= "#)
+              AND (
+                  MAX(
+                      w.next_attempt_at,
+                      CASE WHEN s.status IN ('pending', 'waiting', 'rate_limited')
+                           THEN COALESCE(s.next_attempt_at, 0) ELSE 0 END
+                  ) <= "#)
             .push_bind(now)
-            .push(" ");
+            .push(r#"
+                  OR (
+                      s.status = 'rate_limited'
+                      AND s.degraded_reason = 'upstream429'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM upstream_reconciliation_usage healthy_usage
+                          WHERE healthy_usage.token_id = w.token_id
+                            AND healthy_usage.period_code = w.period_code
+                            AND NOT EXISTS (
+                                SELECT 1
+                                FROM api_key_transient_backoffs cooling_backoff
+                                WHERE cooling_backoff.key_id = healthy_usage.key_id
+                                  AND cooling_backoff.scope = 'period_reconciliation'
+                                  AND cooling_backoff.cooldown_until > "#)
+            .push_bind(now)
+            .push(r#"
+                            )
+                      )
+                  )
+              ) "#);
         match scope {
             ReconciliationCandidateScope::Recent { start, end } => {
                 query

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -21,6 +21,7 @@ pub(crate) const RECONCILIATION_OUTCOME_MISSING_ELIGIBLE_UPSTREAM_KEY: &str =
     "missing_eligible_upstream_key";
 pub(crate) const RECONCILIATION_RETRY_REASON_REMOTE_ATTEMPT_BUDGET: &str =
     "remote_attempt_budget";
+pub(crate) const RECONCILIATION_RETRY_REASON_KEY_COOLDOWN: &str = "key_cooldown";
 pub(crate) const RECONCILIATION_RETRY_REASON_GENERATION_CHANGED: &str = "generation_changed";
 pub(crate) const RECONCILIATION_OUTCOME_REMOTE_ATTEMPT_BUDGET: &str =
     "remote_attempt_budget";
@@ -39,8 +40,6 @@ pub(crate) struct UpstreamReconciliationRunAdmissionState {
     pub(crate) claim_current: bool,
     pub(crate) shadow_ready: bool,
     pub(crate) mode: ReconciliationMode,
-    pub(crate) global_backoff_level: i64,
-    pub(crate) global_backoff_until: i64,
     pub(crate) local_backoff_level: i64,
     pub(crate) local_backoff_until: i64,
 }
@@ -97,6 +96,9 @@ pub(crate) fn classify_reconciliation_retry_reason(reason: Option<&str>) -> &'st
     if reason == RECONCILIATION_RETRY_REASON_REMOTE_ATTEMPT_BUDGET {
         return RECONCILIATION_RETRY_REASON_REMOTE_ATTEMPT_BUDGET;
     }
+    if reason == RECONCILIATION_RETRY_REASON_KEY_COOLDOWN {
+        return RECONCILIATION_RETRY_REASON_KEY_COOLDOWN;
+    }
     if reason == RECONCILIATION_RETRY_REASON_GENERATION_CHANGED {
         return RECONCILIATION_RETRY_REASON_GENERATION_CHANGED;
     }
@@ -145,14 +147,12 @@ impl KeyStore {
                 r#"
             SELECT key, value
             FROM meta
-            WHERE key IN (?, ?, ?, ?, ?, ?, ?)
+            WHERE key IN (?, ?, ?, ?, ?)
             "#,
         )
         .bind(META_KEY_UPSTREAM_PROJECT_ID_MODE_V1)
         .bind(META_KEY_API_REBALANCE_ENABLED_V1)
         .bind(META_KEY_REBALANCE_MCP_ENABLED_V1)
-        .bind(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1)
-        .bind(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1)
         .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1)
         .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
             .fetch_all(&mut *conn)
@@ -188,8 +188,6 @@ impl KeyStore {
             mode: ReconciliationMode::parse(&mode).ok_or_else(|| {
                 ProxyError::Other("invalid persisted upstream reconciliation mode".to_string())
             })?,
-            global_backoff_level: value_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1),
-            global_backoff_until: value_i64(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1),
             local_backoff_level: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_LEVEL_V1),
             local_backoff_until: value_i64(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1),
         })
@@ -672,13 +670,6 @@ impl KeyStore {
         }) else {
             return Ok(None);
         };
-        let (_, _, global_until) = Self::reconciliation_backoff_state_locked(
-            &mut conn,
-            META_KEY_UPSTREAM_RECONCILIATION_PRESSURE_STREAK_V1,
-            META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_LEVEL_V1,
-            META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1,
-        )
-        .await?;
         let (_, _, local_until) = Self::reconciliation_backoff_state_locked(
             &mut conn,
             META_KEY_UPSTREAM_RECONCILIATION_LOCAL_PRESSURE_STREAK_V1,
@@ -686,7 +677,7 @@ impl KeyStore {
             META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1,
         )
         .await?;
-        Ok(Some(pending_at.max(global_until).max(local_until).max(now)))
+        Ok(Some(pending_at.max(local_until).max(now)))
         }
         .await;
         let close = conn.close().await;
@@ -935,6 +926,7 @@ impl KeyStore {
         }
     }
 
+    #[cfg(test)]
     async fn update_upstream_reconciliation_global_backoff_inner(
         &self,
         pressure: bool,
@@ -1009,6 +1001,7 @@ impl KeyStore {
         Ok((streak, level, until))
     }
 
+    #[cfg(test)]
     pub(crate) async fn update_upstream_reconciliation_global_backoff(
         &self,
         pressure: bool,
@@ -1020,23 +1013,6 @@ impl KeyStore {
             now,
             retry_after_until,
             None,
-        )
-        .await
-    }
-
-    pub(crate) async fn update_upstream_reconciliation_global_backoff_claimed(
-        &self,
-        pressure: bool,
-        now: i64,
-        retry_after_until: Option<i64>,
-        job_id: i64,
-        claim_generation: i64,
-    ) -> Result<(i64, i64, i64), ProxyError> {
-        self.update_upstream_reconciliation_global_backoff_inner(
-            pressure,
-            now,
-            retry_after_until,
-            Some((job_id, claim_generation)),
         )
         .await
     }

--- a/src/store/key_store_upstream_reconciliation_admission.rs
+++ b/src/store/key_store_upstream_reconciliation_admission.rs
@@ -1,6 +1,7 @@
 type UpstreamReconciliationLastRunStats = (Option<i64>, i64, i64, i64, i64, bool);
 
 impl KeyStore {
+    #[cfg(test)]
     pub(crate) async fn upstream_reconciliation_global_backoff_state(
         &self,
     ) -> Result<(i64, i64, i64), ProxyError> {
@@ -71,14 +72,14 @@ impl KeyStore {
     where
         T: std::ops::DerefMut<Target = sqlx::SqliteConnection>,
     {
-        let available_at = sqlx::query_scalar::<_, Option<i64>>(
-            "SELECT MAX(CAST(value AS INTEGER)) FROM meta WHERE key IN (?, ?)",
+        // The legacy global 429 metadata remains readable for compatibility but
+        // is not a live reconciliation gate or representative wake source.
+        let available_at = sqlx::query_scalar::<_, i64>(
+            "SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM meta WHERE key = ?), 0)",
         )
         .bind(META_KEY_UPSTREAM_RECONCILIATION_LOCAL_BACKOFF_UNTIL_V1)
-        .bind(META_KEY_UPSTREAM_RECONCILIATION_BACKOFF_UNTIL_V1)
         .fetch_one(&mut **transaction)
-        .await?
-        .unwrap_or(0);
+        .await?;
         if let Some((job_id, claim_generation)) = claimed_job {
             if available_at <= now {
                 if !Self::reconciliation_claim_is_current_locked(

--- a/src/store/reconciliation_observation_store.rs
+++ b/src/store/reconciliation_observation_store.rs
@@ -229,6 +229,7 @@ impl KeyStore {
                 reason,
                 "research_read_budget"
                     | RECONCILIATION_RETRY_REASON_REMOTE_ATTEMPT_BUDGET
+                    | RECONCILIATION_RETRY_REASON_KEY_COOLDOWN
                     | RECONCILIATION_RETRY_REASON_GENERATION_CHANGED
             );
             let local_backoff_until = if preserve_retry_state {
@@ -275,7 +276,7 @@ impl KeyStore {
                 sqlx::query(
                     r#"UPDATE upstream_reconciliation_run_observation
                        SET last_retryable_outcome = CASE
-                               WHEN ? = 'remote_attempt_budget' THEN ?
+                               WHEN ? IN ('remote_attempt_budget', 'key_cooldown') THEN ?
                                ELSE last_retryable_outcome
                            END,
                            continuation_reason = ?, next_retry_at = ?, observed_at = ?

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -1423,6 +1423,46 @@ impl TavilyProxy {
                                 ReconciliationOutcome::SemanticFailure
                             };
                             retry_at = upstream_retry_at;
+                            if outcome == ReconciliationOutcome::Upstream429 && key_count > 1 {
+                                // A 429 belongs to the key that returned it. Persist its
+                                // cooldown, then let healthy siblings use the remaining
+                                // request budget in this same candidate.
+                                ensure_reconciliation_post_process_reserve(
+                                    main_finalization_deadline,
+                                )?;
+                                let cooldown_until = self
+                                    .arm_reconciliation_backoff(
+                                        &key_id,
+                                        retry_at,
+                                        RECONCILIATION_RETRY_REASON_UPSTREAM_429,
+                                        claimed_job,
+                                    )
+                                    .await?;
+                                candidate_key_cooldown_until = Some(
+                                    candidate_key_cooldown_until
+                                        .map_or(cooldown_until, |current| current.min(cooldown_until)),
+                                );
+                                earliest_key_cooldown_until = Some(
+                                    earliest_key_cooldown_until
+                                        .map_or(cooldown_until, |current| current.min(cooldown_until)),
+                                );
+                                upstream_429_retry_windows += 1;
+                                key_backoff_window_count += 1;
+                                cooling_keys.insert(key_id.clone());
+                                key_cooldown_untils.insert(key_id.clone(), cooldown_until);
+                                tracing::debug!(
+                                    component = "reconciliation",
+                                    event = "key_backoff_applied",
+                                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                                    job_type = "upstream_reconciliation",
+                                    key_id = %key_id,
+                                    period_code = %candidate.period_code,
+                                    reason_kind = RECONCILIATION_RETRY_REASON_UPSTREAM_429,
+                                    cooldown_until,
+                                    affected_window_count = 1_i64,
+                                );
+                                continue;
+                            }
                             if outcome == ReconciliationOutcome::TransportFailure {
                                 last_transport_kind = Some(
                                     TransportFailureKind::from_proxy_error(&err).as_str(),

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -10,6 +10,7 @@ struct ResearchSweepOutcome {
     retries: i64,
     skipped_cooldown: i64,
     earliest_cooldown_until: Option<i64>,
+    remote_attempt_budget_deferred: bool,
     budget_exhausted: bool,
     cursor_ready: bool,
 }
@@ -263,6 +264,7 @@ impl TavilyProxy {
         let mut retries = 0_i64;
         let mut skipped_cooldown = 0_i64;
         let mut earliest_cooldown_until = None::<i64>;
+        let mut remote_attempt_budget_deferred = false;
         let mut budget_exhausted = false;
         for candidate in candidates {
             if polled as usize >= Self::RESEARCH_SWEEP_LIMIT {
@@ -312,7 +314,7 @@ impl TavilyProxy {
                     &candidate.key_id,
                     usage_base,
                     &candidate.request_id,
-                    remote_attempt,
+                    remote_attempt.with_attempt_deadline(request_deadline),
                 ),
             )
             .await;
@@ -328,6 +330,22 @@ impl TavilyProxy {
                 });
             }
             match research_result {
+                Ok(Err((err, _))) if ReconciliationEngine::remote_attempt_is_deferred(&err) => {
+                    // Admission failure means no Research request was made. Preserve
+                    // the cursor and retry with the existing durable continuation.
+                    polled = polled.saturating_sub(1);
+                    if ReconciliationEngine::remote_attempt_is_stale(&err)
+                        && let Some((job_id, claim_generation)) = claimed_job
+                    {
+                        return Err(ProxyError::StaleClaim {
+                            job_id,
+                            claim_generation,
+                        });
+                    }
+                    remote_attempt_budget_deferred = true;
+                    budget_exhausted = true;
+                    break;
+                }
                 Err(_) => {
                     let next_poll_at = now.saturating_add(match candidate.poll_attempt_count {
                         0..=1 => 60,
@@ -538,6 +556,7 @@ impl TavilyProxy {
             retries,
             skipped_cooldown,
             earliest_cooldown_until,
+            remote_attempt_budget_deferred,
             budget_exhausted,
             cursor_ready: !budget_exhausted,
         })
@@ -674,6 +693,7 @@ impl TavilyProxy {
             remote_attempt_admission: remote_attempt_admission.as_ref(),
             reconciliation_turn,
             manual_remote_attempt,
+            attempt_deadline: None,
         };
         let mut local_admission_outcome = self.admit_upstream_reconciliation_projection();
         if matches!(
@@ -838,8 +858,9 @@ impl TavilyProxy {
                 Err(err) => return Err(err),
             };
         }
-        preparation_budget_exhausted |=
-            std::time::Instant::now() >= preparation_deadline;
+        if std::time::Instant::now() >= preparation_deadline {
+            return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+        }
         if !preparation_budget_exhausted {
             // The projection is a compatibility bootstrap for usage written
             // before the durable work triggers existed. Advance one bounded
@@ -896,6 +917,9 @@ impl TavilyProxy {
                                 }
                                 Err(err) => return Err(err),
                             };
+                            if std::time::Instant::now() >= preparation_deadline {
+                                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+                            }
                         }
                     }
                     Ok(ReconciliationProjectionSliceOutcome::Deferred {
@@ -922,6 +946,9 @@ impl TavilyProxy {
                             );
                     }
                     Err(err) => return Err(err),
+                }
+                if std::time::Instant::now() >= preparation_deadline {
+                    return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
                 }
             }
         }
@@ -965,6 +992,9 @@ impl TavilyProxy {
                 }
             }
         };
+        if std::time::Instant::now() >= candidate_hydration_deadline {
+            return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+        }
         let all_key_ids = key_ids_by_candidate
             .values()
             .flat_map(|key_ids| key_ids.iter().cloned())
@@ -994,6 +1024,9 @@ impl TavilyProxy {
                 }
             }
         };
+        if std::time::Instant::now() >= candidate_hydration_deadline {
+            return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+        }
         let mut earliest_key_cooldown_until = active_key_cooldowns
             .values()
             .map(|state| state.cooldown_until)
@@ -1021,23 +1054,35 @@ impl TavilyProxy {
                 }
                 Err(err) => return Err(err),
             }
+            if std::time::Instant::now() >= candidate_hydration_deadline {
+                return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+            }
         }
-        preparation_budget_exhausted |= std::time::Instant::now() >= candidate_hydration_deadline;
+        if std::time::Instant::now() >= candidate_hydration_deadline {
+            return Ok(ReconciliationEngine::deferred(self, "local_pressure"));
+        }
         // This indexed eligibility probe is deliberately smaller than the
         // prioritized Research sweep. A deadline here must not turn due
         // Research into a precondition for main settlement: reserve
         // conservatively and select the full sweep only after main durable
         // finalization.
+        let mut research_reservation_read_budget_deferred = false;
         let research_reservation_required = match self
             .key_store
             .has_due_upstream_reconciliation_research()
             .await
         {
             Ok(due) => due,
-            Err(err)
-                if ReconciliationEngine::projection_read_budget_is_deferred(&err)
-                    || is_transient_sqlite_write_error(&err) =>
-            {
+            Err(err) if ReconciliationEngine::projection_read_budget_is_deferred(&err) => {
+                research_reservation_read_budget_deferred = true;
+                tracing::debug!(
+                    component = "reconciliation",
+                    event = "research_reservation_unknown",
+                    "Research eligibility could not be read before main settlement; retaining the bounded reserve"
+                );
+                true
+            }
+            Err(err) if is_transient_sqlite_write_error(&err) => {
                 tracing::debug!(
                     component = "reconciliation",
                     event = "research_reservation_unknown",
@@ -1047,6 +1092,16 @@ impl TavilyProxy {
             }
             Err(err) => return Err(err),
         };
+        if std::time::Instant::now() >= candidate_hydration_deadline {
+            return Ok(ReconciliationEngine::deferred(
+                self,
+                if research_reservation_read_budget_deferred {
+                    "projection_read_budget"
+                } else {
+                    "local_pressure"
+                },
+            ));
+        }
         let ReconciliationRemoteBudget {
             main_remote_deadline,
             main_finalization_deadline,
@@ -1153,6 +1208,12 @@ impl TavilyProxy {
                     .key_store
                     .reconciliation_key_observations(&candidate, work_generation, &key_ids)
                     .await?;
+                if !remote_request_started
+                    && std::time::Instant::now() >= preparation_deadline
+                {
+                    budget_exhausted = true;
+                    break 'candidates;
+                }
                 resumed_run |= !observed_key_usage.is_empty();
                 let mut upstream_usage = observed_key_usage
                     .values()
@@ -1229,6 +1290,12 @@ impl TavilyProxy {
                             break;
                         }
                     }
+                    if !remote_request_started
+                        && std::time::Instant::now() >= preparation_deadline
+                    {
+                        budget_exhausted = true;
+                        break 'candidates;
+                    }
                     if !candidate_attempted {
                         attempted_candidate_count += 1;
                         candidate_attempted = true;
@@ -1248,11 +1315,36 @@ impl TavilyProxy {
                             &key_id,
                             usage_base,
                             &candidate.project_id,
-                            remote_attempt_context,
+                            remote_attempt_context.with_attempt_deadline(main_remote_deadline),
                         ),
                     )
                     .await;
                     match usage_result {
+                        Ok(Err((err, _)))
+                            if ReconciliationEngine::remote_attempt_is_deferred(&err) =>
+                        {
+                            // Admission failure means no outbound request was made. Keep
+                            // metrics and retry semantics distinct from transport/semantic
+                            // failures, and let the durable representative retry later.
+                            remote_request_count = remote_request_count.saturating_sub(1);
+                            if remote_request_count == 0 {
+                                remote_request_started = false;
+                                first_remote_ms = None;
+                            }
+                            if ReconciliationEngine::remote_attempt_is_stale(&err) {
+                                if let Some((job_id, claim_generation)) = claimed_job {
+                                    return Err(ProxyError::StaleClaim {
+                                        job_id,
+                                        claim_generation,
+                                    });
+                                }
+                                budget_exhausted = true;
+                                break;
+                            }
+                            remote_attempt_limit_reached = true;
+                            budget_exhausted = true;
+                            break;
+                        }
                         Err(_) => {
                             transport_failure_windows += 1;
                             last_transport_kind = Some(TransportFailureKind::Timeout.as_str());
@@ -1520,6 +1612,9 @@ impl TavilyProxy {
             })
         }
         .await;
+        if matches!(result.as_ref(), Err(ProxyError::StaleClaim { .. })) {
+            return Ok(ClaimedReconciliationRunOutcome::StaleClaim);
+        }
         if claimed_job.is_some() && result.as_ref().is_ok_and(|value| value.generation_changed) {
             tracing::debug!(
                 component = "reconciliation",
@@ -1653,6 +1748,9 @@ impl TavilyProxy {
                 ..ResearchSweepOutcome::default()
             }
         };
+        if research.remote_attempt_budget_deferred && research_defer_reason.is_none() {
+            research_defer_reason = Some(RECONCILIATION_RETRY_REASON_REMOTE_ATTEMPT_BUDGET);
+        }
         let key_cooldown_retry_at = result
             .as_ref()
             .ok()

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -9,6 +9,7 @@ struct ResearchSweepOutcome {
     pending: i64,
     retries: i64,
     skipped_cooldown: i64,
+    earliest_cooldown_until: Option<i64>,
     budget_exhausted: bool,
     cursor_ready: bool,
 }
@@ -261,6 +262,7 @@ impl TavilyProxy {
         let mut pending = 0_i64;
         let mut retries = 0_i64;
         let mut skipped_cooldown = 0_i64;
+        let mut earliest_cooldown_until = None::<i64>;
         let mut budget_exhausted = false;
         for candidate in candidates {
             if polled as usize >= Self::RESEARCH_SWEEP_LIMIT {
@@ -276,15 +278,21 @@ impl TavilyProxy {
                 self.reconciliation_cooldown_until(&candidate.key_id, self.backend_time.now_ts()),
             )
             .await;
-            let cooldown_active = match cooldown_active {
-                Ok(result) => result?.is_some(),
+            let cooldown_until = match cooldown_active {
+                Ok(result) => result?,
                 Err(_) => {
                     budget_exhausted = true;
                     break;
                 }
             };
-            if cooling_keys.contains(&candidate.key_id) || cooldown_active {
+            if cooling_keys.contains(&candidate.key_id) || cooldown_until.is_some() {
                 skipped_cooldown += 1;
+                if let Some(until) = cooldown_until {
+                    earliest_cooldown_until = Some(
+                        earliest_cooldown_until
+                            .map_or(until, |current| current.min(until)),
+                    );
+                }
                 continue;
             }
             let selected = selected_per_key.entry(candidate.key_id.clone()).or_default();
@@ -446,6 +454,10 @@ impl TavilyProxy {
                             )
                             .await?;
                         cooling_keys.insert(candidate.key_id.clone());
+                        earliest_cooldown_until = Some(
+                            earliest_cooldown_until
+                                .map_or(until, |current| current.min(until)),
+                        );
                         tracing::debug!(
                             component = "reconciliation",
                             event = "research_key_cooldown_applied",
@@ -525,6 +537,7 @@ impl TavilyProxy {
             pending,
             retries,
             skipped_cooldown,
+            earliest_cooldown_until,
             budget_exhausted,
             cursor_ready: !budget_exhausted,
         })
@@ -762,25 +775,6 @@ impl TavilyProxy {
             });
         }
         let now = self.backend_time.now_ts();
-        let global_backoff_level = run_admission_state.global_backoff_level;
-        let global_backoff_until = run_admission_state.global_backoff_until;
-        if global_backoff_until > now {
-            self.key_store
-                .mark_upstream_reconciliation_run_completed_at(now)
-                .await?;
-            tracing::debug!(
-                component = "reconciliation",
-                event = "global_backoff_active",
-                job_type = "upstream_reconciliation",
-                backoff_level = global_backoff_level,
-                backoff_until = global_backoff_until,
-            );
-            return Ok(ClaimedReconciliationRunOutcome::Completed {
-                settled: 0,
-                no_adjustment: 0,
-                observed: 0,
-            });
-        }
         let local_backoff_level = run_admission_state.local_backoff_level;
         let local_backoff_until = run_admission_state.local_backoff_until;
         if local_backoff_until > now {
@@ -1000,6 +994,10 @@ impl TavilyProxy {
                 }
             }
         };
+        let mut earliest_key_cooldown_until = active_key_cooldowns
+            .values()
+            .map(|state| state.cooldown_until)
+            .min();
         if !preparation_budget_exhausted && !candidates.is_empty() {
             let remaining = candidate_hydration_deadline
                 .saturating_duration_since(std::time::Instant::now());
@@ -1099,7 +1097,6 @@ impl TavilyProxy {
             let mut attempted_candidate_count = 0_i64;
             let mut remote_request_count = 0_i64;
             let mut budget_exhausted = preparation_budget_exhausted;
-            let mut max_retry_after_until = None::<i64>;
             let mut cooling_keys = HashSet::<String>::new();
             let mut remote_request_started = false;
             let mut first_remote_ms = None;
@@ -1364,15 +1361,6 @@ impl TavilyProxy {
                             }
                             _ => RECONCILIATION_RETRY_REASON_OTHER,
                         };
-                        if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429
-                            && let Some(retry_after_until) = retry_at
-                        {
-                            max_retry_after_until = Some(
-                                max_retry_after_until
-                                    .unwrap_or_default()
-                                    .max(retry_after_until),
-                            );
-                        }
                         ensure_reconciliation_post_process_reserve(main_finalization_deadline)?;
                         let cooldown_until = if reason_kind
                             == RECONCILIATION_RETRY_REASON_UPSTREAM_429
@@ -1387,6 +1375,12 @@ impl TavilyProxy {
                         } else {
                             retry_at.unwrap_or_else(|| self.backend_time.now_ts().saturating_add(300))
                         };
+                        if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
+                            earliest_key_cooldown_until = Some(
+                                earliest_key_cooldown_until
+                                    .map_or(cooldown_until, |current| current.min(cooldown_until)),
+                            );
+                        }
                         self.key_store
                             .mark_reconciliation_retry(
                                 &candidate,
@@ -1508,11 +1502,11 @@ impl TavilyProxy {
                 other_retry_windows,
                 key_backoff_window_count,
                 skipped_by_key_backoff,
+                earliest_key_cooldown_until,
                 attempted_candidate_count,
                 main_remote_request_count: remote_request_count,
                 budget_exhausted,
                 remote_attempt_limit_reached,
-                max_retry_after_until,
                 hydrate_ms,
                 first_remote_ms,
                 remote_ms: remote_phase_started
@@ -1659,6 +1653,40 @@ impl TavilyProxy {
                 ..ResearchSweepOutcome::default()
             }
         };
+        let key_cooldown_retry_at = result
+            .as_ref()
+            .ok()
+            .and_then(|value| value.earliest_key_cooldown_until)
+            .into_iter()
+            .chain(research.earliest_cooldown_until)
+            .filter(|until| *until > self.backend_time.now_ts())
+            .min();
+        let no_remote_attempts = result
+            .as_ref()
+            .is_ok_and(|value| value.main_remote_request_count == 0)
+            && research.polled == 0;
+        let no_retry_or_terminal = result.as_ref().is_ok_and(|value| {
+            value.upstream_429_retry_windows == 0
+                && value.local_usage_rate_limit_windows == 0
+                && value.other_retry_windows == 0
+                && value.transport_failure_windows == 0
+                && value.semantic_failure_windows == 0
+                && !value.remote_attempt_limit_reached
+        }) && research.retries == 0
+            && research.terminal == 0
+            && research.pending == 0;
+        let key_cooldown_only = no_remote_attempts
+            && no_retry_or_terminal
+            && (result
+                .as_ref()
+                .is_ok_and(|value| value.skipped_by_key_backoff > 0)
+                || research.skipped_cooldown > 0);
+        if research_defer_reason.is_none()
+            && key_cooldown_only
+            && key_cooldown_retry_at.is_some()
+        {
+            research_defer_reason = Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN);
+        }
         if research_defer_reason.is_none() && !research.cursor_ready {
             research_defer_reason = Some("research_budget");
         }
@@ -1693,11 +1721,11 @@ impl TavilyProxy {
                 other_retry_windows,
                 key_backoff_window_count,
                 skipped_by_key_backoff,
+                earliest_key_cooldown_until: _,
                 attempted_candidate_count,
                 main_remote_request_count,
                 mut budget_exhausted,
                 remote_attempt_limit_reached,
-                max_retry_after_until,
                 hydrate_ms,
                 first_remote_ms,
                 remote_ms,
@@ -1816,10 +1844,6 @@ impl TavilyProxy {
                     );
                 }
                 let upstream_429_observed = upstream_429_retry_windows > 0;
-                let qualified_remote_pressure = upstream_429_observed
-                    && completed == 0
-                    && upstream_429_retry_windows.saturating_mul(2)
-                        >= attempted_candidate_count.max(1);
                 let local_pressure = local_usage_rate_limit_windows > 0
                     || research_defer_reason == Some("research_local_pressure")
                     || ((candidate_count > 0 || preparation_budget_exhausted)
@@ -1914,92 +1938,6 @@ impl TavilyProxy {
                         job_type = "upstream_reconciliation",
                     );
                 }
-                let (_, previous_backoff_level, _) = await_reconciliation_post_process(
-                    post_process_deadline,
-                    self.key_store.upstream_reconciliation_global_backoff_state(),
-                )
-                .await?;
-                let (pressure_streak, backoff_level, backoff_until) = if qualified_remote_pressure {
-                    let now = self.backend_time.now_ts();
-                    match claimed_job {
-                        Some((job_id, claim_generation)) => {
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store
-                                    .update_upstream_reconciliation_global_backoff_claimed(
-                                        true,
-                                        now,
-                                        max_retry_after_until,
-                                        job_id,
-                                        claim_generation,
-                                    ),
-                            )
-                            .await?
-                        }
-                        None => {
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store.update_upstream_reconciliation_global_backoff(
-                                    true,
-                                    now,
-                                    max_retry_after_until,
-                                ),
-                            )
-                            .await?
-                        }
-                    }
-                } else if reconciliation_outcome
-                    .is_some_and(ReconciliationEngine::clears_upstream_429)
-                {
-                    let now = self.backend_time.now_ts();
-                    match claimed_job {
-                        Some((job_id, claim_generation)) => {
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store
-                                    .update_upstream_reconciliation_global_backoff_claimed(
-                                        false,
-                                        now,
-                                        None,
-                                        job_id,
-                                        claim_generation,
-                                    ),
-                            )
-                            .await?
-                        }
-                        None => {
-                            await_reconciliation_post_process(
-                                post_process_deadline,
-                                self.key_store.update_upstream_reconciliation_global_backoff(
-                                    false, now, None,
-                                ),
-                            )
-                            .await?
-                        }
-                    }
-                } else {
-                    self.key_store.upstream_reconciliation_global_backoff_state().await?
-                };
-                if backoff_level > previous_backoff_level {
-                    tracing::warn!(
-                        component = "reconciliation",
-                        event = "global_backoff_applied",
-                        job_type = "upstream_reconciliation",
-                        pressure_streak,
-                        backoff_level,
-                        backoff_until,
-                        rate_limited_429_count = upstream_429_retry_windows,
-                        candidate_count,
-                        attempted_candidate_count,
-                    );
-                } else if previous_backoff_level > 0 && backoff_level == 0 {
-                    tracing::warn!(
-                        component = "reconciliation",
-                        event = "global_backoff_recovered",
-                        job_type = "upstream_reconciliation",
-                        previous_backoff_level,
-                    );
-                }
                 let finalization_ms = started_at
                     .elapsed()
                     .as_millis()
@@ -2007,7 +1945,7 @@ impl TavilyProxy {
                     - hydrate_ms
                     - remote_ms
                     - research_ms;
-                let next_retry_at = [local_backoff_until, backoff_until]
+                let next_retry_at = [local_backoff_until, key_cooldown_retry_at.unwrap_or_default()]
                     .into_iter()
                     .filter(|value| *value > self.backend_time.now_ts())
                     .chain(remote_attempt_budget_deferred.then(|| {
@@ -2122,7 +2060,15 @@ impl TavilyProxy {
                         event = "research_sweep_deferred",
                         reason,
                     );
-                    return Ok(ReconciliationEngine::deferred(self, reason));
+                    let retry_at = (reason == RECONCILIATION_RETRY_REASON_KEY_COOLDOWN)
+                        .then_some(key_cooldown_retry_at)
+                        .flatten()
+                        .unwrap_or_else(|| {
+                            self.backend_time
+                                .now_ts()
+                                .saturating_add(ReconciliationEngine::DEFER_RETRY_DELAY_SECS)
+                        });
+                    return Ok(ReconciliationEngine::deferred_at(self, reason, retry_at));
                 }
                 Ok(ClaimedReconciliationRunOutcome::Completed {
                     settled,
@@ -2850,15 +2796,11 @@ impl TavilyProxy {
     }
 
     pub async fn upstream_reconciliation_backoff_until(&self) -> Result<i64, ProxyError> {
-        let (_, _, global_backoff_until) = self
-            .key_store
-            .upstream_reconciliation_global_backoff_state()
-            .await?;
         let (_, _, local_backoff_until) = self
             .key_store
             .upstream_reconciliation_local_backoff_state()
             .await?;
-        Ok(global_backoff_until.max(local_backoff_until))
+        Ok(local_backoff_until)
     }
 
     pub async fn upstream_reconciliation_continuation_at(

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -308,16 +308,14 @@ impl TavilyProxy {
                 budget_exhausted = true;
                 break;
             }
-            let research_result = tokio::time::timeout(
-                remaining,
-                self.fetch_upstream_research_terminal(
+            let research_result = self
+                .fetch_upstream_research_terminal(
                     &candidate.key_id,
                     usage_base,
                     &candidate.request_id,
                     remote_attempt.with_attempt_deadline(request_deadline),
-                ),
-            )
-            .await;
+                )
+                .await;
             if let Some((job_id, claim_generation)) = claimed_job
                 && !self
                     .key_store
@@ -330,7 +328,7 @@ impl TavilyProxy {
                 });
             }
             match research_result {
-                Ok(Err((err, _))) if ReconciliationEngine::remote_attempt_is_deferred(&err) => {
+                Err((err, _)) if ReconciliationEngine::remote_attempt_is_deferred(&err) => {
                     // Admission failure means no Research request was made. Preserve
                     // the cursor and retry with the existing durable continuation.
                     polled = polled.saturating_sub(1);
@@ -346,7 +344,8 @@ impl TavilyProxy {
                     budget_exhausted = true;
                     break;
                 }
-                Err(_) => {
+                Err((err, _)) if ReconciliationEngine::is_remote_request_timeout(&err) =>
+                {
                     let next_poll_at = now.saturating_add(match candidate.poll_attempt_count {
                         0..=1 => 60,
                         2..=3 => 120,
@@ -382,7 +381,7 @@ impl TavilyProxy {
                     budget_exhausted = true;
                     break;
                 }
-                Ok(Ok(true)) => {
+                Ok(true) => {
                     let remaining = request_deadline.saturating_duration_since(std::time::Instant::now());
                     if remaining.is_zero() {
                         budget_exhausted = true;
@@ -415,7 +414,7 @@ impl TavilyProxy {
                         period_code = %candidate.period_code,
                     );
                 }
-                Ok(Ok(false)) => {
+                Ok(false) => {
                     let remaining = request_deadline.saturating_duration_since(std::time::Instant::now());
                     if remaining.is_zero() {
                         budget_exhausted = true;
@@ -447,7 +446,7 @@ impl TavilyProxy {
                     }
                     pending += 1;
                 }
-                Ok(Err((err, retry_after))) => {
+                Err((err, retry_after)) => {
                     let reason = if matches!(
                         &err,
                         ProxyError::UsageHttp { status, .. }
@@ -1149,10 +1148,19 @@ impl TavilyProxy {
             let mut other_retry_windows = 0_i64;
             let mut key_backoff_window_count = 0_i64;
             let mut skipped_by_key_backoff = 0_i64;
+            let mut key_cooldown_deferred = false;
             let mut attempted_candidate_count = 0_i64;
             let mut remote_request_count = 0_i64;
+            let mut main_remote_budget_deferred = false;
             let mut budget_exhausted = preparation_budget_exhausted;
             let mut cooling_keys = HashSet::<String>::new();
+            // Keep cooldowns at key granularity while this run progresses. A
+            // candidate can have several upstream keys; a cooling key must not
+            // prevent healthy siblings from being observed.
+            let mut key_cooldown_untils = active_key_cooldowns
+                .iter()
+                .map(|(key_id, state)| (key_id.clone(), state.cooldown_until))
+                .collect::<std::collections::HashMap<_, _>>();
             let mut remote_request_started = false;
             let mut first_remote_ms = None;
             let remote_phase_started = std::time::Instant::now();
@@ -1188,22 +1196,6 @@ impl TavilyProxy {
                     .get(&(candidate.token_id.clone(), candidate.period_code.clone()))
                     .cloned()
                     .unwrap_or_default();
-                if key_ids.iter().any(|key_id| cooling_keys.contains(key_id)) {
-                    skipped_by_key_backoff += 1;
-                    continue;
-                }
-                let mut key_in_cooldown = false;
-                for key_id in &key_ids {
-                    if active_key_cooldowns.contains_key(key_id) {
-                        cooling_keys.insert(key_id.clone());
-                        key_in_cooldown = true;
-                        break;
-                    }
-                }
-                if key_in_cooldown {
-                    skipped_by_key_backoff += 1;
-                    continue;
-                }
                 let observed_key_usage = self
                     .key_store
                     .reconciliation_key_observations(&candidate, work_generation, &key_ids)
@@ -1243,10 +1235,29 @@ impl TavilyProxy {
                         .await?;
                     continue;
                 }
-                let missing_key_ids = key_ids
-                    .into_iter()
-                    .filter(|key_id| !observed_key_usage.contains_key(key_id))
-                    .collect::<Vec<_>>();
+                let mut candidate_key_cooldown_until: Option<i64> = None;
+                let mut missing_key_ids = Vec::new();
+                for key_id in key_ids {
+                    if observed_key_usage.contains_key(&key_id) {
+                        continue;
+                    }
+                    if let Some(cooldown_until) = key_cooldown_untils.get(&key_id).copied() {
+                        cooling_keys.insert(key_id);
+                        candidate_key_cooldown_until = Some(
+                            candidate_key_cooldown_until
+                                .map_or(cooldown_until, |current| current.min(cooldown_until)),
+                        );
+                    } else {
+                        missing_key_ids.push(key_id);
+                    }
+                }
+                if let Some(cooldown_until) = candidate_key_cooldown_until {
+                    skipped_by_key_backoff += 1;
+                    earliest_key_cooldown_until = Some(
+                        earliest_key_cooldown_until
+                            .map_or(cooldown_until, |current| current.min(cooldown_until)),
+                    );
+                }
                 for key_id in missing_key_ids {
                     if remote_request_count >= ReconciliationEngine::MAX_REMOTE_ATTEMPTS {
                         remote_attempt_limit_reached = true;
@@ -1265,6 +1276,7 @@ impl TavilyProxy {
                         .saturating_duration_since(std::time::Instant::now());
                     let request_timeout = Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS);
                     if remote_remaining < request_timeout {
+                        main_remote_budget_deferred = true;
                         budget_exhausted = true;
                         break;
                     }
@@ -1272,6 +1284,7 @@ impl TavilyProxy {
                         .saturating_duration_since(std::time::Instant::now())
                         .min(remote_remaining.saturating_sub(request_timeout));
                     if reservation_budget.is_zero() {
+                        main_remote_budget_deferred = true;
                         budget_exhausted = true;
                         break;
                     }
@@ -1300,8 +1313,6 @@ impl TavilyProxy {
                         attempted_candidate_count += 1;
                         candidate_attempted = true;
                     }
-                    let remaining = main_remote_deadline
-                        .saturating_duration_since(std::time::Instant::now());
                     remote_request_started = true;
                     if remote_request_count == 0 {
                         first_remote_ms = Some(
@@ -1309,19 +1320,16 @@ impl TavilyProxy {
                         );
                     }
                     remote_request_count += 1;
-                    let usage_result = tokio::time::timeout(
-                        remaining.max(Duration::from_millis(1)),
-                        self.fetch_upstream_project_usage(
+                    let usage_result = self
+                        .fetch_upstream_project_usage(
                             &key_id,
                             usage_base,
                             &candidate.project_id,
                             remote_attempt_context.with_attempt_deadline(main_remote_deadline),
-                        ),
-                    )
-                    .await;
+                        )
+                        .await;
                     match usage_result {
-                        Ok(Err((err, _)))
-                            if ReconciliationEngine::remote_attempt_is_deferred(&err) =>
+                        Err((err, _)) if ReconciliationEngine::remote_attempt_is_deferred(&err) =>
                         {
                             // Admission failure means no outbound request was made. Keep
                             // metrics and retry semantics distinct from transport/semantic
@@ -1342,18 +1350,22 @@ impl TavilyProxy {
                                 break;
                             }
                             remote_attempt_limit_reached = true;
+                            main_remote_budget_deferred = true;
                             budget_exhausted = true;
                             break;
                         }
-                        Err(_) => {
+                        Err((err, retry_after))
+                            if matches!(&err, ProxyError::Http(error) if error.is_timeout()) =>
+                        {
                             transport_failure_windows += 1;
                             last_transport_kind = Some(TransportFailureKind::Timeout.as_str());
                             retry_reason = Some("transport_failure".to_string());
                             retry_key_id = Some(key_id.clone());
                             retry_outcome = Some(ReconciliationOutcome::TransportFailure);
+                            retry_at = retry_after;
                             break;
                         }
-                        Ok(Ok(usage)) => {
+                        Ok(usage) => {
                             upstream_usage = upstream_usage.saturating_add(usage);
                             successful_key_count += 1;
                             let persisted = self
@@ -1394,7 +1406,7 @@ impl TavilyProxy {
                                     partial_key_observations.saturating_add(1);
                             }
                         }
-                        Ok(Err((err, upstream_retry_at))) => {
+                        Err((err, upstream_retry_at)) => {
                             let outcome = if matches!(
                                 &err,
                                 ProxyError::UsageHttp { status, .. }
@@ -1428,7 +1440,9 @@ impl TavilyProxy {
                         }
                     }
                 }
-                if let (Some(_retry_reason), Some(retry_key_id)) = (retry_reason, retry_key_id) {
+                if retry_reason.is_some()
+                    && let Some(retry_key_id) = retry_key_id
+                {
                         if key_count > 1 && successful_key_count < key_count {
                             multi_key_pending = multi_key_pending.saturating_add(1);
                         }
@@ -1505,6 +1519,7 @@ impl TavilyProxy {
                         if reason_kind == RECONCILIATION_RETRY_REASON_UPSTREAM_429 {
                             key_backoff_window_count += affected_window_count;
                             cooling_keys.insert(retry_key_id.clone());
+                            key_cooldown_untils.insert(retry_key_id.clone(), cooldown_until);
                         }
                         tracing::debug!(
                             component = "reconciliation",
@@ -1517,6 +1532,31 @@ impl TavilyProxy {
                             cooldown_until,
                             affected_window_count,
                         );
+                    continue;
+                }
+                if successful_key_count != key_count
+                    && !remote_attempt_limit_reached
+                    && !budget_exhausted
+                    && retry_reason.is_none()
+                    && let Some(cooldown_until) = candidate_key_cooldown_until
+                {
+                    key_cooldown_deferred = true;
+                    if key_count > 1 {
+                        multi_key_pending = multi_key_pending.saturating_add(1);
+                    }
+                    self.key_store
+                        .mark_reconciliation_retry(
+                            &candidate,
+                            "waiting",
+                            cooldown_until,
+                            Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN),
+                            RECONCILIATION_OUTCOME_KEY_COOLDOWN,
+                            Some(ReconciliationWorkFence {
+                                work_generation,
+                                claimed_job,
+                            }),
+                        )
+                        .await?;
                     continue;
                 }
                 if key_count > 1 && successful_key_count != key_count && remote_attempt_limit_reached {
@@ -1595,8 +1635,10 @@ impl TavilyProxy {
                 key_backoff_window_count,
                 skipped_by_key_backoff,
                 earliest_key_cooldown_until,
+                key_cooldown_deferred,
                 attempted_candidate_count,
                 main_remote_request_count: remote_request_count,
+                main_remote_budget_deferred,
                 budget_exhausted,
                 remote_attempt_limit_reached,
                 hydrate_ms,
@@ -1652,7 +1694,15 @@ impl TavilyProxy {
         let remote_attempt_budget_deferred = claimed_job.is_some()
             && result
                 .as_ref()
-                .is_ok_and(|value| value.remote_attempt_limit_reached);
+                .is_ok_and(|value| {
+                    value.remote_attempt_limit_reached || value.main_remote_budget_deferred
+                });
+        let main_remote_budget_deferred = result
+            .as_ref()
+            .is_ok_and(|value| value.main_remote_budget_deferred);
+        let main_key_cooldown_deferred = result
+            .as_ref()
+            .is_ok_and(|value| value.key_cooldown_deferred);
         if remote_attempt_budget_deferred {
             // Main work has durable partial observations but still needs one or
             // more keys. Do not let Research consume the remaining dispatch
@@ -1661,6 +1711,8 @@ impl TavilyProxy {
         }
         let research_page = if result.is_ok()
             && !remote_attempt_budget_deferred
+            && !main_remote_budget_deferred
+            && !main_key_cooldown_deferred
             && research_reservation_required
             && !self.sqlite_maintenance_runs_shutting_down()
         {
@@ -1785,6 +1837,25 @@ impl TavilyProxy {
         {
             research_defer_reason = Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN);
         }
+        if research_defer_reason.is_none()
+            && main_key_cooldown_deferred
+            && key_cooldown_retry_at.is_some()
+        {
+            research_defer_reason = Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN);
+        }
+        // The unclaimed compatibility entry point returns the terminal work
+        // observed during this invocation. It must not discard that count just
+        // because another candidate remains deferred on a key cooldown; the
+        // durable scheduler path still returns the typed defer below.
+        let terminal_work_completed = result.as_ref().is_ok_and(|value| {
+            value.settled.saturating_add(value.no_adjustment).saturating_add(value.observed) > 0
+        }) || research.terminal > 0;
+        if claimed_job.is_none()
+            && terminal_work_completed
+            && research_defer_reason == Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN)
+        {
+            research_defer_reason = None;
+        }
         if research_defer_reason.is_none() && !research.cursor_ready {
             research_defer_reason = Some("research_budget");
         }
@@ -1820,8 +1891,10 @@ impl TavilyProxy {
                 key_backoff_window_count,
                 skipped_by_key_backoff,
                 earliest_key_cooldown_until: _,
+                key_cooldown_deferred: _,
                 attempted_candidate_count,
                 main_remote_request_count,
+                main_remote_budget_deferred: _,
                 mut budget_exhausted,
                 remote_attempt_limit_reached,
                 hydrate_ms,
@@ -1944,7 +2017,8 @@ impl TavilyProxy {
                 let upstream_429_observed = upstream_429_retry_windows > 0;
                 let local_pressure = local_usage_rate_limit_windows > 0
                     || research_defer_reason == Some("research_local_pressure")
-                    || ((candidate_count > 0 || preparation_budget_exhausted)
+                    || (!main_remote_budget_deferred
+                        && (candidate_count > 0 || preparation_budget_exhausted)
                         && attempted_candidate_count == 0
                         && budget_exhausted);
                 let reconciliation_outcome = ReconciliationEngine::outcome(

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -175,14 +175,10 @@ impl TavilyProxy {
                 .api_key_transient_backoff_state(key_id, Self::RECONCILIATION_BACKOFF_SCOPE)
                 .await?
                 .map(|state| state.retry_after_secs));
-        let retry_after_secs = requested_until
-            .map(|until| until.saturating_sub(now).max(1))
-            .unwrap_or_else(|| match prior_retry_after_secs {
-                None | Some(0) => 300,
-                Some(1..=300) => 600,
-                Some(301..=600) => 1200,
-                _ => 1800,
-            });
+        let retry_after_secs = ReconciliationEngine::reconciliation_retry_delay_secs(
+            prior_retry_after_secs,
+            requested_until.map(|until| until.saturating_sub(now)),
+        );
         let cooldown_until = now.saturating_add(retry_after_secs);
         let arm = ApiKeyTransientBackoffArm {
             key_id,
@@ -291,6 +287,26 @@ impl ReconciliationEngine {
     const REMOTE_ATTEMPT_BUDGET_REASON: &'static str = "remote_attempt_budget";
     // The compatibility one-shot API has no durable representative job.
     const ONE_SHOT_ADMISSION_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
+
+    fn reconciliation_retry_ladder_secs(prior_retry_after_secs: Option<i64>) -> i64 {
+        match prior_retry_after_secs {
+            None | Some(0) => 300,
+            Some(1..=300) => 600,
+            Some(301..=600) => 1200,
+            _ => 1800,
+        }
+    }
+
+    fn reconciliation_retry_delay_secs(
+        prior_retry_after_secs: Option<i64>,
+        requested_retry_after_secs: Option<i64>,
+    ) -> i64 {
+        let ladder_secs = Self::reconciliation_retry_ladder_secs(prior_retry_after_secs);
+        requested_retry_after_secs
+            .map(|seconds| seconds.max(1))
+            .unwrap_or_default()
+            .max(ladder_secs)
+    }
 
     fn deferred(proxy: &TavilyProxy, reason: &'static str) -> ClaimedReconciliationRunOutcome {
         Self::deferred_at(
@@ -751,6 +767,26 @@ mod reconciliation_engine_tests {
         );
         assert!(ReconciliationEngine::remote_attempt_is_deferred(&budget));
         assert!(!ReconciliationEngine::remote_attempt_is_stale(&budget));
+    }
+
+    #[test]
+    fn retry_after_never_shortens_the_key_cooldown_ladder() {
+        assert_eq!(
+            ReconciliationEngine::reconciliation_retry_delay_secs(None, Some(1)),
+            300
+        );
+        assert_eq!(
+            ReconciliationEngine::reconciliation_retry_delay_secs(Some(300), Some(1)),
+            600
+        );
+        assert_eq!(
+            ReconciliationEngine::reconciliation_retry_delay_secs(None, Some(600)),
+            600
+        );
+        assert_eq!(
+            ReconciliationEngine::reconciliation_retry_delay_secs(Some(600), Some(1)),
+            1200
+        );
     }
 }
 

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -210,6 +210,7 @@ struct ReconciliationRemoteAttemptContext<'a> {
     remote_attempt_admission: Option<&'a Arc<RemoteAttemptAdmissionController>>,
     reconciliation_turn: Option<&'a crate::ReconciliationTurn>,
     manual_remote_attempt: bool,
+    attempt_deadline: Option<std::time::Instant>,
 }
 
 /// A stable, non-sensitive classification for failures before a reconciliation
@@ -250,14 +251,34 @@ impl TransportFailureKind {
 }
 
 impl ReconciliationRemoteAttemptContext<'_> {
-    async fn acquire(self) -> Result<Option<crate::RemoteAttemptLease>, &'static str> {
-        match (self.reconciliation_turn, self.remote_attempt_admission) {
-        (Some(turn), _) => turn.acquire_attempt().await.map(Some),
-        (None, Some(controller)) if self.manual_remote_attempt => {
-            controller.acquire_manual_attempt().await.map(Some)
+    fn with_attempt_deadline(self, deadline: std::time::Instant) -> Self {
+        Self {
+            attempt_deadline: Some(deadline),
+            ..self
         }
-        (None, Some(controller)) => controller.acquire_reconciliation_attempt().await.map(Some),
-        (None, None) => Ok(None),
+    }
+
+    async fn acquire(self) -> Result<Option<crate::RemoteAttemptLease>, &'static str> {
+        let acquire = async {
+            match (self.reconciliation_turn, self.remote_attempt_admission) {
+                (Some(turn), _) => turn.acquire_attempt().await.map(Some),
+                (None, Some(controller)) if self.manual_remote_attempt => {
+                    controller.acquire_manual_attempt().await.map(Some)
+                }
+                (None, Some(controller)) => {
+                    controller.acquire_reconciliation_attempt().await.map(Some)
+                }
+                (None, None) => Ok(None),
+            }
+        };
+        match self.attempt_deadline {
+            Some(deadline) => tokio::time::timeout(
+                deadline.saturating_duration_since(std::time::Instant::now()),
+                acquire,
+            )
+            .await
+            .map_err(|_| ReconciliationEngine::REMOTE_ATTEMPT_BUDGET_REASON)?,
+            None => acquire.await,
         }
     }
 }
@@ -265,6 +286,9 @@ impl ReconciliationRemoteAttemptContext<'_> {
 impl ReconciliationEngine {
     const MAX_REMOTE_ATTEMPTS: i64 = 2;
     const DEFER_RETRY_DELAY_SECS: i64 = 30;
+    const REMOTE_ATTEMPT_ADMISSION_OPERATION: &'static str = "reconciliation_remote_attempt";
+    const REMOTE_ATTEMPT_STALE_TURN_REASON: &'static str = "reconciliation_turn_stale";
+    const REMOTE_ATTEMPT_BUDGET_REASON: &'static str = "remote_attempt_budget";
     // The compatibility one-shot API has no durable representative job.
     const ONE_SHOT_ADMISSION_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
 
@@ -296,6 +320,33 @@ impl ReconciliationEngine {
             ProxyError::Deferred { operation, reason }
                 if *operation == "reconciliation_projection" && reason == "projection_read_budget"
         )
+    }
+
+    fn remote_attempt_admission_error(reason: &'static str) -> ProxyError {
+        ProxyError::Deferred {
+            operation: Self::REMOTE_ATTEMPT_ADMISSION_OPERATION,
+            reason: reason.to_string(),
+        }
+    }
+
+    fn remote_attempt_admission_reason(error: &ProxyError) -> Option<&str> {
+        match error {
+            ProxyError::Deferred { operation, reason }
+                if *operation == Self::REMOTE_ATTEMPT_ADMISSION_OPERATION =>
+            {
+                Some(reason.as_str())
+            }
+            _ => None,
+        }
+    }
+
+    fn remote_attempt_is_deferred(error: &ProxyError) -> bool {
+        Self::remote_attempt_admission_reason(error).is_some()
+    }
+
+    fn remote_attempt_is_stale(error: &ProxyError) -> bool {
+        Self::remote_attempt_admission_reason(error)
+            == Some(Self::REMOTE_ATTEMPT_STALE_TURN_REASON)
     }
 
     fn post_process_exhaustion_is_deferred(error: &ProxyError) -> bool {
@@ -681,6 +732,26 @@ mod reconciliation_engine_tests {
             "unknown"
         );
     }
+
+    #[test]
+    fn remote_admission_failures_are_typed_without_becoming_transport_or_semantic() {
+        let stale = ReconciliationEngine::remote_attempt_admission_error(
+            ReconciliationEngine::REMOTE_ATTEMPT_STALE_TURN_REASON,
+        );
+        assert!(ReconciliationEngine::remote_attempt_is_deferred(&stale));
+        assert!(ReconciliationEngine::remote_attempt_is_stale(&stale));
+        assert_eq!(
+            ReconciliationEngine::remote_attempt_admission_reason(&stale),
+            Some(ReconciliationEngine::REMOTE_ATTEMPT_STALE_TURN_REASON)
+        );
+        assert!(!ReconciliationEngine::is_transport_failure(&stale));
+
+        let budget = ReconciliationEngine::remote_attempt_admission_error(
+            ReconciliationEngine::REMOTE_ATTEMPT_BUDGET_REASON,
+        );
+        assert!(ReconciliationEngine::remote_attempt_is_deferred(&budget));
+        assert!(!ReconciliationEngine::remote_attempt_is_stale(&budget));
+    }
 }
 
 impl ReconciliationOutcome {
@@ -724,7 +795,7 @@ impl TavilyProxy {
         let remote_attempt = remote_attempt
             .acquire()
             .await
-            .map_err(|reason| (ProxyError::Other(reason.to_string()), None))?;
+            .map_err(|reason| (ReconciliationEngine::remote_attempt_admission_error(reason), None))?;
         let response = self
             .send_with_forward_proxy(key_id, "period_reconciliation", |client| {
                 client
@@ -799,7 +870,7 @@ impl TavilyProxy {
         let remote_attempt = remote_attempt
             .acquire()
             .await
-            .map_err(|reason| (ProxyError::Other(reason.to_string()), None))?;
+            .map_err(|reason| (ReconciliationEngine::remote_attempt_admission_error(reason), None))?;
         let response = self
             .send_with_forward_proxy(key_id, "period_reconciliation", |client| {
                 client

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -24,11 +24,11 @@ struct ReconciliationRunResult {
     other_retry_windows: i64,
     key_backoff_window_count: i64,
     skipped_by_key_backoff: i64,
+    earliest_key_cooldown_until: Option<i64>,
     attempted_candidate_count: i64,
     main_remote_request_count: i64,
     budget_exhausted: bool,
     remote_attempt_limit_reached: bool,
-    max_retry_after_until: Option<i64>,
     hydrate_ms: i64,
     first_remote_ms: Option<i64>,
     remote_ms: i64,
@@ -269,12 +269,24 @@ impl ReconciliationEngine {
     const ONE_SHOT_ADMISSION_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
 
     fn deferred(proxy: &TavilyProxy, reason: &'static str) -> ClaimedReconciliationRunOutcome {
-        ClaimedReconciliationRunOutcome::Deferred {
+        Self::deferred_at(
+            proxy,
             reason,
-            retry_at: proxy
+            proxy
                 .backend_time()
                 .now_ts()
                 .saturating_add(Self::DEFER_RETRY_DELAY_SECS),
+        )
+    }
+
+    fn deferred_at(
+        _proxy: &TavilyProxy,
+        reason: &'static str,
+        retry_at: i64,
+    ) -> ClaimedReconciliationRunOutcome {
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason,
+            retry_at,
         }
     }
 
@@ -502,6 +514,7 @@ impl ReconciliationEngine {
         )
     }
 
+    #[cfg(test)]
     fn clears_upstream_429(outcome: ReconciliationOutcome) -> bool {
         Self::clears_local_pressure(outcome)
     }

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -25,8 +25,10 @@ struct ReconciliationRunResult {
     key_backoff_window_count: i64,
     skipped_by_key_backoff: i64,
     earliest_key_cooldown_until: Option<i64>,
+    key_cooldown_deferred: bool,
     attempted_candidate_count: i64,
     main_remote_request_count: i64,
+    main_remote_budget_deferred: bool,
     budget_exhausted: bool,
     remote_attempt_limit_reached: bool,
     hydrate_ms: i64,
@@ -241,12 +243,33 @@ impl TransportFailureKind {
             ProxyError::Http(error) if error.is_timeout() => Self::Timeout,
             ProxyError::Http(error) if error.is_connect() => Self::Connect,
             ProxyError::Http(_) => Self::ResponseBody,
+            ProxyError::Other(message)
+                if message == ReconciliationEngine::REMOTE_REQUEST_DEADLINE_ERROR =>
+            {
+                Self::Timeout
+            }
             _ => Self::Unknown,
         }
     }
 }
 
 impl ReconciliationRemoteAttemptContext<'_> {
+    fn deadline_remaining(self) -> Option<std::time::Duration> {
+        self.attempt_deadline
+            .map(|deadline| deadline.saturating_duration_since(std::time::Instant::now()))
+    }
+
+    fn request_timeout(self) -> std::time::Duration {
+        self.attempt_deadline
+            .map(|deadline| {
+                deadline
+                    .saturating_duration_since(std::time::Instant::now())
+                    .min(std::time::Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS))
+                    .max(std::time::Duration::from_millis(1))
+            })
+            .unwrap_or_else(|| std::time::Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS))
+    }
+
     fn with_attempt_deadline(self, deadline: std::time::Instant) -> Self {
         Self {
             attempt_deadline: Some(deadline),
@@ -285,6 +308,7 @@ impl ReconciliationEngine {
     const REMOTE_ATTEMPT_ADMISSION_OPERATION: &'static str = "reconciliation_remote_attempt";
     const REMOTE_ATTEMPT_STALE_TURN_REASON: &'static str = "reconciliation_turn_stale";
     const REMOTE_ATTEMPT_BUDGET_REASON: &'static str = "remote_attempt_budget";
+    const REMOTE_REQUEST_DEADLINE_ERROR: &'static str = "reconciliation remote request deadline exceeded";
     // The compatibility one-shot API has no durable representative job.
     const ONE_SHOT_ADMISSION_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
 
@@ -536,6 +560,19 @@ impl ReconciliationEngine {
         matches!(
             err,
             ProxyError::Http(_) | ProxyError::Database(_) | ProxyError::InvalidEndpoint { .. }
+        ) || matches!(
+            err,
+            ProxyError::Other(message) if message == Self::REMOTE_REQUEST_DEADLINE_ERROR
+        )
+    }
+
+    fn is_remote_request_timeout(err: &ProxyError) -> bool {
+        matches!(
+            err,
+            ProxyError::Http(error) if error.is_timeout()
+        ) || matches!(
+            err,
+            ProxyError::Other(message) if message == Self::REMOTE_REQUEST_DEADLINE_ERROR
         )
     }
 
@@ -828,19 +865,51 @@ impl TavilyProxy {
             )
         })?;
         let url = build_path_prefixed_url(&base, "/usage");
-        let remote_attempt = remote_attempt
+        let remote_attempt_context = remote_attempt;
+        let remote_attempt = remote_attempt_context
             .acquire()
             .await
             .map_err(|reason| (ReconciliationEngine::remote_attempt_admission_error(reason), None))?;
-        let response = self
+        let request_timeout = remote_attempt_context.request_timeout();
+        let request_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let outbound = self
             .send_with_forward_proxy(key_id, "period_reconciliation", |client| {
+                request_started.store(true, std::sync::atomic::Ordering::Relaxed);
                 client
                     .get(url.clone())
                     .header("Authorization", format!("Bearer {secret}"))
                     .header("X-Project-ID", project_id)
-                    .timeout(Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS))
-            })
-            .await
+                    .timeout(request_timeout)
+            });
+        let response_result = match remote_attempt_context.deadline_remaining() {
+            Some(remaining) if remaining.is_zero() => {
+                drop(remote_attempt);
+                return Err((
+                    ReconciliationEngine::remote_attempt_admission_error(
+                        ReconciliationEngine::REMOTE_ATTEMPT_BUDGET_REASON,
+                    ),
+                    None,
+                ));
+            }
+            Some(remaining) => match tokio::time::timeout(remaining, outbound).await {
+                Ok(result) => result,
+                Err(_) => {
+                    drop(remote_attempt);
+                    let error = if request_started.load(std::sync::atomic::Ordering::Relaxed) {
+                        ProxyError::Other(
+                            ReconciliationEngine::REMOTE_REQUEST_DEADLINE_ERROR.to_string(),
+                        )
+                    } else {
+                        ReconciliationEngine::remote_attempt_admission_error(
+                            ReconciliationEngine::REMOTE_ATTEMPT_BUDGET_REASON,
+                        )
+                    };
+                    return Err((error, None));
+                }
+            },
+            None => outbound.await,
+        };
+        let response = response_result
             .map(|(response, _)| response)
             .map_err(|err| (err, None))?;
         let status = response.status();
@@ -903,18 +972,50 @@ impl TavilyProxy {
         })?;
         let path = format!("/research/{}", urlencoding::encode(request_id));
         let url = build_path_prefixed_url(&base, &path);
-        let remote_attempt = remote_attempt
+        let remote_attempt_context = remote_attempt;
+        let remote_attempt = remote_attempt_context
             .acquire()
             .await
             .map_err(|reason| (ReconciliationEngine::remote_attempt_admission_error(reason), None))?;
-        let response = self
+        let request_timeout = remote_attempt_context.request_timeout();
+        let request_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let outbound = self
             .send_with_forward_proxy(key_id, "period_reconciliation", |client| {
+                request_started.store(true, std::sync::atomic::Ordering::Relaxed);
                 client
                     .get(url.clone())
                     .header("Authorization", format!("Bearer {secret}"))
-                    .timeout(Duration::from_secs(QUOTA_SYNC_FETCH_TIMEOUT_SECS))
-            })
-            .await
+                    .timeout(request_timeout)
+            });
+        let response_result = match remote_attempt_context.deadline_remaining() {
+            Some(remaining) if remaining.is_zero() => {
+                drop(remote_attempt);
+                return Err((
+                    ReconciliationEngine::remote_attempt_admission_error(
+                        ReconciliationEngine::REMOTE_ATTEMPT_BUDGET_REASON,
+                    ),
+                    None,
+                ));
+            }
+            Some(remaining) => match tokio::time::timeout(remaining, outbound).await {
+                Ok(result) => result,
+                Err(_) => {
+                    drop(remote_attempt);
+                    let error = if request_started.load(std::sync::atomic::Ordering::Relaxed) {
+                        ProxyError::Other(
+                            ReconciliationEngine::REMOTE_REQUEST_DEADLINE_ERROR.to_string(),
+                        )
+                    } else {
+                        ReconciliationEngine::remote_attempt_admission_error(
+                            ReconciliationEngine::REMOTE_ATTEMPT_BUDGET_REASON,
+                        )
+                    };
+                    return Err((error, None));
+                }
+            },
+            None => outbound.await,
+        };
+        let response = response_result
             .map(|(response, _)| response)
             .map_err(|err| (err, None))?;
         let status = response.status();

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -1756,11 +1756,339 @@ async fn reconciliation_global_backoff_counts_only_attempted_candidates() {
         .key_store
         .upstream_reconciliation_global_backoff_state()
         .await
-        .expect("read global backoff state");
-    assert_eq!(pressure_streak, 3);
-    assert_eq!(backoff_level, 1);
-    assert_eq!(backoff_until, now + 902 + 120);
+        .expect("read legacy global backoff state");
+    assert_eq!(
+        (pressure_streak, backoff_level, backoff_until),
+        (0, 0, 0),
+        "legacy global 429 metadata must not be advanced by reconciliation"
+    );
 
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_key_429_does_not_stop_other_key_research() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec![
+            "tvly-reconciliation-global-gate-hot",
+            "tvly-reconciliation-global-gate-research",
+        ],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save compare settings");
+    let hot_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-global-gate-hot")
+        .await
+        .expect("create hot key");
+    let research_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-global-gate-research")
+        .await
+        .expect("create research key");
+
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES ('global-gate-main', ?, '2026-07-15/S1', 'global-gate-main-project',
+                  'account:global-gate-main', ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&hot_key_id)
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert main candidate");
+    sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_insert")
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("keep research fixture out of main work");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+            request_count, first_used_at, last_used_at, updated_at, settlement_mode
+        ) VALUES ('global-gate-research', ?, '2026-07-15/R1', 'global-gate-research-project',
+                  'account:global-gate-research', ?, ?, 1, ?, ?, ?, 'shadow')
+        "#,
+    )
+    .bind(&research_key_id)
+    .bind(now - 4_000)
+    .bind(now - 900)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert research usage");
+    sqlx::query(
+        r#"
+        INSERT INTO upstream_reconciliation_research (
+            request_id, token_id, key_id, period_code, created_at, terminal_at, updated_at
+        ) VALUES ('global-gate-research-request', 'global-gate-research', ?, '2026-07-15/R1', ?, NULL, ?)
+        "#,
+    )
+    .bind(&research_key_id)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert due research");
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_transient_backoffs (
+            key_id, scope, cooldown_until, retry_after_secs, reason_code,
+            source_request_log_id, created_at, updated_at
+        ) VALUES (?, 'period_reconciliation', ?, 300, 'upstream429', NULL, ?, ?)
+        "#,
+    )
+    .bind(&hot_key_id)
+    .bind(now + 600)
+    .bind(now)
+    .bind(now)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("cool the main candidate key");
+    sqlx::query(
+        r#"
+        INSERT INTO meta (key, value) VALUES
+            ('upstream_reconciliation_pressure_streak_v1', '3'),
+            ('upstream_reconciliation_backoff_level_v1', '1'),
+            ('upstream_reconciliation_backoff_until_v1', ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        "#,
+    )
+    .bind(now + 600)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed legacy global gate");
+
+    let usage_hits = Arc::new(AtomicUsize::new(0));
+    let research_hits = Arc::new(AtomicUsize::new(0));
+    let app_usage_hits = Arc::clone(&usage_hits);
+    let app_research_hits = Arc::clone(&research_hits);
+    let app = Router::new()
+        .route(
+            "/usage",
+            get(move || {
+                let app_usage_hits = Arc::clone(&app_usage_hits);
+                async move {
+                    app_usage_hits.fetch_add(1, Ordering::SeqCst);
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }),
+        )
+        .route(
+            "/research/global-gate-research-request",
+            get(move || {
+                let app_research_hits = Arc::clone(&app_research_hits);
+                async move {
+                    app_research_hits.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({ "status": "completed" }))
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve cross-key reconciliation upstream");
+    });
+
+    let observed = proxy
+        .run_upstream_reconciliation_once(&format!("http://{addr}"))
+        .await
+        .expect("run reconciliation with a legacy global gate");
+    assert_eq!(
+        observed, 0,
+        "Research terminal observations do not settle a main candidate"
+    );
+    assert_eq!(usage_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(research_hits.load(Ordering::SeqCst), 1);
+    let terminal_at: Option<i64> = sqlx::query_scalar(
+        "SELECT terminal_at FROM upstream_reconciliation_research WHERE request_id = 'global-gate-research-request'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read research terminal state");
+    assert!(terminal_at.is_some());
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_global_backoff_state()
+            .await
+            .expect("read unchanged legacy global gate"),
+        (3, 1, now + 600)
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_all_key_cooldowns_defer_to_earliest_retry() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec![
+            "tvly-reconciliation-cooldown-earliest-a",
+            "tvly-reconciliation-cooldown-earliest-b",
+        ],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save compare settings");
+    let key_ids = [
+        proxy
+            .add_or_undelete_key("tvly-reconciliation-cooldown-earliest-a")
+            .await
+            .expect("create first key"),
+        proxy
+            .add_or_undelete_key("tvly-reconciliation-cooldown-earliest-b")
+            .await
+            .expect("create second key"),
+    ];
+    for (index, key_id) in key_ids.iter().enumerate() {
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_usage (
+                token_id, key_id, period_code, project_id, billing_subject,
+                period_start, period_end, request_count, first_used_at,
+                last_used_at, updated_at, settlement_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+            "#,
+        )
+        .bind(format!("all-cooldown-token-{index}"))
+        .bind(key_id)
+        .bind(format!("2026-07-15/C{index}"))
+        .bind(format!("all-cooldown-project-{index}"))
+        .bind(format!("account:all-cooldown-{index}"))
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 1_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert cooldown candidate");
+    }
+    for (key_id, cooldown_until) in key_ids.iter().zip([now + 600, now + 300]) {
+        sqlx::query(
+            r#"
+            INSERT INTO api_key_transient_backoffs (
+                key_id, scope, cooldown_until, retry_after_secs, reason_code,
+                source_request_log_id, created_at, updated_at
+            ) VALUES (?, 'period_reconciliation', ?, 300, 'upstream429', NULL, ?, ?)
+            "#,
+        )
+        .bind(key_id)
+        .bind(cooldown_until)
+        .bind(now)
+        .bind(now)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("seed key cooldown");
+    }
+
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim representative")
+        .expect("representative is claimed");
+    let outcome = proxy
+        .run_upstream_reconciliation_once_claimed_outcome(
+            "http://127.0.0.1:9",
+            claim.id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("all key cooldowns produce a typed defer");
+    assert!(matches!(
+        outcome,
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason: RECONCILIATION_RETRY_REASON_KEY_COOLDOWN,
+            retry_at,
+        } if retry_at == now + 300
+    ));
+    let work_counts: (i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), COALESCE(SUM(completed_generation), 0) FROM upstream_reconciliation_work WHERE token_id LIKE 'all-cooldown-token-%'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read unfinished cooldown work");
+    assert_eq!(work_counts, (2, 0));
+
+    let continuation = proxy
+        .finalize_deferred_upstream_reconciliation_claim(
+            claim.id,
+            claim.claim_generation,
+            RECONCILIATION_RETRY_REASON_KEY_COOLDOWN,
+            now + 300,
+        )
+        .await
+        .expect("persist earliest cooldown continuation");
+    assert_eq!(continuation.status, "queued");
+    let representatives: (i64, Option<i64>) = sqlx::query_as(
+        "SELECT COUNT(*), MIN(available_at) FROM scheduled_jobs WHERE job_type = 'upstream_reconciliation' AND status IN ('queued', 'running')",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read unique cooldown representative");
+    assert_eq!(representatives, (1, Some(now + 300)));
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_local_backoff_state()
+            .await
+            .expect("read unchanged local pressure state"),
+        (0, 0, 0)
+    );
+
+    drop(proxy);
     let _ = std::fs::remove_file(db_path);
 }
 

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -2101,6 +2101,162 @@ async fn reconciliation_all_key_cooldowns_defer_to_earliest_retry() {
 }
 
 #[tokio::test]
+async fn reconciliation_mixed_key_cooldown_allows_healthy_sibling() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec![
+            "tvly-reconciliation-mixed-cooldown-a",
+            "tvly-reconciliation-mixed-cooldown-b",
+        ],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let mut settings = proxy.get_system_settings().await.expect("load settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    settings.upstream_precise_reconciliation_enabled = false;
+    proxy
+        .set_system_settings(&settings)
+        .await
+        .expect("save compare settings");
+    let cooling_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-mixed-cooldown-a")
+        .await
+        .expect("create cooling key");
+    let healthy_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-mixed-cooldown-b")
+        .await
+        .expect("create healthy key");
+    for key_id in [&cooling_key_id, &healthy_key_id] {
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_usage (
+                token_id, key_id, period_code, project_id, billing_subject,
+                period_start, period_end, request_count, first_used_at,
+                last_used_at, updated_at, settlement_mode
+            ) VALUES ('mixed-cooldown-token', ?, '2026-07-15/M1',
+                       'mixed-cooldown-project', 'account:mixed-cooldown',
+                       ?, ?, 1, ?, ?, ?, 'shadow')
+            "#,
+        )
+        .bind(key_id)
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 1_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert mixed-key candidate usage");
+    }
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_transient_backoffs (
+            key_id, scope, cooldown_until, retry_after_secs, reason_code,
+            source_request_log_id, created_at, updated_at
+        ) VALUES (?, 'period_reconciliation', ?, 300, 'upstream429', NULL, ?, ?)
+        "#,
+    )
+    .bind(&cooling_key_id)
+    .bind(now + 600)
+    .bind(now)
+    .bind(now)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed one key cooldown");
+
+    let healthy_hits = Arc::new(AtomicUsize::new(0));
+    let cooling_hits = Arc::new(AtomicUsize::new(0));
+    let app_healthy_hits = Arc::clone(&healthy_hits);
+    let app_cooling_hits = Arc::clone(&cooling_hits);
+    let app = Router::new().route(
+        "/usage",
+        get(move |headers: HeaderMap| {
+            let app_healthy_hits = Arc::clone(&app_healthy_hits);
+            let app_cooling_hits = Arc::clone(&app_cooling_hits);
+            async move {
+                let authorization = headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default();
+                if authorization.contains("tvly-reconciliation-mixed-cooldown-b") {
+                    app_healthy_hits.fetch_add(1, Ordering::SeqCst);
+                    return Json(serde_json::json!({ "key": { "usage": 4 } })).into_response();
+                }
+                if authorization.contains("tvly-reconciliation-mixed-cooldown-a") {
+                    app_cooling_hits.fetch_add(1, Ordering::SeqCst);
+                }
+                StatusCode::TOO_MANY_REQUESTS.into_response()
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .expect("serve mixed-key reconciliation upstream");
+    });
+
+    let queued = proxy
+        .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
+        .await
+        .expect("enqueue mixed-key representative");
+    let claim = proxy
+        .scheduled_job_mark_running(queued.job_id)
+        .await
+        .expect("claim mixed-key representative")
+        .expect("mixed-key representative is claimable");
+    let outcome = proxy
+        .run_upstream_reconciliation_once_claimed_outcome(
+            &format!("http://{addr}"),
+            claim.id,
+            claim.claim_generation,
+        )
+        .await
+        .expect("defer mixed-key candidate at cooling key");
+    assert!(matches!(
+        outcome,
+        ClaimedReconciliationRunOutcome::Deferred {
+            reason: RECONCILIATION_RETRY_REASON_KEY_COOLDOWN,
+            retry_at,
+        } if retry_at == now + 600
+    ));
+    assert_eq!(healthy_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(cooling_hits.load(Ordering::SeqCst), 0);
+    let work: (i64, i64, String) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, last_outcome FROM upstream_reconciliation_work WHERE token_id = 'mixed-cooldown-token'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read mixed-key work state");
+    assert!(work.0 > 0, "mixed-key work has a durable generation");
+    assert_eq!(work.1, 0, "cooling key keeps the candidate incomplete");
+    assert_eq!(work.2, RECONCILIATION_OUTCOME_KEY_COOLDOWN.to_string());
+    let observed_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_key_observations WHERE token_id = 'mixed-cooldown-token' AND key_id = ?",
+    )
+    .bind(&healthy_key_id)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read healthy key observation");
+    assert_eq!(observed_count, 1);
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn upstream_429_backoff_escalates_persists_across_restart_and_resets() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -2061,6 +2061,14 @@ async fn reconciliation_all_key_cooldowns_defer_to_earliest_retry() {
     .await
     .expect("read unfinished cooldown work");
     assert_eq!(work_counts, (2, 0));
+    assert_eq!(
+        proxy
+            .key_store
+            .upstream_reconciliation_continuation_at()
+            .await
+            .expect("read earliest key cooldown wake"),
+        Some(now + 300)
+    );
 
     let continuation = proxy
         .finalize_deferred_upstream_reconciliation_claim(

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -1944,6 +1944,13 @@ async fn reconciliation_key_429_does_not_stop_other_key_research() {
             .expect("read unchanged legacy global gate"),
         (3, 1, now + 600)
     );
+    let privacy_status = proxy
+        .upstream_privacy_status()
+        .await
+        .expect("read legacy global diagnostics without using them as a gate");
+    assert_eq!(privacy_status.reconciliation_pressure_streak, 3);
+    assert_eq!(privacy_status.reconciliation_backoff_level, 1);
+    assert_eq!(privacy_status.reconciliation_backoff_until, Some(now + 600));
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);
@@ -2159,22 +2166,6 @@ async fn reconciliation_mixed_key_cooldown_allows_healthy_sibling() {
         .await
         .expect("insert mixed-key candidate usage");
     }
-    sqlx::query(
-        r#"
-        INSERT INTO api_key_transient_backoffs (
-            key_id, scope, cooldown_until, retry_after_secs, reason_code,
-            source_request_log_id, created_at, updated_at
-        ) VALUES (?, 'period_reconciliation', ?, 300, 'upstream429', NULL, ?, ?)
-        "#,
-    )
-    .bind(&cooling_key_id)
-    .bind(now + 600)
-    .bind(now)
-    .bind(now)
-    .execute(&proxy.key_store.pool)
-    .await
-    .expect("seed one key cooldown");
-
     let healthy_hits = Arc::new(AtomicUsize::new(0));
     let cooling_hits = Arc::new(AtomicUsize::new(0));
     let app_healthy_hits = Arc::clone(&healthy_hits);
@@ -2230,10 +2221,10 @@ async fn reconciliation_mixed_key_cooldown_allows_healthy_sibling() {
         ClaimedReconciliationRunOutcome::Deferred {
             reason: RECONCILIATION_RETRY_REASON_KEY_COOLDOWN,
             retry_at,
-        } if retry_at == now + 600
+        } if retry_at == now + 300
     ));
     assert_eq!(healthy_hits.load(Ordering::SeqCst), 1);
-    assert_eq!(cooling_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(cooling_hits.load(Ordering::SeqCst), 1);
     let work: (i64, i64, String) = sqlx::query_as(
         "SELECT work_generation, completed_generation, last_outcome FROM upstream_reconciliation_work WHERE token_id = 'mixed-cooldown-token'",
     )

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -2108,7 +2108,7 @@ async fn reconciliation_all_key_cooldowns_defer_to_earliest_retry() {
 }
 
 #[tokio::test]
-async fn reconciliation_mixed_key_cooldown_allows_healthy_sibling() {
+async fn reconciliation_fresh_429_mixed_key_allows_healthy_sibling() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
     let now = local_ts(2026, 7, 15, 12, 0);

--- a/tests/rust_source_line_budgets.rs
+++ b/tests/rust_source_line_budgets.rs
@@ -50,6 +50,16 @@ const EXCEPTIONS: &[(&str, usize, &str)] = &[
         "The scheduler retains the consolidated durable-job lifecycle while request-scoped remote-attempt admission is rolled out across existing maintenance job types; task-dispatch extraction remains a separate behavior-preserving change.",
     ),
     (
+        "src/tavily_proxy/proxy_quota_sync_and_jobs.rs",
+        3200,
+        "Reconciliation execution and quota synchronization remain together while per-key cooldown and request-scoped admission converge; extracting the remaining run phases is a separate behavior-preserving change.",
+    ),
+    (
+        "src/tests/upstream_reconciliation.rs",
+        3500,
+        "The consolidated upstream reconciliation integration suite carries the multi-key observation, per-key cooldown, and continuation-fencing coverage while a broader test extraction remains a separate behavior-preserving change.",
+    ),
+    (
         "src/store/sqlite_runtime.rs",
         3550,
         "The runtime owns the shared pool, operation budgeting, transaction guards, admission state, workload aggregation, and the bounded reconciliation read session; cooperative query cleanup remains isolated in its dedicated child module.",


### PR DESCRIPTION
## Summary
- Remove the reconciliation-wide 429 runtime gate; cooldowns remain scoped to `period_reconciliation` keys.
- Allow healthy sibling keys in a mixed candidate to make progress while another key cools down.
- Return a claim-fenced `key_cooldown` continuation at the earliest cooldown when all candidate keys are cooling.
- Keep request-scoped remote lease, compare billing truth, and bounded main/Research request budgets.

## Validation
- `cargo test --locked --lib upstream_reconciliation -- --test-threads=1` (67 passed)
- `cargo clippy --locked --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/ci_backend_tests.py verify` (783 lib / 483 bin-main)
- Read-only 101 snapshot testbox baseline/candidate comparison passed with no new 5xx, no final SQLite lock errors, zero projection discards, and zero billing adjustments.

Actual billing remains disabled; no production data or configuration was changed.