### PR TITLE
fix(request-stats): preserve owned commit boundary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,8 +21,10 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   five requests per second, and there was no recent SQLite contention. Request-stats flush is the
   bounded recovery exception: each nominal wake owns at
   most four adaptive `25..250` logical-key transactions within one 50ms retry budget, atomically
-  restoring every uncommitted delta before yielding. That budget includes pool acquisition,
-  `BEGIN IMMEDIATE`, writes, and commit, not only statement retries after a transaction starts.
+  restoring every uncommitted delta before yielding. The budget decides whether to acquire a
+  connection and start another `BEGIN IMMEDIATE`; once a transaction starts, its runtime-owned
+  commit or rollback resolves before the batch is classified. A timeout must never requeue a batch
+  whose commit is still in flight.
 - `recovery debt`: retained work that is safely eligible for automatic catch-up, including expired
   HA outbox events. It progresses through bounded work slices and never receives a special writer
   bypass.

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -78,6 +78,10 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
 - Short maintenance writes use a runtime-owned transaction task. Caller cancellation can no longer
   return an open transaction to the pool: the owner commits or rolls back before restoration.
   Physical detach remains reserved for panic, shutdown, or an unverifiable connection state.
+- A request-stats flush applies its short retry budget before a new transaction starts and before a
+  later chunk begins. Once `BEGIN IMMEDIATE` succeeds, the runtime-owned finish reaches commit or
+  rollback before the coalescer classifies the drained batch; it must never requeue a batch merely
+  because the caller's wall-clock budget elapsed while commit was in flight.
 
 ## Consequences
 

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -104,7 +104,9 @@ reads:
   data rather than inheriting the failed write path.
 - Keep the request-stats cadence bounded without allowing its in-memory tail to become a second
   pressure source: one nominal wake may commit at most four adaptive `25..250` logical-key
-  transactions under one 50ms budget, then returns the remaining tail atomically. During a cold
+  transactions under one 50ms transaction-start/next-chunk budget, then returns the remaining
+  unstarted tail atomically. A transaction already past `BEGIN IMMEDIATE` reaches its owned commit
+  or rollback boundary before any delta is requeued. During a cold
   dashboard singleflight, SSE clients emit degraded frames instead of independently starting
   freshness reads against the small shared pool.
 - When dashboard overview depends on coalesced request-stat rollups, split “probe freshness” from

--- a/docs/solutions/operations/sqlite-write-lock-contention.md
+++ b/docs/solutions/operations/sqlite-write-lock-contention.md
@@ -194,6 +194,10 @@ month-tail public metrics scan.
 - A deferred derived-write batch must atomically return its entire uncommitted logical delta to its
   in-memory coalescer before releasing admission. Report this as a typed defer and retry on the
   next admitted cadence; do not emit an exhaustion warning for every pressure cycle.
+- Never apply that defer by timing out a future that is awaiting an already-started owned
+  transaction. The coalescer may requeue only after runtime-owned rollback or failure before
+  `BEGIN IMMEDIATE`; an in-flight owned commit must settle first, otherwise the same delta can be
+  durably applied and then scheduled again.
 - A request-stats coalescer may probe a released writer at its next nominal wake with one permit
   and a short transaction budget. Its exact delta restore makes this safe; it does not relax the
   contention cooldown for GC, rebuild, or reconciliation projection.

--- a/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
+++ b/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
@@ -38,11 +38,11 @@
   returns `503` instead of claiming acceptance with a synthetic job id; the self-scheduling HA
   controller and worker wake provide the bounded recovery path without inventing a durable row.
 - The short admission budgets are explicit runtime deadlines, not connection-level `PRAGMA busy_timeout` rewrites. A background request-stats admission commits at most four adaptive
-  `25..250` logical-key transactions under one 50ms retry budget, then atomically returns its
-  complete tail to the coalescer and reports `deferred` when needed. The deadline covers pool
-  acquisition, `BEGIN IMMEDIATE`, writes, and commit; manual HA GC wakes reuse an
-  existing durable representative rather than
-  competing for a locked writer merely to promote queue metadata.
+  `25..250` logical-key transactions under one 50ms transaction-start/next-chunk budget, then
+  atomically returns its complete unstarted tail to the coalescer and reports `deferred` when
+  needed. Once `BEGIN IMMEDIATE` succeeds, the runtime-owned finish commits or rolls back before
+  the coalescer classifies that chunk; manual HA GC wakes reuse an existing durable representative
+  rather than competing for a locked writer merely to promote queue metadata.
 - Dashboard snapshot reads preserve a last-good value under admission or SQLite pressure. A cold
   shared loader is bounded per caller to one second without cancelling its in-flight build; startup
   gives that same loader a one-second head start before accepting external connections.

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -70,7 +70,8 @@
   five-minute continuation 让步，不得在同一 slice 重复扫描或删除派生 rollup。Dashboard 仅在有
   last-good 时因 admission、busy 或 refresh 超时直接返回该快照；
   request-stats background wake 每秒最多提交四个自适应 `25..250` logical-key transaction，并受同一
