### PR TITLE
fix(admin): make canonical Alerts warm self-healing

### DIFF
--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -96,6 +96,7 @@
         "store::tests::",
         "tavily_proxy::observability_deferred_writer_tests::",
         "tavily_proxy::privacy_status_phase_budget_tests::",
+        "tavily_proxy::scheduler_step_tests::",
         "tavily_proxy::tests::",
         "tests::request_kind_and_core::parse_",
         "tests::proxy_affinity_and_summary::extract_",

--- a/scripts/test_ci_backend_tests.py
+++ b/scripts/test_ci_backend_tests.py
@@ -427,6 +427,14 @@ class BackendTestRunnerContractTests(unittest.TestCase):
             integrity["include_prefixes"], ["tests::dashboard_rollup_integrity::"]
         )
 
+    def test_lib_core_owns_alert_projection_scheduler_step_tests(self):
+        _targets, shards = RUNNER.load_manifest()
+        core = next(shard for shard in shards if shard["id"] == "lib-core")
+
+        self.assertIn(
+            "tavily_proxy::scheduler_step_tests::", core["include_prefixes"]
+        )
+
     def test_linuxdo_dashboard_overview_has_one_manifest_owner(self):
         _targets, shards = RUNNER.load_manifest()
         forward = next(shard for shard in shards if shard["id"] == "bin-linuxdo-forward")

--- a/src/server/schedulers_dashboard_alert_projection.rs
+++ b/src/server/schedulers_dashboard_alert_projection.rs
@@ -19,11 +19,14 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
             let mut next_delay_secs = DASHBOARD_ALERT_PROJECTION_INTERVAL_SECS;
             match state
                 .proxy
