### PR TITLE
fix(dashboard): bound quota source probes

### DIFF
--- a/src/models/quota_views.rs
+++ b/src/models/quota_views.rs
@@ -71,18 +71,13 @@ impl DashboardQuotaChargeReadModel {
     ) -> bool {
         if next_watermark.source_id < self.watermark.source_id
             || next_watermark.source_captured_at < self.watermark.source_captured_at
-            || next_watermark.source_count < self.watermark.source_count
         {
             return false;
         }
-        if next_watermark.source_count == self.watermark.source_count {
+        if next_watermark.source_id == self.watermark.source_id {
             return next_watermark == self.watermark && samples.is_empty();
         }
-        if next_watermark
-            .source_count
-            .saturating_sub(self.watermark.source_count)
-            != samples.len() as i64
-            || samples.is_empty()
+        if samples.is_empty()
             || samples.first().map(|sample| sample.id)
                 != Some(self.watermark.source_id.saturating_add(1))
             || samples.last().map(|sample| sample.id) != Some(next_watermark.source_id)

--- a/src/models/quota_views.rs
+++ b/src/models/quota_views.rs
@@ -81,6 +81,9 @@ impl DashboardQuotaChargeReadModel {
             || samples.first().map(|sample| sample.id)
                 != Some(self.watermark.source_id.saturating_add(1))
             || samples.last().map(|sample| sample.id) != Some(next_watermark.source_id)
+            || samples
+                .windows(2)
+                .any(|pair| pair[1].id != pair[0].id.saturating_add(1))
         {
             return false;
         }

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -2048,6 +2048,46 @@ async fn dashboard_quota_backfill_recovers_in_background_from_last_good() {
         "the background recovery must recompute the out-of-order quota delta before publishing",
     );
 
+    let future_captured_at = Utc::now().timestamp().saturating_add(172_800);
+    for offset in 0..128_i64 {
+        sqlx::query(
+            r#"
+            INSERT INTO api_key_quota_sync_samples (
+                key_id, quota_limit, quota_remaining, captured_at, source
+            ) VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&key_id)
+        .bind(2_000_i64)
+        .bind(1_500_i64.saturating_sub(offset))
+        .bind(future_captured_at.saturating_add(offset))
+        .bind("future_source_probe")
+        .execute(&pool)
+        .await
+        .expect("insert future quota sample beyond the source probe page budget");
+    }
+
+    expire_dashboard_overview_freshness_probe(&state).await;
+    let served_while_source_probe_is_deferred =
+        load_dashboard_overview_after_background_refresh(&state).await;
+    assert_eq!(
+        served_while_source_probe_is_deferred
+            .freshness
+            .dashboard_quota_charge_token,
+        recovered.freshness.dashboard_quota_charge_token,
+        "a deferred source probe must preserve the immutable last-good Dashboard snapshot",
+    );
+    assert_eq!(
+        served_while_source_probe_is_deferred
+            .payload
+            .summary_windows
+            .month
+            .quota_charge
+            .upstream_actual_credits,
+        300,
+        "a deferred source probe must not publish future quota samples",
+    );
+
     let _ = std::fs::remove_file(db_path);
 }
 

--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -101,16 +101,30 @@ async fn dashboard_quota_source_probe_uses_the_source_id_as_its_revision() {
         },
         Vec::new(),
     );
+    let middle_gap_watermark = DashboardQuotaSampleWatermark {
+        source_id: 4,
+        source_captured_at: 700,
+        source_count: 4,
+    };
     assert!(
         !model.can_hydrate(
-            watermark,
-            &[DashboardQuotaSample {
-                id: 3,
-                key_id: DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID.to_string(),
-                quota_remaining: 997,
-                captured_at: 600,
-                previous_quota_remaining: Some(999),
-            }],
+            middle_gap_watermark,
+            &[
+                DashboardQuotaSample {
+                    id: 2,
+                    key_id: DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID.to_string(),
+                    quota_remaining: 998,
+                    captured_at: 600,
+                    previous_quota_remaining: Some(999),
+                },
+                DashboardQuotaSample {
+                    id: 4,
+                    key_id: DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID.to_string(),
+                    quota_remaining: 997,
+                    captured_at: 700,
+                    previous_quota_remaining: Some(998),
+                },
+            ],
         ),
         "a future-id gap must defer to the existing full recovery path"
     );

--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use tempfile::{TempDir, tempdir};
+
+const DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID: &str = "dashboard-quota-source-probe-key";
+
+async fn dashboard_quota_source_probe_store() -> (TempDir, std::sync::Arc<KeyStore>) {
+    let temp_dir = tempdir().expect("create temp directory");
+    let db_path = temp_dir.path().join("dashboard-quota-source-probe.db");
+    let store = std::sync::Arc::new(
+        KeyStore::new_with_time(&db_path.to_string_lossy(), BackendTime::system())
+            .await
+            .expect("create key store"),
+    );
+    sqlx::query(
+        r#"
+        INSERT INTO api_keys (id, api_key, status, created_at, status_changed_at)
+        VALUES (?, ?, 'active', 0, 0)
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID)
+    .bind("tvly-dashboard-quota-source-probe-key")
+    .execute(&store.pool)
+    .await
+    .expect("insert quota source probe key");
+    (temp_dir, store)
+}
+
+async fn insert_dashboard_quota_source_probe_sample(
+    store: &KeyStore,
+    captured_at: i64,
+    quota_remaining: i64,
+) {
+    sqlx::query(
+        r#"
+        INSERT INTO api_key_quota_sync_samples (
+            key_id, quota_limit, quota_remaining, captured_at, source
+        ) VALUES (?, 1000, ?, ?, 'test')
+        "#,
+    )
+    .bind(DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID)
+    .bind(quota_remaining)
+    .bind(captured_at)
+    .execute(&store.pool)
+    .await
+    .expect("insert quota source probe sample");
+}
+
+#[tokio::test]
+async fn dashboard_quota_source_probe_walks_a_bounded_keyset_page() {
+    let (_temp_dir, store) = dashboard_quota_source_probe_store().await;
+    insert_dashboard_quota_source_probe_sample(&store, 500, 999).await;
+    for offset in 0..DASHBOARD_QUOTA_SOURCE_PAGE_SIZE {
+        insert_dashboard_quota_source_probe_sample(&store, 1_000 + offset, 998 - offset).await;
+    }
+
+    let watermark = store
+        .fetch_dashboard_quota_sample_watermark(1_000)
+        .await
+        .expect("the second staged page finds the active source sample");
+
+    assert_eq!(watermark.source_id, 1);
+    assert_eq!(watermark.source_captured_at, 500);
+    assert_eq!(watermark.source_count, 1);
+}
+
+#[tokio::test]
+async fn dashboard_quota_source_probe_defers_after_its_page_budget() {
+    let (_temp_dir, store) = dashboard_quota_source_probe_store().await;
+    insert_dashboard_quota_source_probe_sample(&store, 500, 999).await;
+    for offset in 0..(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE
+        * i64::try_from(DASHBOARD_QUOTA_SOURCE_MAX_PAGES).expect("page budget fits i64"))
+    {
+        insert_dashboard_quota_source_probe_sample(&store, 1_000 + offset, 998 - offset).await;
+    }
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        store.fetch_dashboard_quota_sample_watermark(1_000),
+    )
+    .await
+    .expect("source probe stops at its staged read budget");
+
+    assert!(
+        matches!(
+            result,
+            Err(ProxyError::Deferred { operation, ref reason })
+                if operation == "admin_alerts_read" && reason == "read_budget"
+        ),
+        "source samples beyond the page budget must preserve the typed defer: {result:?}"
+    );
+}

