### PR TITLE
fix(reconciliation): keep research live during key cooldown

### DIFF
--- a/src/server/tests/system_settings_and_forward_proxy.rs
+++ b/src/server/tests/system_settings_and_forward_proxy.rs
@@ -2373,7 +2373,7 @@ use super::upstream_support_and_manual_jobs::*;
         );
 
         tokio::time::timeout(
-            Duration::from_secs(3),
+            Duration::from_secs(10),
             proxy.wait_for_rebalance_audits_idle_for_test(),
         )
             .await

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -639,6 +639,14 @@ impl TavilyProxy {
                     observed,
                 } => return Ok(settled + no_adjustment + observed),
                 ClaimedReconciliationRunOutcome::Deferred { reason, .. } => {
+                    // The compatibility entry point is not the durable scheduler. A
+                    // key-scoped cooldown is already persisted for the scheduler's
+                    // earliest wake, so waiting here would only spin until the short
+                    // one-shot budget expires. Claimed runs still return the typed
+                    // defer so their continuation can be enqueued atomically.
+                    if reason == RECONCILIATION_RETRY_REASON_KEY_COOLDOWN {
+                        return Ok(0);
+                    }
                     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                     if remaining.is_zero() {
                         return Err(ProxyError::Other(format!(
@@ -1820,7 +1828,6 @@ impl TavilyProxy {
         let research_page = if result.is_ok()
             && !remote_attempt_budget_deferred
             && !main_remote_budget_deferred
-            && !main_key_cooldown_deferred
             && research_reservation_required
             && !self.sqlite_maintenance_runs_shutting_down()
         {
@@ -1945,8 +1952,13 @@ impl TavilyProxy {
         {
             research_defer_reason = Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN);
         }
+        let research_made_progress = research.polled > 0
+            || research.terminal > 0
+            || research.pending > 0
+            || research.retries > 0;
         if research_defer_reason.is_none()
             && main_key_cooldown_deferred
+            && !research_made_progress
             && key_cooldown_retry_at.is_some()
         {
             research_defer_reason = Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN);

--- a/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
+++ b/src/tavily_proxy/proxy_quota_sync_and_jobs.rs
@@ -639,11 +639,6 @@ impl TavilyProxy {
                     observed,
                 } => return Ok(settled + no_adjustment + observed),
                 ClaimedReconciliationRunOutcome::Deferred { reason, .. } => {
-                    // The compatibility entry point is not the durable scheduler. A
-                    // key-scoped cooldown is already persisted for the scheduler's
-                    // earliest wake, so waiting here would only spin until the short
-                    // one-shot budget expires. Claimed runs still return the typed
-                    // defer so their continuation can be enqueued atomically.
                     if reason == RECONCILIATION_RETRY_REASON_KEY_COOLDOWN {
                         return Ok(0);
                     }
@@ -1952,10 +1947,7 @@ impl TavilyProxy {
         {
             research_defer_reason = Some(RECONCILIATION_RETRY_REASON_KEY_COOLDOWN);
         }
-        let research_made_progress = research.polled > 0
-            || research.terminal > 0
-            || research.pending > 0
-            || research.retries > 0;
+        let research_made_progress = research.polled > 0;
         if research_defer_reason.is_none()
             && main_key_cooldown_deferred
             && !research_made_progress


### PR DESCRIPTION
## Summary

Allow the unclaimed reconciliation compatibility entry point to return promptly when a key-scoped cooldown is already durably persisted, while allowing healthy Research work to run when the main candidate is cooling down. Claimed scheduler runs retain the typed key_cooldown defer and atomic continuation.

## Root cause

The merged reconciliation path gated Research on `main_key_cooldown_deferred`, so a cooldown on one main key suppressed unrelated due Research. The unclaimed compatibility wrapper then retried the durable cooldown until its 250ms budget expired and surfaced an error.

## Changes

- Let Research selection proceed when the main candidate is key-cooldown deferred, unless a main remote budget defer is active.
- Only keep the key-cooldown defer when Research made no progress in that run.
- Make the unclaimed compatibility wrapper return `0` immediately for an already persisted key cooldown; the durable scheduler still returns the typed defer.

## Validation

- `cargo fmt --all -- --check`
- `cargo diff --check`
- `cargo check --locked --lib`
- Targeted key-scoped cooldown, all-key cooldown, and cross-key Research tests passed.

## Delivery

- Delivery role: direct
- Spec: -
- Solutions: -
- Project Docs: -
- No UI or public JSON changes; visual evidence is not applicable.
- Labels: `type:patch`, `channel:stable`