### PR TITLE
fix: converge admin Alerts warm and reconciliation candidates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,13 +42,13 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   background until it publishes last-good or shutdown fences it. A true cold miss returns
   `503 Retry-After: 1` without opening a request-owned SQLite transaction.
 - `admin Alerts canonical warm controller`: the AppState owner of the pinned catalog, events page
-  `1/20`, and groups page `1/20` cache keys. It starts only in a low-pressure window with two
-  already-idle connections, foreground activity at most `5 rps`, and no contention in the previous
-  five seconds. The worker asks `SqliteRuntime` to boundedly grow a lazy pool before the admission
-  check; if two idle connections cannot be established it defers instead of borrowing one idle
-  connection. Each `AdminAlertsCacheWarm` slice gets the normal `100ms` acquire and `250ms` native
-  read deadline; all three staged values publish only at one unchanged projection generation.
-  Defers retry after `5s`, `5s`, then `30s`, while a generation change re-arms one controller run.
+  `1/20`, and groups `1/20` cache keys. It starts only in a low-pressure window with one bounded
+  read slot available, foreground activity at most `5 rps`, and no contention in the previous five
+  seconds. It does not grow or reserve a lazy pool before admission; a foreground checkout or
+  acquire waiter produces a typed defer. Each `AdminAlertsCacheWarm` slice gets the normal `100ms`
+  acquire and `250ms` native read deadline; all three staged values publish only at one unchanged
+  projection generation. Defers retry after `5s`, `5s`, then `30s`, while a generation change
+  re-arms one controller run.
   Canonical HTTP handlers never trigger or wait for warm work: a current entry is fresh, an older
   entry within five minutes is stale, and a cold/expired entry returns `503 Retry-After: 1`.
 

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -64,7 +64,9 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   immediate five-second `remote_lease` defer rather than budget-consuming local wait.
 - A candidate that references multiple eligible upstream keys stores each successful key response in
   a local, generation-scoped observation table. Each run requests at most two still-missing keys and
-  only computes a cross-key total after every current-generation key is present. The v22 ledger
+  only computes a cross-key total after every current-generation key is present. Candidates with an
+  existing current-generation observation are ranked ahead of fresh candidates sharing the same
+  scheduling Key, so partial results resume before new work can hide them. The v22 ledger
   migration creates this derived table and index without scanning usage or emitting HA events;
   terminal completion removes the rows. Exhausting the request cap is a typed
   `remote_attempt_budget` continuation at 30 seconds, never a semantic failure.
@@ -108,10 +110,10 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   deadline over one snapshot. Exact-key last-good data may be served stale; a cold key returns
   `503 Retry-After: 1` and never falls back to the raw CTE path. The canonical catalog, events
   page `1/20`, and groups page `1/20` keys are owned by an AppState background warm controller;
-  it performs one bounded `AdminAlertsCacheWarm` read per slice only when two pool connections are
-  already idle, foreground activity is at most five requests per second, and recent contention is
-  clear. Before this admission check, the controller may ask the runtime to grow a lazy pool within
-  the same bounded budget; failure to establish two idle connections defers the slice. It stages all
-  three values behind one projection-generation fence and publishes them together. A deferred warm
-  retries at `5s`, `5s`, then `30s`; a generation change re-arms one warm without allowing HTTP to
-  trigger a rebuild.
+  performs one bounded `AdminAlertsCacheWarm` read per slice when a single pool connection is
+  available, foreground activity is at most five requests per second, and recent contention is
+  clear. It does not prewarm or reserve extra connections: a lazy pool can run the warm slice with
+  its one idle connection, while a foreground checkout or waiter causes a typed defer. It stages
+  all three values behind one projection-generation fence and publishes them together. A deferred
+  warm retries at `5s`, `5s`, then `30s`; a generation change re-arms one warm without allowing
+  HTTP to trigger a rebuild.

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -70,11 +70,12 @@ reads:
   matching stale result with `coverage`, `observedAt`, and `staleReason`; a cold key returns
   `503 Retry-After: 1` rather than starting a raw alert CTE.
 - Treat the default alert catalog, events page `1/20`, and groups page `1/20` as pinned canonical