--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -65,6 +65,58 @@ async fn dashboard_quota_source_probe_walks_a_bounded_keyset_page() {
 }
 
 #[tokio::test]
+async fn dashboard_quota_source_probe_uses_the_source_id_as_its_revision() {
+    let (_temp_dir, store) = dashboard_quota_source_probe_store().await;
+    insert_dashboard_quota_source_probe_sample(&store, 500, 999).await;
+    insert_dashboard_quota_source_probe_sample(&store, 1_000, 998).await;
+    insert_dashboard_quota_source_probe_sample(&store, 600, 997).await;
+
+    let watermark = store
+        .fetch_dashboard_quota_sample_watermark(1_000)
+        .await
+        .expect("source probe finds the newest active source id");
+
+    assert_eq!(watermark.source_id, 3);
+    assert_eq!(watermark.source_captured_at, 600);
+    assert_eq!(watermark.source_count, 3);
+
+    let model = DashboardQuotaChargeReadModel::from_samples(
+        SummaryWindowBounds {
+            today_start: 800,
+            today_end: 1_000,
+            today_period_end: 1_000,
+            yesterday_start: 500,
+            yesterday_end: 800,
+            month_start: 0,
+            month_quota_charge_start: 0,
+            month_period_end: 1_000,
+            previous_month_start: -1_000,
+            previous_month_end: 0,
+        },
+        0,
+        DashboardQuotaSampleWatermark {
+            source_id: 1,
+            source_captured_at: 500,
+            source_count: 1,
+        },
+        Vec::new(),
+    );
+    assert!(
+        !model.can_hydrate(
+            watermark,
+            &[DashboardQuotaSample {
+                id: 3,
+                key_id: DASHBOARD_QUOTA_SOURCE_PROBE_TEST_KEY_ID.to_string(),
+                quota_remaining: 997,
+                captured_at: 600,
+                previous_quota_remaining: Some(999),
+            }],
+        ),
+        "a future-id gap must defer to the existing full recovery path"
+    );
+}
+
+#[tokio::test]
 async fn dashboard_quota_source_probe_defers_after_its_page_budget() {
     let (_temp_dir, store) = dashboard_quota_source_probe_store().await;
     insert_dashboard_quota_source_probe_sample(&store, 500, 999).await;

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -2211,6 +2211,8 @@ impl KeyStore {
         Ok(DashboardQuotaSampleWatermark {
             source_id,
             source_captured_at,
+            // Retain the existing private token shape without an unbounded
+            // count probe. This is an append-only source revision, not a row count.
             source_count: source_id,
         })
     }

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -11,6 +11,9 @@ struct RequestLogCatalogRollupKeyParts<'a> {
     operational_class: &'a str,
 }
 
