### PR TITLE
fix(alerts): fence canonical warm generations (scopefix2)

### DIFF
--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -81,6 +81,9 @@ reads:
   foreground SQLite activity, or client retries can indefinitely defer the background owner. A configured
   passkey session lookup and a noncanonical exact-key bounded-read fallback each record their real
   foreground SQLite work.
+- Treat every durable alert projection advance, including history-only slices, as a canonical cache
+  generation change. The scheduler must fence the three staged values against that generation so a
+  partial or cancelled warm never replaces the prior exact-key last-good set.
 - Apply the same last-good boundary to the single-key privacy-status read. Keep the immutable
   successful snapshot for 60 seconds; warm pressure returns it as stale with the observation time,
   while cold pressure fails fast with `503 Retry-After: 1`. The HTTP path is bounded to 250ms and,

--- a/docs/specs/admin-alert-center-24h-summary/IMPLEMENTATION.md
+++ b/docs/specs/admin-alert-center-24h-summary/IMPLEMENTATION.md
@@ -13,3 +13,11 @@
 - [x] M3: 前端告警中心、共享筛选、请求详情抽屉、dashboard 摘要完成
 - [x] M4: Storybook、浏览器验收与视觉证据完成
 - [x] M5: 快车道 PR 收口到 merge-ready
+
+## Canonical warm recovery
+
+- Canonical catalog, events page `1/20`, and groups page `1/20` are staged by
+  independent bounded `AdminAlertsCacheWarm` reads and published as one set.
+- Every durable alert projection advance moves the cache generation fence,
+  including history-only slices; a deferred, cancelled, or generation-mismatched
+  warm attempt publishes nothing and leaves the exact-key last-good entries intact.

--- a/scripts/ci_backend_test_manifest.json
+++ b/scripts/ci_backend_test_manifest.json
@@ -96,6 +96,7 @@
         "store::tests::",
         "tavily_proxy::observability_deferred_writer_tests::",
         "tavily_proxy::privacy_status_phase_budget_tests::",
+        "tavily_proxy::scheduler_step_tests::",
         "tavily_proxy::tests::",
         "tests::request_kind_and_core::parse_",
         "tests::proxy_affinity_and_summary::extract_",

--- a/src/server/schedulers_dashboard_alert_projection.rs
+++ b/src/server/schedulers_dashboard_alert_projection.rs
@@ -19,10 +19,13 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
             let mut next_delay_secs = DASHBOARD_ALERT_PROJECTION_INTERVAL_SECS;
             match state
                 .proxy
-                .advance_dashboard_alert_projection_scheduler_step()
+                .advance_dashboard_alert_projection_scheduler_step_with_alerts()
                 .await
             {
-                Ok((true, _)) => {
+                Ok(step) if step.canonical_alerts_dirty => {
+                    // A projection advance moves the shared generation fence,
+                    // invalidating canonical Alerts entries before the warmer
+                    // stages a replacement set.
                     mark_dashboard_overview_alert_projection_dirty(state.as_ref()).await;
                     if last_error.take().is_some() {
                         tracing::info!(
@@ -32,7 +35,7 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
                         );
                     }
                 }
-                Ok((false, true)) => {
+                Ok(step) if step.idle => {
                     next_delay_secs = DASHBOARD_ALERT_PROJECTION_IDLE_INTERVAL_SECS;
                     let now = state.proxy.backend_time().now_ts();
                     if now.saturating_sub(last_idle_observation_at)
@@ -54,7 +57,7 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
                         }
                     }
                 }
-                Ok((false, false)) => {}
+                Ok(_) => {}
                 Err(err) => {
                     let error = err.to_string();
                     if last_error.as_deref() != Some(error.as_str()) {
@@ -75,10 +78,9 @@ fn spawn_dashboard_alert_projection_scheduler(state: Arc<AppState>) {
                     last_error = Some(error);
                 }
             }
-            // Keep the canonical administrator Alerts keys warm even when the
-            // projection has no new source rows. The controller is singleflight
-            // and rate-limited, so an idle tick only re-arms one low-priority
-            // background refresh and never adds work to the HTTP path.
+            // The projection worker owns the canonical warm trigger. A
+            // completed projected slice invalidates the generation fence, so
+            // the existing singleflight warmer stages a replacement set.
             prewarm_admin_alerts(state.clone()).await;
             state
                 .proxy

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -772,39 +772,58 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
         }
     }
     assert!(projection_ready, "empty projection must complete before warming admin cache");