-                .advance_dashboard_alert_projection_scheduler_step()
+                .advance_dashboard_alert_projection_scheduler_step_with_alerts()
                 .await
             {
-                Ok((true, _)) => {
-                    mark_dashboard_overview_alert_projection_dirty(state.as_ref()).await;
+                Ok(step) if step.canonical_alerts_dirty => {
+                    if step.dashboard_dirty {
+                        mark_dashboard_overview_alert_projection_dirty(state.as_ref()).await;
+                    }
+                    mark_admin_alerts_projection_generation(state.as_ref()).await;
                     if last_error.take().is_some() {
                         tracing::info!(
                             component = "dashboard_alert_projection",
@@ -32,7 +35,7 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
                         );
                     }
                 }
-                Ok((false, true)) => {
+                Ok(step) if step.idle => {
                     next_delay_secs = DASHBOARD_ALERT_PROJECTION_IDLE_INTERVAL_SECS;
                     let now = state.proxy.backend_time().now_ts();
                     if now.saturating_sub(last_idle_observation_at)
@@ -54,7 +57,7 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
                         }
                     }
                 }
-                Ok((false, false)) => {}
+                Ok(_) => {}
                 Err(err) => {
                     let error = err.to_string();
                     if last_error.as_deref() != Some(error.as_str()) {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -168,9 +168,15 @@ impl DashboardOverviewCacheState {
         true
     }
 
-    fn finish_admin_alerts_prewarm(&mut self) {
+    fn finish_admin_alerts_prewarm(&mut self, attempt_generation: AdminAlertsProjectionGeneration) {
         self.admin_alerts_prewarm_in_flight = false;
         self.admin_alerts_prewarm_defers = 0;
+        if self.admin_alerts_projection_generation != attempt_generation.alerts
+            || self.alert_projection_generation != attempt_generation.dashboard
+        {
+            self.admin_alerts_prewarm_not_before = None;
+            return;
+        }
         self.admin_alerts_prewarm_not_before = Some(
             tokio::time::Instant::now() + ADMIN_ALERTS_PREWARM_MIN_INTERVAL,
         );
@@ -533,7 +539,7 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
                     dashboard_overview_cache_for_state(state.as_ref())
                         .lock()
                         .await
-                        .finish_admin_alerts_prewarm();
+                        .finish_admin_alerts_prewarm(generation);
                     tracing::debug!(
                         component = "admin_read",
                         event = "alerts_canonical_warm_published",
@@ -569,7 +575,7 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
                     dashboard_overview_cache_for_state(state.as_ref())
                         .lock()
                         .await
-                        .finish_admin_alerts_prewarm();
+                        .finish_admin_alerts_prewarm(generation);
                     break;
                 }
             }
@@ -936,7 +942,10 @@ mod admin_alerts_prewarm_tests {
             "an in-flight prewarm must remain singleflight"
         );
 
-        cache.finish_admin_alerts_prewarm();
+        cache.finish_admin_alerts_prewarm(AdminAlertsProjectionGeneration {
+            alerts: 0,
+            dashboard: 0,
+        });
         assert!(
             !cache.try_start_admin_alerts_prewarm(
                 now + ADMIN_ALERTS_PREWARM_MIN_INTERVAL - std::time::Duration::from_secs(1)
@@ -957,8 +966,29 @@ mod admin_alerts_prewarm_tests {
         assert_eq!(cache.defer_admin_alerts_prewarm(now), std::time::Duration::from_secs(5));
         assert_eq!(cache.defer_admin_alerts_prewarm(now), std::time::Duration::from_secs(30));
 
-        cache.finish_admin_alerts_prewarm();
+        cache.finish_admin_alerts_prewarm(AdminAlertsProjectionGeneration {
+            alerts: 0,
+            dashboard: 0,
+        });
         assert_eq!(cache.admin_alerts_prewarm_defers, 0);
+    }
+
+    #[test]
+    fn completing_an_older_alerts_generation_leaves_the_warmer_rearmed() {
+        let mut cache = DashboardOverviewCacheState::default();
+        let prior_generation = AdminAlertsProjectionGeneration {
+            alerts: 0,
+            dashboard: 0,
+        };
+        assert!(cache.try_start_admin_alerts_prewarm(tokio::time::Instant::now()));
+
+        cache.admin_alerts_projection_generation = 1;
+        cache.admin_alerts_prewarm_not_before = None;
+        cache.finish_admin_alerts_prewarm(prior_generation);
+
+        assert!(!cache.admin_alerts_prewarm_in_flight);
+        assert!(cache.admin_alerts_prewarm_not_before.is_none());
+        assert!(cache.try_start_admin_alerts_prewarm(tokio::time::Instant::now()));
     }
 
     #[test]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -79,6 +79,7 @@ struct DashboardOverviewCacheState {
     loading_generation: u64,
     built_request_stats_generation: Option<u64>,
     alert_projection_generation: u64,
+    admin_alerts_projection_generation: u64,
     built_alert_projection_generation: Option<u64>,
     last_refresh_requested_at: Option<tokio::time::Instant>,
     last_freshness_probe_at: Option<tokio::time::Instant>,
@@ -106,6 +107,7 @@ impl Default for DashboardOverviewCacheState {
             loading_generation: 0,
             built_request_stats_generation: None,
             alert_projection_generation: 0,
+            admin_alerts_projection_generation: 0,
             built_alert_projection_generation: None,
             last_refresh_requested_at: None,
             last_freshness_probe_at: None,
@@ -192,11 +194,17 @@ enum AdminAlertsReadCacheValue {
     Groups(PaginatedAlertGroups),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AdminAlertsProjectionGeneration {
+    alerts: u64,
+    dashboard: u64,
+}
+
 #[derive(Debug, Clone)]
 struct AdminAlertsReadCacheEntry {
     key: String,
     value: AdminAlertsReadCacheValue,
-    generation: u64,
+    generation: AdminAlertsProjectionGeneration,
     canonical: bool,
     observed_at: i64,
     stored_at: tokio::time::Instant,
@@ -265,14 +273,23 @@ async fn admin_alerts_last_good(
 async fn admin_alerts_canonical_last_good(
     state: &AppState,
     key: &str,
-) -> Option<(AdminAlertsReadCacheValue, i64, u64, u64)> {
+) -> Option<(
+    AdminAlertsReadCacheValue,
+    i64,
+    AdminAlertsProjectionGeneration,
+    AdminAlertsProjectionGeneration,
+)> {
     let cache = dashboard_overview_cache_for_state(state);
     let mut cache = cache.lock().await;
     let position = cache.admin_alerts.entries.iter().position(|entry| {
         entry.key == key && entry.canonical && entry.stored_at.elapsed() <= ADMIN_ALERTS_CACHE_TTL
     })?;
     let entry = cache.admin_alerts.entries.remove(position)?;
-    let result = (entry.value.clone(), entry.observed_at, entry.generation, cache.alert_projection_generation);
+    let current_generation = AdminAlertsProjectionGeneration {
+        alerts: cache.admin_alerts_projection_generation,
+        dashboard: cache.alert_projection_generation,
+    };
+    let result = (entry.value.clone(), entry.observed_at, entry.generation, current_generation);
     cache.admin_alerts.entries.push_front(entry);
     Some(result)
 }
@@ -291,18 +308,20 @@ async fn record_admin_alerts_last_good(
     .await;
 }
 
-async fn current_admin_alerts_generation(state: &AppState) -> u64 {
-    dashboard_overview_cache_for_state(state)
-        .lock()
-        .await
-        .alert_projection_generation
+async fn current_admin_alerts_generation(state: &AppState) -> AdminAlertsProjectionGeneration {
+    let cache = dashboard_overview_cache_for_state(state);
+    let cache = cache.lock().await;
+    AdminAlertsProjectionGeneration {
+        alerts: cache.admin_alerts_projection_generation,
+        dashboard: cache.alert_projection_generation,
+    }
 }
 
 async fn record_admin_alerts_last_good_at_generation(
     state: &AppState,
     key: String,
     value: AdminAlertsReadCacheValue,
-    generation: u64,
+    generation: AdminAlertsProjectionGeneration,
 ) {
     let cache = dashboard_overview_cache_for_state(state);
     let mut cache = cache.lock().await;
@@ -316,18 +335,7 @@ async fn record_admin_alerts_last_good_at_generation(
         observed_at: state.proxy.backend_time().now_ts(),
         stored_at: tokio::time::Instant::now(),
     });
-    while cache.admin_alerts.entries.len() > ADMIN_ALERTS_CACHE_CAPACITY {
-        if let Some(index) = cache
-            .admin_alerts
-            .entries
-            .iter()
-            .rposition(|entry| !entry.canonical)
-        {
-            cache.admin_alerts.entries.remove(index);
-        } else {
-            break;
-        }
-    }
+    retain_admin_alerts_cache_capacity(&mut cache);
 }
 
 #[cfg(test)]
@@ -349,7 +357,7 @@ pub(crate) async fn expire_admin_alerts_canonical_last_good_for_test(
 
 async fn publish_admin_alerts_canonical(
     state: &AppState,
-    generation: u64,
+    generation: AdminAlertsProjectionGeneration,
     catalog: AlertCatalog,
     events: PaginatedAlertEvents,
     groups: PaginatedAlertGroups,
@@ -369,14 +377,18 @@ async fn publish_admin_alerts_canonical(
 
 fn publish_admin_alerts_canonical_into_cache(
     cache: &mut DashboardOverviewCacheState,
-    generation: u64,
+    generation: AdminAlertsProjectionGeneration,
     observed_at: i64,
     stored_at: tokio::time::Instant,
     catalog: AlertCatalog,
     events: PaginatedAlertEvents,
     groups: PaginatedAlertGroups,
 ) -> bool {
-    if cache.alert_projection_generation != generation {
+    if (AdminAlertsProjectionGeneration {
+        alerts: cache.admin_alerts_projection_generation,
+        dashboard: cache.alert_projection_generation,
+    }) != generation
+    {
         return false;
     }
     for (key, value) in [
@@ -400,6 +412,11 @@ fn publish_admin_alerts_canonical_into_cache(
             stored_at,
         });
     }
+    retain_admin_alerts_cache_capacity(cache);
+    true
+}
+
+fn retain_admin_alerts_cache_capacity(cache: &mut DashboardOverviewCacheState) {
     while cache.admin_alerts.entries.len() > ADMIN_ALERTS_CACHE_CAPACITY {
         if let Some(index) = cache
             .admin_alerts
@@ -412,7 +429,6 @@ fn publish_admin_alerts_canonical_into_cache(
             break;
         }
     }
-    true
 }
 
 fn default_admin_alert_cache_key(kind: &str) -> String {
@@ -429,6 +445,17 @@ fn default_admin_alert_cache_key(kind: &str) -> String {
         20_i64,
     ))
     .expect("default admin Alerts cache key fields are serializable")
+}
+
+pub(crate) async fn mark_admin_alerts_projection_generation(state: &AppState) {
+    let cache = dashboard_overview_cache_for_state(state);
+    let mut cache = cache.lock().await;
+    cache.admin_alerts_projection_generation =
+        cache.admin_alerts_projection_generation.wrapping_add(1);
+    // Every completed Alerts sidecar slice invalidates the canonical cache.
+    // The warm controller can retry immediately, while Dashboard refreshes
+    // remain tied to their narrower recent-summary generation.
+    cache.admin_alerts_prewarm_not_before = None;
 }
 
 pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
@@ -863,9 +890,10 @@ pub(crate) async fn prime_admin_privacy_status_for_test(state: Arc<AppState>) {
 #[cfg(test)]
 mod admin_alerts_prewarm_tests {
     use super::{
-        ADMIN_ALERTS_PREWARM_MIN_INTERVAL, AdminAlertsReadCacheValue, AlertCatalog,
-        DashboardOverviewCacheState, PaginatedAlertEvents, PaginatedAlertGroups,
-        publish_admin_alerts_canonical_into_cache,
+        ADMIN_ALERTS_CACHE_CAPACITY, ADMIN_ALERTS_PREWARM_MIN_INTERVAL,
+        AdminAlertsProjectionGeneration, AdminAlertsReadCacheEntry, AdminAlertsReadCacheValue,
+        AlertCatalog, DashboardOverviewCacheState, PaginatedAlertEvents, PaginatedAlertGroups,
+        publish_admin_alerts_canonical_into_cache, retain_admin_alerts_cache_capacity,
     };
 
     fn empty_catalog() -> AlertCatalog {
@@ -952,16 +980,24 @@ mod admin_alerts_prewarm_tests {
     }
 
     #[test]
-    fn canonical_publish_discards_all_staged_values_after_a_generation_change() {
+    fn canonical_publish_discards_all_staged_values_after_an_alerts_generation_change() {
         let mut cache = DashboardOverviewCacheState {
-            alert_projection_generation: 2,
+            admin_alerts_projection_generation: 2,
             ..Default::default()
+        };
+        let prior_generation = AdminAlertsProjectionGeneration {
+            alerts: 1,
+            dashboard: 0,
+        };
+        let current_generation = AdminAlertsProjectionGeneration {
+            alerts: 2,
+            dashboard: 0,
         };
 
         assert!(
             !publish_admin_alerts_canonical_into_cache(
                 &mut cache,
-                1,
+                prior_generation,
                 123,
                 tokio::time::Instant::now(),
                 empty_catalog(),
@@ -974,7 +1010,7 @@ mod admin_alerts_prewarm_tests {
 
         assert!(publish_admin_alerts_canonical_into_cache(
             &mut cache,
-            2,
+            current_generation,
             124,
             tokio::time::Instant::now(),
             empty_catalog(),
@@ -986,11 +1022,57 @@ mod admin_alerts_prewarm_tests {
             .admin_alerts
             .entries
             .iter()
-            .all(|entry| entry.generation == 2 && entry.canonical));
+            .all(|entry| entry.generation == current_generation && entry.canonical));
         assert!(matches!(
             cache.admin_alerts.entries[0].value,
             AdminAlertsReadCacheValue::Groups(_)
         ));
+    }
+
+    #[test]
+    fn canonical_alerts_entries_remain_pinned_in_a_bounded_cache() {
+        let generation = AdminAlertsProjectionGeneration {
+            alerts: 1,
+            dashboard: 1,
+        };
+        let mut cache = DashboardOverviewCacheState {
+            alert_projection_generation: generation.dashboard,
+            admin_alerts_projection_generation: generation.alerts,
+            ..Default::default()
+        };
+        assert!(publish_admin_alerts_canonical_into_cache(
+            &mut cache,
+            generation,
+            123,
+            tokio::time::Instant::now(),
+            empty_catalog(),
+            empty_events(),
+            empty_groups(),
+        ));
+
+        for index in 0..ADMIN_ALERTS_CACHE_CAPACITY {
+            cache.admin_alerts.entries.push_back(AdminAlertsReadCacheEntry {
+                key: format!("query-{index}"),
+                value: AdminAlertsReadCacheValue::Events(empty_events()),
+                generation,
+                canonical: false,
+                observed_at: 123,
+                stored_at: tokio::time::Instant::now(),
+            });
+        }
+        retain_admin_alerts_cache_capacity(&mut cache);
+
+        assert_eq!(cache.admin_alerts.entries.len(), ADMIN_ALERTS_CACHE_CAPACITY);
+        for key in [
+            "catalog".to_string(),
+            super::default_admin_alert_cache_key("events"),
+            super::default_admin_alert_cache_key("groups"),
+        ] {
+            assert!(
+                cache.admin_alerts.entries.iter().any(|entry| entry.key == key),
+                "canonical cache key {key} must remain pinned"
+            );
+        }
     }
 }
 

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -701,7 +701,7 @@ async fn alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_s
 }
 
 #[tokio::test]
-async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses() {
+async fn admin_alerts_background_warm_retries_and_preserves_last_good_contract() {
     let db_path = temp_db_path("admin-alerts-last-good");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(
@@ -772,39 +772,62 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         }
     }
     assert!(projection_ready, "empty projection must complete before warming admin cache");
-    let catalog = state
-        .proxy
-        .admin_alert_catalog()
-        .await
-        .expect("build canonical catalog for the warm-cache fixture");
-    super::super::record_admin_alerts_last_good(
-        state.as_ref(),
-        "catalog".to_string(),
-        super::super::AdminAlertsReadCacheValue::Catalog(catalog),
-    )
-    .await;
-    let events = state
-        .proxy
-        .admin_alert_events_page(None, None, None, None, None, None, &[], 1, 20)
-        .await
-        .expect("build canonical events for the warm-cache fixture");
-    super::super::record_admin_alerts_last_good(
-        state.as_ref(),
-        super::super::default_admin_alert_cache_key("events"),
-        super::super::AdminAlertsReadCacheValue::Events(events),
-    )
-    .await;
-    let groups = state
-        .proxy
-        .admin_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
-        .await
-        .expect("build canonical groups for the warm-cache fixture");
-    super::super::record_admin_alerts_last_good(
-        state.as_ref(),
-        super::super::default_admin_alert_cache_key("groups"),
-        super::super::AdminAlertsReadCacheValue::Groups(groups),
-    )
-    .await;
+    state.proxy.force_next_admin_alert_read_deadline_for_test();
+    super::super::prewarm_admin_alerts(state.clone()).await;
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            if cache.admin_alerts_prewarm_defers > 0 {
+                assert!(
+                    cache.admin_alerts.entries.iter().all(|entry| !entry.canonical),
+                    "a deferred projected read must not publish a partial canonical generation"
+                );
+                break;
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the forced bounded warm read defers");
+
+    tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            let current_generation = super::super::AdminAlertsProjectionGeneration {
+                alerts: cache.admin_alerts_projection_generation,
+                dashboard: cache.alert_projection_generation,
+            };
+            let complete_generation = cache
+                .admin_alerts
+                .entries
+                .iter()
+                .filter(|entry| entry.canonical)
+                .all(|entry| entry.generation == current_generation)
+                && [
+                    "catalog".to_string(),
+                    super::super::default_admin_alert_cache_key("events"),
+                    super::super::default_admin_alert_cache_key("groups"),
+                ]
+                .into_iter()
+                .all(|key| {
+                    cache
+                        .admin_alerts
+                        .entries
+                        .iter()
+                        .any(|entry| entry.canonical && entry.key == key)
+                });
+            if complete_generation {
+                break;
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the background warmer retries a transient bounded read and publishes all canonical keys");
     for route in ["catalog", "events", "groups"] {
         let warm = client
             .get(format!("http://{admin_addr}/api/alerts/{route}"))

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -701,7 +701,7 @@ async fn alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_s
 }
 
 #[tokio::test]
-async fn admin_alerts_background_warm_retries_and_preserves_last_good_contract() {
+async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses() {
     let db_path = temp_db_path("admin-alerts-last-good");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(

--- a/src/store/key_store_alerts_tests.rs
+++ b/src/store/key_store_alerts_tests.rs
@@ -550,6 +550,127 @@ fn unrecoverable_quota_events_fall_back_to_compat_groups() {
 }
 
 #[tokio::test]
+async fn canonical_alerts_warm_reads_are_independently_bounded_and_reusable() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let db_path = temp_dir.path().join("alerts-canonical-warm-bounded.db");
+    let store = KeyStore::new_with_time(
+        &db_path.to_string_lossy(),
+        BackendTime::system(),
+    )
+    .await
+    .expect("create key store");
+
+    store
+        .sqlite_runtime
+        .force_next_cooperative_query_deadline_for_test();
+    let catalog = store
+        .fetch_admin_alert_catalog_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+        .await;
+    assert!(
+        matches!(
+            &catalog,
+            Err(ProxyError::Deferred { operation, reason })
+                if *operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "catalog warm must use its own bounded projected read: {catalog:?}"
+    );
+    store
+        .fetch_admin_alert_catalog_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+        .await
+        .expect("a later catalog warm read is reusable");
+
+    store
+        .sqlite_runtime
+        .force_next_cooperative_query_deadline_for_test();
+    let events = store
+        .fetch_admin_alert_events_page_for_operation(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+            1,
+            20,
+            SqliteOperation::AdminAlertsCacheWarm,
+        )
+        .await;
+    assert!(
+        matches!(
+            &events,
+            Err(ProxyError::Deferred { operation, reason })
+                if *operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "events warm must use its own bounded projected read: {events:?}"
+    );
+    store
+        .fetch_admin_alert_events_page_for_operation(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+            1,
+            20,
+            SqliteOperation::AdminAlertsCacheWarm,
+        )
+        .await
+        .expect("a later events warm read is reusable");
+
+    store
+        .sqlite_runtime
+        .force_next_cooperative_query_deadline_for_test();
+    let groups = store
+        .fetch_admin_alert_groups_page_for_operation(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+            1,
+            20,
+            SqliteOperation::AdminAlertsCacheWarm,
+        )
+        .await;
+    assert!(
+        matches!(
+            &groups,
+            Err(ProxyError::Deferred { operation, reason })
+                if *operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "groups warm must use its own bounded projected read: {groups:?}"
+    );
+    store
+        .fetch_admin_alert_groups_page_for_operation(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+            1,
+            20,
+            SqliteOperation::AdminAlertsCacheWarm,
+        )
+        .await
+        .expect("a later groups warm read is reusable");
+
+    assert_eq!(
+        store
+            .sqlite_runtime
+            .discarded_connections_for_test(SqliteOperation::AdminAlertsCacheWarm),
+        0,
+        "a deferred cache warm read restores its SQLite connection"
+    );
+}
+
+#[tokio::test]
 async fn fetch_alert_groups_page_executes_sqlite_grouped_query_for_mother_and_compat_groups() {
     let temp_dir = tempdir().expect("create temp dir");
     let db_path = temp_dir.path().join("alerts-groups.db");

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -1,3 +1,40 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AlertProjectionSchedulerStep {
+    pub dashboard_dirty: bool,
+    pub canonical_alerts_dirty: bool,
+    pub idle: bool,
+    refresh_dashboard_summary: bool,
+}
+
+fn classify_dashboard_alert_projection_scheduler_step(
+    outcome: AlertProjectionSliceOutcome,
+) -> AlertProjectionSchedulerStep {
+    match outcome {
+        AlertProjectionSliceOutcome::Advanced {
+            dashboard_dirty,
+            complete,
+            ..
+        } => AlertProjectionSchedulerStep {
+            dashboard_dirty,
+            canonical_alerts_dirty: true,
+            idle: false,
+            refresh_dashboard_summary: dashboard_dirty || complete,
+        },
+        AlertProjectionSliceOutcome::Idle => AlertProjectionSchedulerStep {
+            dashboard_dirty: false,
+            canonical_alerts_dirty: false,
+            idle: true,
+            refresh_dashboard_summary: true,
+        },
+        AlertProjectionSliceOutcome::Deferred { .. } => AlertProjectionSchedulerStep {
+            dashboard_dirty: false,
+            canonical_alerts_dirty: false,
+            idle: false,
+            refresh_dashboard_summary: false,
+        },
+    }
+}
+
 impl TavilyProxy {
     #[doc(hidden)]
     pub fn admin_privacy_status_refresh_defer_reason(&self) -> Option<&'static str> {
@@ -82,27 +119,24 @@ impl TavilyProxy {
     pub async fn advance_dashboard_alert_projection_scheduler_step(
         &self,
     ) -> Result<(bool, bool), ProxyError> {
-        match self.advance_dashboard_alert_projection_slice_outcome().await? {
-            AlertProjectionSliceOutcome::Advanced {
-                dashboard_dirty,
-                complete,
-                ..
-            } => {
-                if dashboard_dirty || complete {
-                    self.key_store
-                        .refresh_dashboard_alert_projection_summary()
-                        .await?;
-                }
-                Ok((dashboard_dirty, false))
-            }
-            AlertProjectionSliceOutcome::Idle => {
-                self.key_store
-                    .refresh_dashboard_alert_projection_summary()
-                    .await?;
-                Ok((false, true))
-            }
-            AlertProjectionSliceOutcome::Deferred { .. } => Ok((false, false)),
+        let step = self
+            .advance_dashboard_alert_projection_scheduler_step_with_alerts()
+            .await?;
+        Ok((step.dashboard_dirty, step.idle))
+    }
+
+    pub async fn advance_dashboard_alert_projection_scheduler_step_with_alerts(
+        &self,
+    ) -> Result<AlertProjectionSchedulerStep, ProxyError> {
+        let step = classify_dashboard_alert_projection_scheduler_step(
+            self.advance_dashboard_alert_projection_slice_outcome().await?,
+        );
+        if step.refresh_dashboard_summary {
+            self.key_store
+                .refresh_dashboard_alert_projection_summary()
+                .await?;
         }
+        Ok(step)
     }
 
     pub async fn refresh_dashboard_alert_projection_observation(&self) -> Result<bool, ProxyError> {
@@ -318,5 +352,26 @@ impl TavilyProxy {
         self.key_store
             .fetch_projected_recent_alerts_summary(window_hours)
             .await
+    }
+}
+
+#[cfg(test)]
+mod scheduler_step_tests {
+    use super::classify_dashboard_alert_projection_scheduler_step;
+    use crate::store::AlertProjectionSliceOutcome;
+
+    #[test]
+    fn history_only_projection_advance_marks_canonical_alerts_dirty() {
+        let step = classify_dashboard_alert_projection_scheduler_step(
+            AlertProjectionSliceOutcome::Advanced {
+                rows: 1,
+                complete: false,
+                dashboard_dirty: false,
+            },
+        );
+
+        assert!(step.canonical_alerts_dirty);
+        assert!(!step.dashboard_dirty);
+        assert!(!step.refresh_dashboard_summary);
     }
 }


### PR DESCRIPTION
## Summary

- Keep default administrator Alerts catalog, events page 1/20, and groups page 1/20 tied to a complete same-generation last-good cache.
- Re-arm the canonical warmer after every durable Alerts sidecar slice, including history-only slices, without changing Dashboard refresh behavior.
- Cover bounded independent warm reads, atomic retry publication, and pinned fresh/stale/cold cache behavior.

## Validation

- cargo test --lib scheduler_step_tests::history_only_projection_advance_marks_canonical_alerts_dirty
- cargo test --bin tavily-hikari canonical_publish_discards_all_staged_values_after_an_alerts_generation_change
- cargo test --bin tavily-hikari canonical_alerts_entries_remain_pinned_in_a_bounded_cache
- cargo test --lib canonical_alerts_warm_reads_are_independently_bounded_and_reusable
- cargo test --bin tavily-hikari admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses (retry/last-good coverage in src/server/tests/alerts_and_ha_dashboard_defaults.rs)
- cargo clippy --locked -j 2 -- -D warnings
- cargo fmt --check

Relates to #577.