### PR TITLE
fix(reconciliation): preserve multi-key observation generations

### DIFF
--- a/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
+++ b/docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md
@@ -47,18 +47,15 @@ scope only; the existing `period_reconciliation` 429 cooldown remains independen
 transitions are claim-fenced and keep raw upstream details out of durable observations.
 
 For a period that maps to more than one eligible upstream key, persist each successful key observation
-by work generation before requesting another key. Cap each run at two remote requests. If keys remain,
-write `remote_attempt_budget` and schedule one durable 30-second continuation; do not write a semantic
-failure or terminal result. Sum usage and enter the existing compare/active terminal path only after
-all current-generation key observations are present. Delete the local observations atomically with
-terminal completion, and fence both observation writes and reads by claim generation.
-
-For a period that maps to more than one eligible upstream key, persist each successful key observation
-by work generation before requesting another key. Cap each run at two remote requests. If keys remain,
-write `remote_attempt_budget` and schedule one durable 30-second continuation; do not write a semantic
-failure or terminal result. Sum usage and enter the existing compare/active terminal path only after
-all current-generation key observations are present. Delete the local observations atomically with
-terminal completion, and fence both observation writes and reads by claim generation.
+by work generation before requesting another key. Advance that generation only for a logical usage
+revision or current Key-set change: storage replay, timestamp refresh, and an equal logical payload
+must retain partial observations. Read missing keys in deterministic order and cap each main run at two
+remote requests. If keys remain, write `remote_attempt_budget` and use the current claim to create or
+reuse one durable 30-second continuation; this must not write a semantic failure, transport or 429
+state, local-pressure state, or billing truth. Sum usage and enter the existing compare/active terminal
+path only after all current-generation key observations are present. Delete local observations
+atomically only with terminal completion, and fence both observation writes and continuations by claim
+generation.
 
 ## Activation controller
 

--- a/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md
@@ -72,16 +72,14 @@
   acceptance window is ten minutes: terminal rate must become positive while pending Research does
   not grow. `upstream429` remains a rate-limited settlement bucket and is not evidence of Research
   convergence or non-convergence.
-- Multi-key candidate observation is durable across runs. Successful key responses are stored by
-  `(token_id, period_code, work_generation, key_id)` in a local derived table; each run fills at most
-  two missing keys and records `remote_attempt_budget` for a 30-second continuation until the full
-  key set is present. Only then can the existing compare/active settlement path terminalize the work;
-  terminal completion removes the local rows without creating HA outbox events.
-- Multi-key candidate observation is durable across runs. Successful key responses are stored by
-  `(token_id, period_code, work_generation, key_id)` in a local derived table; each run fills at most
-  two missing keys and records `remote_attempt_budget` for a 30-second continuation until the full
-  key set is present. Only then can the existing compare/active settlement path terminalize the work;
-  terminal completion removes the local rows without creating HA outbox events.
+- Multi-key candidate observation is durable across runs and restarts. Successful key responses are
+  stored by `(token_id, period_code, work_generation, key_id)` in a local derived table; source
+  generation advances only for a logical usage revision or current Key-set change, so storage replay,
+  timestamp refresh, and equal logical payloads retain partial observations. Each run fills at most two
+  missing keys in deterministic order and records `remote_attempt_budget` for one claim-fenced
+  30-second continuation until the full current-generation key set is present. Only then can the
+  existing compare/active settlement path terminalize the work; terminal completion removes the local
+  rows without creating HA outbox events or changing compare billing truth.
 
 ## Remaining Gaps
 

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -91,9 +91,11 @@
   usage advances stable `(token_id, key_id, period_code)` keyset micro-slices only when no durable
   candidate is ready. A slice reads at most `25..100` rows outside the write transaction, then
   atomically merges work and advances its claim-fenced cursor in one short transaction. Candidate
