### PR TITLE
fix(admin): self-heal canonical Alerts warm reads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,15 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   and waits for an active snapshot's explicit close. A deferred startup prewarm retries in the
   background until it publishes last-good or shutdown fences it. A true cold miss returns
   `503 Retry-After: 1` without opening a request-owned SQLite transaction.
+- `admin Alerts canonical warm controller`: the AppState owner of the pinned catalog, events page
+  `1/20`, and groups page `1/20` cache keys. It starts only in a low-pressure window with two
+  already-idle connections once the lazy pool is established, foreground activity at most `5 rps`,
+  and no contention in the previous five seconds. A cold pool with no acquire waiter may bootstrap
+  through its first bounded warm read. Each `AdminAlertsCacheWarm` slice gets the normal `100ms` acquire and `250ms` native
+  read deadline; all three staged values publish only at one unchanged projection generation.
+  Defers retry after `5s`, `5s`, then `30s`, while a generation change re-arms one controller run.
+  Canonical HTTP handlers never trigger or wait for warm work: a current entry is fresh, an older
+  entry within five minutes is stale, and a cold/expired entry returns `503 Retry-After: 1`.
 
 ## Reconciliation Terms
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,9 +43,10 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   `503 Retry-After: 1` without opening a request-owned SQLite transaction.
 - `admin Alerts canonical warm controller`: the AppState owner of the pinned catalog, events page
   `1/20`, and groups page `1/20` cache keys. It starts only in a low-pressure window with two
-  already-idle connections once the lazy pool is established, foreground activity at most `5 rps`,
-  and no contention in the previous five seconds. A cold pool with no acquire waiter may bootstrap
-  through its first bounded warm read. Each `AdminAlertsCacheWarm` slice gets the normal `100ms` acquire and `250ms` native
+  already-idle connections, foreground activity at most `5 rps`, and no contention in the previous
+  five seconds. The worker asks `SqliteRuntime` to boundedly grow a lazy pool before the admission
+  check; if two idle connections cannot be established it defers instead of borrowing one idle
+  connection. Each `AdminAlertsCacheWarm` slice gets the normal `100ms` acquire and `250ms` native
   read deadline; all three staged values publish only at one unchanged projection generation.
   Defers retry after `5s`, `5s`, then `30s`, while a generation change re-arms one controller run.
   Canonical HTTP handlers never trigger or wait for warm work: a current entry is fresh, an older

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -110,7 +110,8 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   page `1/20`, and groups page `1/20` keys are owned by an AppState background warm controller;
   it performs one bounded `AdminAlertsCacheWarm` read per slice only when two pool connections are
   already idle, foreground activity is at most five requests per second, and recent contention is
-  clear. It stages all three values behind one projection-generation fence and publishes them
-  together. A deferred warm retries at `5s`, `5s`, then `30s`; a generation change re-arms one
-  warm without allowing HTTP to trigger a rebuild. A cold lazy pool with no foreground waiter may
-  bootstrap through its first bounded warm read; once capacity exists, the two-idle reserve applies.
+  clear. Before this admission check, the controller may ask the runtime to grow a lazy pool within
+  the same bounded budget; failure to establish two idle connections defers the slice. It stages all
+  three values behind one projection-generation fence and publishes them together. A deferred warm
+  retries at `5s`, `5s`, then `30s`; a generation change re-arms one warm without allowing HTTP to
+  trigger a rebuild.

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -106,4 +106,11 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   paths; a stale generation or claim cannot consume observations from another run.
 - Admin Alerts reads use their own bounded read session: a 100ms acquire and a 250ms native SQLite
   deadline over one snapshot. Exact-key last-good data may be served stale; a cold key returns
-  `503 Retry-After: 1` and never falls back to the raw CTE path.
+  `503 Retry-After: 1` and never falls back to the raw CTE path. The canonical catalog, events
+  page `1/20`, and groups page `1/20` keys are owned by an AppState background warm controller;
+  it performs one bounded `AdminAlertsCacheWarm` read per slice only when two pool connections are
+  already idle, foreground activity is at most five requests per second, and recent contention is
+  clear. It stages all three values behind one projection-generation fence and publishes them
+  together. A deferred warm retries at `5s`, `5s`, then `30s`; a generation change re-arms one
+  warm without allowing HTTP to trigger a rebuild. A cold lazy pool with no foreground waiter may
+  bootstrap through its first bounded warm read; once capacity exists, the two-idle reserve applies.

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -69,6 +69,14 @@ reads:
   query rather than sharing one broad cache entry. Under SQLite admission pressure return only the
   matching stale result with `coverage`, `observedAt`, and `staleReason`; a cold key returns
   `503 Retry-After: 1` rather than starting a raw alert CTE.
+- Treat the default alert catalog, events page `1/20`, and groups page `1/20` as pinned canonical
+  cache slots. An AppState-owned controller builds them in short `AdminAlertsCacheWarm` read slices
+  only when two connections are already idle, foreground activity is at most `5 rps`, and recent
+  contention is clear; a cold lazy pool with no waiter may bootstrap through its first bounded read.
+  It stages the three values and publishes them atomically at one projection
+  generation; generation changes or partial failures discard the staged set. Retry at `5s/5s/30s`.
+  Canonical HTTP handlers are cache-first and return cold `503 Retry-After: 1` instead of rebuilding
+  or falling back to raw CTEs; noncanonical exact-key reads keep the existing bounded-read fallback.
 - Apply the same last-good boundary to the single-key privacy-status read. Keep the immutable
   successful snapshot for 60 seconds; warm pressure returns it as stale with the observation time,
   while cold pressure fails fast with `503 Retry-After: 1`. The HTTP path is bounded to 250ms and,

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -70,10 +70,10 @@ reads:
   matching stale result with `coverage`, `observedAt`, and `staleReason`; a cold key returns
   `503 Retry-After: 1` rather than starting a raw alert CTE.
 - Treat the default alert catalog, events page `1/20`, and groups page `1/20` as pinned canonical
-  cache slots. An AppState-owned controller builds them in short `AdminAlertsCacheWarm` read slices
-  only when two connections are already idle, foreground activity is at most `5 rps`, and recent
-  contention is clear; a cold lazy pool with no waiter may bootstrap through its first bounded read.
-  It stages the three values and publishes them atomically at one projection
+  cache slots. An AppState-owned controller asks `SqliteRuntime` to boundedly warm a lazy pool, then
+  builds them in short `AdminAlertsCacheWarm` read slices only when two connections are already
+  idle, foreground activity is at most `5 rps`, and recent contention is clear. If that reserve
+  cannot be established it defers instead of borrowing one idle connection. It stages the three values and publishes them atomically at one projection
   generation; generation changes or partial failures discard the staged set. Retry at `5s/5s/30s`.
   Canonical HTTP handlers are cache-first and return cold `503 Retry-After: 1` instead of rebuilding
   or falling back to raw CTEs; noncanonical exact-key reads keep the existing bounded-read fallback.

--- a/docs/specs/admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/admin-alert-center-24h-summary/SPEC.md
@@ -26,6 +26,14 @@
 - Alerts 读取使用独立的 SQLite read session：获取连接最多 `100ms`，同一只读 snapshot 内的
   coverage 与 projection 读取由 `250ms` 原生 deadline 约束。它不是 bulk admission，也不允许
   handler 外层 timeout 或 raw-pool fallback 重新引入无界等待。
+- 默认 catalog、events `1/20` 与 groups `1/20` 是 canonical keys，由 `AppState` 唯一拥有的
+  background warm controller 以 `AdminAlertsCacheWarm` 短读片构建。三项必须来自同一完整
+  projection generation 才能一起发布；任一 defer、取消或 generation 变化都丢弃 staged
+  值并保留 last-good。warm admission 要求两个连接已 idle、前台速率不超过 `5 rps` 且最近
+  `5s` 无 SQLite contention，失败按 `5s/5s/30s` 退避。冷启动且没有连接等待者时允许第一条
+  bounded read 惰性建立连接；HTTP 对 canonical key 只读 exact-key
+  cache：同 generation 为 fresh，generation 落后但未过期为 stale，cold/过期为
+  `503 Retry-After: 1`，绝不触发重建。
 
 ## Non-goals
 

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -205,8 +205,12 @@
 - Admin Alerts acquires its bounded read session directly from `SqliteRuntime`: acquire is capped
   at `100ms`, every SQLite statement has a native `250ms` deadline, and coverage plus projected
   catalog/events/groups reads never borrow a bulk permit or raw pool connection. Canonical
-  catalog, events page `1/20`, and groups page `1/20` are prewarmed when projection coverage is
-  readable.
+  catalog, events page `1/20`, and groups page `1/20` are prewarmed by one AppState-owned
+  low-priority controller. It requires two already-idle connections, foreground activity at most
+  `5 rps`, and no recent contention; it stages the three reads and publishes them only when the
+  projection generation is unchanged. HTTP never starts warm work: canonical misses and expired
+  entries return `503 Retry-After: 1`, while a prior generation remains available as stale until
+  the next complete publish. Warm defers use `5s/5s/30s` backoff and never acquire the bulk permit.
 - AlertProjection 与旧结果在时间窗、过滤、分页、分组和状态跃迁上等价。
 - 30 分钟生产形状基准中进程组 RSS P95 不超过 256MiB。
 - architecture checker 证明目标热路径不存在 raw pool、coalescer、全局 pointer-map gate 或旧 cache。

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -168,6 +168,9 @@
   - `component=admin_read event=/api/alerts/events phase=projection_sidecar|alerts_projection`
   - `component=admin_read event=/api/alerts/groups phase=projection_sidecar|alerts_grouping`
 - `component=admin_read event=alerts_last_good_served|alerts_cold_pressure`
+- `component=admin_read event=alerts_canonical_warm_published|alerts_canonical_warm_deferred`
+  Warm diagnostics report only the defer category, retry delay, projection generation outcome, and
+  aggregate slice counts. They never include SQL, filters, users, tokens, keys, or response bodies.
 - `component=startup event=admin_privacy_status_prewarm_started|admin_privacy_status_prewarm_deferred`
   - `component=admin_read event=low_memory_protection_decision`
 - `sqlite_workload_window` aggregates `observability_deferred_write` alongside other operation

