### PR TITLE
fix(dashboard): make quota freshness comparison complete

### DIFF
--- a/src/server/handlers/public.rs
+++ b/src/server/handlers/public.rs
@@ -1083,32 +1083,18 @@ struct DashboardSnapshot<'a> {
 
 impl DashboardOverviewFreshness {
     fn differs_only_by_quota_charge(&self, next: &Self) -> bool {
-        self.dashboard_quota_charge_token[..3] != next.dashboard_quota_charge_token[..3]
-            && self.summary[..8] == next.summary[..8]
-            && self.summary_last_activity == next.summary_last_activity
-            && self.summary_window_starts == next.summary_window_starts
-            && self.dashboard_rollup_signature == next.dashboard_rollup_signature
-            && self.pending_dashboard_rollup_signature == next.pending_dashboard_rollup_signature
-            && self.rollup_integrity == next.rollup_integrity
-            && self.dashboard_api_key_lifecycle_signature == next.dashboard_api_key_lifecycle_signature
-            && self.dashboard_quarantine_lifecycle_signature
-                == next.dashboard_quarantine_lifecycle_signature
-            && self.dashboard_exhausted_lifecycle_signature
-                == next.dashboard_exhausted_lifecycle_signature
-            && self.forward_proxy == next.forward_proxy
-            && self.exhausted_keys == next.exhausted_keys
-            && self.latest_request_log_id == next.latest_request_log_id
-            && self.recent_request_logs == next.recent_request_logs
-            && self.trend_request_logs == next.trend_request_logs
-            && self.recent_jobs == next.recent_jobs
-            && self.recent_alerts_token == next.recent_alerts_token
-            && self.recent_alerts_total_events == next.recent_alerts_total_events
-            && self.recent_alerts_grouped_count == next.recent_alerts_grouped_count
-            && self.recent_alerts_counts == next.recent_alerts_counts
-            && self.recent_alerts_top_groups == next.recent_alerts_top_groups
-            && self.request_log_retention_days == next.request_log_retention_days
-            && self.hourly_window_anchor == next.hourly_window_anchor
-            && self.retention_since == next.retention_since
+        if self.dashboard_quota_charge_token[..3] == next.dashboard_quota_charge_token[..3] {
+            return false;
+        }
+        let mut normalized_self = self.clone();
+        let mut normalized_next = next.clone();
+        for freshness in [&mut normalized_self, &mut normalized_next] {
+            freshness.dashboard_quota_charge_token = [0; 5];
+            freshness.dashboard_stale_key_count = 0;
+            freshness.latest_quota_sync_sample_at = None;
+            freshness.summary[8..].fill(0);
+        }
+        normalized_self == normalized_next
     }
 }
 

--- a/src/server/tests/dashboard_overview_snapshot.rs
+++ b/src/server/tests/dashboard_overview_snapshot.rs
@@ -440,6 +440,14 @@ async fn dashboard_overview_snapshot_serves_last_good_while_quota_recovery_runs(
         initial.freshness.differs_only_by_quota_charge(&freshness),
         "the controlled refresh must enter the quota-only recovery path"
     );