-  cache slots. An AppState-owned controller asks `SqliteRuntime` to boundedly warm a lazy pool, then
-  builds them in short `AdminAlertsCacheWarm` read slices only when two connections are already
-  idle, foreground activity is at most `5 rps`, and recent contention is clear. If that reserve
-  cannot be established it defers instead of borrowing one idle connection. It stages the three values and publishes them atomically at one projection
-  generation; generation changes or partial failures discard the staged set. Retry at `5s/5s/30s`.
+  cache slots. An AppState-owned controller builds them in short `AdminAlertsCacheWarm` read slices
+  when one bounded read slot is available, foreground activity is at most `5 rps`, and recent
+  contention is clear. It does not reserve two idle connections or grow a lazy pool before the
+  check; a foreground checkout or waiter produces a typed defer. It stages the three values and
+  publishes them atomically at one projection generation; generation changes or partial failures
+  discard the staged set. Retry at `5s/5s/30s`.
   Canonical HTTP handlers are cache-first and return cold `503 Retry-After: 1` instead of rebuilding
   or falling back to raw CTEs; noncanonical exact-key reads keep the existing bounded-read fallback.
 - Apply the same last-good boundary to the single-key privacy-status read. Keep the immutable

--- a/docs/specs/admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/admin-alert-center-24h-summary/SPEC.md
@@ -29,9 +29,10 @@
 - 默认 catalog、events `1/20` 与 groups `1/20` 是 canonical keys，由 `AppState` 唯一拥有的
   background warm controller 以 `AdminAlertsCacheWarm` 短读片构建。三项必须来自同一完整
   projection generation 才能一起发布；任一 defer、取消或 generation 变化都丢弃 staged
-  值并保留 last-good。warm admission 要求两个连接已 idle、前台速率不超过 `5 rps` 且最近
-  `5s` 无 SQLite contention，失败按 `5s/5s/30s` 退避。冷启动且没有连接等待者时允许第一条
-  bounded read 惰性建立连接；HTTP 对 canonical key 只读 exact-key
+  值并保留 last-good。warm admission 只要求一个 bounded read slot、前台速率不超过 `5 rps`
+  且最近 `5s` 无 SQLite contention；不预热或保留第二条连接，前台 checkout/等待者会产生
+  typed defer，失败按 `5s/5s/30s` 退避。冷启动且没有连接等待者时允许第一条 bounded read
+  惰性建立连接；HTTP 对 canonical key 只读 exact-key
   cache：同 generation 为 fresh，generation 落后但未过期为 stale，cold/过期为
   `503 Retry-After: 1`，绝不触发重建。
 

--- a/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
+++ b/docs/specs/performance-architecture-hardening/IMPLEMENTATION.md
@@ -21,8 +21,9 @@
 ## SQLite admission containment
 
 - `SqliteRuntime` is now instance-owned by `KeyStore` and admits a single bulk operation only
-  before pool acquisition. It reserves two actual idle or immediately allocatable pool slots for
-  foreground work, defers bulk work when
+  before pool acquisition. Ordinary bulk work reserves two actual idle or immediately allocatable
+  pool slots for foreground work, while the canonical Alerts warm operation uses one bounded read
+  slot and does not grow or reserve lazy capacity. It defers work when
   foreground arrival, recent busy/timeout signals, or idle capacity violate the runtime contract,
   and aggregates the decision by operation and workload class.
 - HA GC, request-stats persistence, pressure rebuild, reconciliation projection, and Dashboard

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -206,11 +206,12 @@
   at `100ms`, every SQLite statement has a native `250ms` deadline, and coverage plus projected
   catalog/events/groups reads never borrow a bulk permit or raw pool connection. Canonical
   catalog, events page `1/20`, and groups page `1/20` are prewarmed by one AppState-owned