-  selection never aggregates raw usage. New usage is maintained by write triggers, and a usage
-  update after terminal settlement reopens that generation without reviving a completed
-  no-adjustment period through the legacy cursor.
+  selection never aggregates raw usage. New usage is maintained by write triggers: only a logical
+  usage revision or a current upstream-Key-set change opens a new work generation. Storage-only
+  import/replay, timestamp refresh, and equal logical source payloads leave the generation and its
+  partial observations intact; a logical source revision after terminal settlement opens exactly
+  one new generation without reviving a completed no-adjustment period through the legacy cursor.
 - Reconciliation budgets are cooperative boundaries, not cancellation timers. Foreground pressure,
   SQLite contention, and the 20-second run deadline prevent the next safe phase from starting; they
   never cancel an open transaction. An unfinished projection persists a typed continuation and
@@ -163,16 +165,10 @@
   observation are selected before fresh candidates sharing the same scheduling Key so the partial
   set can converge. A partial observation never becomes a semantic failure or terminal result.
   Terminal completion clears these node-local rows, and generation or claim fencing ignores stale
-  observations. The observation table is derived state, not HA outbox truth.
-- When one candidate maps to multiple eligible upstream keys, persist each successful `/usage`
-  response as a local observation keyed by `(token_id, period_code, work_generation, key_id)`. Each
-  run requests at most two missing keys and returns `remote_attempt_budget` with a 30-second
-  continuation while the set is incomplete. Sum usage and enter the existing compare/active terminal
-  path only after all current-generation keys are observed; candidates with an existing partial
-  observation are selected before fresh candidates sharing the same scheduling Key so the partial set
-  can converge. A partial observation never becomes a semantic failure or terminal result. Terminal
-  completion clears these node-local rows, and generation or claim fencing ignores stale observations.
-  The observation table is derived state, not HA outbox truth.
+  observations. A claimed `remote_attempt_budget` defer atomically finishes only its current claim
+  and leaves exactly one 30-second auto continuation; it changes neither billing truth nor
+  semantic, transport, upstream-429, or local-pressure state. The observation table is derived
+  state, not HA outbox truth.
 - 状态页使用门禁清单和 `n/m`，同时覆盖 loading、empty、error 与 degraded 状态。
 
 ## 功能与行为规格（Functional/Behavior Spec）

--- a/src/store/key_store_reconciliation_key_observations.rs
+++ b/src/store/key_store_reconciliation_key_observations.rs
@@ -85,18 +85,9 @@ impl KeyStore {
             tx.rollback().await?;
             return Ok(ReconciliationKeyObservationPersistOutcome::StaleClaim);
         }
-        // A new usage generation must never reuse a previous generation's
-        // local observations. Stale rows are rebuildable and are removed only
-        // after the current claim/generation fence has been acquired.
-        sqlx::query(
-            "DELETE FROM upstream_reconciliation_key_observations \
-             WHERE token_id = ? AND period_code = ? AND work_generation <> ?",
-        )
-        .bind(&candidate.token_id)
-        .bind(&candidate.period_code)
-        .bind(work_generation)
-        .execute(&mut *tx)
-        .await?;
+        // Reads are generation-scoped, so a newer source revision cannot reuse
+        // these rows. Retain obsolete observations until terminal completion so
+        // a claim-fenced source change never discards durable partial state.
         for observation in observations {
             sqlx::query(
                 r#"INSERT INTO upstream_reconciliation_key_observations (

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -97,6 +97,11 @@ const RECONCILIATION_POLL_RESOLUTION_VERSION: i64 = 24;
 const RECONCILIATION_POLL_RESOLUTION_NAME: &str = "reconciliation-research-poll-resolution-v1";
 const RECONCILIATION_POLL_RESOLUTION_CHECKSUM: &str =
     "sha256:7f8e9d0c1b2a3948576e5d4c3b2a1908";
+const RECONCILIATION_SOURCE_REVISION_VERSION: i64 = 25;
+const RECONCILIATION_SOURCE_REVISION_NAME: &str =
+    "reconciliation-logical-source-revision-v1";
+const RECONCILIATION_SOURCE_REVISION_CHECKSUM: &str =
+    "sha256:7c9f1d5e0b4a8d2c6e3f9a1b5d7c2e4f";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -814,6 +819,11 @@ impl KeyStore {
                 RECONCILIATION_POLL_RESOLUTION_NAME,
                 RECONCILIATION_POLL_RESOLUTION_CHECKSUM,
             ),
+            (
+                RECONCILIATION_SOURCE_REVISION_VERSION,
+                RECONCILIATION_SOURCE_REVISION_NAME,
+                RECONCILIATION_SOURCE_REVISION_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -1153,6 +1163,28 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 4".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_SOURCE_REVISION_VERSION)
+            .await?
+            && (!self
+                .schema_named_object_exists(
+                    "main",
+                    "trigger",
+                    "trg_upstream_reconciliation_usage_work_insert",
+                )
+                .await?
+                || !self
+                    .schema_named_object_exists(
+                        "main",
+                        "trigger",
+                        "trg_upstream_reconciliation_usage_work_update",
+                    )
+                    .await?)
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 25".to_string(),
             ));
         }
         Ok(())
