### PR TITLE
fix(alerts): unblock canonical warm recovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,8 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   re-arms one controller run.
   Canonical HTTP handlers never trigger or wait for warm work: a current entry is fresh, an older
   entry within five minutes is stale, and a cold/expired entry returns `503 Retry-After: 1`.
+  These cache-only responses do not count as SQLite foreground activity; only a noncanonical
+  bounded-read fallback is foreground work.
 
 ## Reconciliation Terms
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,8 +51,8 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   re-arms one controller run.
   Canonical HTTP handlers never trigger or wait for warm work: a current entry is fresh, an older
   entry within five minutes is stale, and a cold/expired entry returns `503 Retry-After: 1`.
-  These cache-only responses do not count as SQLite foreground activity; only a noncanonical
-  bounded-read fallback is foreground work.
+  These cache-only payload responses do not count as synthetic SQLite foreground activity. A configured
+  passkey session lookup and a noncanonical bounded-read fallback are each real foreground work.
 
 ## Reconciliation Terms
 

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -77,10 +77,10 @@ reads:
   publishes them atomically at one projection generation; generation changes or partial failures
   discard the staged set. Retry at `5s/5s/30s`.
   Canonical HTTP handlers are cache-first and return cold `503 Retry-After: 1` instead of rebuilding
-  or falling back to raw CTEs. Their fresh, stale, and cold responses must not be counted as
-  foreground SQLite activity, or client retries can indefinitely defer the background owner.
-  Noncanonical exact-key reads keep the existing bounded-read fallback and record foreground activity
-  only when that fallback will execute.
+  or falling back to raw CTEs. Their fresh, stale, and cold payload responses must not create synthetic
+  foreground SQLite activity, or client retries can indefinitely defer the background owner. A configured
+  passkey session lookup and a noncanonical exact-key bounded-read fallback each record their real
+  foreground SQLite work.
 - Apply the same last-good boundary to the single-key privacy-status read. Keep the immutable
   successful snapshot for 60 seconds; warm pressure returns it as stale with the observation time,
   while cold pressure fails fast with `503 Retry-After: 1`. The HTTP path is bounded to 250ms and,

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -77,7 +77,10 @@ reads:
   publishes them atomically at one projection generation; generation changes or partial failures
   discard the staged set. Retry at `5s/5s/30s`.
   Canonical HTTP handlers are cache-first and return cold `503 Retry-After: 1` instead of rebuilding
-  or falling back to raw CTEs; noncanonical exact-key reads keep the existing bounded-read fallback.
+  or falling back to raw CTEs. Their fresh, stale, and cold responses must not be counted as
+  foreground SQLite activity, or client retries can indefinitely defer the background owner.
+  Noncanonical exact-key reads keep the existing bounded-read fallback and record foreground activity
+  only when that fallback will execute.
 - Apply the same last-good boundary to the single-key privacy-status read. Keep the immutable
   successful snapshot for 60 seconds; warm pressure returns it as stale with the observation time,
   while cold pressure fails fast with `503 Retry-After: 1`. The HTTP path is bounded to 250ms and,

--- a/docs/specs/admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/admin-alert-center-24h-summary/SPEC.md
@@ -35,6 +35,8 @@
   惰性建立连接；HTTP 对 canonical key 只读 exact-key
   cache：同 generation 为 fresh，generation 落后但未过期为 stale，cold/过期为
   `503 Retry-After: 1`，绝不触发重建。
+  Canonical HTTP 的 fresh、stale 与 cold 响应不计入 SQLite 前台活动；只有实际进入 bounded
+  database fallback 的 noncanonical 读取才计量，避免 cache-only 重试自行阻止 warm admission。
 
 ## Non-goals
 

--- a/docs/specs/admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/admin-alert-center-24h-summary/SPEC.md
@@ -36,8 +36,9 @@
   cache：同 generation 为 fresh，generation 落后但未过期为 stale，cold/过期为
   `503 Retry-After: 1`，绝不触发重建。
   Canonical HTTP 的 fresh、stale 与 cold payload 响应不计入 synthetic SQLite 前台活动；已配置