-  `50ms` 预算约束后原子回灌尾部；只有 shutdown drain 可以连续处理。冷启动只允许
+  `50ms` 启动/下一 chunk 预算约束后原子回灌未开始尾部；一旦事务已开始，runtime 必须先完成 commit
+  或 rollback，不能因预算到期将该批回灌。只有 shutdown drain 可以连续处理。冷启动只允许
   一个 shared singleflight loader，server 在开始监听前可给同一 loader 一次一秒 head start；每个读取
   请求最多等待一秒。超时只结束该读取请求，不得取消仍在运行的 loader，后续读取在其完成后复用同一快照。
 - 普通 Dashboard、summary、hourly window 与 rankings 读取只消费 durable request stats，不得触发

--- a/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
+++ b/docs/specs/sqlite-write-lock-hardening/IMPLEMENTATION.md
@@ -9,10 +9,11 @@
   seconds.
 - HA GC rechecks admission between SQL statements and records a typed 30-second defer only for
   its selected channel. Request-stats flushes use adaptive `25..250` logical-key chunks; a
-  background admission commits at most four chunks within one 50ms retry budget, returns the
-  remaining tail to the coalescer exactly once, and waits for the next nominal second before its
-  next slice. Explicit shutdown drain paths may continue through further chunks within their own
-  bounded deadline.
+  background admission commits at most four chunks within one 50ms transaction-start/next-chunk
+  budget, returns the remaining unstarted tail to the coalescer exactly once, and waits for the
+  next nominal second before its next slice. A started transaction reaches its runtime-owned commit
+  or rollback boundary before the batch is requeued. Explicit shutdown drain paths may continue
+  through further chunks within their own bounded deadline.
 - Dashboard integrity and pressure rebuild use the same bulk boundary. Claim, finish,
   continuation, and stale recovery are short control transactions and do not wait on the bulk
   permit or run a background retry loop. Runtime transaction deadlines implement their short

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -217,6 +217,10 @@ source when a usable persisted runtime already exists.
   background windows. Dashboard, summary, hourly-window, and rankings reads must serve durable data
   without acquiring a write connection or synchronously flushing; pending/flushing state may affect
   internal freshness while the existing HTTP response shape remains unchanged.
+- A request-stats flush may use its 50ms retry budget to reject pool acquisition, `BEGIN IMMEDIATE`,
+  or a later chunk. Once a transaction has started, its runtime-owned finish must commit or roll
+  back before the coalescer requeues anything; elapsed wall-clock budget alone must not requeue a
+  batch whose commit is still in flight.
 - The three-connection application pool reserves two actual or immediately allocatable slots for
   foreground work. Bulk maintenance takes one instance-local permit only when foreground arrival
   rate is at most `5 rps` and the preceding five seconds contain no pool-timeout or SQLite busy

--- a/src/store/key_store_request_stats_flush_and_public_metrics.rs
+++ b/src/store/key_store_request_stats_flush_and_public_metrics.rs
@@ -525,26 +525,18 @@ impl KeyStore {
             );
             return Err(ProxyError::Database(sqlx::Error::PoolTimedOut));
         }
