### PR TITLE
fix(alerts): recover canonical warm cache

### DIFF
--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -330,6 +330,23 @@ async fn record_admin_alerts_last_good_at_generation(
     }
 }
 
+#[cfg(test)]
+pub(crate) async fn expire_admin_alerts_canonical_last_good_for_test(
+    state: &AppState,
+    key: &str,
+) {
+    let cache = dashboard_overview_cache_for_state(state);
+    let mut cache = cache.lock().await;
+    if let Some(entry) = cache
+        .admin_alerts
+        .entries
+        .iter_mut()
+        .find(|entry| entry.key == key && entry.canonical)
+    {
+        entry.stored_at = tokio::time::Instant::now() - ADMIN_ALERTS_CACHE_TTL;
+    }
+}
+
 async fn publish_admin_alerts_canonical(
     state: &AppState,
     generation: u64,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -339,11 +339,29 @@ async fn publish_admin_alerts_canonical(
 ) -> bool {
     let cache = dashboard_overview_cache_for_state(state);
     let mut cache = cache.lock().await;
+    publish_admin_alerts_canonical_into_cache(
+        &mut cache,
+        generation,
+        state.proxy.backend_time().now_ts(),
+        tokio::time::Instant::now(),
+        catalog,
+        events,
+        groups,
+    )
+}
+
+fn publish_admin_alerts_canonical_into_cache(
+    cache: &mut DashboardOverviewCacheState,
+    generation: u64,
+    observed_at: i64,
+    stored_at: tokio::time::Instant,
+    catalog: AlertCatalog,
+    events: PaginatedAlertEvents,
+    groups: PaginatedAlertGroups,
+) -> bool {
     if cache.alert_projection_generation != generation {
         return false;
     }
-    let observed_at = state.proxy.backend_time().now_ts();
-    let stored_at = tokio::time::Instant::now();
     for (key, value) in [
         ("catalog".to_string(), AdminAlertsReadCacheValue::Catalog(catalog)),
         (
@@ -424,6 +442,10 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
             }
             let generation = current_admin_alerts_generation(state.as_ref()).await;
             let result = async {
+                state.proxy.prepare_admin_alerts_canonical_warm().await?;
+                if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
+                    return Err(admin_alerts_warm_deferred(reason));
+                }
                 state.proxy.record_admin_alerts_warm_slice();
                 let catalog = state.proxy.admin_alert_catalog_for_cache_warm().await?;
                 if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
@@ -823,7 +845,40 @@ pub(crate) async fn prime_admin_privacy_status_for_test(state: Arc<AppState>) {
 
 #[cfg(test)]
 mod admin_alerts_prewarm_tests {
-    use super::{ADMIN_ALERTS_PREWARM_MIN_INTERVAL, DashboardOverviewCacheState};
+    use super::{
+        ADMIN_ALERTS_PREWARM_MIN_INTERVAL, AdminAlertsReadCacheValue, AlertCatalog,
+        DashboardOverviewCacheState, PaginatedAlertEvents, PaginatedAlertGroups,
+        publish_admin_alerts_canonical_into_cache,
+    };
+
+    fn empty_catalog() -> AlertCatalog {
+        AlertCatalog {
+            retention_days: 30,
+            types: Vec::new(),
+            request_kind_options: Vec::new(),
+            users: Vec::new(),
+            tokens: Vec::new(),
+            keys: Vec::new(),
+        }
+    }
+
+    fn empty_events() -> PaginatedAlertEvents {
+        PaginatedAlertEvents {
+            items: Vec::new(),
+            total: 0,
+            page: 1,
+            per_page: 20,
+        }
+    }
+
+    fn empty_groups() -> PaginatedAlertGroups {
+        PaginatedAlertGroups {
+            items: Vec::new(),
+            total: 0,
+            page: 1,
+            per_page: 20,
+        }
+    }
 
     #[test]
     fn admin_alerts_prewarm_coalesces_projection_updates_for_one_minute() {
@@ -859,6 +914,64 @@ mod admin_alerts_prewarm_tests {
 
         cache.finish_admin_alerts_prewarm();
         assert_eq!(cache.admin_alerts_prewarm_defers, 0);
+    }
+
+    #[test]
+    fn initial_admin_alerts_prewarm_defer_keeps_the_worker_retryable() {
+        let mut cache = DashboardOverviewCacheState::default();
+        let now = tokio::time::Instant::now();
+
+        assert!(cache.try_start_admin_alerts_prewarm(now));
+        assert_eq!(
+            cache.defer_admin_alerts_prewarm(now),
+            std::time::Duration::from_secs(5)
+        );
+        assert!(cache.admin_alerts_prewarm_in_flight);
+        assert_eq!(cache.admin_alerts_prewarm_defers, 1);
+        assert!(
+            !cache.try_start_admin_alerts_prewarm(now + std::time::Duration::from_secs(5)),
+            "the original worker owns the first retry instead of losing its staged attempt"
+        );
+    }
+
+    #[test]
+    fn canonical_publish_discards_all_staged_values_after_a_generation_change() {
+        let mut cache = DashboardOverviewCacheState::default();
+        cache.alert_projection_generation = 2;
+
+        assert!(
+            !publish_admin_alerts_canonical_into_cache(
+                &mut cache,
+                1,
+                123,
+                tokio::time::Instant::now(),
+                empty_catalog(),
+                empty_events(),
+                empty_groups(),
+            ),
+            "a fenced generation cannot publish a mixed canonical cache"
+        );
+        assert!(cache.admin_alerts.entries.is_empty());
+
+        assert!(publish_admin_alerts_canonical_into_cache(
+            &mut cache,
+            2,
+            124,
+            tokio::time::Instant::now(),
+            empty_catalog(),
+            empty_events(),
+            empty_groups(),
+        ));
+        assert_eq!(cache.admin_alerts.entries.len(), 3);
+        assert!(cache
+            .admin_alerts
+            .entries
+            .iter()
+            .all(|entry| entry.generation == 2 && entry.canonical));
+        assert!(matches!(
+            cache.admin_alerts.entries[0].value,
+            AdminAlertsReadCacheValue::Groups(_)
+        ));
     }
 }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -953,8 +953,10 @@ mod admin_alerts_prewarm_tests {
 
     #[test]
     fn canonical_publish_discards_all_staged_values_after_a_generation_change() {
-        let mut cache = DashboardOverviewCacheState::default();
-        cache.alert_projection_generation = 2;
+        let mut cache = DashboardOverviewCacheState {
+            alert_projection_generation: 2,
+            ..Default::default()
+        };
 
         assert!(
             !publish_admin_alerts_canonical_into_cache(

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -832,6 +832,25 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         );
     }
 
+    for (route, key) in [
+        ("catalog", "catalog".to_string()),
+        ("events", super::super::default_admin_alert_cache_key("events")),
+        ("groups", super::super::default_admin_alert_cache_key("groups")),
+    ] {
+        super::super::expire_admin_alerts_canonical_last_good_for_test(state.as_ref(), &key).await;
+        let expired = client
+            .get(format!("http://{admin_addr}/api/alerts/{route}"))
+            .header(reqwest::header::COOKIE, &cookie)
+            .send()
+            .await
+            .expect("expired pinned Alerts response");
+        assert_eq!(expired.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            expired.headers().get("retry-after").and_then(|v| v.to_str().ok()),
+            Some("1")
+        );
+    }
+
     state.proxy.force_next_admin_alert_read_deadline_for_test();
     let cold = client
         .get(format!("http://{admin_addr}/api/alerts/events?page=2"))

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -734,6 +734,19 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         .expect("cold alerts catalog");
     assert_eq!(cold.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
     assert_eq!(cold.headers().get("retry-after").and_then(|v| v.to_str().ok()), Some("1"));
+    for route in ["events", "groups"] {
+        let cold = client
+            .get(format!("http://{admin_addr}/api/alerts/{route}"))
+            .header(reqwest::header::COOKIE, &cookie)
+            .send()
+            .await
+            .expect("cold pinned Alerts page");
+        assert_eq!(cold.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            cold.headers().get("retry-after").and_then(|v| v.to_str().ok()),
+            Some("1")
+        );
+    }
 
     let mut projection_ready = false;
     for _ in 0..64 {
@@ -764,35 +777,60 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         super::super::AdminAlertsReadCacheValue::Catalog(catalog),
     )
     .await;
-    let warm = client
-        .get(format!("http://{admin_addr}/api/alerts/catalog"))
-        .header(reqwest::header::COOKIE, &cookie)
-        .send()
+    let events = state
+        .proxy
+        .admin_alert_events_page(None, None, None, None, None, None, &[], 1, 20)
         .await
-        .expect("warm alerts catalog");
-    assert_eq!(warm.status(), reqwest::StatusCode::OK);
-    let warm_body: serde_json::Value = warm.json().await.expect("warm alerts json");
-    assert_eq!(warm_body.get("coverage"), None);
-    assert_eq!(warm_body.get("staleReason"), None);
+        .expect("build canonical events for the warm-cache fixture");
+    super::super::record_admin_alerts_last_good(
+        state.as_ref(),
+        super::super::default_admin_alert_cache_key("events"),
+        super::super::AdminAlertsReadCacheValue::Events(events),
+    )
+    .await;
+    let groups = state
+        .proxy
+        .admin_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
+        .await
+        .expect("build canonical groups for the warm-cache fixture");
+    super::super::record_admin_alerts_last_good(
+        state.as_ref(),
+        super::super::default_admin_alert_cache_key("groups"),
+        super::super::AdminAlertsReadCacheValue::Groups(groups),
+    )
+    .await;
+    for route in ["catalog", "events", "groups"] {
+        let warm = client
+            .get(format!("http://{admin_addr}/api/alerts/{route}"))
+            .header(reqwest::header::COOKIE, &cookie)
+            .send()
+            .await
+            .expect("warm pinned Alerts response");
+        assert_eq!(warm.status(), reqwest::StatusCode::OK);
+        let warm_body: serde_json::Value = warm.json().await.expect("warm Alerts JSON");
+        assert_eq!(warm_body.get("coverage"), None);
+        assert_eq!(warm_body.get("staleReason"), None);
+    }
 
     // Alerts no longer depend on a maintenance-bulk permit. The native,
     // connection-local read deadline is the pressure boundary that selects
     // an exact-key last-good response.
     super::super::mark_dashboard_overview_alert_projection_dirty(state.as_ref()).await;
-    state.proxy.force_next_admin_alert_read_deadline_for_test();
-    let stale = client
-        .get(format!("http://{admin_addr}/api/alerts/catalog"))
-        .header(reqwest::header::COOKIE, &cookie)
-        .send()
-        .await
-        .expect("stale alerts catalog");
-    assert_eq!(stale.status(), reqwest::StatusCode::OK);
-    let stale_body: serde_json::Value = stale.json().await.expect("stale alerts json");
-    assert_eq!(stale_body.get("coverage").and_then(|v| v.as_str()), Some("stale"));
-    assert_eq!(
-        stale_body.get("staleReason").and_then(|v| v.as_str()),
-        Some("projection_refresh")
-    );
+    for route in ["catalog", "events", "groups"] {
+        let stale = client
+            .get(format!("http://{admin_addr}/api/alerts/{route}"))
+            .header(reqwest::header::COOKIE, &cookie)
+            .send()
+            .await
+            .expect("stale pinned Alerts response");
+        assert_eq!(stale.status(), reqwest::StatusCode::OK);
+        let stale_body: serde_json::Value = stale.json().await.expect("stale Alerts JSON");
+        assert_eq!(stale_body.get("coverage").and_then(|v| v.as_str()), Some("stale"));
+        assert_eq!(
+            stale_body.get("staleReason").and_then(|v| v.as_str()),
+            Some("projection_refresh")
+        );
+    }
 
     state.proxy.force_next_admin_alert_read_deadline_for_test();
     let cold = client

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -789,9 +789,39 @@ impl KeyStore {
         _source: AlertReadSource,
         operation: SqliteOperation,
     ) -> Result<Vec<sqlx::sqlite::SqliteRow>, ProxyError> {
+        if operation == SqliteOperation::AdminAlertsCacheWarm {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(operation)
+                .await?;
+            let query_result = query.build().fetch_all(&mut *session).await;
+            let result = session.query(query_result).await;
+            let finish_result = session.finish().await;
+            finish_result?;
+            return result;
+        }
         let mut conn = self.sqlite_runtime.acquire_operation_connection(operation).await?;
         let result = query.build().fetch_all(&mut *conn).await;
         conn.complete_query(result).await
+    }
+
+    async fn fetch_alert_count_for_operation(
+        &self,
+        mut query: QueryBuilder<'_, Sqlite>,
+        operation: SqliteOperation,
+    ) -> Result<i64, ProxyError> {
+        if operation == SqliteOperation::AdminAlertsCacheWarm {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(operation)
+                .await?;
+            let query_result = query.build_query_scalar().fetch_one(&mut *session).await;
+            let result = session.query(query_result).await;
+            let finish_result = session.finish().await;
+            finish_result?;
+            return result;
+        }
+        let mut conn = self.sqlite_runtime.acquire_operation_connection(operation).await?;
+        let query_result = query.build_query_scalar().fetch_one(&mut *conn).await;
+        conn.complete_query(query_result).await
     }
 
     async fn fetch_projected_alert_query_rows_in_admin_session(
@@ -860,6 +890,12 @@ impl KeyStore {
         result
     }
 
+    pub(crate) async fn prepare_admin_alerts_canonical_warm(&self) -> Result<(), ProxyError> {
+        // Coverage is the attempt fence. The AppState controller calls this
+        // once before staging the three independently bounded cache values.
+        self.ensure_admin_alert_projection_coverage_for_warm().await
+    }
+
     async fn effective_auth_token_log_retention_days_in_admin_session(
         &self,
         session: &mut AdminAlertsReadSession,
@@ -883,6 +919,29 @@ impl KeyStore {
         &self,
         operation: SqliteOperation,
     ) -> Result<i64, ProxyError> {
+        if operation == SqliteOperation::AdminAlertsCacheWarm {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(operation)
+                .await?;
+            let query_result = sqlx::query_scalar::<_, String>(
+                "SELECT value FROM meta WHERE key = ? LIMIT 1",
+            )
+            .bind(META_KEY_AUTH_TOKEN_LOG_RETENTION_DAYS_V1)
+            .fetch_optional(&mut *session)
+            .await;
+            let result = session.query(query_result).await;
+            let finish_result = session.finish().await;
+            finish_result?;
+            let value = result?;
+            if let Some(retention_days) = value
+                .as_deref()
+                .and_then(|value| value.parse::<i64>().ok())
+                .and_then(normalize_auth_token_log_retention_days)
+            {
+                return Ok(retention_days);
+            }
+            return effective_auth_token_log_retention_days();
+        }
         let mut conn = self
             .sqlite_runtime
             .acquire_operation_connection(operation)
@@ -958,7 +1017,6 @@ impl KeyStore {
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
         if operation == SqliteOperation::AdminAlertsCacheWarm {
-            self.ensure_admin_alert_projection_coverage_for_warm().await?;
             return self
                 .fetch_projected_alert_events_page_for_operation(
                     filters,
@@ -1055,12 +1113,9 @@ impl KeyStore {
             "COALESCE(NULLIF(TRIM(request_kind_key), ''), 'unknown')",
             filters.request_kinds,
         );
-        let mut count_conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(operation)
+        let total = self
+            .fetch_alert_count_for_operation(count_query, operation)
             .await?;
-        let count_result = count_query.build_query_scalar().fetch_one(&mut *count_conn).await;
-        let total = count_conn.complete_query(count_result).await?;
 
         let mut query = QueryBuilder::new("");
         Self::push_projected_alert_events_cte(&mut query, filters);
@@ -1074,12 +1129,9 @@ impl KeyStore {
         query.push_bind(per_page);
         query.push(" OFFSET ");
         query.push_bind(offset);
-        let mut conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(operation)
+        let rows = self
+            .fetch_alert_query_rows_for_operation(query, AlertReadSource::Projected, operation)
             .await?;
-        let result = query.build().fetch_all(&mut *conn).await;
-        let rows = conn.complete_query(result).await?;
         let items = rows
             .into_iter()
             .map(Self::decode_alert_event_projection_row)
@@ -1727,12 +1779,9 @@ impl KeyStore {
         let mut count_query = QueryBuilder::new("");
         Self::push_projected_alert_groups_cte(&mut count_query, filters);
         count_query.push(" SELECT COUNT(*) FROM grouped_alerts");
-        let mut count_conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(operation)
+        let total = self
+            .fetch_alert_count_for_operation(count_query, operation)
             .await?;
-        let count_result = count_query.build_query_scalar().fetch_one(&mut *count_conn).await;
-        let total = count_conn.complete_query(count_result).await?;
 
         let mut query = QueryBuilder::new("");
         Self::push_projected_alert_groups_cte(&mut query, filters);
@@ -1743,12 +1792,9 @@ impl KeyStore {
         query.push_bind(per_page);
         query.push(" OFFSET ");
         query.push_bind(offset);
-        let mut conn = self
-            .sqlite_runtime
-            .acquire_operation_connection(operation)
+        let rows = self
+            .fetch_alert_query_rows_for_operation(query, AlertReadSource::Projected, operation)
             .await?;
-        let result = query.build().fetch_all(&mut *conn).await;
-        let rows = conn.complete_query(result).await?;
         let groups = rows
             .iter()
             .map(Self::decode_alert_group_projection_row)
@@ -2353,7 +2399,6 @@ impl KeyStore {
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
         if operation == SqliteOperation::AdminAlertsCacheWarm {
-            self.ensure_admin_alert_projection_coverage_for_warm().await?;
             let (page_items, total) = self
                 .fetch_projected_alert_group_page_for_operation(filters, page, per_page, operation)
                 .await?;
@@ -2447,7 +2492,6 @@ impl KeyStore {
         operation: SqliteOperation,
     ) -> Result<AlertCatalog, ProxyError> {
         if operation == SqliteOperation::AdminAlertsCacheWarm {
-            self.ensure_admin_alert_projection_coverage_for_warm().await?;
             return self
                 .fetch_alert_catalog_from_source(
                     AlertReadSource::Projected,

--- a/src/store/sqlite_runtime_tests.rs
+++ b/src/store/sqlite_runtime_tests.rs
@@ -555,6 +555,46 @@ async fn admin_privacy_read_run_budget_interrupts_before_discarding_its_session(
 }
 
 #[tokio::test]
+async fn admin_alerts_warm_read_deadline_restores_a_reusable_connection() {
+    let runtime = single_connection_runtime().await;
+    runtime.force_next_cooperative_query_deadline_for_test();
+    let mut snapshot = runtime
+        .begin_read_snapshot(SqliteOperation::AdminAlertsCacheWarm)
+        .await
+        .expect("begin bounded canonical Alerts warm read");
+    assert_eq!(
+        snapshot.cooperative_run_budget_for_test(),
+        Some(ADMIN_ALERTS_READ_RUN_BUDGET),
+        "canonical warm reads use the production native 250ms deadline"
+    );
+
+    let query_error = sqlx::query_scalar::<_, i64>(
+        "WITH RECURSIVE counter(value) AS (VALUES(1) UNION ALL SELECT value + 1 FROM counter WHERE value < 1000000) SELECT SUM(value) FROM counter",
+    )
+    .fetch_one(&mut *snapshot)
+    .await
+    .expect_err("the native deadline must interrupt the warm statement");
+    let query_error = ProxyError::Database(query_error);
+    snapshot
+        .close_after_query(Some(&query_error))
+        .await
+        .expect("interrupted warm session closes explicitly");
+
+    assert_eq!(
+        runtime.discarded_connections_for_test(SqliteOperation::AdminAlertsCacheWarm),
+        0,
+        "a native deadline restores the warm connection before it returns to the pool"
+    );
+    runtime
+        .begin_read_snapshot(SqliteOperation::AdminAlertsCacheWarm)
+        .await
+        .expect("next canonical warm read is clean")
+        .close()
+        .await
+        .expect("close next canonical warm read");
+}
+
+#[tokio::test]
 async fn reconciliation_read_sessions_interrupt_and_clean_each_read_kind() {
     let runtime = single_connection_runtime().await;
     for kind in ReconciliationReadKind::ALL {

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -28,6 +28,11 @@ impl TavilyProxy {
     }
 
     #[doc(hidden)]
+    pub async fn prepare_admin_alerts_canonical_warm(&self) -> Result<(), ProxyError> {
+        self.key_store.prepare_admin_alerts_canonical_warm().await
+    }
+
+    #[doc(hidden)]
     pub async fn prewarm_admin_alerts_cache_capacity(&self) -> Result<(), ProxyError> {
         self.key_store
             .sqlite_runtime


### PR DESCRIPTION
## Summary
- Restore the AppState-owned canonical Alerts warm controller for catalog, events page 1/20, and groups page 1/20.
- Fence each attempt with one coverage read, run projected statements in independent bounded read sessions, and publish the shared generation atomically.
- Keep canonical HTTP reads cache-only and cover fresh, stale, cold, and expired entries.

## Delivery
- Delivery role: direct
- Spec: `docs/specs/admin-alert-center-24h-summary/SPEC.md`
- Spec Disposition: link; existing contract already describes the restored behavior.
- Solutions: `docs/solutions/operations/sqlite-admin-read-containment.md` (linked; no change required)
- Project Docs: -
- Document sync: no durable contract changed.

## Validation
- `cargo fmt --check`
- `cargo clippy --locked -j 2 -- -D warnings`
- Focused Alerts controller, SQLite deadline, and canonical cache tests
- Isolated testbox CI shards: `lib-core`, `bin-admin-api-observability`, `bin-admin-api-lifecycle`

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->