-  passkey 的 session lookup 与实际进入 bounded database fallback 的 noncanonical 读取仍计量，
-  避免 cache-only 重试自行阻止 warm admission，同时不隐藏真实 SQLite 读取。
+  passkey 的 session lookup 与实际进入 bounded database fallback 的 noncanonical 读取仍计量；
+  前者在开始获取 SQLite 连接之前计量，避免 cache-only 重试自行阻止 warm admission，同时不隐藏
+  真实 SQLite 读取。
 
 ## Non-goals
 

--- a/docs/specs/admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/admin-alert-center-24h-summary/SPEC.md
@@ -35,8 +35,9 @@
   惰性建立连接；HTTP 对 canonical key 只读 exact-key
   cache：同 generation 为 fresh，generation 落后但未过期为 stale，cold/过期为
   `503 Retry-After: 1`，绝不触发重建。
-  Canonical HTTP 的 fresh、stale 与 cold 响应不计入 SQLite 前台活动；只有实际进入 bounded
-  database fallback 的 noncanonical 读取才计量，避免 cache-only 重试自行阻止 warm admission。
+  Canonical HTTP 的 fresh、stale 与 cold payload 响应不计入 synthetic SQLite 前台活动；已配置
+  passkey 的 session lookup 与实际进入 bounded database fallback 的 noncanonical 读取仍计量，
+  避免 cache-only 重试自行阻止 warm admission，同时不隐藏真实 SQLite 读取。
 
 ## Non-goals
 

--- a/src/server/handlers/admin_resources/alerts.rs
+++ b/src/server/handlers/admin_resources/alerts.rs
@@ -187,6 +187,7 @@ async fn get_alert_events(
         );
         return Err(alerts_sqlite_pressure_response());
     }
+    state.proxy.record_foreground_activity();
     match state.proxy.admin_alert_events_page(
             alert_type,
             since,
@@ -291,6 +292,7 @@ async fn get_alert_groups(
         );
         return Err(alerts_sqlite_pressure_response());
     }