@@ -1842,6 +1874,62 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_source_revision_migration(&self) -> Result<(), ProxyError> {
+        sqlx::query("DROP TRIGGER IF EXISTS trg_upstream_reconciliation_usage_work_update")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query(
+            r#"CREATE TRIGGER IF NOT EXISTS trg_upstream_reconciliation_usage_work_update
+               AFTER UPDATE ON upstream_reconciliation_usage
+               WHEN NEW.token_id IS NOT OLD.token_id
+                 OR NEW.key_id IS NOT OLD.key_id
+                 OR NEW.period_code IS NOT OLD.period_code
+                 OR NEW.project_id IS NOT OLD.project_id
+                 OR NEW.billing_subject IS NOT OLD.billing_subject
+                 OR NEW.settlement_mode IS NOT OLD.settlement_mode
+                 OR NEW.period_start IS NOT OLD.period_start
+                 OR NEW.period_end IS NOT OLD.period_end
+                 OR NEW.request_count IS NOT OLD.request_count
+               BEGIN
+                 INSERT INTO upstream_reconciliation_work (
+                   token_id, period_code, project_id, billing_subject, settlement_mode,
+                   period_start, period_end, scheduling_key_id, updated_at,
+                   work_generation, completed_generation, next_attempt_at, last_outcome
+                 ) VALUES (
+                   NEW.token_id, NEW.period_code, NEW.project_id, NEW.billing_subject,
+                   NEW.settlement_mode, NEW.period_start, NEW.period_end, NEW.key_id, NEW.updated_at,
+                   1, 0, 0, NULL
+                 )
+                 ON CONFLICT(token_id, period_code) DO UPDATE SET
+                   project_id = MIN(upstream_reconciliation_work.project_id, excluded.project_id),
+                   billing_subject = MIN(upstream_reconciliation_work.billing_subject, excluded.billing_subject),
+                   settlement_mode = MIN(upstream_reconciliation_work.settlement_mode, excluded.settlement_mode),
+                   period_start = MIN(upstream_reconciliation_work.period_start, excluded.period_start),
+                   period_end = MAX(upstream_reconciliation_work.period_end, excluded.period_end),
+                   scheduling_key_id = MIN(upstream_reconciliation_work.scheduling_key_id, excluded.scheduling_key_id),
+                   updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+                   work_generation = upstream_reconciliation_work.work_generation + 1,
+                   next_attempt_at = 0,
+                   last_outcome = NULL;
+
+                 UPDATE upstream_reconciliation_work
+                    SET work_generation = work_generation + 1,
+                        next_attempt_at = 0,
+                        last_outcome = NULL
+                  WHERE (OLD.token_id IS NOT NEW.token_id OR OLD.period_code IS NOT NEW.period_code)
+                    AND token_id = OLD.token_id AND period_code = OLD.period_code;
+               END"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_SOURCE_REVISION_VERSION,
+            RECONCILIATION_SOURCE_REVISION_NAME,
+            RECONCILIATION_SOURCE_REVISION_CHECKSUM,
+        )
+        .await
+    }
+
     async fn apply_reconciliation_key_observation_migration(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_key_observations (
@@ -2365,6 +2453,12 @@ impl KeyStore {
         {
             self.apply_reconciliation_poll_resolution_migration().await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_SOURCE_REVISION_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_source_revision_migration().await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2424,6 +2518,7 @@ impl KeyStore {
         self.apply_reconciliation_observation_metrics_migration()
             .await?;
         self.apply_reconciliation_poll_resolution_migration().await?;
+        self.apply_reconciliation_source_revision_migration().await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2431,7 +2526,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 24_i64,
+            migration_count = 25_i64,
         );
         Ok(())
     }

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -32,8 +32,18 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25,
         ]
     );
+    let source_revision_triggers: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name IN (\
+         'trg_upstream_reconciliation_usage_work_insert', \
+         'trg_upstream_reconciliation_usage_work_update')",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read reconciliation source-revision triggers");
+    assert_eq!(source_revision_triggers, 2);
     let transport_observation_column: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pragma_table_info('upstream_reconciliation_run_observation') WHERE name = 'last_transport_kind'",
     )