-  low-priority controller. It requires two already-idle connections, foreground activity at most
-  `5 rps`, and no recent contention; it stages the three reads and publishes them only when the
-  projection generation is unchanged. HTTP never starts warm work: canonical misses and expired
-  entries return `503 Retry-After: 1`, while a prior generation remains available as stale until
-  the next complete publish. Warm defers use `5s/5s/30s` backoff and never acquire the bulk permit.
+  low-priority controller. It requires one available bounded read slot, foreground activity at most
+  `5 rps`, and no recent contention; it does not reserve or grow extra pool capacity, stages the
+  three reads, and publishes them only when the projection generation is unchanged. HTTP never
+  starts warm work: canonical misses and expired entries return `503 Retry-After: 1`, while a prior
+  generation remains available as stale until the next complete publish. Warm defers use
+  `5s/5s/30s` backoff and never acquire the bulk permit.
 - AlertProjection 与旧结果在时间窗、过滤、分页、分组和状态跃迁上等价。
 - 30 分钟生产形状基准中进程组 RSS P95 不超过 256MiB。
 - architecture checker 证明目标热路径不存在 raw pool、coalescer、全局 pointer-map gate 或旧 cache。

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -159,18 +159,20 @@
   response as a local observation keyed by `(token_id, period_code, work_generation, key_id)`. Each
   run requests at most two missing keys and returns `remote_attempt_budget` with a 30-second
   continuation while the set is incomplete. Sum usage and enter the existing compare/active terminal
-  path only after all current-generation keys are observed; a partial observation never becomes a
-  semantic failure or terminal result. Terminal completion clears these node-local rows, and
-  generation or claim fencing ignores stale observations. The observation table is derived state,
-  not HA outbox truth.
+  path only after all current-generation keys are observed; candidates with an existing partial
+  observation are selected before fresh candidates sharing the same scheduling Key so the partial
+  set can converge. A partial observation never becomes a semantic failure or terminal result.
+  Terminal completion clears these node-local rows, and generation or claim fencing ignores stale
+  observations. The observation table is derived state, not HA outbox truth.
 - When one candidate maps to multiple eligible upstream keys, persist each successful `/usage`
   response as a local observation keyed by `(token_id, period_code, work_generation, key_id)`. Each
   run requests at most two missing keys and returns `remote_attempt_budget` with a 30-second
   continuation while the set is incomplete. Sum usage and enter the existing compare/active terminal
-  path only after all current-generation keys are observed; a partial observation never becomes a
-  semantic failure or terminal result. Terminal completion clears these node-local rows, and
-  generation or claim fencing ignores stale observations. The observation table is derived state,
-  not HA outbox truth.
+  path only after all current-generation keys are observed; candidates with an existing partial
+  observation are selected before fresh candidates sharing the same scheduling Key so the partial set
+  can converge. A partial observation never becomes a semantic failure or terminal result. Terminal
+  completion clears these node-local rows, and generation or claim fencing ignores stale observations.
+  The observation table is derived state, not HA outbox truth.
 - 状态页使用门禁清单和 `n/m`，同时覆盖 loading、empty、error 与 degraded 状态。
 
 ## 功能与行为规格（Functional/Behavior Spec）