+    state.proxy.record_foreground_activity();
     match state.proxy.admin_alert_groups_page(
             alert_type,
             since,

--- a/src/server/handlers/admin_resources/alerts.rs
+++ b/src/server/handlers/admin_resources/alerts.rs
@@ -33,7 +33,7 @@ async fn get_alert_catalog(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<axum::response::Response, axum::response::Response> {
-    if !is_admin_request(state.as_ref(), &headers).await {
+    if !is_admin_cache_aware_request(state.as_ref(), &headers).await {
         return Err(StatusCode::FORBIDDEN.into_response());
     }
 
@@ -123,7 +123,7 @@ async fn get_alert_events(
     RawQuery(raw_query): RawQuery,
     Query(q): Query<AlertsQuery>,
 ) -> Result<axum::response::Response, axum::response::Response> {
-    if !is_admin_request(state.as_ref(), &headers).await {
+    if !is_admin_cache_aware_request(state.as_ref(), &headers).await {
         return Err(StatusCode::FORBIDDEN.into_response());
     }
 
@@ -228,7 +228,7 @@ async fn get_alert_groups(
     RawQuery(raw_query): RawQuery,
     Query(q): Query<AlertsQuery>,
 ) -> Result<axum::response::Response, axum::response::Response> {
-    if !is_admin_request(state.as_ref(), &headers).await {
+    if !is_admin_cache_aware_request(state.as_ref(), &headers).await {
         return Err(StatusCode::FORBIDDEN.into_response());
     }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2485,7 +2485,7 @@ mod serve_tests {
             .create_admin_passkey_session(&scope, None, 120)
             .await
             .expect("create passkey session");
-        let state = AppState {
+        let state = Arc::new(AppState {
             proxy,
             static_dir: None,
             forward_auth: ForwardAuthConfig::new(None, None, None, None),
@@ -2507,9 +2507,9 @@ mod serve_tests {
             api_key_ip_geo_origin: "https://api.country.is".to_string(),
             dashboard_overview_cache: new_dashboard_overview_cache(),
             remote_attempt_admission: new_remote_attempt_admission(),
-        };
+        });
         let empty_headers = HeaderMap::new();
-        assert!(!is_admin_cache_aware_request(&state, &empty_headers).await);
+        assert!(!is_admin_cache_aware_request(state.as_ref(), &empty_headers).await);
         assert_eq!(state.proxy.foreground_activity_rps(), 0);
 
         let mut passkey_headers = HeaderMap::new();
@@ -2518,12 +2518,50 @@ mod serve_tests {
             HeaderValue::from_str(&format!("{ADMIN_PASSKEY_COOKIE_NAME}={}", session.token))
                 .expect("cookie header should be valid"),
         );
-        assert!(is_admin_cache_aware_request(&state, &passkey_headers).await);
+        assert!(is_admin_cache_aware_request(state.as_ref(), &passkey_headers).await);
         assert_eq!(
             state.proxy.foreground_activity_rps(),
             1,
             "passkey auth must account for its bounded SQLite lookup"
         );
+
+        let release_pool = Arc::new(tokio::sync::Notify::new());
+        let (pool_held_tx, pool_held_rx) = tokio::sync::oneshot::channel();
+        let pool_holder = {
+            let proxy = state.proxy.clone();
+            let release_pool = release_pool.clone();
+            tokio::spawn(async move { proxy.hold_sqlite_pool_until_for_test(pool_held_tx, release_pool).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), pool_held_rx)
+            .await
+            .expect("the app SQLite pool should be exhausted")
+            .expect("the pool holder should signal readiness");
+        let lookups = (0..5)
+            .map(|_| {
+                let state = state.clone();
+                let headers = passkey_headers.clone();
+                tokio::spawn(async move { is_admin_cache_aware_request(state.as_ref(), &headers).await })
+            })
+            .collect::<Vec<_>>();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while state.proxy.foreground_activity_rps() <= 5 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("passkey lookups should record before acquiring SQLite");
+        assert_eq!(
+            state.proxy.admin_alerts_cache_warm_pressure_reason(),
+            Some("foreground_pressure")
+        );
+        release_pool.notify_waiters();
+        for lookup in lookups {
+            assert!(lookup.await.expect("passkey lookup task joins"));
+        }
+        pool_holder
+            .await
+            .expect("pool holder joins")
+            .expect("pool holder releases cleanly");
     }
 
     #[tokio::test]

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -2464,6 +2464,69 @@ mod serve_tests {
     }
 
     #[tokio::test]
+    async fn cache_aware_admin_auth_records_only_passkey_sqlite_lookups() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("cache-aware-passkey-auth.db");
+        let db_str = db_path.to_string_lossy().to_string();
+        let proxy = TavilyProxy::with_endpoint(
+            vec!["tvly-cache-aware-passkey-auth".to_string()],
+            DEFAULT_UPSTREAM,
+            &db_str,
+        )
+        .await
+        .expect("proxy created");
+        let scope = tavily_hikari::AdminPasskeyScope::new(
+            "node-cache-aware-passkey-auth",
+            "admin.example.com",
+            "https://admin.example.com",
+        )
+        .expect("passkey scope");
+        let session = proxy
+            .create_admin_passkey_session(&scope, None, 120)
+            .await
+            .expect("create passkey session");
+        let state = AppState {
+            proxy,
+            static_dir: None,
+            forward_auth: ForwardAuthConfig::new(None, None, None, None),
+            forward_auth_enabled: false,
+            builtin_admin: BuiltinAdminAuth::new(false, None, None),
+            admin_passkey: AdminPasskeyOptions {
+                enabled: true,
+                rp_id: Some("admin.example.com".to_string()),
+                rp_origin: Some("https://admin.example.com".to_string()),
+                scope: Some(scope),
+                challenge_ttl_secs: 300,
+                session_max_age_secs: 120,
+            },
+            linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+            linuxdo_credit: LinuxDoCreditOptions::disabled(),
+            ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+            dev_open_admin: false,
+            usage_base: "http://127.0.0.1:58088".to_string(),
+            api_key_ip_geo_origin: "https://api.country.is".to_string(),
+            dashboard_overview_cache: new_dashboard_overview_cache(),
+            remote_attempt_admission: new_remote_attempt_admission(),
+        };
+        let empty_headers = HeaderMap::new();
+        assert!(!is_admin_cache_aware_request(&state, &empty_headers).await);
+        assert_eq!(state.proxy.foreground_activity_rps(), 0);
+
+        let mut passkey_headers = HeaderMap::new();
+        passkey_headers.insert(
+            COOKIE,
+            HeaderValue::from_str(&format!("{ADMIN_PASSKEY_COOKIE_NAME}={}", session.token))
+                .expect("cookie header should be valid"),
+        );
+        assert!(is_admin_cache_aware_request(&state, &passkey_headers).await);
+        assert_eq!(
+            state.proxy.foreground_activity_rps(),
+            1,
+            "passkey auth must account for its bounded SQLite lookup"
+        );
+    }
+
+    #[tokio::test]
     async fn passkey_authentication_start_is_available_on_standby() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("standby-passkey-auth.db");

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1977,16 +1977,53 @@ async fn is_admin_request(state: &AppState, headers: &HeaderMap) -> bool {
 }
 
 async fn try_is_admin_request(state: &AppState, headers: &HeaderMap) -> Result<bool, ProxyError> {
+    match classify_admin_request_authentication(state, headers).await {
+        AdminRequestAuthentication::InMemory(is_admin) => Ok(is_admin),
+        AdminRequestAuthentication::PasskeyLookup(result) => result,
+    }
+}
+
+async fn is_admin_cache_aware_request(state: &AppState, headers: &HeaderMap) -> bool {
+    match classify_admin_request_authentication(state, headers).await {
+        AdminRequestAuthentication::InMemory(is_admin) => is_admin,
+        AdminRequestAuthentication::PasskeyLookup(result) => {
+            // Canonical Alert payloads are cache-only, but a passkey session
+            // lookup is still a real bounded SQLite read that must constrain
+            // the background warmer.
+            state.proxy.record_foreground_activity();
+            result.unwrap_or(false)
+        }
+    }
+}
+
+enum AdminRequestAuthentication {
+    InMemory(bool),
+    PasskeyLookup(Result<bool, ProxyError>),
+}
+
+async fn classify_admin_request_authentication(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> AdminRequestAuthentication {
     if state.dev_open_admin {
-        return Ok(true);
+        return AdminRequestAuthentication::InMemory(true);
     }
     if state.forward_auth_enabled && state.forward_auth.is_request_admin(headers) {
-        return Ok(true);
+        return AdminRequestAuthentication::InMemory(true);
     }
     if state.builtin_admin.is_admin(headers) {
-        return Ok(true);
+        return AdminRequestAuthentication::InMemory(true);
     }
-    Ok(resolve_admin_passkey_session(state, headers).await?.is_some())
+    if state.admin_passkey.is_configured()
+        && cookie_value(headers, ADMIN_PASSKEY_COOKIE_NAME).is_some()
+    {
+        return AdminRequestAuthentication::PasskeyLookup(
+            resolve_admin_passkey_session(state, headers)
+                .await
+                .map(|session| session.is_some()),
+        );
+    }
+    AdminRequestAuthentication::InMemory(false)
 }
 
 async fn require_full_master_write(state: &AppState) -> Result<(), (StatusCode, String)> {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1145,9 +1145,16 @@ async fn db_maintenance_http_gate(
 fn db_maintenance_gated_path(path: &str) -> bool {
     path == "/mcp"
         || path.starts_with("/mcp/")
-        || path.starts_with("/api/")
+        || (path.starts_with("/api/") && !admin_alerts_cache_aware_path(path))
         || path == "/auth/linuxdo"
         || path.starts_with("/auth/linuxdo/")
+}
+
+fn admin_alerts_cache_aware_path(path: &str) -> bool {
+    matches!(
+        path,
+        "/api/alerts/catalog" | "/api/alerts/events" | "/api/alerts/groups"
+    )
 }
 
 #[cfg(test)]
@@ -1155,11 +1162,15 @@ mod db_maintenance_gate_tests {
     use super::db_maintenance_gated_path;
 
     #[test]
-    fn maintenance_gate_only_covers_db_backed_routes() {
+    fn maintenance_gate_leaves_alerts_to_cache_aware_foreground_measurement() {
         assert!(db_maintenance_gated_path("/api/jobs"));
         assert!(db_maintenance_gated_path("/mcp"));
         assert!(db_maintenance_gated_path("/auth/linuxdo/callback"));
 
+        assert!(!db_maintenance_gated_path("/api/alerts/catalog"));
+        assert!(!db_maintenance_gated_path("/api/alerts/events"));
+        assert!(!db_maintenance_gated_path("/api/alerts/groups"));
+        assert!(db_maintenance_gated_path("/api/alerts/future-db-route"));
         assert!(!db_maintenance_gated_path("/health"));
         assert!(!db_maintenance_gated_path("/admin"));
         assert!(!db_maintenance_gated_path("/assets/admin.js"));

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1977,22 +1977,16 @@ async fn is_admin_request(state: &AppState, headers: &HeaderMap) -> bool {
 }
 
 async fn try_is_admin_request(state: &AppState, headers: &HeaderMap) -> Result<bool, ProxyError> {
-    match classify_admin_request_authentication(state, headers).await {
+    match classify_admin_request_authentication(state, headers, false).await {
         AdminRequestAuthentication::InMemory(is_admin) => Ok(is_admin),
         AdminRequestAuthentication::PasskeyLookup(result) => result,
     }
 }
 
 async fn is_admin_cache_aware_request(state: &AppState, headers: &HeaderMap) -> bool {
-    match classify_admin_request_authentication(state, headers).await {
+    match classify_admin_request_authentication(state, headers, true).await {
         AdminRequestAuthentication::InMemory(is_admin) => is_admin,
-        AdminRequestAuthentication::PasskeyLookup(result) => {
-            // Canonical Alert payloads are cache-only, but a passkey session
-            // lookup is still a real bounded SQLite read that must constrain
-            // the background warmer.
-            state.proxy.record_foreground_activity();
-            result.unwrap_or(false)
-        }
+        AdminRequestAuthentication::PasskeyLookup(result) => result.unwrap_or(false),
     }
 }
 
@@ -2004,6 +1998,7 @@ enum AdminRequestAuthentication {
 async fn classify_admin_request_authentication(
     state: &AppState,
     headers: &HeaderMap,
+    record_passkey_foreground_activity: bool,
 ) -> AdminRequestAuthentication {
     if state.dev_open_admin {
         return AdminRequestAuthentication::InMemory(true);
@@ -2017,6 +2012,12 @@ async fn classify_admin_request_authentication(
     if state.admin_passkey.is_configured()
         && cookie_value(headers, ADMIN_PASSKEY_COOKIE_NAME).is_some()
     {
+        if record_passkey_foreground_activity {
+            // Canonical Alert payloads are cache-only, but a passkey session
+            // lookup is real bounded SQLite work. Record it before acquiring
+            // the connection so the warmer cannot race the lookup.
+            state.proxy.record_foreground_activity();
+        }
         return AdminRequestAuthentication::PasskeyLookup(
             resolve_admin_passkey_session(state, headers)
                 .await

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -725,6 +725,7 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         .expect("admin login");
     let cookie = find_cookie_pair(login.headers(), BUILTIN_ADMIN_COOKIE_NAME)
         .expect("admin session cookie");
+    let foreground_before_canonical = state.proxy.foreground_activity_rps();
 
     let cold = client
         .get(format!("http://{admin_addr}/api/alerts/catalog"))
@@ -747,6 +748,11 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
             Some("1")
         );
     }
+    assert_eq!(
+        state.proxy.foreground_activity_rps(),
+        foreground_before_canonical,
+        "canonical Alerts cache reads must not add synthetic SQLite foreground pressure"
+    );
 
     let mut projection_ready = false;
     for _ in 0..64 {
@@ -851,6 +857,7 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         );
     }
 
+    let foreground_before_fallback = state.proxy.foreground_activity_rps();
     state.proxy.force_next_admin_alert_read_deadline_for_test();
     let cold = client
         .get(format!("http://{admin_addr}/api/alerts/events?page=2"))
@@ -860,6 +867,10 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         .expect("cold alerts page");
     assert_eq!(cold.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
     assert_eq!(cold.headers().get("retry-after").and_then(|v| v.to_str().ok()), Some("1"));
+    assert!(
+        state.proxy.foreground_activity_rps() > foreground_before_fallback,
+        "a noncanonical Alerts fallback must account for its database read"
+    );
     let _ = std::fs::remove_file(db_path);
 }
 

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -960,12 +960,11 @@ impl SqliteRuntime {
         // foreground work and ordinary admin reads. It uses one bounded read
         // slot; requiring two already-idle connections starves a lazy pool
         // under the normal one-connection foreground workload.
-        let idle = self.inner.pool.num_idle();
         if self.foreground_activity_rps() > MAINTENANCE_BULK_MAX_FOREGROUND_RPS {
             Some(SqliteAdmissionDeferReason::ForegroundPressure)
         } else if self.recent_contention_active() {
             Some(SqliteAdmissionDeferReason::RecentContention)
-        } else if idle == 0 || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0 {
+        } else if self.admin_alerts_cache_warm_has_pool_pressure() {
             Some(SqliteAdmissionDeferReason::PoolPressure)
         } else {
             None
@@ -977,13 +976,17 @@ impl SqliteRuntime {
             Some(SqliteAdmissionDeferReason::ForegroundPressure.as_str())
         } else if self.recent_contention_active() {
             Some(SqliteAdmissionDeferReason::RecentContention.as_str())
-        } else if self.inner.pool.num_idle() == 0
-            || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
-        {
+        } else if self.admin_alerts_cache_warm_has_pool_pressure() {
             Some(SqliteAdmissionDeferReason::PoolPressure.as_str())
         } else {
             None
         }
+    }
+
+    fn admin_alerts_cache_warm_has_pool_pressure(&self) -> bool {
+        let has_open_connection = self.inner.pool.size() > 0;
+        (has_open_connection && self.inner.pool.num_idle() == 0)
+            || self.inner.acquire_waiters.load(AtomicOrdering::Acquire) > 0
     }
 
     fn maintenance_bulk_defer_reason_for(

--- a/src/store/sqlite_runtime_tests.rs
+++ b/src/store/sqlite_runtime_tests.rs
@@ -769,14 +769,43 @@ async fn admin_alerts_cache_warm_admits_with_one_idle_connection() {
         "canonical warm uses one bounded read slot and must not require two idle connections"
     );
 
-    runtime
-        .prewarm_maintenance_bulk_capacity()
+    let held_connection = runtime
+        .inner
+        .pool
+        .acquire()
         .await
-        .expect("prewarm admin Alerts capacity");
+        .expect("hold the only open connection");
+    assert_eq!(runtime.inner.pool.num_idle(), 0);
+    assert_eq!(
+        runtime.admin_alerts_cache_warm_defer_reason(),
+        Some(SqliteAdmissionDeferReason::PoolPressure),
+        "a foreground checkout remains pressure even while the lazy pool could grow"
+    );
+    drop(held_connection);
+}
 
-    assert_eq!(runtime.inner.pool.size(), 3);
-    assert!(runtime.inner.pool.num_idle() >= 2);
+#[tokio::test]
+async fn admin_alerts_cache_warm_admits_an_empty_lazy_pool_without_waiters() {
+    let runtime = SqliteRuntime::with_max_connections(
+        SqlitePoolOptions::new()
+            .max_connections(3)
+            .connect_lazy("sqlite::memory:")
+            .expect("lazy three connection pool"),
+        3,
+    );
+
+    assert_eq!(runtime.inner.pool.size(), 0);
+    assert_eq!(runtime.inner.pool.num_idle(), 0);
     assert_eq!(runtime.admin_alerts_cache_warm_defer_reason(), None);
+    assert_eq!(runtime.admin_alerts_cache_warm_pressure_reason(), None);
+
+    runtime
+        .begin_read_snapshot(SqliteOperation::AdminAlertsCacheWarm)
+        .await
+        .expect("the first bounded warm read can establish a lazy connection")
+        .close()
+        .await
+        .expect("close the lazy warm read");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- admit the first bounded canonical Alerts warm read from an empty lazy SQLite pool
- keep cache-only catalog and default events/groups reads out of foreground SQLite pressure
- retain foreground accounting for noncanonical Alerts database fallbacks

## Contract

- preserves the 100ms acquire and 250ms native read deadline
- preserves exact-key fresh/stale/cold behavior, including `503 Retry-After: 1` for cold or expired canonical entries
- does not change SQLite pool settings, PRAGMAs, public JSON, Reconciliation, or production operations

## Validation

- `cargo test --lib admin_alerts_cache_warm -- --nocapture`
- `cargo test --lib admin_alerts_warm_read_deadline_restores_a_reusable_connection -- --nocapture`
- `cargo test --bin tavily-hikari maintenance_gate_leaves_alerts_to_cache_aware_foreground_measurement -- --nocapture`
- `cargo test --bin tavily-hikari admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses -- --nocapture`
- `cargo test --bin tavily-hikari admin_alerts_prewarm -- --nocapture`
- `cargo clippy --locked -j 2 -- -D warnings`

## Documentation

- Spec: `docs/specs/admin-alert-center-24h-summary/SPEC.md` (updated)
- Solution: `docs/solutions/operations/sqlite-admin-read-containment.md` (updated)
- Project context: `CONTEXT.md` (updated)