@@ -970,7 +980,8 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
     assert_eq!(
         versions,
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25,
         ]
     );
 

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -258,8 +258,20 @@ async fn remote_attempt_budget_defer_does_not_raise_local_pressure() {
     .execute(&proxy.key_store.pool)
     .await
     .expect("seed local backoff state");
+    sqlx::query(
+        r#"UPDATE upstream_reconciliation_run_observation
+              SET upstream_429_count = 6,
+                  transport_failure_count = 5,
+                  semantic_failure_count = 4,
+                  local_pressure_count = 3,
+                  last_transport_kind = 'timeout'
+            WHERE id = 'local'"#,
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed unrelated retry state");
 
-    proxy
+    let continuation = proxy
         .finalize_deferred_upstream_reconciliation_claim(
             claim.id,
             claim.claim_generation,
@@ -268,6 +280,7 @@ async fn remote_attempt_budget_defer_does_not_raise_local_pressure() {
         )
         .await
         .expect("persist remote-attempt budget continuation");
+    assert!(continuation.created);
 
     let local_backoff: Vec<(String, String)> = sqlx::query_as(
         "SELECT key, value FROM meta WHERE key IN ('upstream_reconciliation_local_pressure_streak_v1', 'upstream_reconciliation_local_backoff_level_v1') ORDER BY key",
@@ -302,6 +315,44 @@ async fn remote_attempt_budget_defer_does_not_raise_local_pressure() {
         Some(RECONCILIATION_OUTCOME_REMOTE_ATTEMPT_BUDGET)
     );
     assert_eq!(observation.next_retry_at, Some(now + 30));
+    assert_eq!(observation.upstream_429, 6);
+    assert_eq!(observation.transport_failure, 5);
+    assert_eq!(observation.semantic_failure, 4);
+    assert_eq!(observation.local_pressure, 3);
+    assert_eq!(observation.last_transport_kind.as_deref(), Some("timeout"));
+    let active_continuations: (i64, i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), MIN(available_at), MAX(available_at) FROM scheduled_jobs \
+         WHERE job_type = 'upstream_reconciliation' AND status IN ('queued', 'running')",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read remote-attempt continuation");
+    assert_eq!(active_continuations, (1, now + 30, now + 30));
+    assert!(matches!(
+        proxy
+            .finalize_deferred_upstream_reconciliation_claim(
+                claim.id,
+                claim.claim_generation,
+                RECONCILIATION_RETRY_REASON_REMOTE_ATTEMPT_BUDGET,
+                now + 30,
+            )
+            .await,
+        Err(ProxyError::StaleClaim { .. })
+    ));
+    let duplicate_continuations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM scheduled_jobs \
+         WHERE job_type = 'upstream_reconciliation' AND status IN ('queued', 'running')",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count claim-fenced remote-attempt continuations");
+    assert_eq!(duplicate_continuations, 1);
+    let actual_adjustments: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM billing_reconciliation_adjustments")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("count actual reconciliation adjustments");
+    assert_eq!(actual_adjustments, 0);
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);
@@ -2439,6 +2490,26 @@ async fn reconciliation_multi_key_observations_resume_without_partial_terminal()
     .await
     .expect("make settlement continuation due");
 
+    drop(proxy);
+    let (resumed_backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-multi-key-resume"],
+        DEFAULT_UPSTREAM,
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        resumed_backend_time,
+    )
+    .await
+    .expect("restart proxy with durable observations");
+    let persisted_after_restart: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_key_observations \
+         WHERE token_id = 'multi-key-resume-token' AND work_generation = 3",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read observations after restart");
+    assert_eq!(persisted_after_restart, 2);
+
     let resumed = proxy
         .run_upstream_reconciliation_once(&format!("http://{address}"))
         .await
