### PR TITLE
fix(ci): run pipeline on integration branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "prd/**"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Restore CI Pipeline push coverage for prd/** integration branches.
- Retain existing main and pull-request triggers unchanged.

## Validation
- actionlint .github/workflows/ci.yml
- git diff --check

## Release
- type:skip: workflow-only foundation change; no application release is requested.