### PR TITLE
fix(dashboard): bound quota recovery pages

### DIFF
--- a/src/models/quota_views.rs
+++ b/src/models/quota_views.rs
@@ -19,6 +19,14 @@ pub(crate) struct DashboardQuotaSample {
     pub previous_quota_remaining: Option<i64>,
 }
 
+#[derive(Debug, Clone)]
+struct DashboardQuotaRecoveryWindowGroup {
+    key_id: String,
+    captured_at: i64,
+    first_sample: DashboardQuotaSample,
+    last_sample: DashboardQuotaSample,
+}
+
 /// Rebuildable quota-only state for Dashboard's append-only sample source.
 ///
 /// The overview cache owns presentation data. This model retains just enough
@@ -30,30 +38,32 @@ pub(crate) struct DashboardQuotaChargeReadModel {
     pub watermark: DashboardQuotaSampleWatermark,
     bounds: SummaryWindowBounds,
     last_sample_by_key: HashMap<String, DashboardQuotaSample>,
+    recovery_next_sample_by_key: HashMap<String, DashboardQuotaSample>,
+    recovery_baseline_by_key: HashMap<String, DashboardQuotaSample>,
+    recovery_window_group: Option<DashboardQuotaRecoveryWindowGroup>,
     today_sampled_keys: HashSet<String>,
     yesterday_sampled_keys: HashSet<String>,
     month_sampled_keys: HashSet<String>,
 }
 
 impl DashboardQuotaChargeReadModel {
-    pub(crate) fn from_samples(
+    pub(crate) fn empty(
         bounds: SummaryWindowBounds,
         stale_key_count: i64,
         watermark: DashboardQuotaSampleWatermark,
-        samples: Vec<DashboardQuotaSample>,
     ) -> Self {
         let mut model = Self {
             snapshot: DashboardQuotaChargeSnapshot::default(),
             watermark,
             bounds,
             last_sample_by_key: HashMap::new(),
+            recovery_next_sample_by_key: HashMap::new(),
+            recovery_baseline_by_key: HashMap::new(),
+            recovery_window_group: None,
             today_sampled_keys: HashSet::new(),
             yesterday_sampled_keys: HashSet::new(),
             month_sampled_keys: HashSet::new(),
         };
-        for sample in samples {
-            model.apply_sample(&sample);
-        }
         model.set_stale_key_count(stale_key_count);
         model
     }
@@ -111,8 +121,47 @@ impl DashboardQuotaChargeReadModel {
         for sample in samples {
             self.apply_sample(sample);
         }
+        self.refresh_sampled_key_counts();
         self.watermark = next_watermark;
         self.set_stale_key_count(stale_key_count);
+    }
+
+    /// Recovery pages follow the existing `(captured_at DESC, key_id ASC)`
+    /// index. A same-key timestamp group is read by ascending id, then folded
+    /// before the next group so credits retain chronological semantics.
+    pub(crate) fn stage_recovery_page_desc(
+        &mut self,
+        baselines: &[DashboardQuotaSample],
+        samples: &[DashboardQuotaSample],
+    ) {
+        for baseline in baselines {
+            self.recovery_baseline_by_key
+                .entry(baseline.key_id.clone())
+                .or_insert_with(|| baseline.clone());
+        }
+        for sample in samples {
+            self.stage_recovery_window_sample(sample);
+        }
+    }
+
+    /// Finalizes the private reverse-keyset draft after the caller has read
+    /// every window page. Baselines are intentionally delayed until this
+    /// point, because their samples precede every window row for a Key.
+    pub(crate) fn finish_recovery(&mut self) {
+        self.finish_recovery_window_group();
+        let baselines = std::mem::take(&mut self.recovery_baseline_by_key);
+        for (key_id, baseline) in baselines {
+            let Some(next_sample) = self.recovery_next_sample_by_key.get(&key_id).cloned() else {
+                continue;
+            };
+            let delta = baseline
+                .quota_remaining
+                .saturating_sub(next_sample.quota_remaining)
+                .max(0);
+            self.record_sample_charge(&next_sample, delta);
+        }
+        self.recovery_next_sample_by_key.clear();
+        self.refresh_sampled_key_counts();
     }
 
     fn apply_sample(&mut self, sample: &DashboardQuotaSample) {
@@ -125,6 +174,66 @@ impl DashboardQuotaChargeReadModel {
             .map(|previous| previous.saturating_sub(sample.quota_remaining).max(0))
             .unwrap_or_default();
 
+        self.record_sample_charge(sample, delta);
+        self.last_sample_by_key
+            .insert(sample.key_id.clone(), sample.clone());
+    }
+
+    fn stage_recovery_window_sample(&mut self, sample: &DashboardQuotaSample) {
+        let continues_group = self.recovery_window_group.as_ref().is_some_and(|group| {
+            group.key_id == sample.key_id && group.captured_at == sample.captured_at
+        });
+        if !continues_group {
+            self.finish_recovery_window_group();
+            self.recovery_window_group = Some(DashboardQuotaRecoveryWindowGroup {
+                key_id: sample.key_id.clone(),
+                captured_at: sample.captured_at,
+                first_sample: sample.clone(),
+                last_sample: sample.clone(),
+            });
+            return;
+        }
+
+        let previous_sample = self
+            .recovery_window_group
+            .as_ref()
+            .expect("matching recovery group is present")
+            .last_sample
+            .clone();
+        let delta = previous_sample
+            .quota_remaining
+            .saturating_sub(sample.quota_remaining)
+            .max(0);
+        self.record_sample_charge(sample, delta);
+        self.recovery_window_group
+            .as_mut()
+            .expect("matching recovery group is present")
+            .last_sample = sample.clone();
+    }
+
+    fn finish_recovery_window_group(&mut self) {
+        let Some(group) = self.recovery_window_group.take() else {
+            return;
+        };
+
+        if let Some(next_sample) = self.recovery_next_sample_by_key.get(&group.key_id).cloned() {
+            let delta = group
+                .last_sample
+                .quota_remaining
+                .saturating_sub(next_sample.quota_remaining)
+                .max(0);
+            self.record_sample_charge(&next_sample, delta);
+        } else {
+            self.record_sample_charge(&group.last_sample, 0);
+            self.last_sample_by_key
+                .entry(group.key_id.clone())
+                .or_insert(group.last_sample.clone());
+        }
+        self.recovery_next_sample_by_key
+            .insert(group.key_id, group.first_sample);
+    }
+
+    fn record_sample_charge(&mut self, sample: &DashboardQuotaSample, delta: i64) {
         if sample.captured_at >= self.bounds.month_quota_charge_start
             && sample.captured_at < self.bounds.today_end
         {
@@ -158,18 +267,19 @@ impl DashboardQuotaChargeReadModel {
             self.yesterday_sampled_keys.insert(sample.key_id.clone());
             update_latest_sync_at(&mut self.snapshot.yesterday, sample.captured_at);
         }
-
-        self.last_sample_by_key
-            .insert(sample.key_id.clone(), sample.clone());
     }
 
     fn set_stale_key_count(&mut self, stale_key_count: i64) {
-        self.snapshot.today.sampled_key_count = self.today_sampled_keys.len() as i64;
+        self.refresh_sampled_key_counts();
         self.snapshot.today.stale_key_count = stale_key_count;
-        self.snapshot.yesterday.sampled_key_count = self.yesterday_sampled_keys.len() as i64;
         self.snapshot.yesterday.stale_key_count = stale_key_count;
-        self.snapshot.month.sampled_key_count = self.month_sampled_keys.len() as i64;
         self.snapshot.month.stale_key_count = stale_key_count;
+    }
+
+    fn refresh_sampled_key_counts(&mut self) {
+        self.snapshot.today.sampled_key_count = self.today_sampled_keys.len() as i64;
+        self.snapshot.yesterday.sampled_key_count = self.yesterday_sampled_keys.len() as i64;
+        self.snapshot.month.sampled_key_count = self.month_sampled_keys.len() as i64;
     }
 }
 

--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -1,0 +1,399 @@
+use tempfile::{TempDir, tempdir};
+
+const DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID: &str = "dashboard-quota-recovery-key";
+
+async fn dashboard_quota_recovery_store() -> (TempDir, std::sync::Arc<KeyStore>, SummaryWindowBounds) {
+    let temp_dir = tempdir().expect("create temp directory");
+    let db_path = temp_dir.path().join("dashboard-quota-recovery.db");
+    let store = std::sync::Arc::new(
+        KeyStore::new_with_time(&db_path.to_string_lossy(), BackendTime::system())
+            .await
+            .expect("create key store"),
+    );
+    sqlx::query(
+        r#"
+        INSERT INTO api_keys (id, api_key, status, created_at, status_changed_at)
+        VALUES (?, ?, 'active', 0, 0)
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind("tvly-dashboard-quota-recovery-key")
+    .execute(&store.pool)
+    .await
+    .expect("insert quota recovery key");
+
+    let bounds = SummaryWindowBounds {
+        today_start: 800,
+        today_end: 1_000,
+        today_period_end: 1_000,
+        yesterday_start: 500,
+        yesterday_end: 800,
+        month_start: 0,
+        month_quota_charge_start: 0,
+        month_period_end: 1_000,
+        previous_month_start: -1_000,
+        previous_month_end: 0,
+    };
+    (temp_dir, store, bounds)
+}
+
+async fn insert_dashboard_quota_recovery_sample(
+    store: &KeyStore,
+    captured_at: i64,
+    quota_remaining: i64,
+) {
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_quota_sync_samples (
+            key_id, quota_limit, quota_remaining, captured_at, source
+        ) VALUES (?, 1000, ?, ?, 'test')
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(quota_remaining)
+    .bind(captured_at)
+    .execute(&store.pool)
+    .await
+    .expect("insert quota sample");
+}
+
+async fn seed_dashboard_quota_recovery_samples(store: &KeyStore, sample_count: i64) {
+    insert_dashboard_quota_recovery_sample(store, 100, 1_000).await;
+    for offset in 0..sample_count {
+        insert_dashboard_quota_recovery_sample(store, 500, 999 - offset).await;
+    }
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_paginates_exact_keyset_model() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    for offset in 0..33 {
+        insert_dashboard_quota_recovery_sample(&store, 1_000 + offset, 934 - offset).await;
+    }
+
+    let model = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 3)
+        .await
+        .expect("recover all quota pages");
+
+    assert_eq!(model.watermark.source_id, 66);
+    assert_eq!(model.watermark.source_count, 66);
+    assert_eq!(
+        model.watermark,
+        store
+            .fetch_dashboard_quota_sample_watermark(bounds.today_end)
+            .await
+            .expect("read normal quota watermark"),
+        "the staged recovery watermark must retain the normal probe's exact source generation"
+    );
+    assert_eq!(model.snapshot.month.upstream_actual_credits, 65);
+    assert_eq!(model.snapshot.month.latest_sync_at, Some(500));
+    assert_eq!(model.snapshot.month.sampled_key_count, 1);
+    assert_eq!(model.snapshot.month.stale_key_count, 3);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_discards_staged_model_on_source_change() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    let pause = store.install_dashboard_overview_read_pause().await;
+    let recovery_store = std::sync::Arc::clone(&store);
+    let mut recovery = tokio::spawn(async move {
+        recovery_store
+            .fetch_dashboard_quota_charge_read_model(bounds, 0)
+            .await
+    });
+
+    pause.wait_until_arrived().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(10), &mut recovery)
+            .await
+            .is_err(),
+        "a staged model must not complete before its source generation is rechecked"
+    );
+    insert_dashboard_quota_recovery_sample(&store, 565, 934).await;
+    pause.release();
+
+    let model = recovery
+        .await
+        .expect("join quota recovery")
+        .expect("restart recovery from the changed source generation");
+    let final_watermark = store
+        .fetch_dashboard_quota_sample_watermark(bounds.today_end)
+        .await
+        .expect("read final source watermark");
+    assert_eq!(model.watermark, final_watermark);
+    assert_eq!(model.snapshot.month.upstream_actual_credits, 66);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_cancellation_discards_private_model() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    let pause = store.install_dashboard_overview_read_pause().await;
+    let recovery_store = std::sync::Arc::clone(&store);
+    let recovery = tokio::spawn(async move {
+        recovery_store
+            .fetch_dashboard_quota_charge_read_model(bounds, 0)
+            .await
+    });
+
+    pause.wait_until_arrived().await;
+    recovery.abort();
+    assert!(
+        recovery
+            .await
+            .expect_err("cancelled recovery must not return a staged model")
+            .is_cancelled(),
+        "the paused recovery task should be cancelled"
+    );
+    pause.release();
+
+    let restarted = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 0)
+        .await
+        .expect("a later recovery must start from an empty private model");
+    assert_eq!(restarted.watermark.source_count, 66);
+    assert_eq!(restarted.snapshot.month.upstream_actual_credits, 65);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_restarts_after_native_page_deadline() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    store
+        .sqlite_runtime
+        .force_cooperative_query_deadline_after_reads_for_test(2);
+
+    let interrupted = store.fetch_dashboard_quota_charge_read_model(bounds, 0).await;
+    assert!(
+        matches!(
+            interrupted,
+            Err(ProxyError::Deferred { operation, ref reason })
+                if operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "the recovery page must preserve the native 250ms deadline: {interrupted:?}"
+    );
+
+    let restarted = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 0)
+        .await
+        .expect("a later recovery starts from a clean bounded session");
+    assert_eq!(restarted.watermark.source_id, 66);
+    assert_eq!(restarted.snapshot.month.upstream_actual_credits, 65);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_queries_use_existing_indexes() {
+    let (_temp_dir, store, _bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 1).await;
+
+    let window_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+           SELECT id, key_id, quota_remaining, captured_at
+           FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+           WHERE captured_at >= ? AND captured_at < ? AND id <= ?
+           ORDER BY captured_at DESC, key_id ASC, id ASC
+           LIMIT ?"#,
+    )
+    .bind(500_i64)
+    .bind(1_000_i64)
+    .bind(2_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery window query");
+    let window_plan = window_rows
+        .iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        window_plan.contains("idx_api_key_quota_sync_samples_captured"),
+        "window query missed captured index: {window_plan}"
+    );
+    assert!(
+        !window_plan.contains("SCAN api_key_quota_sync_samples"),
+        "window query scanned quota samples: {window_plan}"
+    );
+    assert!(
+        !window_plan.contains("USE TEMP B-TREE"),
+        "window query sorted beyond its keyset page: {window_plan}"
+    );
+
+    let cursor_window_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+           SELECT id, key_id, quota_remaining, captured_at
+           FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+           WHERE captured_at >= ? AND captured_at < ? AND id <= ?
+             AND captured_at <= ?
+             AND (
+                 captured_at < ?
+                 OR (
+                     captured_at = ?
+                     AND (key_id > ? OR (key_id = ? AND id > ?))
+                 )
+             )
+           ORDER BY captured_at DESC, key_id ASC, id ASC
+           LIMIT ?"#,
+    )
+    .bind(500_i64)
+    .bind(1_000_i64)
+    .bind(2_i64)
+    .bind(500_i64)
+    .bind(500_i64)
+    .bind(500_i64)
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(1_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain cursor quota recovery window query");
+    let cursor_window_plan = cursor_window_rows
+        .iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        cursor_window_plan.contains("idx_api_key_quota_sync_samples_captured"),
+        "cursor window missed captured index: {cursor_window_plan}"
+    );
+    assert!(
+        !cursor_window_plan.contains("SCAN api_key_quota_sync_samples")
+            && !cursor_window_plan.contains("USE TEMP B-TREE"),
+        "cursor window escaped its keyset: {cursor_window_plan}"
+    );
+
+    let baseline_capture_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+           SELECT captured_at
+           FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+           WHERE key_id = ? AND captured_at < ? AND id <= ?
+           ORDER BY captured_at DESC
+           LIMIT ?"#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(500_i64)
+    .bind(2_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery baseline capture query");
+    let baseline_capture_plan = baseline_capture_rows
+        .iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        baseline_capture_plan.contains("idx_api_key_quota_sync_samples_key_captured"),
+        "baseline capture missed key/captured index: {baseline_capture_plan}"
+    );
+    assert!(
+        !baseline_capture_plan.contains("SCAN api_key_quota_sync_samples")
+            && !baseline_capture_plan.contains("USE TEMP B-TREE"),
+        "baseline capture escaped its keyset: {baseline_capture_plan}"
+    );
+
+    let baseline_id_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+           SELECT id, key_id, quota_remaining, captured_at
+           FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+           WHERE key_id = ? AND captured_at = ? AND id > ? AND id <= ?
+           ORDER BY id ASC
+           LIMIT ?"#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(100_i64)
+    .bind(0_i64)
+    .bind(2_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery baseline id query");
+    let baseline_id_plan = baseline_id_rows
+        .iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        baseline_id_plan.contains("idx_api_key_quota_sync_samples_key_captured"),
+        "baseline id page missed key/captured index: {baseline_id_plan}"
+    );
+    assert!(
+        !baseline_id_plan.contains("SCAN api_key_quota_sync_samples")
+            && !baseline_id_plan.contains("USE TEMP B-TREE"),
+        "baseline id page escaped its keyset: {baseline_id_plan}"
+    );
+
+    let source_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+           SELECT id, key_id, captured_at
+           FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+           WHERE captured_at < ?
+           ORDER BY captured_at DESC, key_id ASC, id ASC
+           LIMIT ?"#,
+    )
+    .bind(1_000_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery source query");
+    let source_plan = source_rows
+        .iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        source_plan.contains("idx_api_key_quota_sync_samples_captured"),
+        "source query missed captured index: {source_plan}"
+    );
+    assert!(
+        !source_plan.contains("SCAN api_key_quota_sync_samples")
+            && !source_plan.contains("USE TEMP B-TREE"),
+        "source query escaped its keyset: {source_plan}"
+    );
+
+    let source_cursor_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+           SELECT id, key_id, captured_at
+           FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+           WHERE captured_at < ?
+             AND captured_at <= ?
+             AND (
+                 captured_at < ?
+                 OR (
+                     captured_at = ?
+                     AND (key_id > ? OR (key_id = ? AND id > ?))
+                 )
+             )
+           ORDER BY captured_at DESC, key_id ASC, id ASC
+           LIMIT ?"#,
+    )
+    .bind(1_000_i64)
+    .bind(500_i64)
+    .bind(500_i64)
+    .bind(500_i64)
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(1_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain cursor quota recovery source query");
+    let source_cursor_plan = source_cursor_rows
+        .iter()
+        .map(|row| row.get::<String, _>("detail"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        source_cursor_plan.contains("idx_api_key_quota_sync_samples_captured"),
+        "cursor source query missed captured index: {source_cursor_plan}"
+    );
+    assert!(
+        !source_cursor_plan.contains("SCAN api_key_quota_sync_samples")
+            && !source_cursor_plan.contains("USE TEMP B-TREE"),
+        "cursor source query escaped its keyset: {source_cursor_plan}"
+    );
+}

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -11,6 +11,26 @@ struct RequestLogCatalogRollupKeyParts<'a> {
     operational_class: &'a str,
 }
 
