### PR TITLE
test(reconciliation): cover logical revision retention

### DIFF
--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -102,6 +102,11 @@ const RECONCILIATION_SOURCE_REVISION_NAME: &str =
     "reconciliation-logical-source-revision-v1";
 const RECONCILIATION_SOURCE_REVISION_CHECKSUM: &str =
     "sha256:7c9f1d5e0b4a8d2c6e3f9a1b5d7c2e4f";
+const RECONCILIATION_SOURCE_TIMESTAMP_REVISION_VERSION: i64 = 26;
+const RECONCILIATION_SOURCE_TIMESTAMP_REVISION_NAME: &str =
+    "reconciliation-logical-source-timestamps-v1";
+const RECONCILIATION_SOURCE_TIMESTAMP_REVISION_CHECKSUM: &str =
+    "sha256:1e18be281aaa333fffdc1873bac99f9a";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -824,6 +829,11 @@ impl KeyStore {
                 RECONCILIATION_SOURCE_REVISION_NAME,
                 RECONCILIATION_SOURCE_REVISION_CHECKSUM,
             ),
+            (
+                RECONCILIATION_SOURCE_TIMESTAMP_REVISION_VERSION,
+                RECONCILIATION_SOURCE_TIMESTAMP_REVISION_NAME,
+                RECONCILIATION_SOURCE_TIMESTAMP_REVISION_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -1185,6 +1195,21 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 25".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_SOURCE_TIMESTAMP_REVISION_VERSION)
+            .await?
+            && !self
+                .schema_named_object_exists(
+                    "main",
+                    "trigger",
+                    "trg_upstream_reconciliation_usage_work_update",
+                )
+                .await?
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 26".to_string(),
             ));
         }
         Ok(())
@@ -1930,6 +1955,66 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_source_timestamp_revision_migration(
+        &self,
+    ) -> Result<(), ProxyError> {
+        sqlx::query("DROP TRIGGER IF EXISTS trg_upstream_reconciliation_usage_work_update")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query(
+            r#"CREATE TRIGGER IF NOT EXISTS trg_upstream_reconciliation_usage_work_update
+               AFTER UPDATE ON upstream_reconciliation_usage
+               WHEN NEW.token_id IS NOT OLD.token_id
+                 OR NEW.key_id IS NOT OLD.key_id
+                 OR NEW.period_code IS NOT OLD.period_code
+                 OR NEW.project_id IS NOT OLD.project_id
+                 OR NEW.billing_subject IS NOT OLD.billing_subject
+                 OR NEW.settlement_mode IS NOT OLD.settlement_mode
+                 OR NEW.period_start IS NOT OLD.period_start
+                 OR NEW.period_end IS NOT OLD.period_end
+                 OR NEW.request_count IS NOT OLD.request_count
+                 OR NEW.first_used_at IS NOT OLD.first_used_at
+                 OR NEW.last_used_at IS NOT OLD.last_used_at
+               BEGIN
+                 INSERT INTO upstream_reconciliation_work (
+                   token_id, period_code, project_id, billing_subject, settlement_mode,
+                   period_start, period_end, scheduling_key_id, updated_at,
+                   work_generation, completed_generation, next_attempt_at, last_outcome
+                 ) VALUES (
+                   NEW.token_id, NEW.period_code, NEW.project_id, NEW.billing_subject,
+                   NEW.settlement_mode, NEW.period_start, NEW.period_end, NEW.key_id, NEW.updated_at,
+                   1, 0, 0, NULL
+                 )
+                 ON CONFLICT(token_id, period_code) DO UPDATE SET
+                   project_id = MIN(upstream_reconciliation_work.project_id, excluded.project_id),
+                   billing_subject = MIN(upstream_reconciliation_work.billing_subject, excluded.billing_subject),
+                   settlement_mode = MIN(upstream_reconciliation_work.settlement_mode, excluded.settlement_mode),
+                   period_start = MIN(upstream_reconciliation_work.period_start, excluded.period_start),
+                   period_end = MAX(upstream_reconciliation_work.period_end, excluded.period_end),
+                   scheduling_key_id = MIN(upstream_reconciliation_work.scheduling_key_id, excluded.scheduling_key_id),
+                   updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+                   work_generation = upstream_reconciliation_work.work_generation + 1,
+                   next_attempt_at = 0,
+                   last_outcome = NULL;
+
+                 UPDATE upstream_reconciliation_work
+                    SET work_generation = work_generation + 1,
+                        next_attempt_at = 0,
+                        last_outcome = NULL
+                  WHERE (OLD.token_id IS NOT NEW.token_id OR OLD.period_code IS NOT NEW.period_code)
+                    AND token_id = OLD.token_id AND period_code = OLD.period_code;
+               END"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_SOURCE_TIMESTAMP_REVISION_VERSION,
+            RECONCILIATION_SOURCE_TIMESTAMP_REVISION_NAME,
+            RECONCILIATION_SOURCE_TIMESTAMP_REVISION_CHECKSUM,
+        )
+        .await
+    }
+
     async fn apply_reconciliation_key_observation_migration(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_key_observations (
@@ -2459,6 +2544,13 @@ impl KeyStore {
         {
             self.apply_reconciliation_source_revision_migration().await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_SOURCE_TIMESTAMP_REVISION_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_source_timestamp_revision_migration()
+                .await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2519,6 +2611,8 @@ impl KeyStore {
             .await?;
         self.apply_reconciliation_poll_resolution_migration().await?;
         self.apply_reconciliation_source_revision_migration().await?;
+        self.apply_reconciliation_source_timestamp_revision_migration()
+            .await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2526,7 +2620,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 25_i64,
+            migration_count = 26_i64,
         );
         Ok(())
     }

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -32,7 +32,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25,
+            25, 26,
         ]
     );
     let source_revision_triggers: i64 = sqlx::query_scalar(
@@ -981,7 +981,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25,
+            25, 26,
         ]
     );
 

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -2562,7 +2562,7 @@ async fn reconciliation_multi_key_observations_resume_without_partial_terminal()
 }
 
 #[tokio::test]