+    let mut non_quota_change = freshness.clone();
+    non_quota_change.request_log_retention_days += 1;
+    assert!(
+        !initial
+            .freshness
+            .differs_only_by_quota_charge(&non_quota_change),
+        "a non-quota freshness change must not use the quota-only path"
+    );
     let expected_freshness_probe_count = dashboard_overview_freshness_probe_count(&state).await + 1;
 
     let served = tokio::time::timeout(

--- a/src/tavily_proxy/mod.rs
+++ b/src/tavily_proxy/mod.rs
@@ -917,6 +917,8 @@ pub struct TavilyProxy {
     observability_deferred_writer: Arc<Mutex<ObservabilityDeferredWriter>>,
     #[cfg(test)]
     server_pressure_tail_replay_test_gate: Arc<ServerPressureTailReplayTestGate>,
+    #[cfg(test)]
+    reconciliation_controlled_retry: Arc<AtomicBool>,
     health_readiness_grace_until: tokio::time::Instant,
     pub(crate) backend_time: BackendTime,
 }
@@ -2256,6 +2258,21 @@ impl UserBusinessCalls1hWindow {
 }
 
 impl TavilyProxy {
+    #[cfg(test)]
+    pub(crate) fn enable_controlled_reconciliation_retry_for_test(&self) {
+        self.reconciliation_controlled_retry
+            .store(true, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn controlled_reconciliation_retry_enabled(&self) -> bool {
+        self.reconciliation_controlled_retry.load(Ordering::Relaxed)
+    }
+
+    #[cfg(not(test))]
+    pub(crate) fn controlled_reconciliation_retry_enabled(&self) -> bool {
+        false
+    }
     async fn business_calls_1h_limit_verdict_for_subject(
         &self,
         subject: &QuotaSubject,

--- a/src/tavily_proxy/proxy_core.rs
+++ b/src/tavily_proxy/proxy_core.rs
@@ -630,6 +630,8 @@ impl TavilyProxy {
             server_pressure_tail_replay_test_gate: Arc::new(
                 ServerPressureTailReplayTestGate::default(),
             ),
+            #[cfg(test)]
+            reconciliation_controlled_retry: Arc::new(AtomicBool::new(false)),
             health_readiness_grace_until: backend_time
                 .deadline_after(options.health_readiness_grace_period),
             backend_time,

--- a/src/tavily_proxy/reconciliation_engine.rs
+++ b/src/tavily_proxy/reconciliation_engine.rs
@@ -354,17 +354,6 @@ impl ReconciliationEngine {
             .max(ladder_secs)
     }
 
-    #[cfg(test)]
-    fn controlled_retry_is_enabled() -> bool {
-        const CONTROLLED_RETRY_ENV: &str = "HIKARI_RECONCILIATION_RETRIES";
-        std::env::var(CONTROLLED_RETRY_ENV).as_deref() == Ok("1")
-    }
-
-    #[cfg(not(test))]
-    fn controlled_retry_is_enabled() -> bool {
-        false
-    }
-
     fn deferred(proxy: &TavilyProxy, reason: &'static str) -> ClaimedReconciliationRunOutcome {
         Self::deferred_at(
             proxy,
@@ -543,7 +532,7 @@ impl ReconciliationEngine {
             else {
                 return Ok(ClaimedReconciliationRunOutcome::StaleClaim);
             };
-            if Self::controlled_retry_is_enabled() && attempt == 1 {
+            if proxy.controlled_reconciliation_retry_enabled() && attempt == 1 {
                 tracing::debug!(
                     component = "reconciliation",
                     event = "controlled_retry_deferred",

--- a/src/tests/upstream_reconciliation.rs
+++ b/src/tests/upstream_reconciliation.rs
@@ -23,40 +23,8 @@ pub(super) fn reconciliation_test_db_path() -> PathBuf {
     dir.join("test.db")
 }
 
-struct ReconciliationRetriesEnvGuard {
-    previous: Option<String>,
-    _guard: tokio::sync::OwnedMutexGuard<()>,
-}
-
-impl ReconciliationRetriesEnvGuard {
-    async fn enable_once() -> Self {
-        let guard = env_lock().lock_owned().await;
-        let previous = std::env::var("HIKARI_RECONCILIATION_RETRIES").ok();
-        unsafe {
-            std::env::set_var("HIKARI_RECONCILIATION_RETRIES", "1");
-        }
-        Self {
-            previous,
-            _guard: guard,
-        }
-    }
-}
-
-impl Drop for ReconciliationRetriesEnvGuard {
-    fn drop(&mut self) {
-        unsafe {
-            if let Some(previous) = self.previous.as_deref() {
-                std::env::set_var("HIKARI_RECONCILIATION_RETRIES", previous);
-            } else {
-                std::env::remove_var("HIKARI_RECONCILIATION_RETRIES");
-            }
-        }
-    }
-}
-
 #[tokio::test]
 async fn reconciliation_controlled_retry_advances_the_claim_attempt_before_success() {
-    let _retries = ReconciliationRetriesEnvGuard::enable_once().await;
     let db_path = reconciliation_test_db_path();
     let db_string = db_path.to_string_lossy().to_string();
     let now = local_ts(2026, 9, 5, 12, 0);
@@ -70,6 +38,7 @@ async fn reconciliation_controlled_retry_advances_the_claim_attempt_before_succe
     )
     .await
     .expect("create proxy");
+    proxy.enable_controlled_reconciliation_retry_for_test();
     let initial = proxy
         .scheduled_job_enqueue("upstream_reconciliation", "auto", None, 1)
         .await


### PR DESCRIPTION
## Repair scope

Behavioral repair for #602 within initiative #600.

- Normalize every quota-owned freshness field before deciding whether a dashboard update can use a quota-only patch.
- Replace the test-only process environment flag for controlled reconciliation retry with instance-local state, preventing parallel-test interference.

## Exact head

`52dff7e2ed23f615826d60523cb9c9500bbe3ab5`

## Evidence

- `cargo test --locked --lib tests::upstream_reconciliation::reconciliation_controlled_retry_advances_the_claim_attempt_before_success -- --exact --nocapture`
- `cargo test --bin tavily-hikari server::tests::dashboard_overview_snapshot::dashboard_overview_snapshot_patches_contiguous_quota_samples -- --exact --nocapture`
- `python3 scripts/ci_backend_tests.py run-shard --id bin-linuxdo-dashboard-overview`
- `python3 scripts/ci_backend_tests.py verify`
- `cargo fmt --check`
- `cargo clippy --locked -j 2 -- -D warnings`

Independent standards and specification reviews found no unresolved P0/P1/P2.