+const DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE: i64 = 32;
+const DASHBOARD_QUOTA_SOURCE_PAGE_SIZE: i64 = 32;
+
+#[derive(Clone, Debug)]
+struct DashboardQuotaRecoveryCursor {
+    captured_at: i64,
+    key_id: String,
+    id: i64,
+}
+
+impl From<&DashboardQuotaSample> for DashboardQuotaRecoveryCursor {
+    fn from(sample: &DashboardQuotaSample) -> Self {
+        Self {
+            captured_at: sample.captured_at,
+            key_id: sample.key_id.clone(),
+            id: sample.id,
+        }
+    }
+}
+
 impl KeyStore {
     fn request_log_catalog_rollup_key_from_parts(
         parts: RequestLogCatalogRollupKeyParts<'_>,
@@ -2221,6 +2241,103 @@ impl KeyStore {
         })
     }
 
+    async fn fetch_dashboard_quota_recovery_watermark(
+        &self,
+        today_end: i64,
+    ) -> Result<DashboardQuotaSampleWatermark, ProxyError> {
+        let mut cursor: Option<DashboardQuotaRecoveryCursor> = None;
+        let mut source_id = 0_i64;
+        let mut source_captured_at = 0_i64;
+        let mut source_count = 0_i64;
+        loop {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .await?;
+            let query_result = match cursor.as_ref() {
+                Some(cursor) => sqlx::query(
+                    r#"
+                    SELECT id, key_id, captured_at
+                    FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+                    WHERE captured_at < ?
+                      AND captured_at <= ?
+                      AND (
+                        captured_at < ?
+                        OR (
+                            captured_at = ?
+                            AND (
+                                key_id > ?
+                                OR (key_id = ? AND id > ?)
+                            )
+                        )
+                      )
+                    ORDER BY captured_at DESC, key_id ASC, id ASC
+                    LIMIT ?
+                    "#,
+                )
+                .bind(today_end)
+                .bind(cursor.captured_at)
+                .bind(cursor.captured_at)
+                .bind(cursor.captured_at)
+                .bind(&cursor.key_id)
+                .bind(&cursor.key_id)
+                .bind(cursor.id)
+                .bind(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE)
+                .fetch_all(&mut *session)
+                .await,
+                None => sqlx::query(
+                    r#"
+                    SELECT id, key_id, captured_at
+                    FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+                    WHERE captured_at < ?
+                    ORDER BY captured_at DESC, key_id ASC, id ASC
+                    LIMIT ?
+                    "#,
+                )
+                .bind(today_end)
+                .bind(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE)
+                .fetch_all(&mut *session)
+                .await,
+            };
+            let rows = session.query(query_result).await;
+            let finish = session.finish().await;
+            finish?;
+            let rows = rows?;
+            let samples = rows
+                .into_iter()
+                .map(|row| {
+                    Ok::<_, sqlx::Error>(DashboardQuotaRecoveryCursor {
+                        id: row.try_get("id")?,
+                        key_id: row.try_get("key_id")?,
+                        captured_at: row.try_get("captured_at")?,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let Some(last_sample) = samples.last().cloned() else {
+                return Ok(DashboardQuotaSampleWatermark {
+                    source_id,
+                    source_captured_at,
+                    source_count,
+                });
+            };
+            source_id = samples
+                .iter()
+                .map(|sample| sample.id)
+                .max()
+                .unwrap_or(source_id)
+                .max(source_id);
+            source_captured_at = source_captured_at.max(samples[0].captured_at);
+            source_count += samples.len() as i64;
+            if samples.len() < DASHBOARD_QUOTA_SOURCE_PAGE_SIZE as usize {
+                return Ok(DashboardQuotaSampleWatermark {
+                    source_id,
+                    source_captured_at,
+                    source_count,
+                });
+            }
+            cursor = Some(last_sample);
+        }
+    }
+
     pub(crate) async fn fetch_dashboard_quota_charge_read_model(
         &self,
         bounds: SummaryWindowBounds,
@@ -2233,66 +2350,46 @@ impl KeyStore {
             ..
         } = bounds;
         let sample_window_start = yesterday_start.min(month_quota_charge_start);
-        let watermark = self.fetch_dashboard_quota_sample_watermark(today_end).await?;
-        let rows = sqlx::query(
-            r#"
-            WITH window_rows AS (
-                SELECT id, key_id, quota_remaining, captured_at
-                FROM api_key_quota_sync_samples
-                WHERE captured_at >= ?
-                  AND captured_at < ?
-                  AND id <= ?
-            ),
-            sampled_keys AS (
-                SELECT DISTINCT key_id FROM window_rows
-            ),
-            baseline_rows AS (
-                SELECT s.id, s.key_id, s.quota_remaining, s.captured_at
-                FROM api_key_quota_sync_samples s
-                WHERE s.key_id IN (SELECT key_id FROM sampled_keys)
-                  AND s.id = (
-                    SELECT candidate.id
-                    FROM api_key_quota_sync_samples candidate
-                    WHERE candidate.key_id = s.key_id
-                      AND candidate.captured_at < ?
-                      AND candidate.id <= ?
-                    ORDER BY candidate.captured_at DESC, candidate.id DESC
-                    LIMIT 1
-                  )
-            )
-            SELECT id, key_id, quota_remaining, captured_at
-            FROM window_rows
-            UNION ALL
-            SELECT id, key_id, quota_remaining, captured_at
-            FROM baseline_rows
-            ORDER BY key_id ASC, captured_at ASC, id ASC
-            "#,
-        )
-        .bind(sample_window_start)
-        .bind(today_end)
-        .bind(watermark.source_id)
-        .bind(sample_window_start)
-        .bind(watermark.source_id)
-        .fetch_all(&self.pool)
-        .await?;
-        let samples = rows
-            .into_iter()
-            .map(|row| {
-                Ok::<_, sqlx::Error>(DashboardQuotaSample {
-                    id: row.try_get("id")?,
-                    key_id: row.try_get("key_id")?,
-                    quota_remaining: row.try_get("quota_remaining")?,
-                    captured_at: row.try_get("captured_at")?,
-                    previous_quota_remaining: None,
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(DashboardQuotaChargeReadModel::from_samples(
-            bounds,
-            stale_key_count,
-            watermark,
-            samples,
-        ))
+        'restart: loop {
+            let target = self.fetch_dashboard_quota_recovery_watermark(today_end).await?;
+            let mut model = DashboardQuotaChargeReadModel::empty(bounds, stale_key_count, target);
+            let mut cursor = None;
+
+            loop {
+                let samples = self
+                    .fetch_dashboard_quota_recovery_page(
+                        sample_window_start,
+                        today_end,
+                        target.source_id,
+                        cursor.as_ref(),
+                        DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE,
+                    )
+                    .await?;
+                let baselines = self
+                    .fetch_dashboard_quota_recovery_baselines(
+                        sample_window_start,
+                        target.source_id,
+                        &samples,
+                    )
+                    .await?;
+
+                model.stage_recovery_page_desc(&baselines, &samples);
+                #[cfg(debug_assertions)]
+                self.wait_for_dashboard_overview_read_pause_if_installed()
+                    .await;
+                if self.fetch_dashboard_quota_recovery_watermark(today_end).await? != target {
+                    continue 'restart;
+                }
+                if samples.len() < DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE as usize {
+                    model.finish_recovery();
+                    if self.fetch_dashboard_quota_recovery_watermark(today_end).await? == target {
+                        return Ok(model);
+                    }
+                    continue 'restart;
+                }
+                cursor = samples.last().map(DashboardQuotaRecoveryCursor::from);
+            }
+        }
     }
 
     pub(crate) async fn fetch_dashboard_quota_incremental_samples(
@@ -2332,7 +2429,7 @@ impl KeyStore {
                       AND candidate.captured_at < ?
                     ORDER BY candidate.captured_at DESC, candidate.id DESC
                     LIMIT 1
-                )
+            )
             ORDER BY pending.id ASC
             "#,
         )
@@ -2355,6 +2452,205 @@ impl KeyStore {
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok((watermark, samples))
+    }
+
+    async fn fetch_dashboard_quota_recovery_page(
+        &self,
+        sample_window_start: i64,
+        today_end: i64,
+        target_source_id: i64,
+        cursor: Option<&DashboardQuotaRecoveryCursor>,
+        page_size: i64,
+    ) -> Result<Vec<DashboardQuotaSample>, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let page_size = page_size.max(1);
+        let query_result = match cursor {
+            Some(cursor) => sqlx::query(
+                r#"
+                SELECT id, key_id, quota_remaining, captured_at
+                FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+                WHERE captured_at >= ?
+                  AND captured_at < ?
+                  AND id <= ?
+                  AND captured_at <= ?
+                  AND (
+                    captured_at < ?
+                    OR (
+                        captured_at = ?
+                        AND (
+                            key_id > ?
+                            OR (key_id = ? AND id > ?)
+                        )
+                    )
+                  )
+                ORDER BY captured_at DESC, key_id ASC, id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(sample_window_start)
+            .bind(today_end)
+            .bind(target_source_id)
+            .bind(cursor.captured_at)
+            .bind(cursor.captured_at)
+            .bind(cursor.captured_at)
+            .bind(&cursor.key_id)
+            .bind(&cursor.key_id)
+            .bind(cursor.id)
+            .bind(page_size)
+            .fetch_all(&mut *session)
+            .await,
+            None => sqlx::query(
+                r#"
+                SELECT id, key_id, quota_remaining, captured_at
+                FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+                WHERE captured_at >= ?
+                  AND captured_at < ?
+                  AND id <= ?
+                ORDER BY captured_at DESC, key_id ASC, id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(sample_window_start)
+            .bind(today_end)
+            .bind(target_source_id)
+            .bind(page_size)
+            .fetch_all(&mut *session)
+            .await,
+        };
+        let rows = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        rows?
+            .into_iter()
+            .map(|row| {
+                Ok::<_, sqlx::Error>(DashboardQuotaSample {
+                    id: row.try_get("id")?,
+                    key_id: row.try_get("key_id")?,
+                    quota_remaining: row.try_get("quota_remaining")?,
+                    captured_at: row.try_get("captured_at")?,
+                    previous_quota_remaining: None,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ProxyError::Database)
+    }
+
+    async fn fetch_dashboard_quota_recovery_baselines(
+        &self,
+        sample_window_start: i64,
+        target_source_id: i64,
+        samples: &[DashboardQuotaSample],
+    ) -> Result<Vec<DashboardQuotaSample>, ProxyError> {
+        let mut key_ids = samples
+            .iter()
+            .map(|sample| sample.key_id.as_str())
+            .collect::<Vec<_>>();
+        key_ids.sort_unstable();
+        key_ids.dedup();
+        if key_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut baselines = Vec::with_capacity(key_ids.len());
+        for key_id in key_ids {
+            if let Some(baseline) = self
+                .fetch_dashboard_quota_recovery_baseline(
+                    key_id,
+                    sample_window_start,
+                    target_source_id,
+                )
+                .await?
+            {
+                baselines.push(baseline);
+            }
+        }
+        Ok(baselines)
+    }
+
+    async fn fetch_dashboard_quota_recovery_baseline(
+        &self,
+        key_id: &str,
+        sample_window_start: i64,
+        target_source_id: i64,
+    ) -> Result<Option<DashboardQuotaSample>, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let query_result = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT captured_at
+            FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+            WHERE key_id = ?
+              AND captured_at < ?
+              AND id <= ?
+            ORDER BY captured_at DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(key_id)
+        .bind(sample_window_start)
+        .bind(target_source_id)
+        .bind(1_i64)
+        .fetch_optional(&mut *session)
+        .await;
+        let captured_at = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        let Some(captured_at) = captured_at? else {
+            return Ok(None);
+        };
+
+        let mut after_id = 0_i64;
+        let mut baseline = None;
+        loop {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .await?;
+            let query_result = sqlx::query(
+                r#"
+                SELECT id, key_id, quota_remaining, captured_at
+                FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+                WHERE key_id = ?
+                  AND captured_at = ?
+                  AND id > ?
+                  AND id <= ?
+                ORDER BY id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(key_id)
+            .bind(captured_at)
+            .bind(after_id)
+            .bind(target_source_id)
+            .bind(DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE)
+            .fetch_all(&mut *session)
+            .await;
+            let rows = session.query(query_result).await;
+            let finish = session.finish().await;
+            finish?;
+            let samples = rows?
+                .into_iter()
+                .map(|row| {
+                    Ok::<_, sqlx::Error>(DashboardQuotaSample {
+                        id: row.try_get("id")?,
+                        key_id: row.try_get("key_id")?,
+                        quota_remaining: row.try_get("quota_remaining")?,
+                        captured_at: row.try_get("captured_at")?,
+                        previous_quota_remaining: None,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let Some(last_sample) = samples.last().cloned() else {
+                return Ok(baseline);
+            };
+            after_id = last_sample.id;
+            baseline = Some(last_sample);
+            if samples.len() < DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE as usize {
+                return Ok(baseline);
+            }
+        }
     }
 
     pub(crate) async fn list_keys_pending_quota_sync(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2788,6 +2788,7 @@ mod tests {
     }
 
     include!("key_store_runtime_logging_tests.rs");
+    include!("key_store_dashboard_quota_recovery_tests.rs");
 
     #[test]
     fn db_operation_log_format_includes_operation_context_and_error() {


### PR DESCRIPTION
## Summary
- Replace the unbounded Dashboard quota recovery CTE with staged, bounded keyset source, window, and baseline reads.
- Keep the cached last-good quota snapshot immutable until a complete, exact source generation survives every recheck.
- Preserve the normal Dashboard watermark probe and all public request/JSON behavior.

## Validation
- `cargo test --lib dashboard_quota_recovery -- --test-threads=1` (5 passed)
- `cargo test --bin tavily-hikari dashboard_quota -- --test-threads=1` (2 passed)
- `python3 scripts/ci_backend_tests.py run-shard --id lib-core`
- `python3 scripts/ci_backend_tests.py run-shard --id bin-linuxdo-dashboard-overview` (28 passed)
- `cargo clippy --locked -j 2 --tests -- -D warnings`
- `cargo fmt --check` and `git diff --check`

## Delivery
- Delivery role: child
- Parent issue: #576
- Integration branch: `prd/sqlite-admin-read-reconciliation-liveness-v2`
- Wave: aggregate-review P1 repair
- Risk: recovery remains background-only; source changes discard the private staged model before publication.
- Blocker: none

## Documents
- Spec: `docs/specs/performance-architecture-hardening/SPEC.md`
- Spec Disposition: linked; no specification change required.
- Solutions: -
- Project Docs: -

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->