-        match tokio::time::timeout(
-            remaining,
-            Self::flush_request_stats_writes_once_within_deadline(
-                sqlite_runtime,
-                backend_time,
-                retry_deadline,
-                chunk,
-            ),
+        // `begin_immediate_before` applies the remaining retry budget to pool
+        // acquisition and `BEGIN IMMEDIATE`. Once it succeeds, `finish` owns
+        // the commit or rollback boundary. Cancelling that wait after `BEGIN`
+        // would let the coalescer requeue a batch that the owned commit can
+        // still persist.
+        Self::flush_request_stats_writes_once_within_deadline(
+            sqlite_runtime,
+            backend_time,
+            retry_deadline,
+            chunk,
         )
         .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                sqlite_runtime.record_deferred(
-                    SqliteOperation::RequestStatsFlush,
-                    SqliteAdmissionDeferReason::RecentContention,
-                );
-                Err(ProxyError::Database(sqlx::Error::PoolTimedOut))
-            }
-        }
     }
 
     async fn flush_request_stats_writes_once_within_deadline(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -19,6 +19,8 @@ use tracing::{error, info, warn};
 mod immediate_transaction;
 mod sqlite_runtime;
 pub(crate) use immediate_transaction::ImmediateSqliteTransaction;
+#[cfg(test)]
+pub(crate) use sqlite_runtime::install_owned_finish_pause_for_test;
 pub(crate) use sqlite_runtime::{
     AdminAlertsReadSession, SqliteAdmissionDeferReason, SqliteImmediateTransaction,
     SqliteMaintenanceBulkPermit, SqliteOperation, SqliteReadSnapshot, SqliteRuntime,

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -46,16 +46,27 @@ const TRANSACTION_HOLD_BUCKET_UPPER_MS: [u64; 6] = [10, 25, 50, 100, 250, 251];
 
 #[cfg(test)]
 #[derive(Clone)]
-struct OwnedFinishPause {
+pub(crate) struct OwnedFinishPause {
     arrived: Arc<tokio::sync::Notify>,
     release: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(test)]
+impl OwnedFinishPause {
+    pub(crate) async fn wait_until_arrived(&self) {
+        self.arrived.notified().await;
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.notify_one();
+    }
 }
 
 #[cfg(test)]
 static OWNED_FINISH_PAUSE: OnceLock<Mutex<Option<OwnedFinishPause>>> = OnceLock::new();
 
 #[cfg(test)]
-fn install_owned_finish_pause_for_test() -> OwnedFinishPause {
+pub(crate) fn install_owned_finish_pause_for_test() -> OwnedFinishPause {
     let pause = OwnedFinishPause {
         arrived: Arc::new(tokio::sync::Notify::new()),
         release: Arc::new(tokio::sync::Notify::new()),

--- a/src/store/sqlite_runtime_tests.rs
+++ b/src/store/sqlite_runtime_tests.rs
@@ -229,10 +229,10 @@ async fn cancelled_finish_keeps_the_owned_commit_boundary_alive() {
             .expect("write inside transaction");
         transaction.finish(Ok(())).await
     });
-    pause.arrived.notified().await;
+    pause.wait_until_arrived().await;
     task.abort();
     let _ = task.await;
-    pause.release.notify_one();
+    pause.release();
 
     let next = tokio::time::timeout(
         Duration::from_secs(1),

--- a/src/tests/request_rollup_public_metrics.rs
+++ b/src/tests/request_rollup_public_metrics.rs
@@ -1019,6 +1019,88 @@ async fn request_stats_background_flush_defers_before_pool_acquire_and_preserves
 }
 
 #[tokio::test]
+async fn request_stats_flush_commits_once_when_owned_finish_crosses_retry_budget() {
+    let db_path = temp_db_path("request-stats-owned-finish-boundary");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = public_metrics_proxy(&db_str, "tvly-request-stats-owned-finish-boundary").await;
+    proxy
+        .key_store
+        .flush_request_stats_writes()
+        .await
+        .expect("drain setup coalescer state");
+    proxy
+        .shutdown_request_stats_coalescer(Duration::from_secs(2))
+        .await
+        .expect("stop background worker before controlling the flush");
+    let key_id = proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list key metrics")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    proxy
+        .key_store
+        .enqueue_request_stats_rollup_for_test(
+            Some(&key_id),
+            proxy.backend_time().now_ts().saturating_sub(1),
+            OUTCOME_SUCCESS,
+        )
+        .await;
+
+    let pause = crate::store::install_owned_finish_pause_for_test();
+    let store = proxy.key_store.clone();
+    let flush = tokio::spawn(async move { store.flush_request_stats_writes_in_background().await });
+
+    tokio::time::timeout(Duration::from_secs(1), pause.wait_until_arrived())
+        .await
+        .expect("flush reaches the owned commit boundary");
+    tokio::time::sleep(Duration::from_millis(75)).await;
+    pause.release();
+    let outcome = tokio::time::timeout(Duration::from_secs(1), flush)
+        .await
+        .expect("flush completes after the owned commit is released")
+        .expect("flush task joins")
+        .expect("background admission decision must remain typed");
+    assert_eq!(
+        outcome,
+        RequestStatsBackgroundFlushOutcome::Flushed,
+        "a started transaction must not be requeued when its commit crosses the retry budget"
+    );
+
+    let summary = proxy
+        .summary_without_flush()
+        .await
+        .expect("durable summary after the owned commit");
+    assert_eq!(summary.total_requests, 1);
+    assert_eq!(summary.success_count, 1);
+    let pending = proxy.key_store.request_stats_coalescer.state.lock().await;
+    assert_eq!(
+        RequestStatsCoalescer::pending_key_count(&pending),
+        0,
+        "a committed delta must not remain queued for a second flush"
+    );
+    drop(pending);
+
+    let next = tokio::time::timeout(
+        Duration::from_secs(1),
+        proxy
+            .key_store
+            .sqlite_runtime
+            .begin_immediate(SqliteOperation::RequestStatsFlush),
+    )
+    .await
+    .expect("owned commit must return a reusable connection")
+    .expect("next transaction begins");
+    next.rollback().await.expect("rollback next transaction");
+
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
 async fn request_stats_background_flush_defers_on_writer_lock_and_requeues_exact_delta() {
     let db_path = temp_db_path("request-stats-background-writer-lock");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -1695,30 +1695,6 @@ async fn reconciliation_global_backoff_counts_only_attempted_candidates() {
         .add_or_undelete_key("tvly-reconciliation-shared-429")
         .await
         .expect("create upstream key");
-    for candidate in 0..3 {
-        sqlx::query(
-            r#"
-            INSERT INTO upstream_reconciliation_usage (
-                token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
-                request_count, first_used_at, last_used_at, updated_at, settlement_mode
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
-            "#,
-        )
-        .bind(format!("shared-429-token-{candidate}"))
-        .bind(&key_id)
-        .bind("2026-07-15/S1")
-        .bind(format!("shared-429-project-{candidate}"))
-        .bind(format!("account:shared-429-{candidate}"))
-        .bind(now - 4_000)
-        .bind(now - 900)
-        .bind(now - 1_000)
-        .bind(now - 900)
-        .bind(now - 900)
-        .execute(&proxy.key_store.pool)
-        .await
-        .expect("insert reconciliation candidate");
-    }
-
     let upstream_hits = Arc::new(AtomicUsize::new(0));
     let app_hits = Arc::clone(&upstream_hits);
     let app = Router::new().route(
@@ -1742,13 +1718,38 @@ async fn reconciliation_global_backoff_counts_only_attempted_candidates() {
             .expect("serve reconciliation usage upstream");
     });
 
-    for timestamp in [now, now + 301, now + 902] {
+    for (candidate, timestamp) in [now, now + 301, now + 902].into_iter().enumerate() {
+        // Expose one candidate per elapsed key cooldown. The one-shot API is a
+        // compatibility helper, so it must not be asked to spin through other
+        // durable candidates that correctly remain key-cooldown deferred.
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_usage (
+                token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+                request_count, first_used_at, last_used_at, updated_at, settlement_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+            "#,
+        )
+        .bind(format!("shared-429-token-{candidate}"))
+        .bind(&key_id)
+        .bind("2026-07-15/S1")
+        .bind(format!("shared-429-project-{candidate}"))
+        .bind(format!("account:shared-429-{candidate}"))
+        .bind(now - 4_000)
+        .bind(now - 900)
+        .bind(now - 1_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert reconciliation candidate");
         clock.set_now_ts(timestamp);
         let settled = proxy
             .run_upstream_reconciliation_once(&format!("http://{addr}"))
             .await
             .expect("run shared-key reconciliation");
         assert_eq!(settled, 0);
+        assert_eq!(upstream_hits.load(Ordering::SeqCst), candidate + 1);
     }
 
     assert_eq!(upstream_hits.load(Ordering::SeqCst), 3);


### PR DESCRIPTION
## Summary

- Prevent request-stat rollups from requeueing a batch whose runtime-owned SQLite commit is still in flight.
- Keep the 50ms budget at pool acquisition, `BEGIN IMMEDIATE`, and subsequent-chunk boundaries.
- Add a deterministic regression that pauses commit past the budget and proves exactly-once persistence.

## Delivery role

`direct`

## Validation

- `cargo test --locked tests::request_rollup_public_metrics::request_stats_background_flush_defers_before_pool_acquire_and_preserves_pending_delta -- --exact --nocapture`
- `cargo test --locked tests::request_rollup_public_metrics::request_stats_flush_commits_once_when_owned_finish_crosses_retry_budget -- --exact --nocapture`
- `cargo test --locked store::sqlite_runtime::tests::cancelled_finish_keeps_the_owned_commit_boundary_alive -- --exact --nocapture`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-request-rollup-reporting --diagnostic`
- `python3 scripts/ci_backend_tests.py verify`
- `cargo clippy --locked -j 2 -- -D warnings`
- `cargo fmt --check`
- `bunx --bun dprint check ...`

## Contracts

- Spec Disposition: updated `sqlite-write-lock-hardening` and `performance-architecture-hardening`.
- Solutions: updated SQLite write-contention and admin-read containment guidance.
- Project Docs: updated `CONTEXT.md`.
- ADR: clarified the existing scoped SQLite admission boundary in ADR 0002.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->