@@ -2476,6 +2547,237 @@ async fn reconciliation_multi_key_observations_resume_without_partial_terminal()
         settlement.1, 2,
         "partial run and resumed run are two attempts"
     );
+    let actual_adjustments: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM billing_reconciliation_adjustments")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("count actual reconciliation adjustments");
+    assert_eq!(
+        actual_adjustments, 0,
+        "compare-mode multi-key completion must not alter billing truth"
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
+async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_observations() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let now = local_ts(2026, 9, 2, 12, 0);
+    let (backend_time, _) = BackendTime::manual_from_ts(now);
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-source-revision"],
+        DEFAULT_UPSTREAM,
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let first_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-source-revision-a")
+        .await
+        .expect("create first upstream key");
+    let additional_key_ids = vec![
+        proxy
+            .add_or_undelete_key("tvly-reconciliation-source-revision-b")
+            .await
+            .expect("create second upstream key"),
+        proxy
+            .add_or_undelete_key("tvly-reconciliation-source-revision-c")
+            .await
+            .expect("create third upstream key"),
+    ];
+    let candidate = UpstreamReconciliationCandidate {
+        token_id: "source-revision-token".to_string(),
+        period_code: "2026-09-02/S1".to_string(),
+        project_id: "source-revision-project".to_string(),
+        billing_subject: "token:source-revision-token".to_string(),
+        settlement_mode: "shadow".to_string(),
+        period_start: now - 4_000,
+        period_end: now - 900,
+        pending_research: 0,
+        degraded: false,
+    };
+    let insert_usage_sql = r#"INSERT INTO upstream_reconciliation_usage (
+                 token_id, key_id, period_code, project_id, billing_subject,
+                 period_start, period_end, request_count, first_used_at,
+                 last_used_at, updated_at, settlement_mode
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')"#;
+    sqlx::query(insert_usage_sql)
+        .bind(&candidate.token_id)
+        .bind(&first_key_id)
+        .bind(&candidate.period_code)
+        .bind(&candidate.project_id)
+        .bind(&candidate.billing_subject)
+        .bind(candidate.period_start)
+        .bind(candidate.period_end)
+        .bind(now - 1_000)
+        .bind(now - 900)
+        .bind(now - 900)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert initial reconciliation source");
+    proxy
+        .key_store
+        .persist_reconciliation_key_observations(
+            &candidate,
+            1,
+            &[ReconciliationKeyObservation {
+                key_id: first_key_id.clone(),
+                upstream_usage: 7,
+            }],
+            Some(ReconciliationWorkFence {
+                work_generation: 1,
+                claimed_job: None,
+            }),
+        )
+        .await
+        .expect("persist first-generation observation");
+    sqlx::query(
+        "UPDATE upstream_reconciliation_work \
+         SET next_attempt_at = ?, last_outcome = 'remote_attempt_budget' \
+         WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(now + 30)
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed partial work state");
+
+    sqlx::query(
+        "UPDATE upstream_reconciliation_usage \
+         SET first_used_at = first_used_at, last_used_at = last_used_at + 1, \
+             updated_at = updated_at + 1, request_count = request_count \
+         WHERE token_id = ? AND key_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&first_key_id)
+    .bind(&candidate.period_code)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("refresh storage-only source fields");
+    let no_op_state: (i64, i64, i64, Option<String>) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, next_attempt_at, last_outcome \
+         FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read storage-refresh work state");
+    assert_eq!(
+        no_op_state,
+        (1, 0, now + 30, Some("remote_attempt_budget".to_string()))
+    );
+    let first_generation_observations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_key_observations \
+         WHERE token_id = ? AND period_code = ? AND work_generation = 1",
+    )
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count preserved storage-refresh observations");
+    assert_eq!(first_generation_observations, 1);
+
+    sqlx::query(
+        "UPDATE upstream_reconciliation_usage SET request_count = request_count + 1 \
+         WHERE token_id = ? AND key_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&first_key_id)
+    .bind(&candidate.period_code)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("record logical source revision");
+    let reopened_state: (i64, i64, Option<String>) = sqlx::query_as(
+        "SELECT work_generation, next_attempt_at, last_outcome \
+         FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read logically reopened work state");
+    assert_eq!(reopened_state, (2, 0, None));
+    proxy
+        .key_store
+        .persist_reconciliation_key_observations(
+            &candidate,
+            2,
+            &[ReconciliationKeyObservation {
+                key_id: first_key_id.clone(),
+                upstream_usage: 8,
+            }],
+            Some(ReconciliationWorkFence {
+                work_generation: 2,
+                claimed_job: None,
+            }),
+        )
+        .await
+        .expect("persist logically reopened observation");
+
+    for key_id in &additional_key_ids {
+        sqlx::query(insert_usage_sql)
+            .bind(&candidate.token_id)
+            .bind(key_id)
+            .bind(&candidate.period_code)
+            .bind(&candidate.project_id)
+            .bind(&candidate.billing_subject)
+            .bind(candidate.period_start)
+            .bind(candidate.period_end)
+            .bind(now - 1_000)
+            .bind(now - 900)
+            .bind(now - 900)
+            .execute(&proxy.key_store.pool)
+            .await
+            .expect("add current reconciliation key");
+    }
+    let key_set_generation: i64 = sqlx::query_scalar(
+        "SELECT work_generation FROM upstream_reconciliation_work \
+         WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read key-set revision generation");
+    assert_eq!(key_set_generation, 4);
+    let retained_observations: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_key_observations \
+         WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("count retained pre-terminal observations");
+    assert_eq!(retained_observations, 2);
+    let ordered_key_sets = proxy
+        .key_store
+        .reconciliation_key_ids_batch(&[(
+            candidate.token_id.clone(),
+            candidate.period_code.clone(),
+        )])
+        .await
+        .expect("read deterministically ordered current key set");
+    let mut expected_key_ids = vec![first_key_id];
+    expected_key_ids.extend(additional_key_ids);
+    expected_key_ids.sort();
+    assert_eq!(
+        ordered_key_sets.get(&(candidate.token_id.clone(), candidate.period_code.clone())),
+        Some(&expected_key_ids)
+    );
+    let current_generation_observations = proxy
+        .key_store
+        .reconciliation_key_observations(&candidate, key_set_generation, &expected_key_ids)
+        .await
+        .expect("read current generation observations");
+    assert!(current_generation_observations.is_empty());
 
     drop(proxy);
     let _ = std::fs::remove_file(db_path);


### PR DESCRIPTION
## Summary
- advance reconciliation work generations only for logical usage or upstream Key-set revisions
- retain partial, generation-scoped observations across no-op source refreshes and restarts until terminal completion
- preserve claim-fenced 30-second remote-attempt continuations without retry-state or billing side effects

## Validation
- cargo fmt --check
- cargo clippy --locked -j 2 -- -D warnings
- cargo test --lib reconciliation_source_revisions_ignore_storage_refresh_and_retain_observations
- cargo test --lib reconciliation_multi_key_observations_resume_without_partial_terminal
- cargo test --lib remote_attempt_budget_defer_does_not_raise_local_pressure
- cargo test --lib reconciliation_key_observations_reject_stale_generation_and_claim
- cargo test --lib versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift
- python3 scripts/ci_backend_tests.py run-shard --id lib-upstream-reconciliation
- python3 scripts/ci_backend_tests.py run-shard --id lib-reconciliation-maintenance
- bunx --bun dprint check docs/specs/upstream-privacy-period-reconciliation/SPEC.md docs/specs/upstream-privacy-period-reconciliation/IMPLEMENTATION.md docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md

## Testbox
The required isolated testbox invocation was blocked before project tests ran: its source safety filter removed the pre-existing src/lib.rs because it matched the literal dev-open-admin token heuristic, leaving no library target. The run was cleaned up automatically. This PR does not bypass that safety control.