--- a/src/server/dto.rs
+++ b/src/server/dto.rs
@@ -1082,10 +1082,14 @@ impl From<tavily_hikari::PaginatedAlertEvents> for PaginatedAlertEventsView {
 }
 
 impl PaginatedAlertEventsView {
-    fn stale(mut self, observed_at: i64) -> Self {
+    fn stale(self, observed_at: i64) -> Self {
+        self.stale_with_reason(observed_at, "sqlite_pressure")
+    }
+
+    fn stale_with_reason(mut self, observed_at: i64, reason: &str) -> Self {
         self.coverage = Some("stale".to_string());
         self.observed_at = Some(observed_at);
-        self.stale_reason = Some("sqlite_pressure".to_string());
+        self.stale_reason = Some(reason.to_string());
         self
     }
 }
@@ -1120,10 +1124,14 @@ impl From<tavily_hikari::PaginatedAlertGroups> for PaginatedAlertGroupsView {
 }
 
 impl PaginatedAlertGroupsView {
-    fn stale(mut self, observed_at: i64) -> Self {
+    fn stale(self, observed_at: i64) -> Self {
+        self.stale_with_reason(observed_at, "sqlite_pressure")
+    }
+
+    fn stale_with_reason(mut self, observed_at: i64, reason: &str) -> Self {
         self.coverage = Some("stale".to_string());
         self.observed_at = Some(observed_at);
-        self.stale_reason = Some("sqlite_pressure".to_string());
+        self.stale_reason = Some(reason.to_string());
         self
     }
 }
@@ -1166,10 +1174,10 @@ impl From<tavily_hikari::AlertCatalog> for AlertCatalogView {
 }
 
 impl AlertCatalogView {
-    fn stale(mut self, observed_at: i64) -> Self {
+    fn stale_with_reason(mut self, observed_at: i64, reason: &str) -> Self {
         self.coverage = Some("stale".to_string());
         self.observed_at = Some(observed_at);
-        self.stale_reason = Some("sqlite_pressure".to_string());
+        self.stale_reason = Some(reason.to_string());
         self
     }
 }

--- a/src/server/handlers/admin_resources/alerts.rs
+++ b/src/server/handlers/admin_resources/alerts.rs
@@ -38,26 +38,44 @@ async fn get_alert_catalog(
     }
 
     let key = "catalog";
-    match state.proxy.admin_alert_catalog().await {
-        Ok(catalog) => {
-            record_admin_alerts_last_good(
-                state.as_ref(),
-                key.to_string(),
-                AdminAlertsReadCacheValue::Catalog(catalog.clone()),
-            )
-            .await;
-            Ok(Json(AlertCatalogView::from(catalog)).into_response())
+    if let Some((AdminAlertsReadCacheValue::Catalog(catalog), observed_at, entry_generation, generation)) =
+        admin_alerts_canonical_last_good(state.as_ref(), key).await
+    {
+        let pressure_reason = state.proxy.admin_alerts_cache_warm_pressure_reason();
+        let stale_reason = pressure_reason.unwrap_or("projection_refresh");
+        if entry_generation == generation && pressure_reason.is_none() {
+            tracing::debug!(
+                component = "admin_read",
+                event = "alerts_last_good_served",
+                route = "/api/alerts/catalog",
+                coverage = "fresh",
+                "served canonical Alerts catalog from last-good cache"
+            );
+            return Ok(Json(AlertCatalogView::from(catalog)).into_response());
         }
-        Err(error) if tavily_hikari::is_transient_sqlite_write_error(&error) || error.is_deferred() => {
-            match admin_alerts_last_good(state.as_ref(), key).await {
-                Some((AdminAlertsReadCacheValue::Catalog(catalog), observed_at)) => {
-                    Ok(Json(AlertCatalogView::from(catalog).stale(observed_at)).into_response())
-                }
-                _ => Err(alerts_sqlite_pressure_response()),
-            }
-        }
-        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        tracing::debug!(
+            component = "admin_read",
+            event = "alerts_last_good_served",
+            route = "/api/alerts/catalog",
+            coverage = "stale",
+            stale_reason,
+            "served canonical Alerts catalog from prior projection generation"
+        );
+        return Ok(
+            Json(AlertCatalogView::from(catalog).stale_with_reason(observed_at, stale_reason))
+            .into_response(),
+        );
     }
+    // The canonical catalog is owned by the background warm controller. A
+    // cold or expired key must never make an administrator request rebuild it.
+    state.proxy.record_admin_alerts_warm_cold_miss();
+    tracing::debug!(
+        component = "admin_read",
+        event = "alerts_cold_pressure",
+        route = "/api/alerts/catalog",
+        "canonical Alerts catalog cache is cold"
+    );
+    Err(alerts_sqlite_pressure_response())
 }
 
 fn alerts_sqlite_pressure_response() -> axum::response::Response {
@@ -131,6 +149,44 @@ async fn get_alert_events(
         per_page,
     };
     let cache_key = alert_read_cache_key("events", &cache_query);
+    if let Some((AdminAlertsReadCacheValue::Events(events), observed_at, entry_generation, generation)) =
+        admin_alerts_canonical_last_good(state.as_ref(), &cache_key).await
+    {
+        let pressure_reason = state.proxy.admin_alerts_cache_warm_pressure_reason();
+        let stale_reason = pressure_reason.unwrap_or("projection_refresh");
+        if entry_generation == generation && pressure_reason.is_none() {
+            tracing::debug!(
+                component = "admin_read",
+                event = "alerts_last_good_served",
+                route = "/api/alerts/events",
+                coverage = "fresh",
+                "served canonical Alerts events from last-good cache"
+            );
+            return Ok(Json(PaginatedAlertEventsView::from(events)).into_response());
+        }
+        tracing::debug!(
+            component = "admin_read",
+            event = "alerts_last_good_served",
+            route = "/api/alerts/events",
+            coverage = "stale",
+            stale_reason,
+            "served canonical Alerts events from prior projection generation"
+        );
+        return Ok(
+            Json(PaginatedAlertEventsView::from(events).stale_with_reason(observed_at, stale_reason))
+            .into_response(),
+        );
+    }
+    if cache_key == default_admin_alert_cache_key("events") {
+        state.proxy.record_admin_alerts_warm_cold_miss();
+        tracing::debug!(
+            component = "admin_read",
+            event = "alerts_cold_pressure",
+            route = "/api/alerts/events",
+            "canonical Alerts events cache is cold"
+        );
+        return Err(alerts_sqlite_pressure_response());
+    }
     match state.proxy.admin_alert_events_page(
             alert_type,
             since,
@@ -197,6 +253,44 @@ async fn get_alert_groups(
         per_page,
     };
     let cache_key = alert_read_cache_key("groups", &cache_query);
+    if let Some((AdminAlertsReadCacheValue::Groups(groups), observed_at, entry_generation, generation)) =
+        admin_alerts_canonical_last_good(state.as_ref(), &cache_key).await
+    {
+        let pressure_reason = state.proxy.admin_alerts_cache_warm_pressure_reason();
+        let stale_reason = pressure_reason.unwrap_or("projection_refresh");
+        if entry_generation == generation && pressure_reason.is_none() {
+            tracing::debug!(
+                component = "admin_read",
+                event = "alerts_last_good_served",
+                route = "/api/alerts/groups",
+                coverage = "fresh",
+                "served canonical Alerts groups from last-good cache"
+            );
+            return Ok(Json(PaginatedAlertGroupsView::from(groups)).into_response());
+        }
+        tracing::debug!(
+            component = "admin_read",
+            event = "alerts_last_good_served",
+            route = "/api/alerts/groups",
+            coverage = "stale",
+            stale_reason,
+            "served canonical Alerts groups from prior projection generation"
+        );
+        return Ok(
+            Json(PaginatedAlertGroupsView::from(groups).stale_with_reason(observed_at, stale_reason))
+            .into_response(),
+        );
+    }
+    if cache_key == default_admin_alert_cache_key("groups") {
+        state.proxy.record_admin_alerts_warm_cold_miss();
+        tracing::debug!(
+            component = "admin_read",
+            event = "alerts_cold_pressure",
+            route = "/api/alerts/groups",
+            "canonical Alerts groups cache is cold"
+        );
+        return Err(alerts_sqlite_pressure_response());
+    }
     match state.proxy.admin_alert_groups_page(
             alert_type,
             since,

--- a/src/server/handlers/public.rs
+++ b/src/server/handlers/public.rs
@@ -1006,11 +1006,14 @@ async fn expire_dashboard_overview_freshness_probe(state: &Arc<AppState>) {
     );
 }
 
-async fn mark_dashboard_overview_alert_projection_dirty(state: &AppState) {
+pub(crate) async fn mark_dashboard_overview_alert_projection_dirty(state: &AppState) {
     let cache_handle = dashboard_overview_cache_for_state(state);
     let mut cache = cache_handle.lock().await;
     cache.alert_projection_generation = cache.alert_projection_generation.wrapping_add(1);
     cache.last_freshness_probe_at = None;
+    // A completed canonical warm is allowed to rate-limit retries, but a new
+    // projection generation must be eligible for one fresh, fenced publish.
+    cache.admin_alerts_prewarm_not_before = None;
 }
 
 fn acknowledge_dashboard_alert_projection_generation(

--- a/src/server/schedulers_dashboard_alert_projection.rs
+++ b/src/server/schedulers_dashboard_alert_projection.rs
@@ -24,7 +24,6 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
             {
                 Ok((true, _)) => {
                     mark_dashboard_overview_alert_projection_dirty(state.as_ref()).await;
-                    prewarm_admin_alerts(state.clone()).await;
                     if last_error.take().is_some() {
                         tracing::info!(
                             component = "dashboard_alert_projection",
@@ -76,6 +75,11 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
                     last_error = Some(error);
                 }
             }
+            // Keep the canonical administrator Alerts keys warm even when the
+            // projection has no new source rows. The controller is singleflight
+            // and rate-limited, so an idle tick only re-arms one low-priority
+            // background refresh and never adds work to the HTTP path.
+            prewarm_admin_alerts(state.clone()).await;
             state
                 .proxy
                 .backend_time()

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -406,6 +406,7 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
     }
     tokio::spawn(async move {
         loop {
+            state.proxy.prewarm_admin_alerts_cache_capacity().await;
             if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
                 state.proxy.record_admin_alerts_warm_defer();
                 let delay = dashboard_overview_cache_for_state(state.as_ref())

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -87,6 +87,7 @@ struct DashboardOverviewCacheState {
     admin_alerts: AdminAlertsReadCache,
     admin_alerts_prewarm_in_flight: bool,
     admin_alerts_prewarm_not_before: Option<tokio::time::Instant>,
+    admin_alerts_prewarm_defers: u8,
     admin_privacy_status: AdminPrivacyStatusController,
     #[cfg(test)]
     build_count: usize,
@@ -113,6 +114,7 @@ impl Default for DashboardOverviewCacheState {
             admin_alerts: AdminAlertsReadCache::default(),
             admin_alerts_prewarm_in_flight: false,
             admin_alerts_prewarm_not_before: None,
+            admin_alerts_prewarm_defers: 0,
             admin_privacy_status: AdminPrivacyStatusController::default(),
             #[cfg(test)]
             build_count: 0,
@@ -127,6 +129,27 @@ impl Default for DashboardOverviewCacheState {
 const ADMIN_ALERTS_CACHE_CAPACITY: usize = 64;
 const ADMIN_ALERTS_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 const ADMIN_ALERTS_PREWARM_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+fn admin_alerts_warm_deferred(reason: &'static str) -> tavily_hikari::ProxyError {
+    tavily_hikari::ProxyError::Deferred {
+        operation: "admin_alerts_warm",
+        reason: reason.to_string(),
+    }
+}
+
+fn admin_alerts_warm_error_reason(error: &tavily_hikari::ProxyError) -> &'static str {
+    let tavily_hikari::ProxyError::Deferred { reason, .. } = error else {
+        return "sqlite_pressure";
+    };
+    match reason.as_str() {
+        "foreground_pressure" => "foreground_pressure",
+        "pool_pressure" => "pool_pressure",
+        "recent_contention" => "recent_contention",
+        "projection_generation_changed" => "projection_generation_changed",
+        "read_budget" => "read_budget",
+        _ => "deferred",
+    }
+}
 
 impl DashboardOverviewCacheState {
     fn try_start_admin_alerts_prewarm(&mut self, now: tokio::time::Instant) -> bool {
@@ -145,6 +168,20 @@ impl DashboardOverviewCacheState {
 
     fn finish_admin_alerts_prewarm(&mut self) {
         self.admin_alerts_prewarm_in_flight = false;
+        self.admin_alerts_prewarm_defers = 0;
+        self.admin_alerts_prewarm_not_before = Some(
+            tokio::time::Instant::now() + ADMIN_ALERTS_PREWARM_MIN_INTERVAL,
+        );
+    }
+
+    fn defer_admin_alerts_prewarm(&mut self, now: tokio::time::Instant) -> std::time::Duration {
+        self.admin_alerts_prewarm_defers = self.admin_alerts_prewarm_defers.saturating_add(1);
+        let delay = match self.admin_alerts_prewarm_defers {
+            1 | 2 => std::time::Duration::from_secs(5),
+            _ => std::time::Duration::from_secs(30),
+        };
+        self.admin_alerts_prewarm_not_before = Some(now + delay);
+        delay
     }
 }
 
@@ -159,6 +196,8 @@ enum AdminAlertsReadCacheValue {
 struct AdminAlertsReadCacheEntry {
     key: String,
     value: AdminAlertsReadCacheValue,
+    generation: u64,
+    canonical: bool,
     observed_at: i64,
     stored_at: tokio::time::Instant,
 }
@@ -223,24 +262,122 @@ async fn admin_alerts_last_good(
     Some((value, observed_at))
 }
 
+async fn admin_alerts_canonical_last_good(
+    state: &AppState,
+    key: &str,
+) -> Option<(AdminAlertsReadCacheValue, i64, u64, u64)> {
+    let cache = dashboard_overview_cache_for_state(state);
+    let mut cache = cache.lock().await;
+    let position = cache.admin_alerts.entries.iter().position(|entry| {
+        entry.key == key && entry.canonical && entry.stored_at.elapsed() <= ADMIN_ALERTS_CACHE_TTL
+    })?;
+    let entry = cache.admin_alerts.entries.remove(position)?;
+    let result = (entry.value.clone(), entry.observed_at, entry.generation, cache.alert_projection_generation);
+    cache.admin_alerts.entries.push_front(entry);
+    Some(result)
+}
+
 async fn record_admin_alerts_last_good(
     state: &AppState,
     key: String,
     value: AdminAlertsReadCacheValue,
 ) {
+    record_admin_alerts_last_good_at_generation(
+        state,
+        key,
+        value,
+        current_admin_alerts_generation(state).await,
+    )
+    .await;
+}
+
+async fn current_admin_alerts_generation(state: &AppState) -> u64 {
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .alert_projection_generation
+}
+
+async fn record_admin_alerts_last_good_at_generation(
+    state: &AppState,
+    key: String,
+    value: AdminAlertsReadCacheValue,
+    generation: u64,
+) {
     let cache = dashboard_overview_cache_for_state(state);
     let mut cache = cache.lock().await;
+    let canonical = key == "catalog" || key == default_admin_alert_cache_key("events") || key == default_admin_alert_cache_key("groups");
     cache.admin_alerts.entries.retain(|entry| entry.key != key);
     cache.admin_alerts.entries.push_front(AdminAlertsReadCacheEntry {
         key,
         value,
+        generation,
+        canonical,
         observed_at: state.proxy.backend_time().now_ts(),
         stored_at: tokio::time::Instant::now(),
     });
-    cache
-        .admin_alerts
-        .entries
-        .truncate(ADMIN_ALERTS_CACHE_CAPACITY);
+    while cache.admin_alerts.entries.len() > ADMIN_ALERTS_CACHE_CAPACITY {
+        if let Some(index) = cache
+            .admin_alerts
+            .entries
+            .iter()
+            .rposition(|entry| !entry.canonical)
+        {
+            cache.admin_alerts.entries.remove(index);
+        } else {
+            break;
+        }
+    }
+}
+
+async fn publish_admin_alerts_canonical(
+    state: &AppState,
+    generation: u64,
+    catalog: AlertCatalog,
+    events: PaginatedAlertEvents,
+    groups: PaginatedAlertGroups,
+) -> bool {
+    let cache = dashboard_overview_cache_for_state(state);
+    let mut cache = cache.lock().await;
+    if cache.alert_projection_generation != generation {
+        return false;
+    }
+    let observed_at = state.proxy.backend_time().now_ts();
+    let stored_at = tokio::time::Instant::now();
+    for (key, value) in [
+        ("catalog".to_string(), AdminAlertsReadCacheValue::Catalog(catalog)),
+        (
+            default_admin_alert_cache_key("events"),
+            AdminAlertsReadCacheValue::Events(events),
+        ),
+        (
+            default_admin_alert_cache_key("groups"),
+            AdminAlertsReadCacheValue::Groups(groups),
+        ),
+    ] {
+        cache.admin_alerts.entries.retain(|entry| entry.key != key);
+        cache.admin_alerts.entries.push_front(AdminAlertsReadCacheEntry {
+            key,
+            value,
+            generation,
+            canonical: true,
+            observed_at,
+            stored_at,
+        });
+    }
+    while cache.admin_alerts.entries.len() > ADMIN_ALERTS_CACHE_CAPACITY {
+        if let Some(index) = cache
+            .admin_alerts
+            .entries
+            .iter()
+            .rposition(|entry| !entry.canonical)
+        {
+            cache.admin_alerts.entries.remove(index);
+        } else {
+            break;
+        }
+    }
+    true
 }
 
 fn default_admin_alert_cache_key(kind: &str) -> String {
@@ -268,42 +405,109 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
         }
     }
     tokio::spawn(async move {
-        if let Ok(catalog) = state.proxy.admin_alert_catalog().await {
-            record_admin_alerts_last_good(
-                state.as_ref(),
-                "catalog".to_string(),
-                AdminAlertsReadCacheValue::Catalog(catalog),
-            )
+        loop {
+            if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
+                state.proxy.record_admin_alerts_warm_defer();
+                let delay = dashboard_overview_cache_for_state(state.as_ref())
+                    .lock()
+                    .await
+                    .defer_admin_alerts_prewarm(tokio::time::Instant::now());
+                tracing::debug!(
+                    component = "admin_read",
+                    event = "alerts_canonical_warm_deferred",
+                    reason,
+                    retry_after_secs = delay.as_secs(),
+                    "deferred canonical administrator Alerts cache before SQLite admission"
+                );
+                tokio::time::sleep(delay).await;
+                continue;
+            }
+            let generation = current_admin_alerts_generation(state.as_ref()).await;
+            let result = async {
+                state.proxy.record_admin_alerts_warm_slice();
+                let catalog = state.proxy.admin_alert_catalog_for_cache_warm().await?;
+                if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
+                    return Err(admin_alerts_warm_deferred(reason));
+                }
+                state.proxy.record_admin_alerts_warm_slice();
+                let events = state
+                    .proxy
+                    .admin_alert_events_page_for_cache_warm(1, 20)
+                    .await?;
+                if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
+                    return Err(admin_alerts_warm_deferred(reason));
+                }
+                state.proxy.record_admin_alerts_warm_slice();
+                let groups = state
+                    .proxy
+                    .admin_alert_groups_page_for_cache_warm(1, 20)
+                    .await?;
+                if !publish_admin_alerts_canonical(
+                    state.as_ref(),
+                    generation,
+                    catalog,
+                    events,
+                    groups,
+                )
+                .await
+                {
+                    state.proxy.record_admin_alerts_warm_generation_discard();
+                    return Err(tavily_hikari::ProxyError::Deferred {
+                        operation: "admin_alerts_warm",
+                        reason: "projection_generation_changed".to_string(),
+                    });
+                }
+                Ok::<(), tavily_hikari::ProxyError>(())
+            }
             .await;
+
+            match result {
+                Ok(()) => {
+                    state.proxy.record_admin_alerts_warm_publish();
+                    dashboard_overview_cache_for_state(state.as_ref())
+                        .lock()
+                        .await
+                        .finish_admin_alerts_prewarm();
+                    tracing::debug!(
+                        component = "admin_read",
+                        event = "alerts_canonical_warm_published",
+                        "published canonical administrator Alerts cache"
+                    );
+                    break;
+                }
+                Err(error)
+                    if tavily_hikari::is_transient_sqlite_write_error(&error)
+                        || error.is_deferred() =>
+                {
+                    state.proxy.record_admin_alerts_warm_defer();
+                    let delay = dashboard_overview_cache_for_state(state.as_ref())
+                        .lock()
+                        .await
+                        .defer_admin_alerts_prewarm(tokio::time::Instant::now());
+                    tracing::debug!(
+                        component = "admin_read",
+                        event = "alerts_canonical_warm_deferred",
+                        reason = admin_alerts_warm_error_reason(&error),
+                        retry_after_secs = delay.as_secs(),
+                        "deferred canonical administrator Alerts cache"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(error) => {
+                    tracing::error!(
+                        component = "admin_read",
+                        event = "alerts_canonical_warm_failed",
+                        error = %error,
+                        "canonical administrator Alerts cache failed"
+                    );
+                    dashboard_overview_cache_for_state(state.as_ref())
+                        .lock()
+                        .await
+                        .finish_admin_alerts_prewarm();
+                    break;
+                }
+            }
         }
-        if let Ok(events) = state
-            .proxy
-            .admin_alert_events_page(None, None, None, None, None, None, &[], 1, 20)
-            .await
-        {
-            record_admin_alerts_last_good(
-                state.as_ref(),
-                default_admin_alert_cache_key("events"),
-                AdminAlertsReadCacheValue::Events(events),
-            )
-            .await;
-        }
-        if let Ok(groups) = state
-            .proxy
-            .admin_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
-            .await
-        {
-            record_admin_alerts_last_good(
-                state.as_ref(),
-                default_admin_alert_cache_key("groups"),
-                AdminAlertsReadCacheValue::Groups(groups),
-            )
-            .await;
-        }
-        dashboard_overview_cache_for_state(state.as_ref())
-            .lock()
-            .await
-            .finish_admin_alerts_prewarm();
     });
 }
 
@@ -639,7 +843,22 @@ mod admin_alerts_prewarm_tests {
             ),
             "a busy projection must not restart the full admin cache warmup every slice"
         );
-        assert!(cache.try_start_admin_alerts_prewarm(now + ADMIN_ALERTS_PREWARM_MIN_INTERVAL));
+        assert!(cache.try_start_admin_alerts_prewarm(
+            now + ADMIN_ALERTS_PREWARM_MIN_INTERVAL + std::time::Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn admin_alerts_prewarm_backoff_is_bounded_and_recovers() {
+        let mut cache = DashboardOverviewCacheState::default();
+        let now = tokio::time::Instant::now();
+
+        assert_eq!(cache.defer_admin_alerts_prewarm(now), std::time::Duration::from_secs(5));
+        assert_eq!(cache.defer_admin_alerts_prewarm(now), std::time::Duration::from_secs(5));
+        assert_eq!(cache.defer_admin_alerts_prewarm(now), std::time::Duration::from_secs(30));
+
+        cache.finish_admin_alerts_prewarm();
+        assert_eq!(cache.admin_alerts_prewarm_defers, 0);
     }
 }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -406,7 +406,21 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
     }
     tokio::spawn(async move {
         loop {
-            state.proxy.prewarm_admin_alerts_cache_capacity().await;
+            if let Err(error) = state.proxy.prewarm_admin_alerts_cache_capacity().await
+                && !error.is_deferred()
+            {
+                tracing::error!(
+                    component = "admin_read",
+                    event = "alerts_canonical_warm_capacity_failed",
+                    error = %error,
+                    "canonical administrator Alerts cache capacity warm failed"
+                );
+                dashboard_overview_cache_for_state(state.as_ref())
+                    .lock()
+                    .await
+                    .finish_admin_alerts_prewarm();
+                break;
+            }
             if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
                 state.proxy.record_admin_alerts_warm_defer();
                 let delay = dashboard_overview_cache_for_state(state.as_ref())

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -771,6 +771,9 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         .await
         .expect("warm alerts catalog");
     assert_eq!(warm.status(), reqwest::StatusCode::OK);
+    let warm_body: serde_json::Value = warm.json().await.expect("warm alerts json");
+    assert_eq!(warm_body.get("coverage"), None);
+    assert_eq!(warm_body.get("staleReason"), None);
 
     // Alerts no longer depend on a maintenance-bulk permit. The native,
     // connection-local read deadline is the pressure boundary that selects

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -296,6 +296,36 @@ async fn alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_s
     let admin_password = "alerts-dashboard-default-window-password";
     let (admin_addr, dashboard_state) =
         spawn_builtin_keys_admin_server_with_state(proxy, admin_password).await;
+    let canonical_catalog = projection_proxy
+        .admin_alert_catalog()
+        .await
+        .expect("build canonical alert catalog fixture");
+    super::super::record_admin_alerts_last_good(
+        dashboard_state.as_ref(),
+        "catalog".to_string(),
+        super::super::AdminAlertsReadCacheValue::Catalog(canonical_catalog),
+    )
+    .await;
+    let canonical_events = projection_proxy
+        .admin_alert_events_page(None, None, None, None, None, None, &[], 1, 20)
+        .await
+        .expect("build canonical alert events fixture");
+    super::super::record_admin_alerts_last_good(
+        dashboard_state.as_ref(),
+        super::super::default_admin_alert_cache_key("events"),
+        super::super::AdminAlertsReadCacheValue::Events(canonical_events),
+    )
+    .await;
+    let canonical_groups = projection_proxy
+        .admin_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
+        .await
+        .expect("build canonical alert groups fixture");
+    super::super::record_admin_alerts_last_good(
+        dashboard_state.as_ref(),
+        super::super::default_admin_alert_cache_key("groups"),
+        super::super::AdminAlertsReadCacheValue::Groups(canonical_groups),
+    )
+    .await;
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -696,6 +726,15 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
     let cookie = find_cookie_pair(login.headers(), BUILTIN_ADMIN_COOKIE_NAME)
         .expect("admin session cookie");
 
+    let cold = client
+        .get(format!("http://{admin_addr}/api/alerts/catalog"))
+        .header(reqwest::header::COOKIE, &cookie)
+        .send()
+        .await
+        .expect("cold alerts catalog");
+    assert_eq!(cold.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(cold.headers().get("retry-after").and_then(|v| v.to_str().ok()), Some("1"));
+
     let mut projection_ready = false;
     for _ in 0..64 {
         state
@@ -714,6 +753,17 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         }
     }
     assert!(projection_ready, "empty projection must complete before warming admin cache");
+    let catalog = state
+        .proxy
+        .admin_alert_catalog()
+        .await
+        .expect("build canonical catalog for the warm-cache fixture");
+    super::super::record_admin_alerts_last_good(
+        state.as_ref(),
+        "catalog".to_string(),
+        super::super::AdminAlertsReadCacheValue::Catalog(catalog),
+    )
+    .await;
     let warm = client
         .get(format!("http://{admin_addr}/api/alerts/catalog"))
         .header(reqwest::header::COOKIE, &cookie)
@@ -725,6 +775,7 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
     // Alerts no longer depend on a maintenance-bulk permit. The native,
     // connection-local read deadline is the pressure boundary that selects
     // an exact-key last-good response.
+    super::super::mark_dashboard_overview_alert_projection_dirty(state.as_ref()).await;
     state.proxy.force_next_admin_alert_read_deadline_for_test();
     let stale = client
         .get(format!("http://{admin_addr}/api/alerts/catalog"))
@@ -737,7 +788,7 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
     assert_eq!(stale_body.get("coverage").and_then(|v| v.as_str()), Some("stale"));
     assert_eq!(
         stale_body.get("staleReason").and_then(|v| v.as_str()),
-        Some("sqlite_pressure")
+        Some("projection_refresh")
     );
 
     state.proxy.force_next_admin_alert_read_deadline_for_test();
@@ -1195,9 +1246,30 @@ async fn alerts_and_dashboard_recent_alerts_include_api_key_exhausted_and_job_fa
         tokio::time::sleep(std::time::Duration::from_millis(5)).await;
     }
     assert!(direct_alerts.is_some(), "direct admin alerts read did not become ready");
+    let canonical_groups = proxy
+        .admin_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
+        .await
+        .expect("canonical groups fixture");
 
     let admin_password = "alerts-dashboard-api-key-exhausted-job-failed-password";
-    let admin_addr = spawn_builtin_keys_admin_server(proxy, admin_password).await;
+    let (admin_addr, state) =
+        spawn_builtin_keys_admin_server_with_state(proxy, admin_password).await;
+    let canonical_events = direct_alerts
+        .as_ref()
+        .expect("canonical events fixture")
+        .clone();
+    super::super::record_admin_alerts_last_good(
+        state.as_ref(),
+        super::super::default_admin_alert_cache_key("events"),
+        super::super::AdminAlertsReadCacheValue::Events(canonical_events),
+    )
+    .await;
+    super::super::record_admin_alerts_last_good(
+        state.as_ref(),
+        super::super::default_admin_alert_cache_key("groups"),
+        super::super::AdminAlertsReadCacheValue::Groups(canonical_groups),
+    )
+    .await;
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -807,6 +807,51 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
 }
 
 #[tokio::test]
+async fn admin_alerts_canonical_read_waits_for_history_projection_coverage() {
+    let db_path = temp_db_path("admin-alerts-history-coverage");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-admin-alerts-history-coverage".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    // Drain the empty sidecar so the recent lane is healthy before isolating
+    // the history lane. This mirrors the scheduler's normal catch-up path.
+    for _ in 0..64 {
+        proxy
+            .advance_dashboard_alert_projection_scheduler_step()
+            .await
+            .expect("advance alert projection");
+        if proxy.admin_alert_catalog().await.is_ok() {
+            break;
+        }
+    }
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query(
+        "UPDATE observability.dashboard_alert_projection_history_state SET phase = 'catching_up'",
+    )
+    .execute(&pool)
+    .await
+    .expect("hold history projection in catch-up");
+
+    let result = proxy.admin_alert_catalog().await;
+    assert!(
+        matches!(
+            result,
+            Err(tavily_hikari::ProxyError::Deferred { ref operation, ref reason })
+                if *operation == "admin_alerts_read" && reason == "history_projection_catching_up"
+        ),
+        "canonical admin reads must not publish while history is incomplete: {result:?}"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn admin_privacy_status_uses_a_dedicated_read_session_outside_bulk_admission() {
     let db_path = temp_db_path("admin-privacy-status-last-good");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -842,8 +842,8 @@ async fn admin_alerts_canonical_read_waits_for_history_projection_coverage() {
     assert!(
         matches!(
             result,
-            Err(tavily_hikari::ProxyError::Deferred { ref operation, ref reason })
-                if *operation == "admin_alerts_read" && reason == "history_projection_catching_up"
+            Err(tavily_hikari::ProxyError::Deferred { operation, ref reason })
+                if operation == "admin_alerts_read" && reason == "history_projection_catching_up"
         ),
         "canonical admin reads must not publish while history is incomplete: {result:?}"
     );

--- a/src/store/key_store_alert_projection.rs
+++ b/src/store/key_store_alert_projection.rs
@@ -417,13 +417,6 @@ impl KeyStore {
     pub(crate) async fn advance_alert_projection_slice(
         &self,
     ) -> Result<AlertProjectionSliceOutcome, ProxyError> {
-        // A lazy three-connection pool can transiently have one checked-out
-        // connection and one idle connection without foreground pressure.
-        // Grow the unopened final slot within the runtime's short budget
-        // before deciding whether a projection slice must defer.
-        self.sqlite_runtime
-            .prewarm_maintenance_bulk_capacity()
-            .await;
         let _admission = match self.try_admit_alert_projection() {
             Ok(permit) => permit,
             Err(reason) => {
@@ -867,9 +860,6 @@ impl KeyStore {
     }
 
     pub(crate) async fn refresh_dashboard_alert_projection_summary(&self) -> Result<bool, ProxyError> {
-        self.sqlite_runtime
-            .prewarm_maintenance_bulk_capacity()
-            .await;
         let Ok(_permit) = self.try_admit_alert_projection() else {
             return Ok(false);
         };

--- a/src/store/key_store_alert_projection.rs
+++ b/src/store/key_store_alert_projection.rs
@@ -423,7 +423,7 @@ impl KeyStore {
         // whether the slice can run.
         self.sqlite_runtime
             .prewarm_maintenance_bulk_capacity()
-            .await;
+            .await?;
         let _admission = match self.try_admit_alert_projection() {
             Ok(permit) => permit,
             Err(reason) => {
@@ -869,7 +869,7 @@ impl KeyStore {
     pub(crate) async fn refresh_dashboard_alert_projection_summary(&self) -> Result<bool, ProxyError> {
         self.sqlite_runtime
             .prewarm_maintenance_bulk_capacity()
-            .await;
+            .await?;
         let Ok(_permit) = self.try_admit_alert_projection() else {
             return Ok(false);
         };

--- a/src/store/key_store_alert_projection.rs
+++ b/src/store/key_store_alert_projection.rs
@@ -417,6 +417,13 @@ impl KeyStore {
     pub(crate) async fn advance_alert_projection_slice(
         &self,
     ) -> Result<AlertProjectionSliceOutcome, ProxyError> {
+        // A lazy pool can have a foreground connection checked out before the
+        // projection worker starts. Let the runtime-owned capacity warm grow
+        // unopened slots within its bounded budget before admission decides
+        // whether the slice can run.
+        self.sqlite_runtime
+            .prewarm_maintenance_bulk_capacity()
+            .await;
         let _admission = match self.try_admit_alert_projection() {
             Ok(permit) => permit,
             Err(reason) => {
@@ -860,6 +867,9 @@ impl KeyStore {
     }
 
     pub(crate) async fn refresh_dashboard_alert_projection_summary(&self) -> Result<bool, ProxyError> {
+        self.sqlite_runtime
+            .prewarm_maintenance_bulk_capacity()
+            .await;
         let Ok(_permit) = self.try_admit_alert_projection() else {
             return Ok(false);
         };

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -872,6 +872,35 @@ impl KeyStore {
         page: i64,
         per_page: i64,
     ) -> Result<PaginatedAlertEvents, ProxyError> {
+        self.fetch_admin_alert_events_page_for_operation(
+            alert_type,
+            since,
+            until,
+            user_id,
+            token_id,
+            key_id,
+            request_kinds,
+            page,
+            per_page,
+            SqliteOperation::AdminAlertsRead,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn fetch_admin_alert_events_page_for_operation(
+        &self,
+        alert_type: Option<&str>,
+        since: Option<i64>,
+        until: Option<i64>,
+        user_id: Option<&str>,
+        token_id: Option<&str>,
+        key_id: Option<&str>,
+        request_kinds: &[String],
+        page: i64,
+        per_page: i64,
+        operation: SqliteOperation,
+    ) -> Result<PaginatedAlertEvents, ProxyError> {
         let filters = AlertEventFilters {
             alert_type,
             since,
@@ -884,7 +913,9 @@ impl KeyStore {
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
         let offset = (page - 1) * per_page;
-        let mut session = self.begin_admin_alerts_read_session().await?;
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(operation)
+            .await?;
         let result = async {
             self.ensure_admin_alert_projection_coverage(&mut session).await?;
 
@@ -2191,6 +2222,35 @@ impl KeyStore {
         page: i64,
         per_page: i64,
     ) -> Result<PaginatedAlertGroups, ProxyError> {
+        self.fetch_admin_alert_groups_page_for_operation(
+            alert_type,
+            since,
+            until,
+            user_id,
+            token_id,
+            key_id,
+            request_kinds,
+            page,
+            per_page,
+            SqliteOperation::AdminAlertsRead,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn fetch_admin_alert_groups_page_for_operation(
+        &self,
+        alert_type: Option<&str>,
+        since: Option<i64>,
+        until: Option<i64>,
+        user_id: Option<&str>,
+        token_id: Option<&str>,
+        key_id: Option<&str>,
+        request_kinds: &[String],
+        page: i64,
+        per_page: i64,
+        operation: SqliteOperation,
+    ) -> Result<PaginatedAlertGroups, ProxyError> {
         let filters = AlertEventFilters {
             alert_type,
             since,
@@ -2200,7 +2260,9 @@ impl KeyStore {
             key_id,
             request_kinds,
         };
-        let mut session = self.begin_admin_alerts_read_session().await?;
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(operation)
+            .await?;
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
         let offset = (page - 1) * per_page;
@@ -2260,7 +2322,17 @@ impl KeyStore {
     }
 
     pub(crate) async fn fetch_admin_alert_catalog(&self) -> Result<AlertCatalog, ProxyError> {
-        let mut session = self.begin_admin_alerts_read_session().await?;
+        self.fetch_admin_alert_catalog_for_operation(SqliteOperation::AdminAlertsRead)
+            .await
+    }
+
+    pub(crate) async fn fetch_admin_alert_catalog_for_operation(
+        &self,
+        operation: SqliteOperation,
+    ) -> Result<AlertCatalog, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(operation)
+            .await?;
         self.ensure_admin_alert_projection_coverage(&mut session).await?;
         let result = self
             .fetch_alert_catalog_from_source(AlertReadSource::Projected, Some(&mut session))

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -833,7 +833,26 @@ impl KeyStore {
             && fresh_sources == sources
             && stale_reason.is_none()
         {
-            return Ok(());
+            // Administrator Events and Groups include the durable history
+            // lane. A recent-tail generation alone is not a complete
+            // canonical read: publishing while history is still catching up
+            // would permanently cache a partial payload until the next warm
+            // interval. Check both lanes in this same snapshot before the
+            // caller builds any canonical value.
+            let history_result = sqlx::query_as::<_, (i64, i64)>(
+                r#"SELECT COUNT(*),
+                          SUM(CASE WHEN phase = 'idle' THEN 1 ELSE 0 END)
+                     FROM observability.dashboard_alert_projection_history_state"#,
+            )
+            .fetch_one(&mut **session)
+            .await;
+            let (history_sources, idle_history_sources) = session.query(history_result).await?;
+            if history_sources == ALERT_PROJECTION_SOURCES.len() as i64
+                && idle_history_sources == history_sources
+            {
+                return Ok(());
+            }
+            return session.defer("history_projection_catching_up").await;
         }
         session
             .defer(stale_reason.unwrap_or_else(|| "coverage_projecting".to_string()))

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -117,10 +117,12 @@ impl KeyStore {
             .try_admit_maintenance_bulk(SqliteOperation::ReconciliationProjection)
     }
 
-    pub(crate) async fn prewarm_upstream_reconciliation_projection_capacity(&self) {
+    pub(crate) async fn prewarm_upstream_reconciliation_projection_capacity(
+        &self,
+    ) -> Result<(), ProxyError> {
         self.sqlite_runtime
             .prewarm_reconciliation_projection_capacity()
-            .await;
+            .await
     }
 
     pub(crate) async fn upstream_reconciliation_run_admission_state(

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -117,7 +117,6 @@ impl KeyStore {
             .try_admit_maintenance_bulk(SqliteOperation::ReconciliationProjection)
     }
 
-    #[cfg(test)]
     pub(crate) async fn prewarm_upstream_reconciliation_projection_capacity(&self) {
         self.sqlite_runtime
             .prewarm_reconciliation_projection_capacity()

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -117,6 +117,7 @@ impl KeyStore {
             .try_admit_maintenance_bulk(SqliteOperation::ReconciliationProjection)
     }
 
+    #[cfg(test)]
     pub(crate) async fn prewarm_upstream_reconciliation_projection_capacity(&self) {
         self.sqlite_runtime
             .prewarm_reconciliation_projection_capacity()

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -838,12 +838,12 @@ impl SqliteRuntime {
             .map(|permit| SqliteMaintenanceRunLease { _permit: permit })
     }
 
-    pub(crate) async fn prewarm_maintenance_bulk_capacity(&self) {
+    pub(crate) async fn prewarm_maintenance_bulk_capacity(&self) -> Result<(), ProxyError> {
         if self.inner.pool.num_idle() >= MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
             || self.inner.pool.size() >= self.inner.maximum_connections
             || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
         {
-            return;
+            return Ok(());
         }
 
         let deadline = Instant::now() + Duration::from_millis(100);
@@ -874,7 +874,13 @@ impl SqliteRuntime {
                         break;
                     }
                 }
-                Err(_) => break,
+                Err(ProxyError::Database(sqlx::Error::PoolTimedOut)) => {
+                    // A bounded pool wait is expected pressure. Leave the
+                    // admission decision to the caller, which will return a
+                    // typed pool-pressure defer without hiding the timeout.
+                    break;
+                }
+                Err(error) => return Err(error),
             }
         }
         for (conn, pool_wait) in held {
@@ -893,10 +899,13 @@ impl SqliteRuntime {
         {
             tokio::task::yield_now().await;
         }
+        Ok(())
     }
 
-    pub(crate) async fn prewarm_reconciliation_projection_capacity(&self) {
-        self.prewarm_maintenance_bulk_capacity().await;
+    pub(crate) async fn prewarm_reconciliation_projection_capacity(
+        &self,
+    ) -> Result<(), ProxyError> {
+        self.prewarm_maintenance_bulk_capacity().await
     }
 
     pub(crate) fn maintenance_bulk_continue_reason(&self) -> Option<SqliteAdmissionDeferReason> {

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -124,6 +124,7 @@ pub(crate) struct SqliteMaintenanceRunLease {
 pub(crate) enum SqliteOperation {
     AdminMutation,
     AdminAlertsRead,
+    AdminAlertsCacheWarm,
     AdminPrivacyRead,
     AdminRead,
     AlertProjection,
@@ -180,6 +181,7 @@ impl SqliteOperation {
         match self {
             Self::AdminMutation => "admin_mutation",
             Self::AdminAlertsRead => "admin_alerts_read",
+            Self::AdminAlertsCacheWarm => "admin_alerts_cache_warm",
             Self::AdminPrivacyRead => "admin_privacy_read",
             Self::AdminRead => "admin_read",
             Self::AlertProjection => "alert_projection",
@@ -203,6 +205,7 @@ impl SqliteOperation {
         match self {
             Self::AdminMutation | Self::ForegroundJobTrigger => "foreground_work",
             Self::AdminAlertsRead
+            | Self::AdminAlertsCacheWarm
             | Self::AdminPrivacyRead
             | Self::BillingLedgerAuditRead
             | Self::HaBaselineRead
@@ -224,6 +227,7 @@ impl SqliteOperation {
         match self {
             Self::AdminMutation => Duration::from_millis(100),
             Self::AdminAlertsRead
+            | Self::AdminAlertsCacheWarm
             | Self::AdminPrivacyRead
             | Self::AdminRead
             | Self::AlertProjection
@@ -245,6 +249,7 @@ impl SqliteOperation {
         match self {
             Self::AdminMutation => Duration::from_millis(100),
             Self::AdminAlertsRead
+            | Self::AdminAlertsCacheWarm
             | Self::AdminPrivacyRead
             | Self::AdminRead
             | Self::AlertProjection
@@ -269,6 +274,7 @@ impl SqliteOperation {
             // returns writer contention as a typed defer without cancelling
             // a future that still owns the physical connection.
             Self::AdminAlertsRead
+            | Self::AdminAlertsCacheWarm
             | Self::AdminPrivacyRead
             | Self::AdminRead
             | Self::AdminMutation
@@ -346,6 +352,15 @@ struct ReconciliationReadWindow {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
+struct AdminAlertsWarmWindow {
+    slices: u64,
+    publishes: u64,
+    generation_discards: u64,
+    defers: u64,
+    cold_misses: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SqliteOperationTelemetry {
     pub(crate) connection_cache_write_pages: u64,
     pub(crate) connection_cache_write_sampled: bool,
@@ -387,6 +402,7 @@ struct WorkloadWindow {
     started_at: Instant,
     operations: BTreeMap<SqliteOperation, OperationWindow>,
     reconciliation_reads: BTreeMap<ReconciliationReadKind, ReconciliationReadWindow>,
+    admin_alerts_warm: AdminAlertsWarmWindow,
     last_process_write_bytes: Option<u64>,
     last_cgroup_write_bytes: Option<u64>,
     minimum_idle_connections: Option<u32>,
@@ -406,6 +422,7 @@ impl Default for WorkloadWindow {
             started_at: Instant::now(),
             operations: BTreeMap::new(),
             reconciliation_reads: BTreeMap::new(),
+            admin_alerts_warm: AdminAlertsWarmWindow::default(),
             last_process_write_bytes: None,
             last_cgroup_write_bytes: None,
             minimum_idle_connections: None,
@@ -826,12 +843,22 @@ impl SqliteRuntime {
         let deadline = Instant::now() + Duration::from_millis(100);
         let mut held = Vec::new();
         while self.inner.pool.size() < self.inner.maximum_connections {
+            if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS
+                || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
+            {
+                break;
+            }
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 break;
             }
             match tokio::time::timeout(remaining, self.inner.pool.acquire()).await {
-                Ok(Ok(conn)) => held.push(conn),
+                Ok(Ok(conn)) => {
+                    held.push(conn);
+                    if self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0 {
+                        break;
+                    }
+                }
                 _ => break,
             }
         }
@@ -888,6 +915,46 @@ impl SqliteRuntime {
             || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
         {
             Some(SqliteAdmissionDeferReason::PoolPressure)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn admin_alerts_cache_warm_defer_reason(
+        &self,
+    ) -> Option<SqliteAdmissionDeferReason> {
+        // Canonical Alerts warmup is deliberately lower priority than both
+        // foreground work and ordinary admin reads. Require two already-idle
+        // connections once the lazy pool has been established. A cold pool
+        // (or its first single idle connection) may bootstrap through the
+        // bounded warm read itself, as long as no foreground waiter exists.
+        let idle = self.inner.pool.num_idle();
+        let pool_size = self.inner.pool.size();
+        let cold_bootstrap = pool_size <= 1 && idle == pool_size as usize;
+        if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS {
+            Some(SqliteAdmissionDeferReason::ForegroundPressure)
+        } else if self.recent_contention_active() {
+            Some(SqliteAdmissionDeferReason::RecentContention)
+        } else if (!cold_bootstrap
+            && idle < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize)
+            || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
+        {
+            Some(SqliteAdmissionDeferReason::PoolPressure)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn admin_alerts_cache_warm_pressure_reason(&self) -> Option<&'static str> {
+        if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS {
+            Some(SqliteAdmissionDeferReason::ForegroundPressure.as_str())
+        } else if self.recent_contention_active() {
+            Some(SqliteAdmissionDeferReason::RecentContention.as_str())
+        } else if self.inner.pool.num_idle()
+            < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
+            || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
+        {
+            Some(SqliteAdmissionDeferReason::PoolPressure.as_str())
         } else {
             None
         }
@@ -1005,7 +1072,10 @@ impl SqliteRuntime {
                     return Err(err);
                 }
             };
-        let cooperative_run_deadline = if operation == SqliteOperation::AdminAlertsRead {
+        let cooperative_run_deadline = if matches!(
+            operation,
+            SqliteOperation::AdminAlertsRead | SqliteOperation::AdminAlertsCacheWarm
+        ) {
             let deadline = Instant::now() + ADMIN_ALERTS_READ_RUN_BUDGET;
             let mut handle = conn.lock_handle().await.map_err(ProxyError::Database)?;
             handle.set_progress_handler(ADMIN_ALERTS_READ_PROGRESS_HANDLER_OPS, move || {
@@ -1060,7 +1130,9 @@ impl SqliteRuntime {
         };
         let begin_result = if matches!(
             operation,
-            SqliteOperation::AdminPrivacyRead | SqliteOperation::AdminAlertsRead
+            SqliteOperation::AdminPrivacyRead
+                | SqliteOperation::AdminAlertsRead
+                | SqliteOperation::AdminAlertsCacheWarm
         ) {
             // Admin privacy refreshes are detached from the HTTP budget. Its
             // connection-local busy timeout is the bounded defer mechanism;
@@ -1112,6 +1184,10 @@ impl SqliteRuntime {
                 ADMIN_PRIVACY_READ_PROGRESS_HANDLER_OPS,
             )),
             SqliteOperation::AdminAlertsRead => Some((
+                ADMIN_ALERTS_READ_RUN_BUDGET,
+                ADMIN_ALERTS_READ_PROGRESS_HANDLER_OPS,
+            )),
+            SqliteOperation::AdminAlertsCacheWarm => Some((
                 ADMIN_ALERTS_READ_RUN_BUDGET,
                 ADMIN_ALERTS_READ_PROGRESS_HANDLER_OPS,
             )),
@@ -1426,6 +1502,45 @@ impl SqliteRuntime {
         }
     }
 
+    pub(crate) fn record_admin_alerts_warm_slice(&self) {
+        self.record_admin_alerts_warm_event(|metrics| {
+            metrics.slices = metrics.slices.saturating_add(1);
+        });
+    }
+
+    pub(crate) fn record_admin_alerts_warm_publish(&self) {
+        self.record_admin_alerts_warm_event(|metrics| {
+            metrics.publishes = metrics.publishes.saturating_add(1);
+        });
+    }
+
+    pub(crate) fn record_admin_alerts_warm_generation_discard(&self) {
+        self.record_admin_alerts_warm_event(|metrics| {
+            metrics.generation_discards = metrics.generation_discards.saturating_add(1);
+        });
+    }
+
+    pub(crate) fn record_admin_alerts_warm_defer(&self) {
+        self.record_admin_alerts_warm_event(|metrics| {
+            metrics.defers = metrics.defers.saturating_add(1);
+        });
+    }
+
+    pub(crate) fn record_admin_alerts_warm_cold_miss(&self) {
+        self.record_admin_alerts_warm_event(|metrics| {
+            metrics.cold_misses = metrics.cold_misses.saturating_add(1);
+        });
+    }
+
+    fn record_admin_alerts_warm_event(&self, update: impl FnOnce(&mut AdminAlertsWarmWindow)) {
+        let mut window = self
+            .inner
+            .workload
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        update(&mut window.admin_alerts_warm);
+    }
+
     pub(crate) fn record_deferred(
         &self,
         operation: SqliteOperation,
@@ -1441,6 +1556,23 @@ impl SqliteRuntime {
             false,
             Some(reason),
         );
+    }
+
+    fn record_deferred_error(&self, operation: SqliteOperation, error: &ProxyError) {
+        let ProxyError::Deferred { reason, .. } = error else {
+            self.record_error(operation, Duration::ZERO, Duration::ZERO, error);
+            return;
+        };
+        let reason = match reason.as_str() {
+            "foreground_pressure" => SqliteAdmissionDeferReason::ForegroundPressure,
+            "pool_pressure" => SqliteAdmissionDeferReason::PoolPressure,
+            "recent_contention" => SqliteAdmissionDeferReason::RecentContention,
+            "query_deadline" | "read_budget" => SqliteAdmissionDeferReason::QueryDeadline,
+            // Generation fencing is a normal retry boundary rather than a
+            // database failure; keep it in the typed deadline/defer bucket.
+            _ => SqliteAdmissionDeferReason::QueryDeadline,
+        };
+        self.record_deferred(operation, reason);
     }
 
     fn record_error(
@@ -1619,6 +1751,7 @@ impl SqliteRuntime {
             monotonic_delta(cgroup_write_bytes, window.last_cgroup_write_bytes);
         let top_operations =
             format_operation_window(&window.operations, &window.reconciliation_reads);
+        let admin_alerts_warm = format_admin_alerts_warm_window(window.admin_alerts_warm);
         let sqlite_file_state = self.sqlite_file_state();
         info!(
             component = "db",
@@ -1633,11 +1766,13 @@ impl SqliteRuntime {
             peak_acquire_waiters = window.maximum_acquire_waiters,
             sqlite_file_state = %sqlite_file_state,
             top_operations,
+            admin_alerts_warm,
             "SQLite workload summary"
         );
         window.started_at = now;
         window.operations.clear();
         window.reconciliation_reads.clear();
+        window.admin_alerts_warm = AdminAlertsWarmWindow::default();
         window.last_process_write_bytes = process_write_bytes;
         window.last_cgroup_write_bytes = cgroup_write_bytes;
         window.minimum_idle_connections = None;
@@ -1696,6 +1831,39 @@ impl KeyStore {
         Some(reason.as_str())
     }
 
+    pub(crate) fn admin_alerts_cache_warm_defer_reason(&self) -> Option<&'static str> {
+        let reason = self.sqlite_runtime.admin_alerts_cache_warm_defer_reason()?;
+        self.sqlite_runtime
+            .record_deferred(SqliteOperation::AdminAlertsCacheWarm, reason);
+        Some(reason.as_str())
+    }
+
+    pub(crate) fn admin_alerts_cache_warm_pressure_reason(&self) -> Option<&'static str> {
+        self.sqlite_runtime
+            .admin_alerts_cache_warm_pressure_reason()
+    }
+
+    pub(crate) fn record_admin_alerts_warm_slice(&self) {
+        self.sqlite_runtime.record_admin_alerts_warm_slice();
+    }
+
+    pub(crate) fn record_admin_alerts_warm_publish(&self) {
+        self.sqlite_runtime.record_admin_alerts_warm_publish();
+    }
+
+    pub(crate) fn record_admin_alerts_warm_generation_discard(&self) {
+        self.sqlite_runtime
+            .record_admin_alerts_warm_generation_discard();
+    }
+
+    pub(crate) fn record_admin_alerts_warm_defer(&self) {
+        self.sqlite_runtime.record_admin_alerts_warm_defer();
+    }
+
+    pub(crate) fn record_admin_alerts_warm_cold_miss(&self) {
+        self.sqlite_runtime.record_admin_alerts_warm_cold_miss();
+    }
+
     pub(crate) async fn begin_admin_privacy_read_session(
         &self,
     ) -> Result<SqliteReadSnapshot, ProxyError> {
@@ -1704,15 +1872,12 @@ impl KeyStore {
             .await
     }
 
-    pub(crate) async fn begin_admin_alerts_read_session(
+    pub(crate) async fn begin_admin_alerts_read_session_for_operation(
         &self,
+        operation: SqliteOperation,
     ) -> Result<AdminAlertsReadSession, ProxyError> {
         Ok(AdminAlertsReadSession {
-            snapshot: Some(
-                self.sqlite_runtime
-                    .begin_read_snapshot(SqliteOperation::AdminAlertsRead)
-                    .await?,
-            ),
+            snapshot: Some(self.sqlite_runtime.begin_read_snapshot(operation).await?),
         })
     }
 
@@ -2192,12 +2357,16 @@ impl SqliteReadSnapshot {
                     return Err(err);
                 }
                 if let Some(error) = query_error {
-                    self.runtime.record_error(
-                        self.operation,
-                        self.pool_wait,
-                        self.begin_wait,
-                        error,
-                    );
+                    if error.is_deferred() {
+                        self.runtime.record_deferred_error(self.operation, error);
+                    } else {
+                        self.runtime.record_error(
+                            self.operation,
+                            self.pool_wait,
+                            self.begin_wait,
+                            error,
+                        );
+                    }
                 } else {
                     self.runtime.record_success(
                         self.operation,
@@ -2908,6 +3077,17 @@ fn format_operation_window(
         }))
         .collect::<Vec<_>>()
         .join(";")
+}
+
+fn format_admin_alerts_warm_window(metrics: AdminAlertsWarmWindow) -> String {
+    format!(
+        "slices={},publishes={},generation_discards={},defers={},cold_misses={}",
+        metrics.slices,
+        metrics.publishes,
+        metrics.generation_discards,
+        metrics.defers,
+        metrics.cold_misses,
+    )
 }
 
 fn format_sqlite_file_state(paths: &SqliteFileStatePaths) -> String {

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -832,6 +832,7 @@ impl SqliteRuntime {
             .map(|permit| SqliteMaintenanceRunLease { _permit: permit })
     }
 
+    #[cfg(test)]
     pub(crate) async fn prewarm_maintenance_bulk_capacity(&self) {
         if self.has_foreground_pool_capacity()
             || self.inner.pool.size() >= self.inner.maximum_connections
@@ -871,6 +872,7 @@ impl SqliteRuntime {
         }
     }
 
+    #[cfg(test)]
     pub(crate) async fn prewarm_reconciliation_projection_capacity(&self) {
         self.prewarm_maintenance_bulk_capacity().await;
     }
@@ -950,8 +952,7 @@ impl SqliteRuntime {
             Some(SqliteAdmissionDeferReason::ForegroundPressure.as_str())
         } else if self.recent_contention_active() {
             Some(SqliteAdmissionDeferReason::RecentContention.as_str())
-        } else if self.inner.pool.num_idle()
-            < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
+        } else if self.inner.pool.num_idle() == 0
             || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
         {
             Some(SqliteAdmissionDeferReason::PoolPressure.as_str())

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -839,7 +839,7 @@ impl SqliteRuntime {
     }
 
     pub(crate) async fn prewarm_maintenance_bulk_capacity(&self) {
-        if self.has_foreground_pool_capacity()
+        if self.inner.pool.num_idle() >= MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
             || self.inner.pool.size() >= self.inner.maximum_connections
             || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
         {
@@ -861,29 +861,20 @@ impl SqliteRuntime {
             if remaining.is_zero() {
                 break;
             }
-            match tokio::time::timeout(
-                remaining,
-                self.acquire_pool_connection(SqliteOperation::MaintenanceCapacityWarm),
-            )
-            .await
+            match self
+                .acquire_pool_connection_with_budget(
+                    SqliteOperation::MaintenanceCapacityWarm,
+                    remaining,
+                )
+                .await
             {
-                Ok(Ok((conn, pool_wait))) => {
+                Ok((conn, pool_wait)) => {
                     held.push((conn, pool_wait));
                     if self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0 {
                         break;
                     }
                 }
-                Ok(Err(_)) | Err(_) => {
-                    if self.inner.pool.num_idle()
-                        < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
-                    {
-                        self.record_deferred(
-                            SqliteOperation::MaintenanceCapacityWarm,
-                            SqliteAdmissionDeferReason::PoolPressure,
-                        );
-                    }
-                    break;
-                }
+                Err(_) => break,
             }
         }
         for (conn, pool_wait) in held {
@@ -957,19 +948,15 @@ impl SqliteRuntime {
         &self,
     ) -> Option<SqliteAdmissionDeferReason> {
         // Canonical Alerts warmup is deliberately lower priority than both
-        // foreground work and ordinary admin reads. Require two already-idle
-        // connections once the lazy pool has been established. A cold pool
-        // (or its first single idle connection) may bootstrap through the
-        // bounded warm read itself, as long as no foreground waiter exists.
+        // foreground work and ordinary admin reads. The worker prewarms the
+        // lazy pool before reaching this gate, so require two returned
+        // connections here rather than treating unopened capacity as idle.
         let idle = self.inner.pool.num_idle();
-        let pool_size = self.inner.pool.size();
-        let cold_bootstrap = pool_size <= 1 && idle == pool_size as usize;
         if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS {
             Some(SqliteAdmissionDeferReason::ForegroundPressure)
         } else if self.recent_contention_active() {
             Some(SqliteAdmissionDeferReason::RecentContention)
-        } else if (!cold_bootstrap
-            && idle < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize)
+        } else if idle < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
             || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
         {
             Some(SqliteAdmissionDeferReason::PoolPressure)
@@ -1066,9 +1053,18 @@ impl SqliteRuntime {
         &self,
         operation: SqliteOperation,
     ) -> Result<(sqlx::pool::PoolConnection<Sqlite>, Duration), ProxyError> {
+        self.acquire_pool_connection_with_budget(operation, operation.acquire_budget())
+            .await
+    }
+
+    async fn acquire_pool_connection_with_budget(
+        &self,
+        operation: SqliteOperation,
+        budget: Duration,
+    ) -> Result<(sqlx::pool::PoolConnection<Sqlite>, Duration), ProxyError> {
         let acquire_started = Instant::now();
         let acquire_waiter = self.pool_acquire_waiter();
-        match tokio::time::timeout(operation.acquire_budget(), self.inner.pool.acquire()).await {
+        match tokio::time::timeout(budget, self.inner.pool.acquire()).await {
             Ok(Ok(conn)) => {
                 drop(acquire_waiter);
                 Ok((conn, acquire_started.elapsed()))
@@ -1677,6 +1673,13 @@ impl SqliteRuntime {
                     operation,
                     SqliteOperation::ScheduledJobControl | SqliteOperation::HaOutboxGcWatchdog
                 ));
+        let maintenance_defer_reason = maintenance_transient_defer.then_some(
+            if matches!(operation, SqliteOperation::MaintenanceCapacityWarm) {
+                SqliteAdmissionDeferReason::PoolPressure
+            } else {
+                SqliteAdmissionDeferReason::RecentContention
+            },
+        );
         self.record(
             operation,
             pool_wait,
@@ -1685,7 +1688,7 @@ impl SqliteRuntime {
             0,
             !maintenance_transient_defer,
             false,
-            maintenance_transient_defer.then_some(SqliteAdmissionDeferReason::RecentContention),
+            maintenance_defer_reason,
         );
     }
 

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -141,6 +141,7 @@ pub(crate) enum SqliteOperation {
     ServerPressureRebuild,
     ReconciliationProjection,
     ScheduledJobControl,
+    MaintenanceCapacityWarm,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -198,6 +199,7 @@ impl SqliteOperation {
             Self::ServerPressureRebuild => "server_pressure_rebuild",
             Self::ReconciliationProjection => "reconciliation_projection",
             Self::ScheduledJobControl => "scheduled_job_control",
+            Self::MaintenanceCapacityWarm => "maintenance_capacity_warm",
         }
     }
 
@@ -220,6 +222,7 @@ impl SqliteOperation {
             | Self::ServerPressureRebuild
             | Self::ReconciliationProjection => "maintenance_bulk",
             Self::ScheduledJobControl | Self::HaOutboxGcWatchdog => "maintenance_control",
+            Self::MaintenanceCapacityWarm => "maintenance_bulk",
         }
     }
 
@@ -241,6 +244,7 @@ impl SqliteOperation {
             | Self::ObservabilityDeferredWrite
             | Self::ServerPressureRebuild
             | Self::ReconciliationProjection => Duration::from_millis(100),
+            Self::MaintenanceCapacityWarm => Duration::from_millis(100),
             _ => Duration::from_secs(5),
         }
     }
@@ -263,6 +267,7 @@ impl SqliteOperation {
             | Self::ServerPressureRebuild
             | Self::ReconciliationProjection => Duration::from_millis(250),
             Self::ObservabilityDeferredWrite => Duration::from_millis(100),
+            Self::MaintenanceCapacityWarm => Duration::from_millis(100),
             _ => Duration::from_secs(5),
         }
     }
@@ -298,6 +303,7 @@ impl SqliteOperation {
                 | Self::ObservabilityDeferredWrite
                 | Self::ServerPressureRebuild
                 | Self::ReconciliationProjection
+                | Self::MaintenanceCapacityWarm
         )
     }
 
@@ -832,7 +838,6 @@ impl SqliteRuntime {
             .map(|permit| SqliteMaintenanceRunLease { _permit: permit })
     }
 
-    #[cfg(test)]
     pub(crate) async fn prewarm_maintenance_bulk_capacity(&self) {
         if self.has_foreground_pool_capacity()
             || self.inner.pool.size() >= self.inner.maximum_connections
@@ -842,6 +847,9 @@ impl SqliteRuntime {
         }
 
         let deadline = Instant::now() + Duration::from_millis(100);
+        // Capacity growth is runtime-owned: callers never acquire the raw
+        // pool. Each bounded acquire is accounted under its own operation so
+        // pool pressure remains distinguishable from a projection failure.
         let mut held = Vec::new();
         while self.inner.pool.size() < self.inner.maximum_connections {
             if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS
@@ -853,17 +861,41 @@ impl SqliteRuntime {
             if remaining.is_zero() {
                 break;
             }
-            match tokio::time::timeout(remaining, self.inner.pool.acquire()).await {
-                Ok(Ok(conn)) => {
-                    held.push(conn);
+            match tokio::time::timeout(
+                remaining,
+                self.acquire_pool_connection(SqliteOperation::MaintenanceCapacityWarm),
+            )
+            .await
+            {
+                Ok(Ok((conn, pool_wait))) => {
+                    held.push((conn, pool_wait));
                     if self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0 {
                         break;
                     }
                 }
-                _ => break,
+                Ok(Err(_)) | Err(_) => {
+                    if self.inner.pool.num_idle()
+                        < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
+                    {
+                        self.record_deferred(
+                            SqliteOperation::MaintenanceCapacityWarm,
+                            SqliteAdmissionDeferReason::PoolPressure,
+                        );
+                    }
+                    break;
+                }
             }
         }
-        drop(held);
+        for (conn, pool_wait) in held {
+            drop(conn);
+            self.record_success(
+                SqliteOperation::MaintenanceCapacityWarm,
+                pool_wait,
+                Duration::ZERO,
+                Duration::ZERO,
+                0,
+            );
+        }
         while Instant::now() < deadline
             && self.inner.pool.num_idle()
                 < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
@@ -872,7 +904,6 @@ impl SqliteRuntime {
         }
     }
 
-    #[cfg(test)]
     pub(crate) async fn prewarm_reconciliation_projection_capacity(&self) {
         self.prewarm_maintenance_bulk_capacity().await;
     }

--- a/src/store/sqlite_runtime_metrics_tests.rs
+++ b/src/store/sqlite_runtime_metrics_tests.rs
@@ -26,6 +26,50 @@ async fn workload_window_records_typed_admission_defers_without_statement_text()
 }
 
 #[tokio::test]
+async fn deferred_read_close_is_not_reported_as_a_database_error() {
+    let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
+    let error = ProxyError::Deferred {
+        operation: "admin_alerts_read",
+        reason: "read_budget".to_string(),
+    };
+    runtime.record_deferred_error(SqliteOperation::AdminAlertsCacheWarm, &error);
+
+    let window = runtime.inner.workload.lock().unwrap();
+    let metrics = &window.operations[&SqliteOperation::AdminAlertsCacheWarm];
+    assert_eq!(metrics.errors, 0);
+    assert_eq!(metrics.deferred, 1);
+    assert_eq!(
+        metrics
+            .deferred_by_reason
+            .get(&SqliteAdmissionDeferReason::QueryDeadline),
+        Some(&1)
+    );
+}
+
+#[tokio::test]
+async fn workload_window_reports_canonical_alerts_warm_events_without_sensitive_fields() {
+    let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
+    runtime.record_admin_alerts_warm_slice();
+    runtime.record_admin_alerts_warm_publish();
+    runtime.record_admin_alerts_warm_generation_discard();
+    runtime.record_admin_alerts_warm_defer();
+    runtime.record_admin_alerts_warm_cold_miss();
+
+    let window = runtime
+        .inner
+        .workload
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let formatted = format_admin_alerts_warm_window(window.admin_alerts_warm);
+    assert_eq!(
+        formatted,
+        "slices=1,publishes=1,generation_discards=1,defers=1,cold_misses=1"
+    );
+    assert!(!formatted.contains("SELECT"));
+    assert!(!formatted.contains("token"));
+}
+
+#[tokio::test]
 async fn sqlite_workload_window_reports_scoped_reconciliation_metrics() {
     let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
     runtime.record_connection_cache_write_pages(SqliteOperation::ReconciliationProjection, Some(7));

--- a/src/store/sqlite_runtime_tests.rs
+++ b/src/store/sqlite_runtime_tests.rs
@@ -704,6 +704,31 @@ async fn reconciliation_projection_can_probe_a_partially_open_idle_pool() {
 }
 
 #[tokio::test]
+async fn admin_alerts_cache_warm_prewarm_grows_lazy_pool_before_admission() {
+    let runtime = SqliteRuntime::with_max_connections(
+        SqlitePoolOptions::new()
+            .min_connections(1)
+            .max_connections(3)
+            .connect_with(
+                SqliteConnectOptions::from_str("sqlite::memory:")
+                    .expect("SQLite options")
+                    .create_if_missing(true),
+            )
+            .await
+            .expect("lazy three connection pool"),
+        3,
+    );
+    assert_eq!(runtime.inner.pool.size(), 1);
+    assert_eq!(runtime.inner.pool.num_idle(), 1);
+
+    runtime.prewarm_maintenance_bulk_capacity().await;
+
+    assert_eq!(runtime.inner.pool.size(), 3);
+    assert!(runtime.inner.pool.num_idle() >= 2);
+    assert_eq!(runtime.admin_alerts_cache_warm_defer_reason(), None);
+}
+
+#[tokio::test]
 async fn reconciliation_projection_prewarm_does_not_block_foreground_capacity() {
     let runtime = SqliteRuntime::with_max_connections(
         SqlitePoolOptions::new()

--- a/src/store/sqlite_runtime_tests.rs
+++ b/src/store/sqlite_runtime_tests.rs
@@ -681,7 +681,10 @@ async fn reconciliation_projection_can_probe_a_partially_open_idle_pool() {
             .expect_err("ordinary bulk work still reserves two foreground slots"),
         SqliteAdmissionDeferReason::PoolPressure
     );
-    runtime.prewarm_reconciliation_projection_capacity().await;
+    runtime
+        .prewarm_reconciliation_projection_capacity()
+        .await
+        .expect("prewarm reconciliation capacity");
     assert_eq!(runtime.inner.pool.size(), 3);
     assert_eq!(runtime.inner.pool.num_idle(), 2);
     runtime.mark_recent_contention_for_test();
@@ -721,11 +724,29 @@ async fn admin_alerts_cache_warm_prewarm_grows_lazy_pool_before_admission() {
     assert_eq!(runtime.inner.pool.size(), 1);
     assert_eq!(runtime.inner.pool.num_idle(), 1);
 
-    runtime.prewarm_maintenance_bulk_capacity().await;
+    runtime
+        .prewarm_maintenance_bulk_capacity()
+        .await
+        .expect("prewarm admin Alerts capacity");
 
     assert_eq!(runtime.inner.pool.size(), 3);
     assert!(runtime.inner.pool.num_idle() >= 2);
     assert_eq!(runtime.admin_alerts_cache_warm_defer_reason(), None);
+}
+
+#[tokio::test]
+async fn maintenance_capacity_warm_propagates_non_transient_pool_errors() {
+    let runtime = single_connection_runtime().await;
+    runtime.inner.pool.close().await;
+
+    let error = runtime
+        .prewarm_maintenance_bulk_capacity()
+        .await
+        .expect_err("closed pool must not be treated as pressure");
+    assert!(matches!(
+        error,
+        ProxyError::Database(sqlx::Error::PoolClosed)
+    ));
 }
 
 #[tokio::test]
@@ -750,7 +771,7 @@ async fn reconciliation_projection_prewarm_does_not_block_foreground_capacity() 
     let prewarm_runtime = runtime.clone();
     let foreground_pool = runtime.inner.pool.clone();
     let started = Instant::now();
-    let ((), foreground) = tokio::join!(
+    let (prewarm_result, foreground) = tokio::join!(
         prewarm_runtime.prewarm_reconciliation_projection_capacity(),
         async {
             tokio::time::timeout(Duration::from_millis(250), foreground_pool.acquire())
@@ -759,6 +780,7 @@ async fn reconciliation_projection_prewarm_does_not_block_foreground_capacity() 
                 .expect("foreground connection")
         }
     );
+    prewarm_result.expect("prewarm reconciliation capacity");
     assert!(started.elapsed() < Duration::from_millis(250));
 
     drop((foreground, existing_foreground));

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -17,6 +17,41 @@ impl TavilyProxy {
         None
     }
 
+    #[doc(hidden)]
+    pub fn admin_alerts_cache_warm_defer_reason(&self) -> Option<&'static str> {
+        self.key_store.admin_alerts_cache_warm_defer_reason()
+    }
+
+    #[doc(hidden)]
+    pub fn admin_alerts_cache_warm_pressure_reason(&self) -> Option<&'static str> {
+        self.key_store.admin_alerts_cache_warm_pressure_reason()
+    }
+
+    #[doc(hidden)]
+    pub fn record_admin_alerts_warm_slice(&self) {
+        self.key_store.record_admin_alerts_warm_slice();
+    }
+
+    #[doc(hidden)]
+    pub fn record_admin_alerts_warm_publish(&self) {
+        self.key_store.record_admin_alerts_warm_publish();
+    }
+
+    #[doc(hidden)]
+    pub fn record_admin_alerts_warm_generation_discard(&self) {
+        self.key_store.record_admin_alerts_warm_generation_discard();
+    }
+
+    #[doc(hidden)]
+    pub fn record_admin_alerts_warm_defer(&self) {
+        self.key_store.record_admin_alerts_warm_defer();
+    }
+
+    #[doc(hidden)]
+    pub fn record_admin_alerts_warm_cold_miss(&self) {
+        self.key_store.record_admin_alerts_warm_cold_miss();
+    }
+
     #[cfg(debug_assertions)]
     #[doc(hidden)]
     pub fn force_next_admin_alert_read_deadline_for_test(&self) {
@@ -144,6 +179,28 @@ impl TavilyProxy {
         .await
     }
 
+    #[doc(hidden)]
+    pub async fn admin_alert_events_page_for_cache_warm(
+        &self,
+        page: i64,
+        per_page: i64,
+    ) -> Result<PaginatedAlertEvents, ProxyError> {
+        self.key_store
+            .fetch_admin_alert_events_page_for_operation(
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                &[],
+                page,
+                per_page,
+                crate::store::SqliteOperation::AdminAlertsCacheWarm,
+            )
+            .await
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn alert_groups_page(
         &self,
@@ -200,12 +257,45 @@ impl TavilyProxy {
         .await
     }
 
+    #[doc(hidden)]
+    pub async fn admin_alert_groups_page_for_cache_warm(
+        &self,
+        page: i64,
+        per_page: i64,
+    ) -> Result<PaginatedAlertGroups, ProxyError> {
+        self.key_store
+            .fetch_admin_alert_groups_page_for_operation(
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                &[],
+                page,
+                per_page,
+                crate::store::SqliteOperation::AdminAlertsCacheWarm,
+            )
+            .await
+    }
+
     pub async fn alert_catalog(&self) -> Result<AlertCatalog, ProxyError> {
         self.key_store.fetch_alert_catalog().await
     }
 
     pub async fn admin_alert_catalog(&self) -> Result<AlertCatalog, ProxyError> {
         self.key_store.fetch_admin_alert_catalog().await
+    }
+
+    #[doc(hidden)]
+    pub async fn admin_alert_catalog_for_cache_warm(
+        &self,
+    ) -> Result<AlertCatalog, ProxyError> {
+        self.key_store
+            .fetch_admin_alert_catalog_for_operation(
+                crate::store::SqliteOperation::AdminAlertsCacheWarm,
+            )
+            .await
     }
 
     pub async fn recent_alerts_summary(

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -28,6 +28,14 @@ impl TavilyProxy {
     }
 
     #[doc(hidden)]
+    pub async fn prewarm_admin_alerts_cache_capacity(&self) {
+        self.key_store
+            .sqlite_runtime
+            .prewarm_maintenance_bulk_capacity()
+            .await;
+    }
+
+    #[doc(hidden)]
     pub fn record_admin_alerts_warm_slice(&self) {
         self.key_store.record_admin_alerts_warm_slice();
     }

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -28,11 +28,11 @@ impl TavilyProxy {
     }
 
     #[doc(hidden)]
-    pub async fn prewarm_admin_alerts_cache_capacity(&self) {
+    pub async fn prewarm_admin_alerts_cache_capacity(&self) -> Result<(), ProxyError> {
         self.key_store
             .sqlite_runtime
             .prewarm_maintenance_bulk_capacity()
-            .await;
+            .await
     }
 
     #[doc(hidden)]

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -465,10 +465,12 @@ impl TavilyProxy {
         }
     }
 
-    pub async fn prewarm_upstream_reconciliation_projection_capacity(&self) {
+    pub async fn prewarm_upstream_reconciliation_projection_capacity(
+        &self,
+    ) -> Result<(), ProxyError> {
         self.key_store
             .prewarm_upstream_reconciliation_projection_capacity()
-            .await;
+            .await
     }
 
     pub fn record_foreground_activity(&self) {

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -465,7 +465,6 @@ impl TavilyProxy {
         }
     }
 
-    #[cfg(test)]
     pub async fn prewarm_upstream_reconciliation_projection_capacity(&self) {
         self.key_store
             .prewarm_upstream_reconciliation_projection_capacity()

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -465,6 +465,7 @@ impl TavilyProxy {
         }
     }
 
+    #[cfg(test)]
     pub async fn prewarm_upstream_reconciliation_projection_capacity(&self) {
         self.key_store
             .prewarm_upstream_reconciliation_projection_capacity()

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -764,8 +764,13 @@ impl TavilyProxy {
                 reason: "pool_pressure"
             }
         ) {
-            self.prewarm_upstream_reconciliation_projection_capacity()
-                .await;
+            if let Err(error) = self
+                .prewarm_upstream_reconciliation_projection_capacity()
+                .await
+                && !error.is_deferred()
+            {
+                return Err(error);
+            }
             local_admission_outcome = self.admit_upstream_reconciliation_projection();
         }
         let mut local_admission = match local_admission_outcome {

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -757,17 +757,7 @@ impl TavilyProxy {
             try_remote_attempt: false,
             attempt_deadline: None,
         };
-        let mut local_admission_outcome = self.admit_upstream_reconciliation_projection();
-        if matches!(
-            local_admission_outcome,
-            SqliteAdmissionOutcome::Deferred {
-                reason: "pool_pressure"
-            }
-        ) {
-            self.prewarm_upstream_reconciliation_projection_capacity()
-                .await;
-            local_admission_outcome = self.admit_upstream_reconciliation_projection();
-        }
+        let local_admission_outcome = self.admit_upstream_reconciliation_projection();
         let mut local_admission = match local_admission_outcome {
             SqliteAdmissionOutcome::Admitted(admission) => admission,
             SqliteAdmissionOutcome::Deferred { reason } => {

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -757,7 +757,17 @@ impl TavilyProxy {
             try_remote_attempt: false,
             attempt_deadline: None,
         };
-        let local_admission_outcome = self.admit_upstream_reconciliation_projection();
+        let mut local_admission_outcome = self.admit_upstream_reconciliation_projection();
+        if matches!(
+            local_admission_outcome,
+            SqliteAdmissionOutcome::Deferred {
+                reason: "pool_pressure"
+            }
+        ) {
+            self.prewarm_upstream_reconciliation_projection_capacity()
+                .await;
+            local_admission_outcome = self.admit_upstream_reconciliation_projection();
+        }
         let mut local_admission = match local_admission_outcome {
             SqliteAdmissionOutcome::Admitted(admission) => admission,
             SqliteAdmissionOutcome::Deferred { reason } => {

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -1134,7 +1134,8 @@ async fn reconciliation_rejects_reclaimed_scheduled_job_claim() {
     // admission timing assertion before the fenced claim is inspected.
     proxy
         .prewarm_upstream_reconciliation_projection_capacity()
-        .await;
+        .await
+        .expect("prewarm reconciliation projection capacity");
     assert!(matches!(
         proxy
             .run_upstream_reconciliation_once_claimed_outcome(
@@ -1257,7 +1258,8 @@ async fn reconciliation_rejects_reclaimed_claim_after_remote_fetch() {
     // does not turn it into a foreground-admission timing test.
     proxy
         .prewarm_upstream_reconciliation_projection_capacity()
-        .await;
+        .await
+        .expect("prewarm reconciliation projection capacity");
     let running_proxy = proxy.clone();
     let running = tokio::spawn(async move {
         running_proxy


### PR DESCRIPTION
## Summary
- Add an AppState-owned canonical warm controller for catalog, events page 1/20, and groups page 1/20.
- Keep canonical HTTP handlers cache-first: fresh/stale last-good responses, bounded 503 on cold/expired keys, and no request-path rebuild or raw CTE fallback.
- Run each warm slice through the bounded `AdminAlertsCacheWarm` SQLite read operation with generation fencing, retry backoff, and typed defer accounting.
- Preserve public JSON shape and non-canonical exact-key behavior.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --locked -j 2 --all-targets -- -D warnings`
- `cargo test --locked --lib` (797 passed)
- `cargo test --locked --bin tavily-hikari` (493 passed)
- `python3 scripts/ci_backend_tests.py verify`
- `python3 scripts/ci_backend_tests.py run-shard --id bin-admin-api-observability`
- `bunx --bun dprint check`
- Final SHA `316c4e93335963e4f605b4131239b4ea49bdf5ef` testbox baseline/candidate: 600s each, stub upstream and read-only snapshots; candidate `researchTerminalDelta=18`, `researchPendingDelta=-17`, `terminalDelta=2`, `dashboardHttp5xx=0`, `foregroundHttp5xx=0`, `sqliteFinalLockErrors=0`, `nestedTransactionErrors=0`, `reconciliationProjectionDiscarded=0`, `projectionTransactionP95Ms=10`, billing adjustment count/sum unchanged at 0; temporary resources cleaned.
- Final testbox snapshot checksums: core `464acb25048af48f4589dc703afe02b332d4be33bdc5e0a1e86629617cd94829`, observability `b237d96f5ab4afad846ed575d950d24deb52f6d4346ec3f03944ae7c6e9572f5`.

## Scope
- Specs refreshed, solution updated, ADR 0002 refreshed, and `CONTEXT.md` updated.
- No schema, SQLite configuration, public endpoint, UI source, 101 deployment, or visual evidence changes.