-async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_observations() {
+async fn reconciliation_source_revisions_distinguish_storage_and_logical_timestamps() {
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
     let now = local_ts(2026, 9, 2, 12, 0);
@@ -2694,8 +2694,7 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
 
     sqlx::query(
         "UPDATE upstream_reconciliation_usage \
-         SET first_used_at = first_used_at, last_used_at = last_used_at + 1, \
-             updated_at = updated_at + 1, request_count = request_count \
+         SET updated_at = updated_at + 1 \
          WHERE token_id = ? AND key_id = ? AND period_code = ?",
     )
     .bind(&candidate.token_id)
@@ -2703,7 +2702,7 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     .bind(&candidate.period_code)
     .execute(&proxy.key_store.pool)
     .await
-    .expect("refresh storage-only source fields");
+    .expect("refresh storage-only source timestamp");
     let no_op_state: (i64, i64, i64, Option<String>) = sqlx::query_as(
         "SELECT work_generation, completed_generation, next_attempt_at, last_outcome \
          FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = ?",
@@ -2712,7 +2711,7 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     .bind(&candidate.period_code)
     .fetch_one(&proxy.key_store.pool)
     .await
-    .expect("read storage-refresh work state");
+    .expect("read storage-only refresh work state");
     assert_eq!(
         no_op_state,
         (1, 0, now + 30, Some("remote_attempt_budget".to_string()))
@@ -2725,8 +2724,34 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     .bind(&candidate.period_code)
     .fetch_one(&proxy.key_store.pool)
     .await
-    .expect("count preserved storage-refresh observations");
+    .expect("count preserved storage-only observations");
     assert_eq!(first_generation_observations, 1);
+
+    for (field, delta, expected_generation) in [
+        ("first_used_at", -1_i64, 2_i64),
+        ("last_used_at", 1_i64, 3_i64),
+    ] {
+        sqlx::query(&format!(
+            "UPDATE upstream_reconciliation_usage SET {field} = {field} + {delta} \
+             WHERE token_id = ? AND key_id = ? AND period_code = ?",
+        ))
+        .bind(&candidate.token_id)
+        .bind(&first_key_id)
+        .bind(&candidate.period_code)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("record logical source timestamp revision");
+        let timestamp_state: (i64, i64, Option<String>) = sqlx::query_as(
+            "SELECT work_generation, next_attempt_at, last_outcome \
+             FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = ?",
+        )
+        .bind(&candidate.token_id)
+        .bind(&candidate.period_code)
+        .fetch_one(&proxy.key_store.pool)
+        .await
+        .expect("read logical timestamp revision");
+        assert_eq!(timestamp_state, (expected_generation, 0, None), "{field}");
+    }
 
     sqlx::query(
         "UPDATE upstream_reconciliation_usage SET request_count = request_count + 1 \
@@ -2747,18 +2772,18 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("read logically reopened work state");
-    assert_eq!(reopened_state, (2, 0, None));
+    assert_eq!(reopened_state, (4, 0, None));
     proxy
         .key_store
         .persist_reconciliation_key_observations(
             &candidate,
-            2,
+            4,
             &[ReconciliationKeyObservation {
                 key_id: first_key_id.clone(),
                 upstream_usage: 8,
             }],
             Some(ReconciliationWorkFence {
-                work_generation: 2,
+                work_generation: 4,
                 claimed_job: None,
             }),
         )
@@ -2790,7 +2815,7 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("read key-set revision generation");
-    assert_eq!(key_set_generation, 4);
+    assert_eq!(key_set_generation, 6);
     let retained_observations: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM upstream_reconciliation_key_observations \
          WHERE token_id = ? AND period_code = ?",

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -2649,6 +2649,50 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     .expect("seed partial work state");
 
     sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_usage (
+             token_id, key_id, period_code, project_id, billing_subject,
+             period_start, period_end, request_count, first_used_at,
+             last_used_at, updated_at, settlement_mode
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'shadow')
+           ON CONFLICT(token_id, key_id, period_code) DO UPDATE SET
+             project_id = excluded.project_id,
+             billing_subject = excluded.billing_subject,
+             period_start = excluded.period_start,
+             period_end = excluded.period_end,
+             request_count = excluded.request_count,
+             first_used_at = excluded.first_used_at,
+             last_used_at = excluded.last_used_at,
+             updated_at = excluded.updated_at,
+             settlement_mode = excluded.settlement_mode"#,
+    )
+    .bind(&candidate.token_id)
+    .bind(&first_key_id)
+    .bind(&candidate.period_code)
+    .bind(&candidate.project_id)
+    .bind(&candidate.billing_subject)
+    .bind(candidate.period_start)
+    .bind(candidate.period_end)
+    .bind(now - 1_000)
+    .bind(now - 900)
+    .bind(now - 900)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("replay an equal reconciliation source payload");
+    let replayed_state: (i64, i64, i64, Option<String>) = sqlx::query_as(
+        "SELECT work_generation, completed_generation, next_attempt_at, last_outcome \
+         FROM upstream_reconciliation_work WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(&candidate.token_id)
+    .bind(&candidate.period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read replayed work state");
+    assert_eq!(
+        replayed_state,
+        (1, 0, now + 30, Some("remote_attempt_budget".to_string()))
+    );
+
+    sqlx::query(
         "UPDATE upstream_reconciliation_usage \
          SET first_used_at = first_used_at, last_used_at = last_used_at + 1, \
              updated_at = updated_at + 1, request_count = request_count \
@@ -2827,6 +2871,22 @@ async fn reconciliation_key_observations_reject_stale_generation_and_claim() {
     .execute(&proxy.key_store.pool)
     .await
     .expect("insert durable work");
+    proxy
+        .key_store
+        .persist_reconciliation_key_observations(
+            &candidate,
+            1,
+            &[ReconciliationKeyObservation {
+                key_id: "key-observation-fence-key".to_string(),
+                upstream_usage: 4,
+            }],
+            Some(ReconciliationWorkFence {
+                work_generation: 1,
+                claimed_job: None,
+            }),
+        )
+        .await
+        .expect("persist a partial observation before stale work");
 
     let stale_generation = proxy
         .key_store
@@ -2855,7 +2915,10 @@ async fn reconciliation_key_observations_reject_stale_generation_and_claim() {
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("read rejected generation observations");
-    assert_eq!(count, 0);
+    assert_eq!(
+        count, 1,
+        "a stale generation must retain prior observations"
+    );
 
     let queued = proxy
         .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
@@ -2895,7 +2958,7 @@ async fn reconciliation_key_observations_reject_stale_generation_and_claim() {
     .fetch_one(&proxy.key_store.pool)
     .await
     .expect("read rejected stale-claim observations");
-    assert_eq!(count, 0);
+    assert_eq!(count, 1, "a stale claim must retain prior observations");
 
     sqlx::query(
         "UPDATE scheduled_jobs SET available_at = 0 WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",


### PR DESCRIPTION
## Summary

- Add an additive v26 reconciliation migration so `first_used_at` and `last_used_at` advance the logical source generation, while `updated_at` remains storage-only.
- Cover equal-payload replay, storage-only partial-observation retention, logical timestamp revisions, and stale-generation/stale-claim retention.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked -j 2 -- -D warnings`
- `cargo test --lib tests::schema_migrations::versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift -- --exact`
- `cargo test --lib tests::schema_migrations::baseline_adoption_records_compatible_existing_schema_without_full_bootstrap -- --exact`
- `cargo test --lib tests::upstream_reconciliation_engine::reconciliation_source_revisions_distinguish_storage_and_logical_timestamps -- --exact`
- `cargo test --lib tests::upstream_reconciliation_engine::reconciliation_multi_key_observations_resume_without_partial_terminal -- --exact`
- `cargo test --lib tests::upstream_reconciliation_engine::reconciliation_key_observations_reject_stale_generation_and_claim -- --exact`
- Repository `$code-review` against `prd/sqlite-admin-read-reconciliation-liveness-v2...a68df3fe58651238b77be4abf817803f23c6de81`: Standards 0 findings, Spec 0 findings

## Initiative Child Metadata

- Delivery role: `child`
- Parent issue: #578
- Integration branch: `prd/sqlite-admin-read-reconciliation-liveness-v2`
- Wave: `1` (unblocked)
- Risk: low; additive SQLite trigger migration with focused local SQLite regressions
- Blocker: none
- Spec: `docs/specs/performance-architecture-hardening/SPEC.md`
- Spec Disposition: `reuse`
- Solutions: `docs/solutions/operations/period-scoped-upstream-usage-reconciliation.md` (reused; no sync needed)
- Project Docs: -
- Document sync: Spec and Solution contracts were inspected; no contract update is required.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->