### PR TITLE
fix(dashboard): bound quota recovery reads

### DIFF
--- a/src/models/quota_views.rs
+++ b/src/models/quota_views.rs
@@ -19,6 +19,14 @@ pub(crate) struct DashboardQuotaSample {
     pub previous_quota_remaining: Option<i64>,
 }
 
+#[derive(Debug, Clone)]
+struct DashboardQuotaRecoveryWindowGroup {
+    key_id: String,
+    captured_at: i64,
+    first_sample: DashboardQuotaSample,
+    last_sample: DashboardQuotaSample,
+}
+
 /// Rebuildable quota-only state for Dashboard's append-only sample source.
 ///
 /// The overview cache owns presentation data. This model retains just enough
@@ -30,30 +38,32 @@ pub(crate) struct DashboardQuotaChargeReadModel {
     pub watermark: DashboardQuotaSampleWatermark,
     bounds: SummaryWindowBounds,
     last_sample_by_key: HashMap<String, DashboardQuotaSample>,
+    recovery_next_sample_by_key: HashMap<String, DashboardQuotaSample>,
+    recovery_baseline_by_key: HashMap<String, DashboardQuotaSample>,
+    recovery_window_group: Option<DashboardQuotaRecoveryWindowGroup>,
     today_sampled_keys: HashSet<String>,
     yesterday_sampled_keys: HashSet<String>,
     month_sampled_keys: HashSet<String>,
 }
 
 impl DashboardQuotaChargeReadModel {
-    pub(crate) fn from_samples(
+    pub(crate) fn empty(
         bounds: SummaryWindowBounds,
         stale_key_count: i64,
         watermark: DashboardQuotaSampleWatermark,
-        samples: Vec<DashboardQuotaSample>,
     ) -> Self {
         let mut model = Self {
             snapshot: DashboardQuotaChargeSnapshot::default(),
             watermark,
             bounds,
             last_sample_by_key: HashMap::new(),
+            recovery_next_sample_by_key: HashMap::new(),
+            recovery_baseline_by_key: HashMap::new(),
+            recovery_window_group: None,
             today_sampled_keys: HashSet::new(),
             yesterday_sampled_keys: HashSet::new(),
             month_sampled_keys: HashSet::new(),
         };
-        for sample in samples {
-            model.apply_sample(&sample);
-        }
         model.set_stale_key_count(stale_key_count);
         model
     }
@@ -115,6 +125,44 @@ impl DashboardQuotaChargeReadModel {
         self.set_stale_key_count(stale_key_count);
     }
 
+    /// Recovery pages follow the existing `(captured_at DESC, key_id ASC)`
+    /// index. Rows with the same Key and timestamp are folded together before
+    /// the older group is processed, preserving chronological charge deltas.
+    pub(crate) fn stage_recovery_page_desc(
+        &mut self,
+        baselines: &[DashboardQuotaSample],
+        samples: &[DashboardQuotaSample],
+    ) {
+        for baseline in baselines {
+            self.recovery_baseline_by_key
+                .entry(baseline.key_id.clone())
+                .or_insert_with(|| baseline.clone());
+        }
+        for sample in samples {
+            self.stage_recovery_window_sample(sample);
+        }
+    }
+
+    /// Finalizes a private recovery draft after every page has been read. A
+    /// baseline only contributes after the complete window has a known next
+    /// sample for its Key.
+    pub(crate) fn finish_recovery(&mut self) {
+        self.finish_recovery_window_group();
+        let baselines = std::mem::take(&mut self.recovery_baseline_by_key);
+        for (key_id, baseline) in baselines {
+            let Some(next_sample) = self.recovery_next_sample_by_key.get(&key_id).cloned() else {
+                continue;
+            };
+            let delta = baseline
+                .quota_remaining
+                .saturating_sub(next_sample.quota_remaining)
+                .max(0);
+            self.record_sample_charge(&next_sample, delta);
+        }
+        self.recovery_next_sample_by_key.clear();
+        self.refresh_sampled_key_counts();
+    }
+
     fn apply_sample(&mut self, sample: &DashboardQuotaSample) {
         let previous = self
             .last_sample_by_key
@@ -125,6 +173,66 @@ impl DashboardQuotaChargeReadModel {
             .map(|previous| previous.saturating_sub(sample.quota_remaining).max(0))
             .unwrap_or_default();
 
+        self.record_sample_charge(sample, delta);
+        self.last_sample_by_key
+            .insert(sample.key_id.clone(), sample.clone());
+    }
+
+    fn stage_recovery_window_sample(&mut self, sample: &DashboardQuotaSample) {
+        let continues_group = self.recovery_window_group.as_ref().is_some_and(|group| {
+            group.key_id == sample.key_id && group.captured_at == sample.captured_at
+        });
+        if !continues_group {
+            self.finish_recovery_window_group();
+            self.recovery_window_group = Some(DashboardQuotaRecoveryWindowGroup {
+                key_id: sample.key_id.clone(),
+                captured_at: sample.captured_at,
+                first_sample: sample.clone(),
+                last_sample: sample.clone(),
+            });
+            return;
+        }
+
+        let previous_sample = self
+            .recovery_window_group
+            .as_ref()
+            .expect("matching recovery group is present")
+            .last_sample
+            .clone();
+        let delta = previous_sample
+            .quota_remaining
+            .saturating_sub(sample.quota_remaining)
+            .max(0);
+        self.record_sample_charge(sample, delta);
+        self.recovery_window_group
+            .as_mut()
+            .expect("matching recovery group is present")
+            .last_sample = sample.clone();
+    }
+
+    fn finish_recovery_window_group(&mut self) {
+        let Some(group) = self.recovery_window_group.take() else {
+            return;
+        };
+
+        if let Some(next_sample) = self.recovery_next_sample_by_key.get(&group.key_id).cloned() {
+            let delta = group
+                .last_sample
+                .quota_remaining
+                .saturating_sub(next_sample.quota_remaining)
+                .max(0);
+            self.record_sample_charge(&next_sample, delta);
+        } else {
+            self.record_sample_charge(&group.last_sample, 0);
+            self.last_sample_by_key
+                .entry(group.key_id.clone())
+                .or_insert(group.last_sample.clone());
+        }
+        self.recovery_next_sample_by_key
+            .insert(group.key_id, group.first_sample);
+    }
+
+    fn record_sample_charge(&mut self, sample: &DashboardQuotaSample, delta: i64) {
         if sample.captured_at >= self.bounds.month_quota_charge_start
             && sample.captured_at < self.bounds.today_end
         {
@@ -158,18 +266,19 @@ impl DashboardQuotaChargeReadModel {
             self.yesterday_sampled_keys.insert(sample.key_id.clone());
             update_latest_sync_at(&mut self.snapshot.yesterday, sample.captured_at);
         }
-
-        self.last_sample_by_key
-            .insert(sample.key_id.clone(), sample.clone());
     }
 
     fn set_stale_key_count(&mut self, stale_key_count: i64) {
-        self.snapshot.today.sampled_key_count = self.today_sampled_keys.len() as i64;
+        self.refresh_sampled_key_counts();
         self.snapshot.today.stale_key_count = stale_key_count;
-        self.snapshot.yesterday.sampled_key_count = self.yesterday_sampled_keys.len() as i64;
         self.snapshot.yesterday.stale_key_count = stale_key_count;
-        self.snapshot.month.sampled_key_count = self.month_sampled_keys.len() as i64;
         self.snapshot.month.stale_key_count = stale_key_count;
+    }
+
+    fn refresh_sampled_key_counts(&mut self) {
+        self.snapshot.today.sampled_key_count = self.today_sampled_keys.len() as i64;
+        self.snapshot.yesterday.sampled_key_count = self.yesterday_sampled_keys.len() as i64;
+        self.snapshot.month.sampled_key_count = self.month_sampled_keys.len() as i64;
     }
 }
 

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -350,7 +350,7 @@ async fn dashboard_overview_snapshot_is_reused_within_the_same_freshness_wave() 
 }
 
 #[tokio::test]
-async fn dashboard_overview_snapshot_serves_last_good_while_refresh_is_running() {
+async fn dashboard_overview_snapshot_serves_last_good_while_quota_recovery_runs() {
     let db_path = temp_db_path("dashboard-overview-last-good-refresh");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(
@@ -378,6 +378,33 @@ async fn dashboard_overview_snapshot_serves_last_good_while_refresh_is_running()
         remote_attempt_admission: new_remote_attempt_admission(),
     });
 
+    let key_id = state
+        .proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list seeded keys")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_quota_sync_samples (
+            key_id, quota_limit, quota_remaining, captured_at, source
+        ) VALUES (?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(&key_id)
+    .bind(1_000_i64)
+    .bind(999_i64)
+    .bind(now - 20)
+    .bind("test")
+    .execute(&pool)
+    .await
+    .expect("insert initial quota sample");
+
     let initial = load_dashboard_overview_snapshot(&state)
         .await
         .expect("initial overview snapshot");
@@ -386,11 +413,34 @@ async fn dashboard_overview_snapshot_serves_last_good_while_refresh_is_running()
         .proxy
         .install_dashboard_overview_read_pause_for_test()
         .await;
-    state
-        .proxy
-        .debug_enqueue_dashboard_credit_rollups(Utc::now().timestamp(), 1)
-        .await;
+    for offset in 0..34_i64 {
+        sqlx::query(
+            r#"
+            INSERT INTO api_key_quota_sync_samples (
+                key_id, quota_limit, quota_remaining, captured_at, source
+            ) VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&key_id)
+        .bind(1_000_i64)
+        .bind(999 - offset)
+        .bind(now - 100 + offset)
+        .bind("test")
+        .execute(&pool)
+        .await
+        .expect("record quota sample");
+    }
+    state.proxy.mark_dashboard_read_dirty_for_test().await;
     expire_dashboard_overview_freshness_probe(&state).await;
+
+    let freshness = compute_dashboard_overview_freshness(&state)
+        .await
+        .expect("read quota-change freshness");
+    assert!(
+        initial.freshness.differs_only_by_quota_charge(&freshness),
+        "the controlled refresh must enter the quota-only recovery path"
+    );
+    let expected_freshness_probe_count = dashboard_overview_freshness_probe_count(&state).await + 1;
 
     let served = tokio::time::timeout(
         Duration::from_millis(250),
@@ -403,6 +453,16 @@ async fn dashboard_overview_snapshot_serves_last_good_while_refresh_is_running()
         Arc::ptr_eq(&served, &initial),
         "warm refresh should serve the existing immutable snapshot",
     );
+    let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
+    let cache = cache_handle.lock().await;
+    assert!(
+        cache.loading,
+        "quota-only change must start a background refresh; request_generation={:?}, built_generation={:?}, last_probe={:?}",
+        state.proxy.dashboard_read_generation(),
+        cache.built_request_stats_generation,
+        cache.last_freshness_probe_at,
+    );
+    drop(cache);
 
     tokio::time::timeout(Duration::from_secs(2), pause.wait_until_arrived())
         .await
@@ -418,10 +478,16 @@ async fn dashboard_overview_snapshot_serves_last_good_while_refresh_is_running()
     assert!(signatures.iter().all(Result::is_ok));
     assert_eq!(
         dashboard_overview_freshness_probe_count(&state).await,
-        1,
-        "subscriber count must not multiply the singleflight freshness probe",
+        expected_freshness_probe_count,
+        "subscriber count must not multiply the background freshness probe",
     );
     pause.release();
+
+    let recovered = wait_for_dashboard_overview_refresh(&state).await;
+    assert!(
+        !Arc::ptr_eq(&recovered, &initial),
+        "the completed recovery must replace last-good only after the staged model is ready",
+    );
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -493,6 +493,170 @@ async fn dashboard_overview_snapshot_serves_last_good_while_quota_recovery_runs(
 }
 
 #[tokio::test]
+async fn dashboard_overview_releases_loading_after_quota_recovery_restart_budget() {
+    const QUOTA_RECOVERY_ATTEMPTS: usize = 3;
+
+    let db_path = temp_db_path("dashboard-overview-quota-recovery-restart-budget");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-dashboard-overview-quota-recovery-restart-budget".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let state = Arc::new(AppState {
+        proxy,
+        static_dir: None,
+        forward_auth: ForwardAuthConfig::new(None, None, None, None),
+        forward_auth_enabled: false,
+        builtin_admin: BuiltinAdminAuth::new(false, None, None),
+        admin_passkey: AdminPasskeyOptions::disabled(),
+        linuxdo_oauth: LinuxDoOAuthOptions::disabled(),
+        linuxdo_credit: LinuxDoCreditOptions::disabled(),
+        ha: tavily_hikari::HaRuntime::new(tavily_hikari::HaConfig::default()),
+        dev_open_admin: false,
+        usage_base: "http://127.0.0.1:58088".to_string(),
+        api_key_ip_geo_origin: "https://api.country.is".to_string(),
+        dashboard_overview_cache: new_dashboard_overview_cache(),
+        remote_attempt_admission: new_remote_attempt_admission(),
+    });
+
+    let key_id = state
+        .proxy
+        .list_api_key_metrics()
+        .await
+        .expect("list seeded keys")
+        .into_iter()
+        .next()
+        .expect("seeded key")
+        .id;
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_quota_sync_samples (
+            key_id, quota_limit, quota_remaining, captured_at, source
+        ) VALUES (?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(&key_id)
+    .bind(1_000_i64)
+    .bind(999_i64)
+    .bind(now - 20)
+    .bind("test")
+    .execute(&pool)
+    .await
+    .expect("insert initial quota sample");
+
+    let initial = load_dashboard_overview_snapshot(&state)
+        .await
+        .expect("initial overview snapshot");
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_quota_sync_samples (
+            key_id, quota_limit, quota_remaining, captured_at, source
+        ) VALUES (?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(&key_id)
+    .bind(1_000_i64)
+    .bind(998_i64)
+    .bind(now - 100)
+    .bind("test")
+    .execute(&pool)
+    .await
+    .expect("insert out-of-order quota sample");
+    state.proxy.mark_dashboard_read_dirty_for_test().await;
+    expire_dashboard_overview_freshness_probe(&state).await;
+
+    let freshness = compute_dashboard_overview_freshness(&state)
+        .await
+        .expect("read quota-change freshness");
+    assert!(
+        initial.freshness.differs_only_by_quota_charge(&freshness),
+        "the controlled refresh must enter quota recovery"
+    );
+
+    let mut next_pause = Some(
+        state
+            .proxy
+            .install_dashboard_overview_read_pause_for_test()
+            .await,
+    );
+    let served = tokio::time::timeout(
+        Duration::from_millis(250),
+        load_dashboard_overview_snapshot(&state),
+    )
+    .await
+    .expect("warm overview must not wait for a refresh")
+    .expect("last-good overview snapshot");
+    assert!(
+        Arc::ptr_eq(&served, &initial),
+        "the initial request must retain immutable last-good while recovery stages",
+    );
+
+    for attempt in 0..QUOTA_RECOVERY_ATTEMPTS {
+        let pause = next_pause
+            .take()
+            .expect("every restarted recovery stages a page");
+        tokio::time::timeout(Duration::from_secs(2), pause.wait_until_arrived())
+            .await
+            .expect("background recovery staged a page");
+        sqlx::query(
+            r#"
+            INSERT INTO api_key_quota_sync_samples (
+                key_id, quota_limit, quota_remaining, captured_at, source
+            ) VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&key_id)
+        .bind(1_000_i64)
+        .bind(997_i64 - attempt as i64)
+        .bind(now - 101 - attempt as i64)
+        .bind("test")
+        .execute(&pool)
+        .await
+        .expect("advance source after each staged page");
+        pause.release();
+        if attempt + 1 < QUOTA_RECOVERY_ATTEMPTS {
+            next_pause = Some(
+                state
+                    .proxy
+                    .install_dashboard_overview_read_pause_for_test()
+                    .await,
+            );
+        }
+    }
+
+    let settled = wait_for_dashboard_overview_refresh(&state).await;
+    assert!(
+        Arc::ptr_eq(&settled, &initial),
+        "a deferred recovery must leave immutable last-good published",
+    );
+    let cache_handle = dashboard_overview_cache_for_state(state.as_ref());
+    let cache = cache_handle.lock().await;
+    assert!(
+        !cache.loading,
+        "a bounded deferred recovery must release the overview singleflight loader",
+    );
+    assert!(
+        Arc::ptr_eq(
+            &cache
+                .cached
+                .as_ref()
+                .expect("last-good cache entry")
+                .snapshot,
+            &initial
+        ),
+        "the cache must not publish a partial or mixed recovery model",
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn dashboard_pressure_returns_last_good_without_refresh() {
     let db_path = temp_db_path("dashboard-overview-pressure-last-good");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -1,0 +1,398 @@
+use tempfile::{TempDir, tempdir};
+
+const DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID: &str = "dashboard-quota-recovery-key";
+
+async fn dashboard_quota_recovery_store() -> (TempDir, std::sync::Arc<KeyStore>, SummaryWindowBounds)
+{
+    let temp_dir = tempdir().expect("create temp directory");
+    let db_path = temp_dir.path().join("dashboard-quota-recovery.db");
+    let store = std::sync::Arc::new(
+        KeyStore::new_with_time(&db_path.to_string_lossy(), BackendTime::system())
+            .await
+            .expect("create key store"),
+    );
+    sqlx::query(
+        r#"
+        INSERT INTO api_keys (id, api_key, status, created_at, status_changed_at)
+        VALUES (?, ?, 'active', 0, 0)
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind("tvly-dashboard-quota-recovery-key")
+    .execute(&store.pool)
+    .await
+    .expect("insert quota recovery key");
+
+    let bounds = SummaryWindowBounds {
+        today_start: 800,
+        today_end: 1_000,
+        today_period_end: 1_000,
+        yesterday_start: 500,
+        yesterday_end: 800,
+        month_start: 0,
+        month_quota_charge_start: 0,
+        month_period_end: 1_000,
+        previous_month_start: -1_000,
+        previous_month_end: 0,
+    };
+    (temp_dir, store, bounds)
+}
+
+async fn insert_dashboard_quota_recovery_sample(
+    store: &KeyStore,
+    captured_at: i64,
+    quota_remaining: i64,
+) {
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_quota_sync_samples (
+            key_id, quota_limit, quota_remaining, captured_at, source
+        ) VALUES (?, 1000, ?, ?, 'test')
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(quota_remaining)
+    .bind(captured_at)
+    .execute(&store.pool)
+    .await
+    .expect("insert quota sample");
+}
+
+async fn seed_dashboard_quota_recovery_samples(store: &KeyStore, sample_count: i64) {
+    insert_dashboard_quota_recovery_sample(store, 100, 1_000).await;
+    for offset in 0..sample_count {
+        insert_dashboard_quota_recovery_sample(store, 500 + offset, 999 - offset).await;
+    }
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_discards_a_multi_page_draft_on_native_deadline() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    store
+        .sqlite_runtime
+        .force_cooperative_query_deadline_after_reads_for_test(2);
+
+    let result = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 0)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(ProxyError::Deferred { operation, ref reason })
+                if operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "recovery must discard its draft when a bounded source page reaches the native deadline: {result:?}"
+    );
+
+    let restarted = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 0)
+        .await
+        .expect("a later recovery starts from a clean bounded stage");
+    assert_eq!(restarted.watermark.source_id, 66);
+    assert_eq!(restarted.snapshot.month.upstream_actual_credits, 65);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_paginates_an_exact_multi_page_window() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    for offset in 0..33 {
+        insert_dashboard_quota_recovery_sample(&store, 1_000 + offset, 934 - offset).await;
+    }
+
+    let model = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 3)
+        .await
+        .expect("recover every bounded quota page");
+
+    assert_eq!(model.watermark.source_id, 66);
+    assert_eq!(model.snapshot.month.upstream_actual_credits, 65);
+    assert_eq!(model.snapshot.month.latest_sync_at, Some(564));
+    assert_eq!(model.snapshot.month.sampled_key_count, 1);
+    assert_eq!(model.snapshot.month.stale_key_count, 3);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_restarts_after_an_out_of_order_backfill() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    let pause = store.install_dashboard_overview_read_pause().await;
+    let recovery_store = std::sync::Arc::clone(&store);
+    let mut recovery = tokio::spawn(async move {
+        recovery_store
+            .fetch_dashboard_quota_charge_read_model(bounds, 0)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), pause.wait_until_arrived())
+        .await
+        .expect("recovery staged its first page");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(10), &mut recovery)
+            .await
+            .is_err(),
+        "a staged model must not finish before its source revision is rechecked"
+    );
+    insert_dashboard_quota_recovery_sample(&store, 520, 978).await;
+    pause.release();
+
+    let model = tokio::time::timeout(Duration::from_secs(2), recovery)
+        .await
+        .expect("recovery restarts after the source changes")
+        .expect("join quota recovery")
+        .expect("rebuild from the new source watermark");
+    let watermark = store
+        .fetch_dashboard_quota_sample_watermark(bounds.today_end)
+        .await
+        .expect("read final source watermark");
+    assert_eq!(model.watermark, watermark);
+    assert_eq!(model.snapshot.month.upstream_actual_credits, 65);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_cancellation_leaves_no_partial_stage_to_reuse() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 65).await;
+    let pause = store.install_dashboard_overview_read_pause().await;
+    let recovery_store = std::sync::Arc::clone(&store);
+    let recovery = tokio::spawn(async move {
+        recovery_store
+            .fetch_dashboard_quota_charge_read_model(bounds, 0)
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), pause.wait_until_arrived())
+        .await
+        .expect("recovery staged its first page before cancellation");
+    recovery.abort();
+    assert!(recovery.await.is_err(), "recovery task was cancelled");
+    pause.release();
+
+    let restarted = store
+        .fetch_dashboard_quota_charge_read_model(bounds, 0)
+        .await
+        .expect("a new recovery starts from an empty stage after cancellation");
+    assert_eq!(restarted.watermark.source_id, 66);
+    assert_eq!(restarted.snapshot.month.upstream_actual_credits, 65);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_queries_use_existing_indexes() {
+    let (_temp_dir, store, _bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 1).await;
+
+    let window_plan = explain_dashboard_quota_recovery_window_query(&store).await;
+    assert_dashboard_quota_recovery_index_plan(
+        &window_plan,
+        "idx_api_key_quota_sync_samples_captured",
+        "window keyset",
+    );
+
+    let window_cursor_plan = explain_dashboard_quota_recovery_window_cursor_query(&store).await;
+    assert_dashboard_quota_recovery_index_plan(
+        &window_cursor_plan,
+        "idx_api_key_quota_sync_samples_captured",
+        "window keyset cursor",
+    );
+
+    let baseline_timestamp_plan =
+        explain_dashboard_quota_recovery_baseline_timestamp_query(&store).await;
+    assert_dashboard_quota_recovery_index_plan(
+        &baseline_timestamp_plan,
+        "idx_api_key_quota_sync_samples_key_captured",
+        "baseline timestamp",
+    );
+
+    let baseline_page_plan = explain_dashboard_quota_recovery_baseline_page_query(&store).await;
+    assert_dashboard_quota_recovery_index_plan(
+        &baseline_page_plan,
+        "idx_api_key_quota_sync_samples_key_captured",
+        "baseline page",
+    );
+
+    let source_id_plan = explain_dashboard_quota_recovery_source_id_query(&store).await;
+    assert!(
+        source_id_plan.contains("INTEGER PRIMARY KEY"),
+        "source revision keyset missed rowid access: {source_id_plan}"
+    );
+    assert!(
+        !source_id_plan.contains("SCAN api_key_quota_sync_samples"),
+        "source revision keyset scanned quota samples: {source_id_plan}"
+    );
+
+    let source_timestamp_plan =
+        explain_dashboard_quota_recovery_source_timestamp_query(&store).await;
+    assert_dashboard_quota_recovery_index_plan(
+        &source_timestamp_plan,
+        "idx_api_key_quota_sync_samples_captured",
+        "source timestamp",
+    );
+}
+
+async fn explain_dashboard_quota_recovery_window_query(store: &KeyStore) -> String {
+    sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT id, key_id, quota_remaining, captured_at
+        FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+        WHERE captured_at >= ? AND captured_at < ? AND id <= ?
+        ORDER BY captured_at DESC, key_id ASC, id ASC
+        LIMIT ?
+        "#,
+    )
+    .bind(500_i64)
+    .bind(1_000_i64)
+    .bind(2_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery window query")
+    .iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+async fn explain_dashboard_quota_recovery_window_cursor_query(store: &KeyStore) -> String {
+    sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT id, key_id, quota_remaining, captured_at
+        FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+        WHERE captured_at >= ?
+          AND captured_at < ?
+          AND id <= ?
+          AND (
+            captured_at < ?
+            OR (
+                captured_at = ?
+                AND (key_id > ? OR (key_id = ? AND id > ?))
+            )
+          )
+        ORDER BY captured_at DESC, key_id ASC, id ASC
+        LIMIT ?
+        "#,
+    )
+    .bind(500_i64)
+    .bind(1_000_i64)
+    .bind(2_i64)
+    .bind(550_i64)
+    .bind(550_i64)
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(1_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery window cursor query")
+    .iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+async fn explain_dashboard_quota_recovery_baseline_timestamp_query(store: &KeyStore) -> String {
+    sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT captured_at
+        FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+        WHERE key_id = ? AND captured_at < ? AND id <= ?
+        ORDER BY captured_at DESC
+        LIMIT ?
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(500_i64)
+    .bind(2_i64)
+    .bind(1_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery baseline timestamp query")
+    .iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+async fn explain_dashboard_quota_recovery_baseline_page_query(store: &KeyStore) -> String {
+    sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT id, key_id, quota_remaining, captured_at
+        FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+        WHERE key_id = ? AND captured_at = ? AND id > ? AND id <= ?
+        ORDER BY id ASC
+        LIMIT ?
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_RECOVERY_TEST_KEY_ID)
+    .bind(100_i64)
+    .bind(0_i64)
+    .bind(1_i64)
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery baseline page query")
+    .iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+async fn explain_dashboard_quota_recovery_source_id_query(store: &KeyStore) -> String {
+    sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT id, captured_at
+        FROM api_key_quota_sync_samples
+        WHERE id > 0
+        ORDER BY id DESC
+        LIMIT ?
+        "#,
+    )
+    .bind(32_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery source id query")
+    .iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+async fn explain_dashboard_quota_recovery_source_timestamp_query(store: &KeyStore) -> String {
+    sqlx::query(
+        r#"
+        EXPLAIN QUERY PLAN
+        SELECT captured_at
+        FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+        WHERE captured_at < ?
+        ORDER BY captured_at DESC, key_id ASC, id ASC
+        LIMIT ?
+        "#,
+    )
+    .bind(1_000_i64)
+    .bind(1_i64)
+    .fetch_all(&store.pool)
+    .await
+    .expect("explain quota recovery source timestamp query")
+    .iter()
+    .map(|row| row.get::<String, _>("detail"))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn assert_dashboard_quota_recovery_index_plan(plan: &str, index: &str, label: &str) {
+    assert!(plan.contains(index), "{label} missed {index}: {plan}");
+    assert!(
+        !plan.contains("SCAN api_key_quota_sync_samples"),
+        "{label} scanned quota samples: {plan}"
+    );
+    assert!(
+        !plan.contains("USE TEMP B-TREE"),
+        "{label} sorted outside its keyset index: {plan}"
+    );
+}

--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -95,6 +95,31 @@ async fn dashboard_quota_recovery_discards_a_multi_page_draft_on_native_deadline
 }
 
 #[tokio::test]
+async fn dashboard_quota_source_probe_defers_after_future_page_budget() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    insert_dashboard_quota_recovery_sample(&store, 500, 999).await;
+    for offset in 0..(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE * DASHBOARD_QUOTA_SOURCE_MAX_PAGES as i64) {
+        insert_dashboard_quota_recovery_sample(&store, 1_000 + offset, 998 - offset).await;
+    }
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        store.fetch_dashboard_quota_sample_watermark(bounds.today_end),
+    )
+    .await
+    .expect("source probe must have a whole-operation page budget");
+
+    assert!(
+        matches!(
+            result,
+            Err(ProxyError::Deferred { operation, ref reason })
+                if operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "future samples spanning multiple keyset pages must defer instead of extending the probe: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn dashboard_quota_recovery_paginates_an_exact_multi_page_window() {
     let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
     seed_dashboard_quota_recovery_samples(&store, 65).await;
@@ -112,6 +137,47 @@ async fn dashboard_quota_recovery_paginates_an_exact_multi_page_window() {
     assert_eq!(model.snapshot.month.latest_sync_at, Some(564));
     assert_eq!(model.snapshot.month.sampled_key_count, 1);
     assert_eq!(model.snapshot.month.stale_key_count, 3);
+}
+
+#[tokio::test]
+async fn dashboard_quota_recovery_defers_when_source_changes_on_every_staged_page() {
+    let (_temp_dir, store, bounds) = dashboard_quota_recovery_store().await;
+    seed_dashboard_quota_recovery_samples(&store, 1).await;
+    let mut next_pause = Some(store.install_dashboard_overview_read_pause().await);
+    let recovery_store = std::sync::Arc::clone(&store);
+    let recovery = tokio::spawn(async move {
+        recovery_store
+            .fetch_dashboard_quota_charge_read_model(bounds, 0)
+            .await
+    });
+
+    for attempt in 0..DASHBOARD_QUOTA_RECOVERY_MAX_ATTEMPTS {
+        let pause = next_pause
+            .take()
+            .expect("each restart stages a page before its source check");
+        tokio::time::timeout(Duration::from_secs(2), pause.wait_until_arrived())
+            .await
+            .expect("recovery staged a page");
+        insert_dashboard_quota_recovery_sample(&store, 600 + attempt as i64, 998 - attempt as i64)
+            .await;
+        pause.release();
+        if attempt + 1 < DASHBOARD_QUOTA_RECOVERY_MAX_ATTEMPTS {
+            next_pause = Some(store.install_dashboard_overview_read_pause().await);
+        }
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(2), recovery)
+        .await
+        .expect("recovery must stop after a bounded number of source changes")
+        .expect("join quota recovery");
+    assert!(
+        matches!(
+            result,
+            Err(ProxyError::Deferred { operation, ref reason })
+                if operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "recovery must defer rather than restart forever when every staged page changes source: {result:?}"
+    );
 }
 
 #[tokio::test]

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -11,6 +11,26 @@ struct RequestLogCatalogRollupKeyParts<'a> {
     operational_class: &'a str,
 }
 
+const DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE: i64 = 32;
+const DASHBOARD_QUOTA_SOURCE_PAGE_SIZE: i64 = 32;
+
+#[derive(Clone, Debug)]
+struct DashboardQuotaRecoveryCursor {
+    captured_at: i64,
+    key_id: String,
+    id: i64,
+}
+
+impl From<&DashboardQuotaSample> for DashboardQuotaRecoveryCursor {
+    fn from(sample: &DashboardQuotaSample) -> Self {
+        Self {
+            captured_at: sample.captured_at,
+            key_id: sample.key_id.clone(),
+            id: sample.id,
+        }
+    }
+}
+
 impl KeyStore {
     fn request_log_catalog_rollup_key_from_parts(
         parts: RequestLogCatalogRollupKeyParts<'_>,
@@ -2201,24 +2221,99 @@ impl KeyStore {
         &self,
         today_end: i64,
     ) -> Result<DashboardQuotaSampleWatermark, ProxyError> {
-        let row = sqlx::query(
+        let source_id = self.fetch_dashboard_quota_source_id(today_end).await?;
+        let source_captured_at = self
+            .fetch_dashboard_quota_source_captured_at(today_end)
+            .await?;
+        Ok(DashboardQuotaSampleWatermark {
+            source_id,
+            source_captured_at,
+            // This is the append-only source revision used by hydration. It
+            // deliberately keeps the existing private token shape without a
+            // table-wide aggregate read on a Dashboard freshness probe.
+            source_count: source_id,
+        })
+    }
+
+    async fn fetch_dashboard_quota_source_id(&self, today_end: i64) -> Result<i64, ProxyError> {
+        let mut before_id = None;
+        loop {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .await?;
+            let query_result = match before_id {
+                Some(before_id) => sqlx::query(
+                    r#"
+                    SELECT id, captured_at
+                    FROM api_key_quota_sync_samples
+                    WHERE id > 0 AND id < ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                    "#,
+                )
+                .bind(before_id)
+                .bind(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE)
+                .fetch_all(&mut *session)
+                .await,
+                None => sqlx::query(
+                    r#"
+                    SELECT id, captured_at
+                    FROM api_key_quota_sync_samples
+                    WHERE id > 0
+                    ORDER BY id DESC
+                    LIMIT ?
+                    "#,
+                )
+                .bind(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE)
+                .fetch_all(&mut *session)
+                .await,
+            };
+            let rows = session.query(query_result).await;
+            let finish = session.finish().await;
+            finish?;
+            let samples = rows?
+                .into_iter()
+                .map(|row| Ok::<_, sqlx::Error>((row.try_get("id")?, row.try_get("captured_at")?)))
+                .collect::<Result<Vec<(i64, i64)>, _>>()?;
+
+            if let Some((id, _)) = samples
+                .iter()
+                .copied()
+                .find(|(_, captured_at)| *captured_at < today_end)
+            {
+                return Ok(id);
+            }
+            let Some((last_id, _)) = samples.last().copied() else {
+                return Ok(0);
+            };
+            before_id = Some(last_id);
+        }
+    }
+
+    async fn fetch_dashboard_quota_source_captured_at(
+        &self,
+        today_end: i64,
+    ) -> Result<i64, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let query_result = sqlx::query_scalar::<_, i64>(
             r#"
-            SELECT
-                COALESCE(MAX(id), 0) AS source_id,
-                COALESCE(MAX(captured_at), 0) AS source_captured_at,
-                COUNT(*) AS source_count
-            FROM api_key_quota_sync_samples
+            SELECT captured_at
+            FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
             WHERE captured_at < ?
+            ORDER BY captured_at DESC, key_id ASC, id ASC
+            LIMIT ?
             "#,
         )
         .bind(today_end)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(DashboardQuotaSampleWatermark {
-            source_id: row.try_get("source_id")?,
-            source_captured_at: row.try_get("source_captured_at")?,
-            source_count: row.try_get("source_count")?,
-        })
+        .bind(1_i64)
+        .fetch_optional(&mut *session)
+        .await;
+        let source_captured_at = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        Ok(source_captured_at?.unwrap_or_default())
     }
 
     pub(crate) async fn fetch_dashboard_quota_charge_read_model(
@@ -2233,66 +2328,48 @@ impl KeyStore {
             ..
         } = bounds;
         let sample_window_start = yesterday_start.min(month_quota_charge_start);
-        let watermark = self.fetch_dashboard_quota_sample_watermark(today_end).await?;
-        let rows = sqlx::query(
-            r#"
-            WITH window_rows AS (
-                SELECT id, key_id, quota_remaining, captured_at
-                FROM api_key_quota_sync_samples
-                WHERE captured_at >= ?
-                  AND captured_at < ?
-                  AND id <= ?
-            ),
-            sampled_keys AS (
-                SELECT DISTINCT key_id FROM window_rows
-            ),
-            baseline_rows AS (
-                SELECT s.id, s.key_id, s.quota_remaining, s.captured_at
-                FROM api_key_quota_sync_samples s
-                WHERE s.key_id IN (SELECT key_id FROM sampled_keys)
-                  AND s.id = (
-                    SELECT candidate.id
-                    FROM api_key_quota_sync_samples candidate
-                    WHERE candidate.key_id = s.key_id
-                      AND candidate.captured_at < ?
-                      AND candidate.id <= ?
-                    ORDER BY candidate.captured_at DESC, candidate.id DESC
-                    LIMIT 1
-                  )
-            )
-            SELECT id, key_id, quota_remaining, captured_at
-            FROM window_rows
-            UNION ALL
-            SELECT id, key_id, quota_remaining, captured_at
-            FROM baseline_rows
-            ORDER BY key_id ASC, captured_at ASC, id ASC
-            "#,
-        )
-        .bind(sample_window_start)
-        .bind(today_end)
-        .bind(watermark.source_id)
-        .bind(sample_window_start)
-        .bind(watermark.source_id)
-        .fetch_all(&self.pool)
-        .await?;
-        let samples = rows
-            .into_iter()
-            .map(|row| {
-                Ok::<_, sqlx::Error>(DashboardQuotaSample {
-                    id: row.try_get("id")?,
-                    key_id: row.try_get("key_id")?,
-                    quota_remaining: row.try_get("quota_remaining")?,
-                    captured_at: row.try_get("captured_at")?,
-                    previous_quota_remaining: None,
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(DashboardQuotaChargeReadModel::from_samples(
-            bounds,
-            stale_key_count,
-            watermark,
-            samples,
-        ))
+        'restart: loop {
+            let target = self.fetch_dashboard_quota_sample_watermark(today_end).await?;
+            let mut model = DashboardQuotaChargeReadModel::empty(bounds, stale_key_count, target);
+            let mut cursor = None;
+            let mut staged_key_ids = std::collections::HashSet::new();
+
+            loop {
+                let samples = self
+                    .fetch_dashboard_quota_recovery_page(
+                        sample_window_start,
+                        today_end,
+                        target.source_id,
+                        cursor.as_ref(),
+                        DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE,
+                    )
+                    .await?;
+                let baselines = self
+                    .fetch_dashboard_quota_recovery_baselines(
+                        sample_window_start,
+                        target.source_id,
+                        &samples,
+                        &mut staged_key_ids,
+                    )
+                    .await?;
+
+                model.stage_recovery_page_desc(&baselines, &samples);
+                #[cfg(debug_assertions)]
+                self.wait_for_dashboard_overview_read_pause_if_installed()
+                    .await;
+                if self.fetch_dashboard_quota_sample_watermark(today_end).await? != target {
+                    continue 'restart;
+                }
+                if samples.len() < DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE as usize {
+                    model.finish_recovery();
+                    if self.fetch_dashboard_quota_sample_watermark(today_end).await? == target {
+                        return Ok(model);
+                    }
+                    continue 'restart;
+                }
+                cursor = samples.last().map(DashboardQuotaRecoveryCursor::from);
+            }
+        }
     }
 
     pub(crate) async fn fetch_dashboard_quota_incremental_samples(
@@ -2306,7 +2383,10 @@ impl KeyStore {
             return Ok((watermark, Vec::new()));
         }
 
-        let rows = sqlx::query(
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let query_result = sqlx::query(
             r#"
             WITH pending AS (
                 SELECT id, key_id, quota_remaining, captured_at
@@ -2340,9 +2420,12 @@ impl KeyStore {
         .bind(today_end)
         .bind(today_end)
         .bind(limit.max(1))
-        .fetch_all(&self.pool)
-        .await?;
-        let samples = rows
+        .fetch_all(&mut *session)
+        .await;
+        let rows = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        let samples = rows?
             .into_iter()
             .map(|row| {
                 Ok::<_, sqlx::Error>(DashboardQuotaSample {
@@ -2355,6 +2438,202 @@ impl KeyStore {
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok((watermark, samples))
+    }
+
+    async fn fetch_dashboard_quota_recovery_page(
+        &self,
+        sample_window_start: i64,
+        today_end: i64,
+        target_source_id: i64,
+        cursor: Option<&DashboardQuotaRecoveryCursor>,
+        page_size: i64,
+    ) -> Result<Vec<DashboardQuotaSample>, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let page_size = page_size.max(1);
+        let query_result = match cursor {
+            Some(cursor) => sqlx::query(
+                r#"
+                SELECT id, key_id, quota_remaining, captured_at
+                FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+                WHERE captured_at >= ?
+                  AND captured_at < ?
+                  AND id <= ?
+                  AND (
+                    captured_at < ?
+                    OR (
+                        captured_at = ?
+                        AND (
+                            key_id > ?
+                            OR (key_id = ? AND id > ?)
+                        )
+                    )
+                  )
+                ORDER BY captured_at DESC, key_id ASC, id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(sample_window_start)
+            .bind(today_end)
+            .bind(target_source_id)
+            .bind(cursor.captured_at)
+            .bind(cursor.captured_at)
+            .bind(&cursor.key_id)
+            .bind(&cursor.key_id)
+            .bind(cursor.id)
+            .bind(page_size)
+            .fetch_all(&mut *session)
+            .await,
+            None => sqlx::query(
+                r#"
+                SELECT id, key_id, quota_remaining, captured_at
+                FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
+                WHERE captured_at >= ?
+                  AND captured_at < ?
+                  AND id <= ?
+                ORDER BY captured_at DESC, key_id ASC, id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(sample_window_start)
+            .bind(today_end)
+            .bind(target_source_id)
+            .bind(page_size)
+            .fetch_all(&mut *session)
+            .await,
+        };
+        let rows = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        rows?
+            .into_iter()
+            .map(|row| {
+                Ok::<_, sqlx::Error>(DashboardQuotaSample {
+                    id: row.try_get("id")?,
+                    key_id: row.try_get("key_id")?,
+                    quota_remaining: row.try_get("quota_remaining")?,
+                    captured_at: row.try_get("captured_at")?,
+                    previous_quota_remaining: None,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ProxyError::Database)
+    }
+
+    async fn fetch_dashboard_quota_recovery_baselines(
+        &self,
+        sample_window_start: i64,
+        target_source_id: i64,
+        samples: &[DashboardQuotaSample],
+        staged_key_ids: &mut std::collections::HashSet<String>,
+    ) -> Result<Vec<DashboardQuotaSample>, ProxyError> {
+        let key_ids = samples
+            .iter()
+            .filter_map(|sample| {
+                staged_key_ids
+                    .insert(sample.key_id.clone())
+                    .then_some(sample.key_id.clone())
+            })
+            .collect::<Vec<_>>();
+        let mut baselines = Vec::with_capacity(key_ids.len());
+        for key_id in key_ids {
+            if let Some(baseline) = self
+                .fetch_dashboard_quota_recovery_baseline(
+                    &key_id,
+                    sample_window_start,
+                    target_source_id,
+                )
+                .await?
+            {
+                baselines.push(baseline);
+            }
+        }
+        Ok(baselines)
+    }
+
+    async fn fetch_dashboard_quota_recovery_baseline(
+        &self,
+        key_id: &str,
+        sample_window_start: i64,
+        target_source_id: i64,
+    ) -> Result<Option<DashboardQuotaSample>, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let query_result = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT captured_at
+            FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+            WHERE key_id = ?
+              AND captured_at < ?
+              AND id <= ?
+            ORDER BY captured_at DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(key_id)
+        .bind(sample_window_start)
+        .bind(target_source_id)
+        .bind(1_i64)
+        .fetch_optional(&mut *session)
+        .await;
+        let captured_at = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        let Some(captured_at) = captured_at? else {
+            return Ok(None);
+        };
+
+        let mut after_id = 0_i64;
+        let mut baseline = None;
+        loop {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .await?;
+            let query_result = sqlx::query(
+                r#"
+                SELECT id, key_id, quota_remaining, captured_at
+                FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_key_captured
+                WHERE key_id = ?
+                  AND captured_at = ?
+                  AND id > ?
+                  AND id <= ?
+                ORDER BY id ASC
+                LIMIT ?
+                "#,
+            )
+            .bind(key_id)
+            .bind(captured_at)
+            .bind(after_id)
+            .bind(target_source_id)
+            .bind(DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE)
+            .fetch_all(&mut *session)
+            .await;
+            let rows = session.query(query_result).await;
+            let finish = session.finish().await;
+            finish?;
+            let samples = rows?
+                .into_iter()
+                .map(|row| {
+                    Ok::<_, sqlx::Error>(DashboardQuotaSample {
+                        id: row.try_get("id")?,
+                        key_id: row.try_get("key_id")?,
+                        quota_remaining: row.try_get("quota_remaining")?,
+                        captured_at: row.try_get("captured_at")?,
+                        previous_quota_remaining: None,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let Some(last_sample) = samples.last().cloned() else {
+                return Ok(baseline);
+            };
+            after_id = last_sample.id;
+            baseline = Some(last_sample);
+            if samples.len() < DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE as usize {
+                return Ok(baseline);
+            }
+        }
     }
 
     pub(crate) async fn list_keys_pending_quota_sync(

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -13,6 +13,8 @@ struct RequestLogCatalogRollupKeyParts<'a> {
 
 const DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE: i64 = 32;
 const DASHBOARD_QUOTA_SOURCE_PAGE_SIZE: i64 = 32;
+const DASHBOARD_QUOTA_SOURCE_MAX_PAGES: usize = 4;
+const DASHBOARD_QUOTA_RECOVERY_MAX_ATTEMPTS: usize = 3;
 
 #[derive(Clone, Debug)]
 struct DashboardQuotaRecoveryCursor {
@@ -2235,9 +2237,20 @@ impl KeyStore {
         })
     }
 
+    fn dashboard_quota_read_budget_deferred(&self) -> ProxyError {
+        self.sqlite_runtime.record_deferred(
+            SqliteOperation::AdminAlertsCacheWarm,
+            SqliteAdmissionDeferReason::QueryDeadline,
+        );
+        ProxyError::Deferred {
+            operation: "admin_alerts_read",
+            reason: "read_budget".to_string(),
+        }
+    }
+
     async fn fetch_dashboard_quota_source_id(&self, today_end: i64) -> Result<i64, ProxyError> {
         let mut before_id = None;
-        loop {
+        for _ in 0..DASHBOARD_QUOTA_SOURCE_MAX_PAGES {
             let mut session = self
                 .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
                 .await?;
@@ -2286,8 +2299,12 @@ impl KeyStore {
             let Some((last_id, _)) = samples.last().copied() else {
                 return Ok(0);
             };
+            if samples.len() < DASHBOARD_QUOTA_SOURCE_PAGE_SIZE as usize {
+                return Ok(0);
+            }
             before_id = Some(last_id);
         }
+        Err(self.dashboard_quota_read_budget_deferred())
     }
 
     async fn fetch_dashboard_quota_source_captured_at(
@@ -2328,7 +2345,7 @@ impl KeyStore {
             ..
         } = bounds;
         let sample_window_start = yesterday_start.min(month_quota_charge_start);
-        'restart: loop {
+        for _ in 0..DASHBOARD_QUOTA_RECOVERY_MAX_ATTEMPTS {
             let target = self.fetch_dashboard_quota_sample_watermark(today_end).await?;
             let mut model = DashboardQuotaChargeReadModel::empty(bounds, stale_key_count, target);
             let mut cursor = None;
@@ -2358,18 +2375,19 @@ impl KeyStore {
                 self.wait_for_dashboard_overview_read_pause_if_installed()
                     .await;
                 if self.fetch_dashboard_quota_sample_watermark(today_end).await? != target {
-                    continue 'restart;
+                    break;
                 }
                 if samples.len() < DASHBOARD_QUOTA_RECOVERY_PAGE_SIZE as usize {
                     model.finish_recovery();
                     if self.fetch_dashboard_quota_sample_watermark(today_end).await? == target {
                         return Ok(model);
                     }
-                    continue 'restart;
+                    break;
                 }
                 cursor = samples.last().map(DashboardQuotaRecoveryCursor::from);
             }
         }
+        Err(self.dashboard_quota_read_budget_deferred())
     }
 
     pub(crate) async fn fetch_dashboard_quota_incremental_samples(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2788,6 +2788,7 @@ mod tests {
     }
 
     include!("key_store_runtime_logging_tests.rs");
+    include!("key_store_dashboard_quota_recovery_tests.rs");
 
     #[test]
     fn db_operation_log_format_includes_operation_context_and_error() {


### PR DESCRIPTION
## Summary

- Replace the unbounded quota charge recovery read with staged bounded keyset pages.
- Fence every staged rebuild by its source watermark and restart on source change, cancellation, or native read deadline.
- Preserve the immutable Dashboard snapshot until recovery completes, with focused recovery and query-plan regressions.

## Delivery

- Delivery role: child
- Parent issue: #576
- Integration branch: prd/sqlite-admin-read-reconciliation-liveness-v2
- Wave: recovery repair
- Risk: shared Dashboard quota read model and SQLite read liveness
- Blocker: none

## Documentation

- Spec: docs/specs/performance-architecture-hardening/SPEC.md
- Spec Disposition: existing contract remains applicable; no durable documentation change.
- Solutions: -
- Project Docs: -
- Sync: not applicable; no durable document changed.

## Validation

- cargo test --lib store::tests::dashboard_quota_recovery -- --test-threads=1
- cargo test --bin tavily-hikari dashboard_quota_ -- --nocapture
- cargo test --bin tavily-hikari dashboard_overview_snapshot_serves_last_good_while_quota_recovery_runs -- --nocapture
- cargo clippy --locked -j 2 -- -D warnings
- Recovery query-plan assertions cover source, initial/continued window, and baseline index paths.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->