+const DASHBOARD_QUOTA_SOURCE_PAGE_SIZE: i64 = 32;
+const DASHBOARD_QUOTA_SOURCE_MAX_PAGES: usize = 4;
+
 impl KeyStore {
     fn request_log_catalog_rollup_key_from_parts(
         parts: RequestLogCatalogRollupKeyParts<'_>,
@@ -2201,24 +2204,111 @@ impl KeyStore {
         &self,
         today_end: i64,
     ) -> Result<DashboardQuotaSampleWatermark, ProxyError> {
-        let row = sqlx::query(
+        let source_id = self.fetch_dashboard_quota_source_id(today_end).await?;
+        let source_captured_at = self
+            .fetch_dashboard_quota_source_captured_at(today_end)
+            .await?;
+        Ok(DashboardQuotaSampleWatermark {
+            source_id,
+            source_captured_at,
+            source_count: source_id,
+        })
+    }
+
+    fn dashboard_quota_read_budget_deferred(&self) -> ProxyError {
+        self.sqlite_runtime.record_deferred(
+            SqliteOperation::AdminAlertsCacheWarm,
+            SqliteAdmissionDeferReason::QueryDeadline,
+        );
+        ProxyError::Deferred {
+            operation: "admin_alerts_read",
+            reason: "read_budget".to_string(),
+        }
+    }
+
+    async fn fetch_dashboard_quota_source_id(&self, today_end: i64) -> Result<i64, ProxyError> {
+        let mut before_id = None;
+        for _ in 0..DASHBOARD_QUOTA_SOURCE_MAX_PAGES {
+            let mut session = self
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .await?;
+            let query_result = match before_id {
+                Some(before_id) => sqlx::query(
+                    r#"
+                    SELECT id, captured_at
+                    FROM api_key_quota_sync_samples
+                    WHERE id > 0 AND id < ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                    "#,
+                )
+                .bind(before_id)
+                .bind(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE)
+                .fetch_all(&mut *session)
+                .await,
+                None => sqlx::query(
+                    r#"
+                    SELECT id, captured_at
+                    FROM api_key_quota_sync_samples
+                    WHERE id > 0
+                    ORDER BY id DESC
+                    LIMIT ?
+                    "#,
+                )
+                .bind(DASHBOARD_QUOTA_SOURCE_PAGE_SIZE)
+                .fetch_all(&mut *session)
+                .await,
+            };
+            let rows = session.query(query_result).await;
+            let finish = session.finish().await;
+            finish?;
+            let samples = rows?
+                .into_iter()
+                .map(|row| Ok::<_, sqlx::Error>((row.try_get("id")?, row.try_get("captured_at")?)))
+                .collect::<Result<Vec<(i64, i64)>, _>>()?;
+
+            if let Some((id, _)) = samples
+                .iter()
+                .copied()
+                .find(|(_, captured_at)| *captured_at < today_end)
+            {
+                return Ok(id);
+            }
+            let Some((last_id, _)) = samples.last().copied() else {
+                return Ok(0);
+            };
+            if samples.len() < DASHBOARD_QUOTA_SOURCE_PAGE_SIZE as usize {
+                return Ok(0);
+            }
+            before_id = Some(last_id);
+        }
+
+        Err(self.dashboard_quota_read_budget_deferred())
+    }
+
+    async fn fetch_dashboard_quota_source_captured_at(
+        &self,
+        today_end: i64,
+    ) -> Result<i64, ProxyError> {
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let query_result = sqlx::query_scalar::<_, i64>(
             r#"
-            SELECT
-                COALESCE(MAX(id), 0) AS source_id,
-                COALESCE(MAX(captured_at), 0) AS source_captured_at,
-                COUNT(*) AS source_count
-            FROM api_key_quota_sync_samples
+            SELECT captured_at
+            FROM api_key_quota_sync_samples INDEXED BY idx_api_key_quota_sync_samples_captured
             WHERE captured_at < ?
+            ORDER BY captured_at DESC, key_id ASC, id ASC
+            LIMIT 1
             "#,
         )
         .bind(today_end)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(DashboardQuotaSampleWatermark {
-            source_id: row.try_get("source_id")?,
-            source_captured_at: row.try_get("source_captured_at")?,
-            source_count: row.try_get("source_count")?,
-        })
+        .fetch_optional(&mut *session)
+        .await;
+        let source_captured_at = session.query(query_result).await;
+        let finish = session.finish().await;
+        finish?;
+        Ok(source_captured_at?.unwrap_or_default())
     }
 
     pub(crate) async fn fetch_dashboard_quota_charge_read_model(
@@ -3075,3 +3165,6 @@ impl KeyStore {
     }
 
 }
+
+#[cfg(test)]
+include!("key_store_dashboard_quota_recovery_tests.rs");

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -3165,6 +3165,3 @@ impl KeyStore {
     }
 
 }
-
-#[cfg(test)]
-include!("key_store_dashboard_quota_recovery_tests.rs");

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2788,6 +2788,7 @@ mod tests {
     }
 
     include!("key_store_runtime_logging_tests.rs");
+    include!("key_store_dashboard_quota_recovery_tests.rs");
 
     #[test]
     fn db_operation_log_format_includes_operation_context_and_error() {


### PR DESCRIPTION
## Summary

- Bound Dashboard quota source-watermark probing to four staged 32-row keyset reads.
- Return the existing `admin_alerts_read/read_budget` typed defer when the budget is exhausted.
- Preserve last-good Dashboard responses and reject gapped source IDs before incremental hydration.

## Delivery

- Delivery role: child
- Parent issue: #586
- Integration branch: prd/sqlite-dashboard-quota-recovery-repair
- Wave: first vertical slice
- Risk: Dashboard quota freshness and immutable cache behavior
- Blocker: none

## Documentation

- Spec: docs/specs/performance-architecture-hardening/SPEC.md
- Spec Disposition: existing contract remains applicable; no durable documentation change.
- Solutions: -
- Project Docs: -
- Sync: not applicable; no durable document changed.

## Validation

- cargo test --lib store::tests::dashboard_quota_source_probe_ -- --test-threads=1
- cargo test --bin tavily-hikari dashboard_quota_backfill_recovers_in_background_from_last_good -- --nocapture
- python3 scripts/ci_backend_tests.py verify
- cargo clippy --locked -j 2 -- -D warnings
- Current-head standards and spec review: no findings.

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->