--- a/scripts/test_ci_backend_tests.py
+++ b/scripts/test_ci_backend_tests.py
@@ -306,6 +306,7 @@ class BackendTestRunnerContractTests(unittest.TestCase):
         self.assertEqual(
             set(prefixes),
             {
+                "server::admin_alerts_prewarm_tests::",
                 "server::tests::admin_logs_and_summary::admin_",
                 "server::tests::admin_token_filters_and_maintenance::admin_",
                 "server::tests::admin_analysis_pressure::analysis_",

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -406,21 +406,6 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
     }
     tokio::spawn(async move {
         loop {
-            if let Err(error) = state.proxy.prewarm_admin_alerts_cache_capacity().await
-                && !error.is_deferred()
-            {
-                tracing::error!(
-                    component = "admin_read",
-                    event = "alerts_canonical_warm_capacity_failed",
-                    error = %error,
-                    "canonical administrator Alerts cache capacity warm failed"
-                );
-                dashboard_overview_cache_for_state(state.as_ref())
-                    .lock()
-                    .await
-                    .finish_admin_alerts_prewarm();
-                break;
-            }
             if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
                 state.proxy.record_admin_alerts_warm_defer();
                 let delay = dashboard_overview_cache_for_state(state.as_ref())

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -783,15 +783,6 @@ impl KeyStore {
         Ok(status.coverage == "ok" && status.stale_reason.is_none())
     }
 
-    async fn fetch_alert_query_rows(
-        &self,
-        query: QueryBuilder<'_, Sqlite>,
-        source: AlertReadSource,
-    ) -> Result<Vec<sqlx::sqlite::SqliteRow>, ProxyError> {
-        self.fetch_alert_query_rows_for_operation(query, source, SqliteOperation::AdminAlertsRead)
-            .await
-    }
-
     async fn fetch_alert_query_rows_for_operation(
         &self,
         mut query: QueryBuilder<'_, Sqlite>,
@@ -859,6 +850,16 @@ impl KeyStore {
             .await
     }
 
+    async fn ensure_admin_alert_projection_coverage_for_warm(&self) -> Result<(), ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let result = self.ensure_admin_alert_projection_coverage(&mut session).await;
+        let finish = session.finish().await;
+        finish?;
+        result
+    }
+
     async fn effective_auth_token_log_retention_days_in_admin_session(
         &self,
         session: &mut AdminAlertsReadSession,
@@ -868,6 +869,31 @@ impl KeyStore {
             .fetch_optional(&mut **session)
             .await;
         let value = session.query(result).await?;
+        if let Some(retention_days) = value
+            .as_deref()
+            .and_then(|value| value.parse::<i64>().ok())
+            .and_then(normalize_auth_token_log_retention_days)
+        {
+            return Ok(retention_days);
+        }
+        effective_auth_token_log_retention_days()
+    }
+
+    async fn effective_auth_token_log_retention_days_for_operation(
+        &self,
+        operation: SqliteOperation,
+    ) -> Result<i64, ProxyError> {
+        let mut conn = self
+            .sqlite_runtime
+            .acquire_operation_connection(operation)
+            .await?;
+        let result = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM meta WHERE key = ? LIMIT 1",
+        )
+        .bind(META_KEY_AUTH_TOKEN_LOG_RETENTION_DAYS_V1)
+        .fetch_optional(&mut *conn)
+        .await;
+        let value = conn.complete_query(result).await?;
         if let Some(retention_days) = value
             .as_deref()
             .and_then(|value| value.parse::<i64>().ok())
@@ -931,6 +957,17 @@ impl KeyStore {
         };
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
+        if operation == SqliteOperation::AdminAlertsCacheWarm {
+            self.ensure_admin_alert_projection_coverage_for_warm().await?;
+            return self
+                .fetch_projected_alert_events_page_for_operation(
+                    filters,
+                    page,
+                    per_page,
+                    operation,
+                )
+                .await;
+        }
         let offset = (page - 1) * per_page;
         let mut session = self
             .begin_admin_alerts_read_session_for_operation(operation)
@@ -989,6 +1026,22 @@ impl KeyStore {
         page: i64,
         per_page: i64,
     ) -> Result<PaginatedAlertEvents, ProxyError> {
+        self.fetch_projected_alert_events_page_for_operation(
+            filters,
+            page,
+            per_page,
+            SqliteOperation::AdminAlertsRead,
+        )
+        .await
+    }
+
+    async fn fetch_projected_alert_events_page_for_operation(
+        &self,
+        filters: AlertEventFilters<'_>,
+        page: i64,
+        per_page: i64,
+        operation: SqliteOperation,
+    ) -> Result<PaginatedAlertEvents, ProxyError> {
         let started = Instant::now();
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
@@ -1004,7 +1057,7 @@ impl KeyStore {
         );
         let mut count_conn = self
             .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::AdminAlertsRead)
+            .acquire_operation_connection(operation)
             .await?;
         let count_result = count_query.build_query_scalar().fetch_one(&mut *count_conn).await;
         let total = count_conn.complete_query(count_result).await?;
@@ -1023,7 +1076,7 @@ impl KeyStore {
         query.push_bind(offset);
         let mut conn = self
             .sqlite_runtime
-            .acquire_operation_connection(SqliteOperation::AdminAlertsRead)
+            .acquire_operation_connection(operation)
             .await?;
         let result = query.build().fetch_all(&mut *conn).await;
         let rows = conn.complete_query(result).await?;
@@ -1748,6 +1801,22 @@ impl KeyStore {
         groups: Vec<AlertGroupRecord>,
         source: AlertReadSource,
     ) -> Result<Vec<AlertGroupRecord>, ProxyError> {
+        self.populate_selected_mother_groups_for_operation(
+            filters,
+            groups,
+            source,
+            SqliteOperation::AdminAlertsRead,
+        )
+        .await
+    }
+
+    async fn populate_selected_mother_groups_for_operation(
+        &self,
+        filters: AlertEventFilters<'_>,
+        groups: Vec<AlertGroupRecord>,
+        source: AlertReadSource,
+        operation: SqliteOperation,
+    ) -> Result<Vec<AlertGroupRecord>, ProxyError> {
         if groups.is_empty() {
             return Ok(groups);
         }
@@ -1820,7 +1889,9 @@ impl KeyStore {
         query.push(")");
         query.push(" ORDER BY occurred_at DESC, row_sort_id DESC");
 
-        let rows = self.fetch_alert_query_rows(query, source).await?;
+        let rows = self
+            .fetch_alert_query_rows_for_operation(query, source, operation)
+            .await?;
         let all_events = rows
             .into_iter()
             .map(Self::decode_alert_event_projection_row)
@@ -2279,11 +2350,31 @@ impl KeyStore {
             key_id,
             request_kinds,
         };
+        let page = page.max(1);
+        let per_page = per_page.clamp(1, 100);
+        if operation == SqliteOperation::AdminAlertsCacheWarm {
+            self.ensure_admin_alert_projection_coverage_for_warm().await?;
+            let (page_items, total) = self
+                .fetch_projected_alert_group_page_for_operation(filters, page, per_page, operation)
+                .await?;
+            let items = self
+                .populate_selected_mother_groups_for_operation(
+                    filters,
+                    page_items,
+                    AlertReadSource::Projected,
+                    operation,
+                )
+                .await?;
+            return Ok(PaginatedAlertGroups {
+                items,
+                total,
+                page,
+                per_page,
+            });
+        }
         let mut session = self
             .begin_admin_alerts_read_session_for_operation(operation)
             .await?;
-        let page = page.max(1);
-        let per_page = per_page.clamp(1, 100);
         let offset = (page - 1) * per_page;
         let result = async {
             self.ensure_admin_alert_projection_coverage(&mut session).await?;
@@ -2337,7 +2428,13 @@ impl KeyStore {
         } else {
             AlertReadSource::Raw
         };
-        self.fetch_alert_catalog_from_source(source, None).await
+        self
+            .fetch_alert_catalog_from_source(
+                source,
+                None,
+                SqliteOperation::AdminAlertsRead,
+            )
+            .await
     }
 
     pub(crate) async fn fetch_admin_alert_catalog(&self) -> Result<AlertCatalog, ProxyError> {
@@ -2349,12 +2446,26 @@ impl KeyStore {
         &self,
         operation: SqliteOperation,
     ) -> Result<AlertCatalog, ProxyError> {
+        if operation == SqliteOperation::AdminAlertsCacheWarm {
+            self.ensure_admin_alert_projection_coverage_for_warm().await?;
+            return self
+                .fetch_alert_catalog_from_source(
+                    AlertReadSource::Projected,
+                    None,
+                    operation,
+                )
+                .await;
+        }
         let mut session = self
             .begin_admin_alerts_read_session_for_operation(operation)
             .await?;
         self.ensure_admin_alert_projection_coverage(&mut session).await?;
         let result = self
-            .fetch_alert_catalog_from_source(AlertReadSource::Projected, Some(&mut session))
+            .fetch_alert_catalog_from_source(
+                AlertReadSource::Projected,
+                Some(&mut session),
+                operation,
+            )
             .await;
         let finish_result = session.finish().await;
         finish_result?;
@@ -2365,6 +2476,7 @@ impl KeyStore {
         &self,
         source: AlertReadSource,
         mut session: Option<&mut AdminAlertsReadSession>,
+        operation: SqliteOperation,
     ) -> Result<AlertCatalog, ProxyError> {
         let filters = AlertEventFilters {
             alert_type: None,
@@ -2392,7 +2504,9 @@ impl KeyStore {
             Some(session) => self
                 .fetch_projected_alert_query_rows_in_admin_session(session, request_kind_query)
                 .await?,
-            None => self.fetch_alert_query_rows(request_kind_query, source).await?,
+            None => self
+                .fetch_alert_query_rows_for_operation(request_kind_query, source, operation)
+                .await?,
         };
         let request_kind_options = request_kind_rows
             .into_iter()
@@ -2428,7 +2542,9 @@ impl KeyStore {
             Some(session) => self
                 .fetch_projected_alert_query_rows_in_admin_session(session, users_query)
                 .await?,
-            None => self.fetch_alert_query_rows(users_query, source).await?,
+            None => self
+                .fetch_alert_query_rows_for_operation(users_query, source, operation)
+                .await?,
         }
             .into_iter()
             .map(|row| -> Result<AlertFacetOption, sqlx::Error> {
@@ -2456,7 +2572,9 @@ impl KeyStore {
             Some(session) => self
                 .fetch_projected_alert_query_rows_in_admin_session(session, tokens_query)
                 .await?,
-            None => self.fetch_alert_query_rows(tokens_query, source).await?,
+            None => self
+                .fetch_alert_query_rows_for_operation(tokens_query, source, operation)
+                .await?,
         }
             .into_iter()
             .map(|row| -> Result<AlertFacetOption, sqlx::Error> {
@@ -2484,7 +2602,9 @@ impl KeyStore {
             Some(session) => self
                 .fetch_projected_alert_query_rows_in_admin_session(session, keys_query)
                 .await?,
-            None => self.fetch_alert_query_rows(keys_query, source).await?,
+            None => self
+                .fetch_alert_query_rows_for_operation(keys_query, source, operation)
+                .await?,
         }
             .into_iter()
             .map(|row| -> Result<AlertFacetOption, sqlx::Error> {
@@ -2508,7 +2628,9 @@ impl KeyStore {
             Some(session) => self
                 .fetch_projected_alert_query_rows_in_admin_session(session, types_query)
                 .await?,
-            None => self.fetch_alert_query_rows(types_query, source).await?,
+            None => self
+                .fetch_alert_query_rows_for_operation(types_query, source, operation)
+                .await?,
         };
         let types = Self::summarize_alert_type_count_rows(types_rows)
         .into_iter()
@@ -2522,7 +2644,9 @@ impl KeyStore {
             Some(session) => self
                 .effective_auth_token_log_retention_days_in_admin_session(session)
                 .await?,
-            None => self.effective_auth_token_log_retention_days().await?,
+            None => self
+                .effective_auth_token_log_retention_days_for_operation(operation)
+                .await?,
         };
         Ok(AlertCatalog {
             retention_days,

--- a/src/store/key_store_upstream_reconciliation.rs
+++ b/src/store/key_store_upstream_reconciliation.rs
@@ -1440,7 +1440,14 @@ impl KeyStore {
                     WHERE r.token_id = w.token_id
                       AND r.period_code = w.period_code
                       AND r.terminal_at IS NULL
-                ) THEN 1 ELSE 0 END AS pending_research
+                ) THEN 1 ELSE 0 END AS pending_research,
+                COALESCE((
+                    SELECT COUNT(*)
+                    FROM upstream_reconciliation_key_observations o
+                    WHERE o.token_id = w.token_id
+                      AND o.period_code = w.period_code
+                      AND o.work_generation = w.work_generation
+                ), 0) AS observed_key_count
             FROM upstream_reconciliation_work w
             LEFT JOIN upstream_reconciliation_settlements s
               ON s.settlement_key = 'v1:' || w.token_id || ':' || w.period_code
@@ -1507,7 +1514,9 @@ impl KeyStore {
               SELECT eligible.*,
                      ROW_NUMBER() OVER (
                        PARTITION BY scheduling_key_id
-                       ORDER BY period_end "#,
+                       ORDER BY CASE WHEN observed_key_count > 0 THEN 0 ELSE 1 END,
+                                observed_key_count DESC,
+                                period_end "#,
             )
             .push(if newest_first { "DESC" } else { "ASC" })
             .push(

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -957,17 +957,15 @@ impl SqliteRuntime {
         &self,
     ) -> Option<SqliteAdmissionDeferReason> {
         // Canonical Alerts warmup is deliberately lower priority than both
-        // foreground work and ordinary admin reads. The worker prewarms the
-        // lazy pool before reaching this gate, so require two returned
-        // connections here rather than treating unopened capacity as idle.
+        // foreground work and ordinary admin reads. It uses one bounded read
+        // slot; requiring two already-idle connections starves a lazy pool
+        // under the normal one-connection foreground workload.
         let idle = self.inner.pool.num_idle();
         if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS {
             Some(SqliteAdmissionDeferReason::ForegroundPressure)
         } else if self.recent_contention_active() {
             Some(SqliteAdmissionDeferReason::RecentContention)
-        } else if idle < MAINTENANCE_BULK_RESERVED_FOREGROUND_CONNECTIONS as usize
-            || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
-        {
+        } else if idle == 0 || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0 {
             Some(SqliteAdmissionDeferReason::PoolPressure)
         } else {
             None

--- a/src/store/sqlite_runtime_tests.rs
+++ b/src/store/sqlite_runtime_tests.rs
@@ -707,7 +707,7 @@ async fn reconciliation_projection_can_probe_a_partially_open_idle_pool() {
 }
 
 #[tokio::test]
-async fn admin_alerts_cache_warm_prewarm_grows_lazy_pool_before_admission() {
+async fn admin_alerts_cache_warm_admits_with_one_idle_connection() {
     let runtime = SqliteRuntime::with_max_connections(
         SqlitePoolOptions::new()
             .min_connections(1)
@@ -723,6 +723,11 @@ async fn admin_alerts_cache_warm_prewarm_grows_lazy_pool_before_admission() {
     );
     assert_eq!(runtime.inner.pool.size(), 1);
     assert_eq!(runtime.inner.pool.num_idle(), 1);
+    assert_eq!(
+        runtime.admin_alerts_cache_warm_defer_reason(),
+        None,
+        "canonical warm uses one bounded read slot and must not require two idle connections"
+    );
 
     runtime
         .prewarm_maintenance_bulk_capacity()

--- a/src/tests/upstream_reconciliation_projection.rs
+++ b/src/tests/upstream_reconciliation_projection.rs
@@ -8,6 +8,81 @@ use std::{
 use tokio::net::TcpListener;
 
 #[tokio::test]
+async fn reconciliation_candidates_prioritize_partial_observations() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 7, 15, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-partial-priority"],
+        "http://127.0.0.1:9",
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-partial-priority")
+        .await
+        .expect("create shared upstream key");
+    let period_start = now - 1_200;
+    let period_end = now - 900;
+    for (token_id, period_code) in [
+        ("token-partial-observation", "2026-07-15/S1-partial"),
+        ("token-fresh-candidate", "2026-07-15/S1-fresh"),
+    ] {
+        sqlx::query(
+            r#"
+            INSERT INTO upstream_reconciliation_usage (
+                token_id, key_id, period_code, project_id, billing_subject, period_start, period_end,
+                request_count, first_used_at, last_used_at, updated_at, settlement_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+            "#,
+        )
+        .bind(token_id)
+        .bind(&key_id)
+        .bind(period_code)
+        .bind(format!("project-{token_id}"))
+        .bind(format!("account:{token_id}"))
+        .bind(period_start)
+        .bind(period_end)
+        .bind(period_start)
+        .bind(period_end)
+        .bind(period_end)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert candidate usage");
+    }
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_key_observations (
+             token_id, period_code, work_generation, key_id, upstream_usage, observed_at
+           ) VALUES (?, ?, 1, ?, 5, ?)"#,
+    )
+    .bind("token-partial-observation")
+    .bind("2026-07-15/S1-partial")
+    .bind(&key_id)
+    .bind(now - 10)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert partial key observation");
+
+    let batch = proxy
+        .key_store
+        .next_upstream_reconciliation_candidates(2)
+        .await
+        .expect("load candidate batch");
+    assert_eq!(batch.candidates.len(), 2);
+    assert_eq!(
+        batch.candidates[0].token_id, "token-partial-observation",
+        "a candidate with a durable partial observation must resume before a fresh candidate"
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn reconciliation_projection_micro_slices_resume() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary
- Allow the canonical Admin Alerts warm worker to use one bounded read slot instead of requiring two already-idle connections or growing the lazy pool first.
- Route canonical warm coverage, catalog facets, event pages, group pages, and mother-group hydration through the `AdminAlertsCacheWarm` operation so warm reads keep their own admission and deadline telemetry.
- Prioritize reconciliation candidates with current-generation partial key observations ahead of fresh candidates sharing the same scheduling key, allowing multi-key work to resume and converge.
- Refresh the SQLite/admin-read and reconciliation contracts and add focused regression coverage.

## Scope
- Compare reconciliation remains unchanged; no actual billing, schema, public JSON, SQLite PRAGMA, pool size, WAL, or upstream concurrency changes.
- No UI surface changed, so visual evidence is not applicable.
- No 101 deployment or production data operation was performed.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test --locked` (802 library tests, 494 main tests, integration tests, source budgets, and doc-tests)
- Focused reconciliation, Alerts prewarm, source-budget, and backend manifest tests
- `cargo clippy --locked -j 2 -- -D warnings`
- `python3 -m unittest scripts/test_ci_backend_tests.py`
- `python3 scripts/ci_backend_tests.py verify`
- `bunx --bun dprint check` on changed Markdown

## Testbox evidence
- Run ID: `20260903_0715_d17344f8_recovery_compare`; 101 core/observability snapshots were read-only backups, checksum/integrity verified, and source staging was removed.
- Baseline and candidate each ran `600s` with the same isolated stub upstream, `540s` traffic, and one scheduled app restart.
- Candidate result: `passed`; Research terminal delta `+36`, pending delta `-35`, general terminal delta `+4`, projection transaction p95 `10ms`, projection connection discards `0`.
- Candidate foreground/dashboard/maintenance HTTP 5xx `0`, final SQLite lock errors `0`, nested transaction errors `0`, billing adjustment count/sum `0`.
- The isolated testbox run and temporary containers/volumes were removed after collection.

## Delivery
- Final head: `d17344f8f560bc6c055c8fb768d762aff1c70197`
- Required CI, release build, and Compose smoke checks pass.
- No production deployment, restart, cleanup, or data write was performed.