-    let catalog = state
-        .proxy
-        .admin_alert_catalog()
-        .await
-        .expect("build canonical catalog for the warm-cache fixture");
-    super::super::record_admin_alerts_last_good(
-        state.as_ref(),
-        "catalog".to_string(),
-        super::super::AdminAlertsReadCacheValue::Catalog(catalog),
-    )
-    .await;
-    let events = state
-        .proxy
-        .admin_alert_events_page(None, None, None, None, None, None, &[], 1, 20)
-        .await
-        .expect("build canonical events for the warm-cache fixture");
-    super::super::record_admin_alerts_last_good(
-        state.as_ref(),
-        super::super::default_admin_alert_cache_key("events"),
-        super::super::AdminAlertsReadCacheValue::Events(events),
-    )
-    .await;
-    let groups = state
-        .proxy
-        .admin_alert_groups_page(None, None, None, None, None, None, &[], 1, 20)
-        .await
-        .expect("build canonical groups for the warm-cache fixture");
-    super::super::record_admin_alerts_last_good(
-        state.as_ref(),
-        super::super::default_admin_alert_cache_key("groups"),
-        super::super::AdminAlertsReadCacheValue::Groups(groups),
-    )
-    .await;
+    state.proxy.force_next_admin_alert_read_deadline_for_test();
+    super::super::prewarm_admin_alerts(state.clone()).await;
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            if cache.admin_alerts_prewarm_defers > 0 {
+                assert!(
+                    cache.admin_alerts.entries.iter().all(|entry| !entry.canonical),
+                    "a deferred projected read must not publish a partial canonical generation"
+                );
+                break;
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the forced bounded warm read defers");
+
+    tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            let complete_generation = cache
+                .admin_alerts
+                .entries
+                .iter()
+                .filter(|entry| entry.canonical)
+                .all(|entry| entry.generation == cache.alert_projection_generation)
+                && [
+                    "catalog".to_string(),
+                    super::super::default_admin_alert_cache_key("events"),
+                    super::super::default_admin_alert_cache_key("groups"),
+                ]
+                .into_iter()
+                .all(|key| {
+                    cache
+                        .admin_alerts
+                        .entries
+                        .iter()
+                        .any(|entry| entry.canonical && entry.key == key)
+                });
+            if complete_generation {
+                break;
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the background warmer retries a bounded read and publishes all canonical keys");
     for route in ["catalog", "events", "groups"] {
         let warm = client
             .get(format!("http://{admin_addr}/api/alerts/{route}"))

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -1,3 +1,40 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AlertProjectionSchedulerStep {
+    pub dashboard_dirty: bool,
+    pub canonical_alerts_dirty: bool,
+    pub idle: bool,
+    refresh_dashboard_summary: bool,
+}
+
+fn classify_dashboard_alert_projection_scheduler_step(
+    outcome: AlertProjectionSliceOutcome,
+) -> AlertProjectionSchedulerStep {
+    match outcome {
+        AlertProjectionSliceOutcome::Advanced {
+            dashboard_dirty,
+            complete,
+            ..
+        } => AlertProjectionSchedulerStep {
+            dashboard_dirty,
+            canonical_alerts_dirty: true,
+            idle: false,
+            refresh_dashboard_summary: dashboard_dirty || complete,
+        },
+        AlertProjectionSliceOutcome::Idle => AlertProjectionSchedulerStep {
+            dashboard_dirty: false,
+            canonical_alerts_dirty: false,
+            idle: true,
+            refresh_dashboard_summary: true,
+        },
+        AlertProjectionSliceOutcome::Deferred { .. } => AlertProjectionSchedulerStep {
+            dashboard_dirty: false,
+            canonical_alerts_dirty: false,
+            idle: false,
+            refresh_dashboard_summary: false,
+        },
+    }
+}
+
 impl TavilyProxy {
     #[doc(hidden)]
     pub fn admin_privacy_status_refresh_defer_reason(&self) -> Option<&'static str> {
@@ -82,27 +119,24 @@ impl TavilyProxy {
     pub async fn advance_dashboard_alert_projection_scheduler_step(
         &self,
     ) -> Result<(bool, bool), ProxyError> {
-        match self.advance_dashboard_alert_projection_slice_outcome().await? {
-            AlertProjectionSliceOutcome::Advanced {
-                dashboard_dirty,
-                complete,
-                ..
-            } => {
-                if dashboard_dirty || complete {
-                    self.key_store
-                        .refresh_dashboard_alert_projection_summary()
-                        .await?;
-                }
-                Ok((dashboard_dirty, false))
-            }
-            AlertProjectionSliceOutcome::Idle => {
-                self.key_store
-                    .refresh_dashboard_alert_projection_summary()
-                    .await?;
-                Ok((false, true))
-            }
-            AlertProjectionSliceOutcome::Deferred { .. } => Ok((false, false)),
+        let step = self
+            .advance_dashboard_alert_projection_scheduler_step_with_alerts()
+            .await?;
+        Ok((step.dashboard_dirty, step.idle))
+    }
+
+    pub async fn advance_dashboard_alert_projection_scheduler_step_with_alerts(
+        &self,
+    ) -> Result<AlertProjectionSchedulerStep, ProxyError> {
+        let step = classify_dashboard_alert_projection_scheduler_step(
+            self.advance_dashboard_alert_projection_slice_outcome().await?,
+        );
+        if step.refresh_dashboard_summary {
+            self.key_store
+                .refresh_dashboard_alert_projection_summary()
+                .await?;
         }
+        Ok(step)
     }
 
     pub async fn refresh_dashboard_alert_projection_observation(&self) -> Result<bool, ProxyError> {
@@ -318,5 +352,26 @@ impl TavilyProxy {
         self.key_store
             .fetch_projected_recent_alerts_summary(window_hours)
             .await
+    }
+}
+
+#[cfg(test)]
+mod scheduler_step_tests {
+    use super::classify_dashboard_alert_projection_scheduler_step;
+    use crate::store::AlertProjectionSliceOutcome;
+
+    #[test]
+    fn history_only_projection_advance_marks_canonical_alerts_dirty() {
+        let step = classify_dashboard_alert_projection_scheduler_step(
+            AlertProjectionSliceOutcome::Advanced {
+                rows: 1,
+                complete: false,
+                dashboard_dirty: false,
+            },
+        );
+
+        assert!(step.canonical_alerts_dirty);
+        assert!(!step.dashboard_dirty);
+        assert!(!step.refresh_dashboard_summary);
     }
 }


### PR DESCRIPTION
Delivery role: child\nParent Tracking Issue: #600\nTicket: #601\nIntegration base: prd/sqlite-dashboard-quota-recovery-repair-v4-scopefix2\nWave: 1\nSpec baseline: docs/specs/performance-architecture-hardening/SPEC.md@9e2f79ce5160ecdf19dd3fca44eae972daa86649\n\nThis child makes canonical administrator Alerts warm publication generation-fenced and preserves exact-key last-good values across history-only projection advances, defer, and cancellation.\n\nValidation completed on head 8c78f0a5036cd4eb719a56ed7c1a2b9b3706c76c:\n- scheduler history-only invalidation regression\n- admin Alerts pressure regression\n- cargo fmt, clippy, Markdown formatting, commitlint\n\nRefs #601