### PR TITLE
fix(reconciliation): rederive current work identity

### DIFF
--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1793,7 +1793,11 @@ async fn apply_ha_baseline_response_stream(
             return Err(err.into());
         }
     }
-    let result = session.finish().await.map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
+    let result = state
+        .proxy
+        .finish_ha_baseline_apply(session)
+        .await
+        .map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
     refresh_admin_password_state_after_ha_apply(state, channel).await?;
     let detail = match mode {
         tavily_hikari::HaBaselineApplyMode::Replace => "replace",

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1793,11 +1793,13 @@ async fn apply_ha_baseline_response_stream(
             return Err(err.into());
         }
     }
-    let result = state
-        .proxy
-        .finish_ha_baseline_apply(session)
+    let result = session
+        .finish()
         .await
         .map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
+    if channel == tavily_hikari::HaSyncChannel::Runtime {
+        state.proxy.ensure_upstream_reconciliation_representative_job().await?;
+    }
     refresh_admin_password_state_after_ha_apply(state, channel).await?;
     let detail = match mode {
         tavily_hikari::HaBaselineApplyMode::Replace => "replace",

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -553,7 +553,14 @@ impl KeyStore {
                 return Err(err);
             }
         }
-        self.finish_ha_baseline_apply(session).await
+        let reconciliation_identity_repair_rearmed =
+            session.reconciliation_identity_repair_rearmed();
+        let result = session.finish().await?;
+        if reconciliation_identity_repair_rearmed {
+            self.ensure_upstream_reconciliation_representative_job()
+                .await?;
+        }
+        Ok(result)
     }
 
     pub(crate) async fn apply_ha_events_ndjson(
@@ -1253,20 +1260,6 @@ impl KeyStore {
             quota_cache_generation: Arc::clone(&self.account_quota_resolution_generation),
             quota_cache_transitions: Arc::clone(&self.account_quota_resolution_transitions),
         })
-    }
-
-    pub(crate) async fn finish_ha_baseline_apply(
-        &self,
-        session: HaBaselineApplySession,
-    ) -> Result<HaApplyResult, ProxyError> {
-        let reconciliation_identity_repair_rearmed =
-            session.reconciliation_identity_repair_rearmed();
-        let result = session.finish().await?;
-        if reconciliation_identity_repair_rearmed {
-            self.ensure_upstream_reconciliation_representative_job()
-                .await?;
-        }
-        Ok(result)
     }
 
     pub(crate) async fn begin_ha_events_apply(
@@ -2712,7 +2705,7 @@ impl HaBaselineApplySession {
         }
         if self.reconciliation_identity_repair_dirty {
             sqlx::query(
-            r#"UPDATE upstream_reconciliation_projection_state
+                r#"UPDATE upstream_reconciliation_projection_state
                    SET cursor_token_id = '', cursor_key_id = '', cursor_period_code = '',
                        identity_repair_generation = identity_repair_generation + 1,
                        completed = CASE WHEN EXISTS(

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -1248,6 +1248,7 @@ impl KeyStore {
             saw_end: false,
             quota_cache_dirty: mode == HaBaselineApplyMode::Replace
                 && channel != HaSyncChannel::Billing,
+            reconciliation_identity_repair_dirty: false,
             quota_cache: Arc::clone(&self.account_quota_resolution_cache),
             quota_cache_generation: Arc::clone(&self.account_quota_resolution_generation),
             quota_cache_transitions: Arc::clone(&self.account_quota_resolution_transitions),
@@ -2632,6 +2633,11 @@ impl HaBaselineApplySession {
                 }
                 ensure_ha_resource_whitelisted(self.channel, resource)?;
                 self.quota_cache_dirty |= ha_resource_affects_account_quota(resource);
+                self.reconciliation_identity_repair_dirty |= self.channel == HaSyncChannel::Runtime
+                    && matches!(
+                        resource,
+                        "upstream_reconciliation_usage" | "upstream_reconciliation_work"
+                    );
                 let data = value
                     .get("data")
                     .cloned()
@@ -2689,6 +2695,22 @@ impl HaBaselineApplySession {
             return Err(ProxyError::Other(
                 "HA baseline must include baseline_start and baseline_end".to_string(),
             ));
+        }
+        if self.reconciliation_identity_repair_dirty {
+            sqlx::query(
+                r#"UPDATE upstream_reconciliation_projection_state
+                   SET cursor_token_id = '', cursor_key_id = '', cursor_period_code = '',
+                       completed = CASE WHEN EXISTS(
+                           SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
+                       ) THEN 0 ELSE 1 END,
+                       next_retry_at = 0,
+                       last_defer_reason = CASE WHEN EXISTS(
+                           SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
+                       ) THEN 'identity_repair_pending' ELSE NULL END
+                   WHERE id = 'local'"#,
+            )
+            .execute(&mut *self.conn)
+            .await?;
         }
         if let Err(err) = clear_ha_outbox_suppression_on_conn(&mut self.conn).await {
             let _ = self.conn.rollback_and_reenable_foreign_keys().await;

--- a/src/store/key_store_ha.rs
+++ b/src/store/key_store_ha.rs
@@ -553,7 +553,7 @@ impl KeyStore {
                 return Err(err);
             }
         }
-        session.finish().await
+        self.finish_ha_baseline_apply(session).await
     }
 
     pub(crate) async fn apply_ha_events_ndjson(
@@ -1253,6 +1253,20 @@ impl KeyStore {
             quota_cache_generation: Arc::clone(&self.account_quota_resolution_generation),
             quota_cache_transitions: Arc::clone(&self.account_quota_resolution_transitions),
         })
+    }
+
+    pub(crate) async fn finish_ha_baseline_apply(
+        &self,
+        session: HaBaselineApplySession,
+    ) -> Result<HaApplyResult, ProxyError> {
+        let reconciliation_identity_repair_rearmed =
+            session.reconciliation_identity_repair_rearmed();
+        let result = session.finish().await?;
+        if reconciliation_identity_repair_rearmed {
+            self.ensure_upstream_reconciliation_representative_job()
+                .await?;
+        }
+        Ok(result)
     }
 
     pub(crate) async fn begin_ha_events_apply(
@@ -2698,8 +2712,9 @@ impl HaBaselineApplySession {
         }
         if self.reconciliation_identity_repair_dirty {
             sqlx::query(
-                r#"UPDATE upstream_reconciliation_projection_state
+            r#"UPDATE upstream_reconciliation_projection_state
                    SET cursor_token_id = '', cursor_key_id = '', cursor_period_code = '',
+                       identity_repair_generation = identity_repair_generation + 1,
                        completed = CASE WHEN EXISTS(
                            SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
                        ) THEN 0 ELSE 1 END,

--- a/src/store/key_store_ha_defs.rs
+++ b/src/store/key_store_ha_defs.rs
@@ -44,6 +44,7 @@ pub struct HaBaselineApplySession {
     saw_start: bool,
     saw_end: bool,
     quota_cache_dirty: bool,
+    reconciliation_identity_repair_dirty: bool,
     quota_cache: Arc<RwLock<HashMap<String, AccountQuotaResolutionCacheEntry>>>,
     quota_cache_generation: Arc<std::sync::atomic::AtomicU64>,
     quota_cache_transitions: Arc<std::sync::atomic::AtomicU64>,

--- a/src/store/key_store_ha_defs.rs
+++ b/src/store/key_store_ha_defs.rs
@@ -50,6 +50,12 @@ pub struct HaBaselineApplySession {
     quota_cache_transitions: Arc<std::sync::atomic::AtomicU64>,
 }
 
+impl HaBaselineApplySession {
+    pub(crate) fn reconciliation_identity_repair_rearmed(&self) -> bool {
+        self.reconciliation_identity_repair_dirty
+    }
+}
+
 #[derive(Debug)]
 pub struct HaBaselineReadSession {
     channel: HaSyncChannel,

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -107,6 +107,11 @@ const RECONCILIATION_SOURCE_TIMESTAMP_REVISION_NAME: &str =
     "reconciliation-logical-source-timestamps-v1";
 const RECONCILIATION_SOURCE_TIMESTAMP_REVISION_CHECKSUM: &str =
     "sha256:1e18be281aaa333fffdc1873bac99f9a";
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_VERSION: i64 = 27;
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_NAME: &str =
+    "reconciliation-current-source-identity-v1";
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_CHECKSUM: &str =
+    "sha256:f7275e2b95b62ec59ad164fbc4160ae0ca648bc4696dc27c5578f942fdab32a3";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -834,6 +839,11 @@ impl KeyStore {
                 RECONCILIATION_SOURCE_TIMESTAMP_REVISION_NAME,
                 RECONCILIATION_SOURCE_TIMESTAMP_REVISION_CHECKSUM,
             ),
+            (
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_VERSION,
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_NAME,
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -1210,6 +1220,21 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 26".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_VERSION)
+            .await?
+            && !self
+                .schema_named_object_exists(
+                    "main",
+                    "trigger",
+                    "trg_upstream_reconciliation_usage_work_update",
+                )
+                .await?
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 27".to_string(),
             ));
         }
         Ok(())
@@ -2015,6 +2040,115 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_current_source_identity_migration(
+        &self,
+    ) -> Result<(), ProxyError> {
+        sqlx::query("DROP TRIGGER IF EXISTS trg_upstream_reconciliation_usage_work_update")
+            .execute(&self.pool)
+            .await?;
+        sqlx::query(
+            r#"CREATE TRIGGER IF NOT EXISTS trg_upstream_reconciliation_usage_work_update
+               AFTER UPDATE ON upstream_reconciliation_usage
+               WHEN NEW.token_id IS NOT OLD.token_id
+                 OR NEW.key_id IS NOT OLD.key_id
+                 OR NEW.period_code IS NOT OLD.period_code
+                 OR NEW.project_id IS NOT OLD.project_id
+                 OR NEW.billing_subject IS NOT OLD.billing_subject
+                 OR NEW.settlement_mode IS NOT OLD.settlement_mode
+                 OR NEW.period_start IS NOT OLD.period_start
+                 OR NEW.period_end IS NOT OLD.period_end
+                 OR NEW.request_count IS NOT OLD.request_count
+                 OR NEW.first_used_at IS NOT OLD.first_used_at
+                 OR NEW.last_used_at IS NOT OLD.last_used_at
+               BEGIN
+                 INSERT INTO upstream_reconciliation_work (
+                   token_id, period_code, project_id, billing_subject, settlement_mode,
+                   period_start, period_end, scheduling_key_id, updated_at,
+                   work_generation, completed_generation, next_attempt_at, last_outcome
+                 )
+                 SELECT
+                   NEW.token_id, NEW.period_code, MIN(project_id), MIN(billing_subject),
+                   MIN(settlement_mode), MIN(period_start), MAX(period_end), MIN(key_id),
+                   MAX(updated_at), 1, 0, 0, NULL
+                 FROM upstream_reconciliation_usage
+                 WHERE token_id = NEW.token_id AND period_code = NEW.period_code
+                 ON CONFLICT(token_id, period_code) DO UPDATE SET
+                   project_id = excluded.project_id,
+                   billing_subject = excluded.billing_subject,
+                   settlement_mode = excluded.settlement_mode,
+                   period_start = excluded.period_start,
+                   period_end = excluded.period_end,
+                   scheduling_key_id = excluded.scheduling_key_id,
+                   updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+                   work_generation = upstream_reconciliation_work.work_generation + 1,
+                   next_attempt_at = 0,
+                   last_outcome = NULL;
+
+                 UPDATE upstream_reconciliation_work
+                    SET project_id = (
+                          SELECT MIN(project_id)
+                          FROM upstream_reconciliation_usage
+                          WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                        ),
+                        billing_subject = (
+                          SELECT MIN(billing_subject)
+                          FROM upstream_reconciliation_usage
+                          WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                        ),
+                        settlement_mode = (
+                          SELECT MIN(settlement_mode)
+                          FROM upstream_reconciliation_usage
+                          WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                        ),
+                        period_start = (
+                          SELECT MIN(period_start)
+                          FROM upstream_reconciliation_usage
+                          WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                        ),
+                        period_end = (
+                          SELECT MAX(period_end)
+                          FROM upstream_reconciliation_usage
+                          WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                        ),
+                        scheduling_key_id = (
+                          SELECT MIN(key_id)
+                          FROM upstream_reconciliation_usage
+                          WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                        ),
+                        updated_at = MAX(
+                          updated_at,
+                          COALESCE((
+                            SELECT MAX(updated_at)
+                            FROM upstream_reconciliation_usage
+                            WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                          ), updated_at)
+                        )
+                  WHERE (OLD.token_id IS NOT NEW.token_id OR OLD.period_code IS NOT NEW.period_code)
+                    AND token_id = OLD.token_id AND period_code = OLD.period_code
+                    AND EXISTS (
+                      SELECT 1
+                      FROM upstream_reconciliation_usage
+                      WHERE token_id = OLD.token_id AND period_code = OLD.period_code
+                    );
+
+                 UPDATE upstream_reconciliation_work
+                    SET work_generation = work_generation + 1,
+                        next_attempt_at = 0,
+                        last_outcome = NULL
+                  WHERE (OLD.token_id IS NOT NEW.token_id OR OLD.period_code IS NOT NEW.period_code)
+                    AND token_id = OLD.token_id AND period_code = OLD.period_code;
+               END"#,
+        )
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_VERSION,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_NAME,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_CHECKSUM,
+        )
+        .await
+    }
+
     async fn apply_reconciliation_key_observation_migration(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_key_observations (
@@ -2551,6 +2685,13 @@ impl KeyStore {
             self.apply_reconciliation_source_timestamp_revision_migration()
                 .await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_current_source_identity_migration()
+                .await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2613,6 +2754,8 @@ impl KeyStore {
         self.apply_reconciliation_source_revision_migration().await?;
         self.apply_reconciliation_source_timestamp_revision_migration()
             .await?;
+        self.apply_reconciliation_current_source_identity_migration()
+            .await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2620,7 +2763,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 26_i64,
+            migration_count = 27_i64,
         );
         Ok(())
     }

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -112,6 +112,11 @@ const RECONCILIATION_CURRENT_SOURCE_IDENTITY_NAME: &str =
     "reconciliation-current-source-identity-v1";
 const RECONCILIATION_CURRENT_SOURCE_IDENTITY_CHECKSUM: &str =
     "sha256:f7275e2b95b62ec59ad164fbc4160ae0ca648bc4696dc27c5578f942fdab32a3";
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION: i64 = 28;
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME: &str =
+    "reconciliation-current-source-identity-repair-v1";
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM: &str =
+    "sha256:ab30da1112183f3ea75cde687ab08e1685588e3885e5183c6ffb5f788f49b0af";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -844,6 +849,11 @@ impl KeyStore {
                 RECONCILIATION_CURRENT_SOURCE_IDENTITY_NAME,
                 RECONCILIATION_CURRENT_SOURCE_IDENTITY_CHECKSUM,
             ),
+            (
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION,
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME,
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -1235,6 +1245,21 @@ impl KeyStore {
         {
             return Err(ProxyError::Other(
                 "schema migration object validation failed at version 27".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION)
+            .await?
+            && !self
+                .schema_named_object_exists(
+                    "main",
+                    "index",
+                    "idx_upstream_reconciliation_usage_identity_repair",
+                )
+                .await?
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 28".to_string(),
             ));
         }
         Ok(())
@@ -2149,6 +2174,41 @@ impl KeyStore {
         .await
     }
 
+    async fn apply_reconciliation_current_source_identity_repair_migration(
+        &self,
+    ) -> Result<(), ProxyError> {
+        // Rebuild stale v26 work identities through the existing bounded, claim-fenced
+        // projection controller. The migration itself performs no historical scan.
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_upstream_reconciliation_usage_identity_repair \
+             ON upstream_reconciliation_usage(token_id, period_code, key_id)",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"UPDATE upstream_reconciliation_projection_state
+               SET cursor_token_id = '', cursor_key_id = '', cursor_period_code = '',
+                   completed = CASE WHEN EXISTS(
+                       SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
+                   ) THEN 0 ELSE 1 END,
+                   next_retry_at = 0,
+                   last_defer_reason = CASE WHEN EXISTS(
+                       SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
+                   ) THEN 'identity_repair_pending' ELSE NULL END,
+                   updated_at = ?
+               WHERE id = 'local'"#,
+        )
+        .bind(self.backend_time.now_ts())
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM,
+        )
+        .await
+    }
+
     async fn apply_reconciliation_key_observation_migration(&self) -> Result<(), ProxyError> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS upstream_reconciliation_key_observations (
@@ -2692,6 +2752,13 @@ impl KeyStore {
             self.apply_reconciliation_current_source_identity_migration()
                 .await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_current_source_identity_repair_migration()
+                .await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2756,6 +2823,8 @@ impl KeyStore {
             .await?;
         self.apply_reconciliation_current_source_identity_migration()
             .await?;
+        self.apply_reconciliation_current_source_identity_repair_migration()
+            .await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2763,7 +2832,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 27_i64,
+            migration_count = 28_i64,
         );
         Ok(())
     }

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -116,7 +116,12 @@ const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION: i64 = 28;
 const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME: &str =
     "reconciliation-current-source-identity-repair-v1";
 const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM: &str =
-    "sha256:0e7d9125e32e321c1bad42d11970145c522da5de4c3b84111fceb589217cb049";
+    "sha256:ab30da1112183f3ea75cde687ab08e1685588e3885e5183c6ffb5f788f49b0af";
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_VERSION: i64 = 29;
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_NAME: &str =
+    "reconciliation-current-source-identity-fence-v1";
+const RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_CHECKSUM: &str =
+    "sha256:4e52e9dc9aa2a9fedcab4ccd12da3bc8fed407a2b0f936ff3fae535f48ccac1f";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -854,6 +859,11 @@ impl KeyStore {
                 RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME,
                 RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM,
             ),
+            (
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_VERSION,
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_NAME,
+                RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_CHECKSUM,
+            ),
         ];
         let recorded: Vec<(i64, String, String)> = sqlx::query_as(
             "SELECT version, name, checksum FROM schema_migrations ORDER BY version",
@@ -1251,6 +1261,21 @@ impl KeyStore {
             .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION)
             .await?
             && !self
+                .schema_named_object_exists(
+                    "main",
+                    "index",
+                    "idx_upstream_reconciliation_usage_identity_repair",
+                )
+                .await?
+        {
+            return Err(ProxyError::Other(
+                "schema migration object validation failed at version 28".to_string(),
+            ));
+        }
+        if self
+            .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_VERSION)
+            .await?
+            && !self
                 .table_column_exists(
                     "upstream_reconciliation_projection_state",
                     "identity_repair_generation",
@@ -1258,7 +1283,7 @@ impl KeyStore {
                 .await?
         {
             return Err(ProxyError::Other(
-                "schema migration object validation failed at version 28".to_string(),
+                "schema migration object validation failed at version 29".to_string(),
             ));
         }
         Ok(())
@@ -2177,8 +2202,42 @@ impl KeyStore {
         &self,
     ) -> Result<(), ProxyError> {
         // Rebuild stale v26 work identities through the existing bounded, claim-fenced
-        // projection controller. Startup only resets derived state; it does not scan or
-        // add an index to the business usage table.
+        // projection controller. The migration itself performs no historical scan.
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_upstream_reconciliation_usage_identity_repair \
+             ON upstream_reconciliation_usage(token_id, period_code, key_id)",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"UPDATE upstream_reconciliation_projection_state
+               SET cursor_token_id = '', cursor_key_id = '', cursor_period_code = '',
+                   completed = CASE WHEN EXISTS(
+                       SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
+                   ) THEN 0 ELSE 1 END,
+                   next_retry_at = 0,
+                   last_defer_reason = CASE WHEN EXISTS(
+                       SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
+                   ) THEN 'identity_repair_pending' ELSE NULL END,
+                   updated_at = ?
+               WHERE id = 'local'"#,
+        )
+        .bind(self.backend_time.now_ts())
+        .execute(&self.pool)
+        .await?;
+        self.record_schema_migration(
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM,
+        )
+        .await
+    }
+
+    async fn apply_reconciliation_current_source_identity_fence_migration(
+        &self,
+    ) -> Result<(), ProxyError> {
+        // Fence resumable repair slices against a source revision or HA baseline reset that
+        // occurs after their snapshot. Startup only resets derived state; it does not scan.
         if !self
             .table_column_exists(
                 "upstream_reconciliation_projection_state",
@@ -2211,9 +2270,9 @@ impl KeyStore {
         .execute(&self.pool)
         .await?;
         self.record_schema_migration(
-            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION,
-            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME,
-            RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_VERSION,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_NAME,
+            RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_CHECKSUM,
         )
         .await
     }
@@ -2768,6 +2827,13 @@ impl KeyStore {
             self.apply_reconciliation_current_source_identity_repair_migration()
                 .await?;
         }
+        if !self
+            .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_FENCE_VERSION)
+            .await?
+        {
+            self.apply_reconciliation_current_source_identity_fence_migration()
+                .await?;
+        }
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::debug!(
@@ -2834,6 +2900,8 @@ impl KeyStore {
             .await?;
         self.apply_reconciliation_current_source_identity_repair_migration()
             .await?;
+        self.apply_reconciliation_current_source_identity_fence_migration()
+            .await?;
         self.validate_applied_migration_objects().await?;
         self.clear_new_database_bootstrap_marker().await?;
         tracing::info!(
@@ -2841,7 +2909,7 @@ impl KeyStore {
             event = "baseline_adopted",
             outcome = "applied",
             elapsed_ms = started.elapsed().as_millis() as u64,
-            migration_count = 28_i64,
+            migration_count = 29_i64,
         );
         Ok(())
     }

--- a/src/store/key_store_schema_migrations.rs
+++ b/src/store/key_store_schema_migrations.rs
@@ -116,7 +116,7 @@ const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION: i64 = 28;
 const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_NAME: &str =
     "reconciliation-current-source-identity-repair-v1";
 const RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_CHECKSUM: &str =
-    "sha256:ab30da1112183f3ea75cde687ab08e1685588e3885e5183c6ffb5f788f49b0af";
+    "sha256:0e7d9125e32e321c1bad42d11970145c522da5de4c3b84111fceb589217cb049";
 const NEW_DATABASE_BOOTSTRAP_MARKER: &str = "tavily-hikari-schema-bootstrap-v1";
 
 impl KeyStore {
@@ -1251,10 +1251,9 @@ impl KeyStore {
             .schema_migration_applied(RECONCILIATION_CURRENT_SOURCE_IDENTITY_REPAIR_VERSION)
             .await?
             && !self
-                .schema_named_object_exists(
-                    "main",
-                    "index",
-                    "idx_upstream_reconciliation_usage_identity_repair",
+                .table_column_exists(
+                    "upstream_reconciliation_projection_state",
+                    "identity_repair_generation",
                 )
                 .await?
         {
@@ -2178,16 +2177,26 @@ impl KeyStore {
         &self,
     ) -> Result<(), ProxyError> {
         // Rebuild stale v26 work identities through the existing bounded, claim-fenced
-        // projection controller. The migration itself performs no historical scan.
-        sqlx::query(
-            "CREATE INDEX IF NOT EXISTS idx_upstream_reconciliation_usage_identity_repair \
-             ON upstream_reconciliation_usage(token_id, period_code, key_id)",
-        )
-        .execute(&self.pool)
-        .await?;
+        // projection controller. Startup only resets derived state; it does not scan or
+        // add an index to the business usage table.
+        if !self
+            .table_column_exists(
+                "upstream_reconciliation_projection_state",
+                "identity_repair_generation",
+            )
+            .await?
+        {
+            sqlx::query(
+                "ALTER TABLE upstream_reconciliation_projection_state \
+                 ADD COLUMN identity_repair_generation INTEGER NOT NULL DEFAULT 0",
+            )
+            .execute(&self.pool)
+            .await?;
+        }
         sqlx::query(
             r#"UPDATE upstream_reconciliation_projection_state
                SET cursor_token_id = '', cursor_key_id = '', cursor_period_code = '',
+                   identity_repair_generation = identity_repair_generation + 1,
                    completed = CASE WHEN EXISTS(
                        SELECT 1 FROM upstream_reconciliation_usage LIMIT 1
                    ) THEN 0 ELSE 1 END,

--- a/src/store/reconciliation_projection_controller.rs
+++ b/src/store/reconciliation_projection_controller.rs
@@ -17,6 +17,7 @@ struct ReconciliationProjectionAggregate {
     scheduling_key_id: String,
     updated_at: i64,
     terminal_outcome: Option<String>,
+    source_work_generation: Option<i64>,
 }
 
 type ReconciliationProjectionSourceRow = (
@@ -31,10 +32,25 @@ type ReconciliationProjectionSourceRow = (
     i64,
     Option<String>,
     Option<i64>,
+    Option<i64>,
 );
 
 type ReconciliationProjectionStateRow =
-    (String, String, String, i64, i64, i64, i64, i64, i64, i64, i64, i64);
+    (
+        String,
+        String,
+        String,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+        i64,
+    );
 
 struct ReconciliationProjectionController<'a> {
     store: &'a KeyStore,
@@ -155,7 +171,8 @@ impl<'a> ReconciliationProjectionController<'a> {
             r#"SELECT cursor_token_id, cursor_key_id, cursor_period_code,
                   batch_size, fast_slice_streak, completed,
                   tx_hold_le_10, tx_hold_le_25, tx_hold_le_50,
-                  tx_hold_le_100, tx_hold_le_250, tx_hold_over_250
+                  tx_hold_le_100, tx_hold_le_250, tx_hold_over_250,
+                  identity_repair_generation
            FROM upstream_reconciliation_projection_state WHERE id = 'local'"#,
         )
         .fetch_one(&mut *state_connection)
@@ -179,9 +196,11 @@ impl<'a> ReconciliationProjectionController<'a> {
             r#"SELECT u.token_id, u.period_code, MIN(u.project_id),
                       MIN(u.billing_subject), MIN(u.settlement_mode),
                       MIN(u.period_start), MAX(u.period_end), MIN(u.key_id),
-                      MAX(u.updated_at), MIN(s.status), MIN(s.delta_credits)
+                      MAX(u.updated_at), MIN(s.status), MIN(s.delta_credits),
+                      MAX(w.work_generation)
                FROM upstream_reconciliation_usage u
-               INDEXED BY idx_upstream_reconciliation_usage_identity_repair
+               LEFT JOIN upstream_reconciliation_work w
+                 ON w.token_id = u.token_id AND w.period_code = u.period_code
                LEFT JOIN upstream_reconciliation_settlements s
                  ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
                WHERE (u.token_id, u.period_code) > (?, ?)
@@ -214,17 +233,22 @@ impl<'a> ReconciliationProjectionController<'a> {
                 if !Self::claim_is_current(&mut tx, claimed_job).await? {
                     return Ok(ReconciliationProjectionWriteStatus::StaleClaim);
                 }
+                if !Self::projection_snapshot_is_current(&mut tx, &state).await? {
+                    return Ok(ReconciliationProjectionWriteStatus::CursorConflict);
+                }
                 let updated = sqlx::query(
                     r#"UPDATE upstream_reconciliation_projection_state
                        SET completed = 1, next_retry_at = 0, last_defer_reason = NULL,
                            updated_at = ?
                        WHERE id = 'local' AND cursor_token_id = ? AND cursor_key_id = ?
-                         AND cursor_period_code = ? AND completed = 0"#,
+                         AND cursor_period_code = ? AND completed = 0
+                         AND identity_repair_generation = ?"#,
                 )
                 .bind(self.store.backend_time.now_ts())
                 .bind(&state.0)
                 .bind(&state.1)
                 .bind(&state.2)
+                .bind(state.12)
                 .execute(&mut *tx)
                 .await?;
                 if updated.rows_affected() != 1 {
@@ -287,6 +311,7 @@ impl<'a> ReconciliationProjectionController<'a> {
                         row.9.as_deref(),
                         row.10,
                     ),
+                    source_work_generation: row.11,
                 });
         }
 
@@ -308,6 +333,11 @@ impl<'a> ReconciliationProjectionController<'a> {
         let write_result = async {
             if !Self::claim_is_current(&mut tx, claimed_job).await? {
                 return Ok(ReconciliationProjectionWriteStatus::StaleClaim);
+            }
+            if !Self::projection_snapshot_is_current(&mut tx, &state).await?
+                || !Self::aggregate_generations_match_current_work(&mut tx, &aggregates).await?
+            {
+                return Ok(ReconciliationProjectionWriteStatus::CursorConflict);
             }
             if !aggregates.is_empty() {
             let mut merge = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
@@ -425,7 +455,8 @@ impl<'a> ReconciliationProjectionController<'a> {
                    tx_hold_over_250 = ?,
                    next_retry_at = ?, last_defer_reason = NULL, updated_at = ?
                WHERE id = 'local' AND cursor_token_id = ? AND cursor_key_id = ?
-                 AND cursor_period_code = ? AND completed = 0"#,
+                 AND cursor_period_code = ? AND completed = 0
+                 AND identity_repair_generation = ?"#,
         )
         .bind(&last.0)
         .bind(&last.1)
@@ -450,6 +481,7 @@ impl<'a> ReconciliationProjectionController<'a> {
         .bind(&state.0)
         .bind(&state.1)
         .bind(&state.2)
+        .bind(state.12)
             .execute(&mut *tx)
             .await?;
             if updated.rows_affected() != 1 {
@@ -504,6 +536,60 @@ impl<'a> ReconciliationProjectionController<'a> {
         .fetch_one(&mut **tx)
         .await?
             != 0)
+    }
+
+    async fn projection_snapshot_is_current(
+        tx: &mut SqliteImmediateTransaction,
+        state: &ReconciliationProjectionStateRow,
+    ) -> Result<bool, ProxyError> {
+        Ok(sqlx::query_scalar::<_, i64>(
+            r#"SELECT EXISTS(
+                 SELECT 1 FROM upstream_reconciliation_projection_state
+                 WHERE id = 'local' AND cursor_token_id = ? AND cursor_key_id = ?
+                   AND cursor_period_code = ? AND completed = 0
+                   AND identity_repair_generation = ?
+               )"#,
+        )
+        .bind(&state.0)
+        .bind(&state.1)
+        .bind(&state.2)
+        .bind(state.12)
+        .fetch_one(&mut **tx)
+        .await?
+            != 0)
+    }
+
+    async fn aggregate_generations_match_current_work(
+        tx: &mut SqliteImmediateTransaction,
+        aggregates: &std::collections::BTreeMap<
+            (String, String),
+            ReconciliationProjectionAggregate,
+        >,
+    ) -> Result<bool, ProxyError> {
+        if aggregates.is_empty() {
+            return Ok(true);
+        }
+        let mut query = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "WITH expected(token_id, period_code, work_generation) AS (",
+        );
+        query.push_values(aggregates.iter(), |mut values, ((token_id, period_code), aggregate)| {
+            values
+                .push_bind(token_id)
+                .push_bind(period_code)
+                .push_bind(aggregate.source_work_generation);
+        });
+        query.push(
+            r#") SELECT e.work_generation, w.work_generation
+                  FROM expected e
+             LEFT JOIN upstream_reconciliation_work w
+                    ON w.token_id = e.token_id AND w.period_code = e.period_code"#,
+        );
+        let generations: Vec<(Option<i64>, Option<i64>)> =
+            query.build_query_as().fetch_all(&mut **tx).await?;
+        Ok(generations.len() == aggregates.len()
+            && generations
+                .into_iter()
+                .all(|(expected, current)| expected == current))
     }
 
     async fn defer_source_read_budget(

--- a/src/store/reconciliation_projection_controller.rs
+++ b/src/store/reconciliation_projection_controller.rs
@@ -25,9 +25,9 @@ type ReconciliationProjectionSourceRow = (
     String,
     String,
     String,
+    i64,
+    i64,
     String,
-    i64,
-    i64,
     i64,
     Option<String>,
     Option<i64>,
@@ -176,18 +176,20 @@ impl<'a> ReconciliationProjectionController<'a> {
             .begin_reconciliation_read(ReconciliationReadKind::HistoricalProjection)
             .await?;
         let rows_result = sqlx::query_as(
-            r#"SELECT u.token_id, u.key_id, u.period_code, u.project_id,
-                      u.billing_subject, u.settlement_mode, u.period_start,
-                      u.period_end, u.updated_at, s.status, s.delta_credits
+            r#"SELECT u.token_id, u.period_code, MIN(u.project_id),
+                      MIN(u.billing_subject), MIN(u.settlement_mode),
+                      MIN(u.period_start), MAX(u.period_end), MIN(u.key_id),
+                      MAX(u.updated_at), MIN(s.status), MIN(s.delta_credits)
                FROM upstream_reconciliation_usage u
+               INDEXED BY idx_upstream_reconciliation_usage_identity_repair
                LEFT JOIN upstream_reconciliation_settlements s
                  ON s.settlement_key = 'v1:' || u.token_id || ':' || u.period_code
-               WHERE (u.token_id, u.key_id, u.period_code) > (?, ?, ?)
-               ORDER BY u.token_id, u.key_id, u.period_code
+               WHERE (u.token_id, u.period_code) > (?, ?)
+               GROUP BY u.token_id, u.period_code
+               ORDER BY u.token_id, u.period_code
                LIMIT ?"#,
         )
         .bind(&state.0)
-        .bind(&state.1)
         .bind(&state.2)
         .bind(batch_size)
         .fetch_all(&mut *snapshot)
@@ -199,7 +201,9 @@ impl<'a> ReconciliationProjectionController<'a> {
                     return self.defer_source_read_budget(claimed_job).await;
                 }
             };
-        let Some(last) = rows.last().map(|row| (row.0.clone(), row.1.clone(), row.2.clone()))
+        let Some(last) = rows
+            .last()
+            .map(|row| (row.0.clone(), String::new(), row.1.clone()))
         else {
             let mut tx = self
                 .store
@@ -269,39 +273,21 @@ impl<'a> ReconciliationProjectionController<'a> {
             ReconciliationProjectionAggregate,
         >::new();
         for row in &rows {
-            let entry = aggregates
-                .entry((row.0.clone(), row.2.clone()))
+            aggregates
+                .entry((row.0.clone(), row.1.clone()))
                 .or_insert_with(|| ReconciliationProjectionAggregate {
-                    project_id: row.3.clone(),
-                    billing_subject: row.4.clone(),
-                    settlement_mode: row.5.clone(),
-                    period_start: row.6,
-                    period_end: row.7,
-                    scheduling_key_id: row.1.clone(),
+                    project_id: row.2.clone(),
+                    billing_subject: row.3.clone(),
+                    settlement_mode: row.4.clone(),
+                    period_start: row.5,
+                    period_end: row.6,
+                    scheduling_key_id: row.7.clone(),
                     updated_at: row.8,
                     terminal_outcome: projection_terminal_outcome(
                         row.9.as_deref(),
                         row.10,
                     ),
                 });
-            if row.3 < entry.project_id {
-                entry.project_id.clone_from(&row.3);
-            }
-            if row.4 < entry.billing_subject {
-                entry.billing_subject.clone_from(&row.4);
-            }
-            if row.5 < entry.settlement_mode {
-                entry.settlement_mode.clone_from(&row.5);
-            }
-            entry.period_start = entry.period_start.min(row.6);
-            entry.period_end = entry.period_end.max(row.7);
-            if row.1 < entry.scheduling_key_id {
-                entry.scheduling_key_id.clone_from(&row.1);
-            }
-            entry.updated_at = entry.updated_at.max(row.8);
-            if entry.terminal_outcome.is_none() {
-                entry.terminal_outcome = projection_terminal_outcome(row.9.as_deref(), row.10);
-            }
         }
 
         let terminal_repairs = aggregates
@@ -344,13 +330,37 @@ impl<'a> ReconciliationProjectionController<'a> {
             });
             merge.push(
                 r#" ON CONFLICT(token_id, period_code) DO UPDATE SET
-                     project_id = MIN(upstream_reconciliation_work.project_id, excluded.project_id),
-                     billing_subject = MIN(upstream_reconciliation_work.billing_subject, excluded.billing_subject),
-                     settlement_mode = MIN(upstream_reconciliation_work.settlement_mode, excluded.settlement_mode),
-                     period_start = MIN(upstream_reconciliation_work.period_start, excluded.period_start),
-                     period_end = MAX(upstream_reconciliation_work.period_end, excluded.period_end),
-                     scheduling_key_id = MIN(upstream_reconciliation_work.scheduling_key_id, excluded.scheduling_key_id),
-                     updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at)"#,
+                     project_id = excluded.project_id,
+                     billing_subject = excluded.billing_subject,
+                     settlement_mode = excluded.settlement_mode,
+                     period_start = excluded.period_start,
+                     period_end = excluded.period_end,
+                     scheduling_key_id = excluded.scheduling_key_id,
+                     updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+                     work_generation = upstream_reconciliation_work.work_generation +
+                       CASE WHEN upstream_reconciliation_work.project_id IS NOT excluded.project_id
+                              OR upstream_reconciliation_work.billing_subject IS NOT excluded.billing_subject
+                              OR upstream_reconciliation_work.settlement_mode IS NOT excluded.settlement_mode
+                              OR upstream_reconciliation_work.period_start IS NOT excluded.period_start
+                              OR upstream_reconciliation_work.period_end IS NOT excluded.period_end
+                              OR upstream_reconciliation_work.scheduling_key_id IS NOT excluded.scheduling_key_id
+                            THEN 1 ELSE 0 END,
+                     next_attempt_at = CASE
+                       WHEN upstream_reconciliation_work.project_id IS NOT excluded.project_id
+                         OR upstream_reconciliation_work.billing_subject IS NOT excluded.billing_subject
+                         OR upstream_reconciliation_work.settlement_mode IS NOT excluded.settlement_mode
+                         OR upstream_reconciliation_work.period_start IS NOT excluded.period_start
+                         OR upstream_reconciliation_work.period_end IS NOT excluded.period_end
+                         OR upstream_reconciliation_work.scheduling_key_id IS NOT excluded.scheduling_key_id
+                       THEN 0 ELSE upstream_reconciliation_work.next_attempt_at END,
+                     last_outcome = CASE
+                       WHEN upstream_reconciliation_work.project_id IS NOT excluded.project_id
+                         OR upstream_reconciliation_work.billing_subject IS NOT excluded.billing_subject
+                         OR upstream_reconciliation_work.settlement_mode IS NOT excluded.settlement_mode
+                         OR upstream_reconciliation_work.period_start IS NOT excluded.period_start
+                         OR upstream_reconciliation_work.period_end IS NOT excluded.period_end
+                         OR upstream_reconciliation_work.scheduling_key_id IS NOT excluded.scheduling_key_id
+                       THEN NULL ELSE upstream_reconciliation_work.last_outcome END"#,
             );
                 merge.build().execute(&mut *tx).await?;
             }

--- a/src/store/reconciliation_projection_controller.rs
+++ b/src/store/reconciliation_projection_controller.rs
@@ -35,22 +35,21 @@ type ReconciliationProjectionSourceRow = (
     Option<i64>,
 );
 
-type ReconciliationProjectionStateRow =
-    (
-        String,
-        String,
-        String,
-        i64,
-        i64,
-        i64,
-        i64,
-        i64,
-        i64,
-        i64,
-        i64,
-        i64,
-        i64,
-    );
+type ReconciliationProjectionStateRow = (
+    String,
+    String,
+    String,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+);
 
 struct ReconciliationProjectionController<'a> {
     store: &'a KeyStore,

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -612,13 +612,6 @@ impl TavilyProxy {
             .await
     }
 
-    pub async fn finish_ha_baseline_apply(
-        &self,
-        session: crate::store::HaBaselineApplySession,
-    ) -> Result<HaApplyResult, ProxyError> {
-        self.key_store.finish_ha_baseline_apply(session).await
-    }
-
     pub async fn begin_ha_events_apply(
         &self,
         channel: HaSyncChannel,

--- a/src/tavily_proxy/proxy_ha.rs
+++ b/src/tavily_proxy/proxy_ha.rs
@@ -612,6 +612,13 @@ impl TavilyProxy {
             .await
     }
 
+    pub async fn finish_ha_baseline_apply(
+        &self,
+        session: crate::store::HaBaselineApplySession,
+    ) -> Result<HaApplyResult, ProxyError> {
+        self.key_store.finish_ha_baseline_apply(session).await
+    }
+
     pub async fn begin_ha_events_apply(
         &self,
         channel: HaSyncChannel,

--- a/src/tests/ha_baseline_streaming_and_sessions.rs
+++ b/src/tests/ha_baseline_streaming_and_sessions.rs
@@ -48,10 +48,37 @@ async fn runtime_baseline_rearms_current_source_identity_repair() {
     )
     .await
     .expect("create target proxy");
-    target
-        .apply_ha_baseline_ndjson(HaSyncChannel::Runtime, &baseline.ndjson)
+    let mut settings = target
+        .get_system_settings()
         .await
-        .expect("import runtime baseline");
+        .expect("load target reconciliation settings");
+    settings.upstream_project_id_mode = UpstreamProjectIdMode::AccessToken;
+    settings.api_rebalance_enabled = true;
+    settings.api_rebalance_percent = 100;
+    settings.rebalance_mcp_enabled = true;
+    settings.rebalance_mcp_session_percent = 100;
+    target
+        .set_system_settings(&settings)
+        .await
+        .expect("enable target reconciliation representative");
+    let mut session = target
+        .begin_ha_baseline_apply(HaSyncChannel::Runtime)
+        .await
+        .expect("begin runtime baseline apply");
+    for line in baseline
+        .ndjson
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+    {
+        session
+            .apply_line(line)
+            .await
+            .expect("apply runtime baseline line");
+    }
+    target
+        .finish_ha_baseline_apply(session)
+        .await
+        .expect("finish runtime baseline through the shared finalizer");
 
     let pending: (i64, Option<String>) = sqlx::query_as(
         "SELECT completed, last_defer_reason FROM upstream_reconciliation_projection_state \
@@ -61,6 +88,14 @@ async fn runtime_baseline_rearms_current_source_identity_repair() {
     .await
     .expect("read rearmed identity repair state");
     assert_eq!(pending, (0, Some("identity_repair_pending".to_string())));
+    let representative_jobs: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM scheduled_jobs \
+         WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",
+    )
+    .fetch_one(&target.key_store.pool)
+    .await
+    .expect("read rearmed reconciliation representative");
+    assert_eq!(representative_jobs, 1);
     assert_eq!(
         target
             .key_store

--- a/src/tests/ha_baseline_streaming_and_sessions.rs
+++ b/src/tests/ha_baseline_streaming_and_sessions.rs
@@ -75,19 +75,28 @@ async fn runtime_baseline_rearms_current_source_identity_repair() {
             .await
             .expect("apply runtime baseline line");
     }
-    target
-        .finish_ha_baseline_apply(session)
+    session
+        .finish()
         .await
-        .expect("finish runtime baseline through the shared finalizer");
+        .expect("finish runtime baseline before enqueueing representative");
+    target
+        .ensure_upstream_reconciliation_representative_job()
+        .await
+        .expect("enqueue the rearmed reconciliation representative");
 
-    let pending: (i64, Option<String>) = sqlx::query_as(
-        "SELECT completed, last_defer_reason FROM upstream_reconciliation_projection_state \
+    let pending: (i64, Option<String>, i64) = sqlx::query_as(
+        "SELECT completed, last_defer_reason, identity_repair_generation \
+         FROM upstream_reconciliation_projection_state \
          WHERE id = 'local'",
     )
     .fetch_one(&target.key_store.pool)
     .await
     .expect("read rearmed identity repair state");
-    assert_eq!(pending, (0, Some("identity_repair_pending".to_string())));
+    assert_eq!(
+        pending,
+        (0, Some("identity_repair_pending".to_string()), 2),
+        "the Runtime baseline must fence snapshots from before the import"
+    );
     let representative_jobs: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM scheduled_jobs \
          WHERE job_type = 'upstream_reconciliation' AND status = 'queued'",

--- a/src/tests/ha_baseline_streaming_and_sessions.rs
+++ b/src/tests/ha_baseline_streaming_and_sessions.rs
@@ -1,6 +1,110 @@
 use super::*;
 
 #[tokio::test]
+async fn runtime_baseline_rearms_current_source_identity_repair() {
+    let source_path = temp_db_path("ha-current-source-identity-source");
+    let source_str = source_path.to_string_lossy().to_string();
+    let source = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-current-source-identity-source".to_string()],
+        DEFAULT_UPSTREAM,
+        &source_str,
+    )
+    .await
+    .expect("create source proxy");
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_usage (
+             token_id, key_id, period_code, project_id, billing_subject,
+             settlement_mode, period_start, period_end, request_count,
+             first_used_at, last_used_at, updated_at
+           ) VALUES ('ha-identity-token', 'ha-identity-key', '2026-07-15/S1',
+                     'identity-current', 'token:identity-current', 'shadow',
+                     100, 400, 1, 100, 200, 300)"#,
+    )
+    .execute(&source.key_store.pool)
+    .await
+    .expect("insert current reconciliation source");
+    sqlx::query(
+        r#"UPDATE upstream_reconciliation_work
+           SET project_id = 'identity-stale', billing_subject = 'token:identity-stale',
+               period_start = 1, period_end = 2, scheduling_key_id = 'stale-key',
+               work_generation = 3, completed_generation = 3, next_attempt_at = 999,
+               last_outcome = 'settled'
+           WHERE token_id = 'ha-identity-token' AND period_code = '2026-07-15/S1'"#,
+    )
+    .execute(&source.key_store.pool)
+    .await
+    .expect("seed stale durable work identity");
+    let baseline = source
+        .export_ha_baseline_ndjson(HaSyncChannel::Runtime, "identity-target")
+        .await
+        .expect("export runtime baseline with stale work");
+
+    let target_path = temp_db_path("ha-current-source-identity-target");
+    let target_str = target_path.to_string_lossy().to_string();
+    let target = TavilyProxy::with_endpoint(
+        vec!["tvly-ha-current-source-identity-target".to_string()],
+        DEFAULT_UPSTREAM,
+        &target_str,
+    )
+    .await
+    .expect("create target proxy");
+    target
+        .apply_ha_baseline_ndjson(HaSyncChannel::Runtime, &baseline.ndjson)
+        .await
+        .expect("import runtime baseline");
+
+    let pending: (i64, Option<String>) = sqlx::query_as(
+        "SELECT completed, last_defer_reason FROM upstream_reconciliation_projection_state \
+         WHERE id = 'local'",
+    )
+    .fetch_one(&target.key_store.pool)
+    .await
+    .expect("read rearmed identity repair state");
+    assert_eq!(pending, (0, Some("identity_repair_pending".to_string())));
+    assert_eq!(
+        target
+            .key_store
+            .advance_upstream_reconciliation_work_projection()
+            .await
+            .expect("repair imported stale work"),
+        ReconciliationProjectionSliceOutcome::Advanced {
+            scanned_rows: 1,
+            completed: false,
+        }
+    );
+    let repaired: (String, String, i64, i64, String, i64, i64, Option<String>) = sqlx::query_as(
+        "SELECT project_id, billing_subject, period_start, period_end, scheduling_key_id, \
+                    work_generation, next_attempt_at, last_outcome \
+             FROM upstream_reconciliation_work \
+             WHERE token_id = 'ha-identity-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&target.key_store.pool)
+    .await
+    .expect("read repaired imported work identity");
+    assert_eq!(
+        repaired,
+        (
+            "identity-current".to_string(),
+            "token:identity-current".to_string(),
+            100,
+            400,
+            "ha-identity-key".to_string(),
+            4,
+            0,
+            None,
+        )
+    );
+
+    drop(source);
+    drop(target);
+    for path in [&source_path, &target_path] {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(path.with_extension("db-shm"));
+        let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    }
+}
+
+#[tokio::test]
 async fn ha_quota_truth_apply_invalidates_cached_account_resolution() {
     let db_path = temp_db_path("ha-quota-cache-invalidation");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -32,7 +32,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26,
+            25, 26, 27,
         ]
     );
     let source_revision_triggers: i64 = sqlx::query_scalar(
@@ -44,6 +44,17 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
     .await
     .expect("read reconciliation source-revision triggers");
     assert_eq!(source_revision_triggers, 2);
+    let source_identity_trigger_sql: String = sqlx::query_scalar(
+        "SELECT sql FROM sqlite_master WHERE type = 'trigger' \
+         AND name = 'trg_upstream_reconciliation_usage_work_update'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read current reconciliation source-identity trigger");
+    assert!(
+        source_identity_trigger_sql.contains("FROM upstream_reconciliation_usage"),
+        "v27 must derive updated work identity from the current source group"
+    );
     let transport_observation_column: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pragma_table_info('upstream_reconciliation_run_observation') WHERE name = 'last_transport_kind'",
     )
@@ -264,6 +275,191 @@ async fn reconciliation_transport_observation_migration_is_additive_and_warm_saf
     .await
     .expect("warm reopen after v18 migration");
     drop(reopened);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
+async fn reconciliation_current_source_identity_migration_replaces_v26_update_trigger() {
+    let db_path = temp_db_path("reconciliation-current-source-identity-v27");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-current-source-identity-v27".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("create migrated database");
+
+    let mut transaction = proxy
+        .key_store
+        .pool
+        .begin()
+        .await
+        .expect("begin v26 migration fixture");
+    sqlx::query("DELETE FROM schema_migrations WHERE version = 27")
+        .execute(&mut *transaction)
+        .await
+        .expect("simulate an existing v26 ledger");
+    sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_update")
+        .execute(&mut *transaction)
+        .await
+        .expect("remove v27 source-identity trigger");
+    sqlx::query(
+        r#"CREATE TRIGGER trg_upstream_reconciliation_usage_work_update
+           AFTER UPDATE ON upstream_reconciliation_usage
+           WHEN NEW.token_id IS NOT OLD.token_id
+             OR NEW.key_id IS NOT OLD.key_id
+             OR NEW.period_code IS NOT OLD.period_code
+             OR NEW.project_id IS NOT OLD.project_id
+             OR NEW.billing_subject IS NOT OLD.billing_subject
+             OR NEW.settlement_mode IS NOT OLD.settlement_mode
+             OR NEW.period_start IS NOT OLD.period_start
+             OR NEW.period_end IS NOT OLD.period_end
+             OR NEW.request_count IS NOT OLD.request_count
+             OR NEW.first_used_at IS NOT OLD.first_used_at
+             OR NEW.last_used_at IS NOT OLD.last_used_at
+           BEGIN
+             INSERT INTO upstream_reconciliation_work (
+               token_id, period_code, project_id, billing_subject, settlement_mode,
+               period_start, period_end, scheduling_key_id, updated_at,
+               work_generation, completed_generation, next_attempt_at, last_outcome
+             ) VALUES (
+               NEW.token_id, NEW.period_code, NEW.project_id, NEW.billing_subject,
+               NEW.settlement_mode, NEW.period_start, NEW.period_end, NEW.key_id, NEW.updated_at,
+               1, 0, 0, NULL
+             )
+             ON CONFLICT(token_id, period_code) DO UPDATE SET
+               project_id = MIN(upstream_reconciliation_work.project_id, excluded.project_id),
+               billing_subject = MIN(upstream_reconciliation_work.billing_subject, excluded.billing_subject),
+               settlement_mode = MIN(upstream_reconciliation_work.settlement_mode, excluded.settlement_mode),
+               period_start = MIN(upstream_reconciliation_work.period_start, excluded.period_start),
+               period_end = MAX(upstream_reconciliation_work.period_end, excluded.period_end),
+               scheduling_key_id = MIN(upstream_reconciliation_work.scheduling_key_id, excluded.scheduling_key_id),
+               updated_at = MAX(upstream_reconciliation_work.updated_at, excluded.updated_at),
+               work_generation = upstream_reconciliation_work.work_generation + 1,
+               next_attempt_at = 0,
+               last_outcome = NULL;
+
+             UPDATE upstream_reconciliation_work
+                SET work_generation = work_generation + 1,
+                    next_attempt_at = 0,
+                    last_outcome = NULL
+              WHERE (OLD.token_id IS NOT NEW.token_id OR OLD.period_code IS NOT NEW.period_code)
+                AND token_id = OLD.token_id AND period_code = OLD.period_code;
+           END"#,
+    )
+    .execute(&mut *transaction)
+    .await
+    .expect("restore the v26 usage-update trigger");
+    transaction
+        .commit()
+        .await
+        .expect("commit v26 migration fixture");
+
+    for (key_id, project_id, billing_subject, period_start, period_end) in [
+        (
+            "source-identity-key-a",
+            "identity-a",
+            "token:identity-a",
+            100_i64,
+            400_i64,
+        ),
+        (
+            "source-identity-key-m",
+            "identity-m",
+            "token:identity-m",
+            200_i64,
+            500_i64,
+        ),
+    ] {
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_usage (
+                 token_id, key_id, period_code, project_id, billing_subject,
+                 settlement_mode, period_start, period_end, request_count,
+                 first_used_at, last_used_at, updated_at
+               ) VALUES ('source-identity-v26-token', ?, '2026-07-15/S1', ?, ?,
+                         'shadow', ?, ?, 1, 100, 200, 300)"#,
+        )
+        .bind(key_id)
+        .bind(project_id)
+        .bind(billing_subject)
+        .bind(period_start)
+        .bind(period_end)
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert v26 reconciliation source");
+    }
+
+    assert!(
+        !proxy
+            .key_store
+            .prepare_versioned_schema()
+            .await
+            .expect("upgrade a v26 database to v27"),
+        "an existing v26 database must not request full bootstrap"
+    );
+    let v27_recorded: i64 =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = 27)")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read v27 ledger record");
+    assert_eq!(v27_recorded, 1);
+
+    sqlx::query(
+        "UPDATE upstream_reconciliation_usage SET token_id = 'source-identity-v27-token' \
+         WHERE token_id = 'source-identity-v26-token' AND key_id = 'source-identity-key-a'",
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("move the lexically first source after v27 upgrade");
+
+    let old_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
+        "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
+                scheduling_key_id, work_generation \
+         FROM upstream_reconciliation_work \
+         WHERE token_id = 'source-identity-v26-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read rederived old work group");
+    assert_eq!(
+        old_group,
+        (
+            "identity-m".to_string(),
+            "token:identity-m".to_string(),
+            "shadow".to_string(),
+            200,
+            500,
+            "source-identity-key-m".to_string(),
+            3,
+        )
+    );
+
+    let current_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
+        "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
+                scheduling_key_id, work_generation \
+         FROM upstream_reconciliation_work \
+         WHERE token_id = 'source-identity-v27-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read rederived current work group");
+    assert_eq!(
+        current_group,
+        (
+            "identity-a".to_string(),
+            "token:identity-a".to_string(),
+            "shadow".to_string(),
+            100,
+            400,
+            "source-identity-key-a".to_string(),
+            1,
+        )
+    );
+
+    drop(proxy);
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
@@ -981,7 +1177,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26,
+            25, 26, 27,
         ]
     );
 

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -32,7 +32,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27,
+            25, 26, 27, 28,
         ]
     );
     let source_revision_triggers: i64 = sqlx::query_scalar(
@@ -55,6 +55,14 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         source_identity_trigger_sql.contains("FROM upstream_reconciliation_usage"),
         "v27 must derive updated work identity from the current source group"
     );
+    let identity_repair_index: i64 = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' \
+         AND name = 'idx_upstream_reconciliation_usage_identity_repair')",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read v28 identity-repair index");
+    assert_eq!(identity_repair_index, 1);
     let transport_observation_column: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pragma_table_info('upstream_reconciliation_run_observation') WHERE name = 'last_transport_kind'",
     )
@@ -281,11 +289,11 @@ async fn reconciliation_transport_observation_migration_is_additive_and_warm_saf
 }
 
 #[tokio::test]
-async fn reconciliation_current_source_identity_migration_replaces_v26_update_trigger() {
-    let db_path = temp_db_path("reconciliation-current-source-identity-v27");
+async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v26_work() {
+    let db_path = temp_db_path("reconciliation-current-source-identity-repair-v28");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(
-        vec!["tvly-reconciliation-current-source-identity-v27".to_string()],
+        vec!["tvly-reconciliation-current-source-identity-repair-v28".to_string()],
         DEFAULT_UPSTREAM,
         &db_str,
     )
@@ -298,10 +306,14 @@ async fn reconciliation_current_source_identity_migration_replaces_v26_update_tr
         .begin()
         .await
         .expect("begin v26 migration fixture");
-    sqlx::query("DELETE FROM schema_migrations WHERE version = 27")
+    sqlx::query("DELETE FROM schema_migrations WHERE version IN (27, 28)")
         .execute(&mut *transaction)
         .await
         .expect("simulate an existing v26 ledger");
+    sqlx::query("DROP INDEX idx_upstream_reconciliation_usage_identity_repair")
+        .execute(&mut *transaction)
+        .await
+        .expect("remove v28 identity-repair index");
     sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_update")
         .execute(&mut *transaction)
         .await
@@ -392,28 +404,77 @@ async fn reconciliation_current_source_identity_migration_replaces_v26_update_tr
         .expect("insert v26 reconciliation source");
     }
 
-    assert!(
-        !proxy
-            .key_store
-            .prepare_versioned_schema()
-            .await
-            .expect("upgrade a v26 database to v27"),
-        "an existing v26 database must not request full bootstrap"
-    );
-    let v27_recorded: i64 =
-        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = 27)")
-            .fetch_one(&proxy.key_store.pool)
-            .await
-            .expect("read v27 ledger record");
-    assert_eq!(v27_recorded, 1);
-
     sqlx::query(
         "UPDATE upstream_reconciliation_usage SET token_id = 'source-identity-v27-token' \
          WHERE token_id = 'source-identity-v26-token' AND key_id = 'source-identity-key-a'",
     )
     .execute(&proxy.key_store.pool)
     .await
-    .expect("move the lexically first source after v27 upgrade");
+    .expect("create a stale v26 work identity before upgrade");
+    let stale_generation: i64 = sqlx::query_scalar(
+        "SELECT work_generation FROM upstream_reconciliation_work \
+         WHERE token_id = 'source-identity-v26-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read stale v26 work generation");
+    sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_key_observations (
+             token_id, period_code, work_generation, key_id, upstream_usage, observed_at
+           ) VALUES ('source-identity-v26-token', '2026-07-15/S1', ?,
+                     'source-identity-key-m', 17, 300)"#,
+    )
+    .bind(stale_generation)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("record partial observation for stale generation");
+    for index in 0..24 {
+        sqlx::query(
+            r#"INSERT INTO upstream_reconciliation_usage (
+                 token_id, key_id, period_code, project_id, billing_subject,
+                 settlement_mode, period_start, period_end, request_count,
+                 first_used_at, last_used_at, updated_at
+               ) VALUES (?, ?, '2026-07-15/S1', 'identity-filler',
+                         'token:identity-filler', 'shadow', 100, 400, 1, 100, 200, 300)"#,
+        )
+        .bind(format!("source-identity-z-{index:02}"))
+        .bind(format!("source-identity-filler-key-{index:02}"))
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("insert resumable identity-repair filler");
+    }
+
+    assert!(
+        !proxy
+            .key_store
+            .prepare_versioned_schema()
+            .await
+            .expect("upgrade a v26 database to v28"),
+        "an existing v26 database must not request full bootstrap"
+    );
+    let v28_recorded: i64 =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = 28)")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read v28 ledger record");
+    assert_eq!(v28_recorded, 1);
+    let repair_state: (String, String, String, i64, Option<String>) = sqlx::query_as(
+        "SELECT cursor_token_id, cursor_key_id, cursor_period_code, completed, last_defer_reason \
+         FROM upstream_reconciliation_projection_state WHERE id = 'local'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read identity-repair projection state");
+    assert_eq!(
+        repair_state,
+        (
+            String::new(),
+            String::new(),
+            String::new(),
+            0,
+            Some("identity_repair_pending".to_string()),
+        )
+    );
 
     let old_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
         "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
@@ -427,15 +488,58 @@ async fn reconciliation_current_source_identity_migration_replaces_v26_update_tr
     assert_eq!(
         old_group,
         (
+            "identity-a".to_string(),
+            "token:identity-a".to_string(),
+            "shadow".to_string(),
+            100,
+            500,
+            "source-identity-key-a".to_string(),
+            stale_generation,
+        )
+    );
+
+    assert_eq!(
+        proxy
+            .key_store
+            .advance_upstream_reconciliation_work_projection()
+            .await
+            .expect("repair first stale work identity"),
+        ReconciliationProjectionSliceOutcome::Advanced {
+            scanned_rows: 25,
+            completed: false,
+        }
+    );
+    let repaired_old_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
+        "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
+                scheduling_key_id, work_generation \
+         FROM upstream_reconciliation_work \
+         WHERE token_id = 'source-identity-v26-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read repaired old work group");
+    assert_eq!(
+        repaired_old_group,
+        (
             "identity-m".to_string(),
             "token:identity-m".to_string(),
             "shadow".to_string(),
             200,
             500,
             "source-identity-key-m".to_string(),
-            3,
+            stale_generation + 1,
         )
     );
+    let preserved_observation: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_key_observations \
+         WHERE token_id = 'source-identity-v26-token' AND period_code = '2026-07-15/S1' \
+           AND work_generation = ? AND key_id = 'source-identity-key-m'",
+    )
+    .bind(stale_generation)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read preserved stale-generation observation");
+    assert_eq!(preserved_observation, 1);
 
     let current_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
         "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
@@ -460,6 +564,44 @@ async fn reconciliation_current_source_identity_migration_replaces_v26_update_tr
     );
 
     drop(proxy);
+    let reopened = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-current-source-identity-repair-v28".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("restart resumable identity repair");
+    assert_eq!(
+        reopened
+            .key_store
+            .advance_upstream_reconciliation_work_projection()
+            .await
+            .expect("repair next identity after restart"),
+        ReconciliationProjectionSliceOutcome::Advanced {
+            scanned_rows: 1,
+            completed: false,
+        }
+    );
+    assert_eq!(
+        reopened
+            .key_store
+            .advance_upstream_reconciliation_work_projection()
+            .await
+            .expect("complete identity repair after restart"),
+        ReconciliationProjectionSliceOutcome::Advanced {
+            scanned_rows: 0,
+            completed: true,
+        }
+    );
+    let repaired_generation: i64 = sqlx::query_scalar(
+        "SELECT work_generation FROM upstream_reconciliation_work \
+         WHERE token_id = 'source-identity-v26-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&reopened.key_store.pool)
+    .await
+    .expect("read repaired generation after restart");
+    assert_eq!(repaired_generation, stale_generation + 1);
+    drop(reopened);
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
@@ -1177,7 +1319,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27,
+            25, 26, 27, 28,
         ]
     );
 

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -55,14 +55,22 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         source_identity_trigger_sql.contains("FROM upstream_reconciliation_usage"),
         "v27 must derive updated work identity from the current source group"
     );
+    let identity_repair_generation_column: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('upstream_reconciliation_projection_state') \
+         WHERE name = 'identity_repair_generation'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read v28 identity-repair generation column");
+    assert_eq!(identity_repair_generation_column, 1);
     let identity_repair_index: i64 = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' \
          AND name = 'idx_upstream_reconciliation_usage_identity_repair')",
     )
     .fetch_one(&pool)
     .await
-    .expect("read v28 identity-repair index");
-    assert_eq!(identity_repair_index, 1);
+    .expect("check v28 does not add a business-table index");
+    assert_eq!(identity_repair_index, 0);
     let transport_observation_column: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pragma_table_info('upstream_reconciliation_run_observation') WHERE name = 'last_transport_kind'",
     )
@@ -310,10 +318,13 @@ async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v
         .execute(&mut *transaction)
         .await
         .expect("simulate an existing v26 ledger");
-    sqlx::query("DROP INDEX idx_upstream_reconciliation_usage_identity_repair")
-        .execute(&mut *transaction)
-        .await
-        .expect("remove v28 identity-repair index");
+    sqlx::query(
+        "ALTER TABLE upstream_reconciliation_projection_state \
+         DROP COLUMN identity_repair_generation",
+    )
+    .execute(&mut *transaction)
+    .await
+    .expect("remove v28 identity-repair generation");
     sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_update")
         .execute(&mut *transaction)
         .await
@@ -540,6 +551,16 @@ async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v
     .await
     .expect("read preserved stale-generation observation");
     assert_eq!(preserved_observation, 1);
+    let current_generation_observation: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM upstream_reconciliation_key_observations \
+         WHERE token_id = 'source-identity-v26-token' AND period_code = '2026-07-15/S1' \
+           AND work_generation = ?",
+    )
+    .bind(stale_generation + 1)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read fenced replacement-generation observations");
+    assert_eq!(current_generation_observation, 0);
 
     let current_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
         "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
@@ -629,11 +650,11 @@ async fn reconciliation_engine_state_migration_resumes_an_incomplete_legacy_proj
         "ALTER TABLE upstream_reconciliation_work DROP COLUMN transport_retry_at",
         "ALTER TABLE upstream_reconciliation_work DROP COLUMN semantic_failure_streak",
         "ALTER TABLE upstream_reconciliation_work DROP COLUMN semantic_retry_at",
-        // Rebuild the full post-v8 migration tail from the legacy fixture.  Keeping
-        // v19 recorded while its observation table is intentionally dropped would
+        // Rebuild the full post-v8 migration tail from the legacy fixture. Keeping
+        // a later migration recorded while its prerequisite object is intentionally dropped would
         // correctly trigger warm-start drift rejection before the missing migrations
         // can be replayed.
-        "DELETE FROM schema_migrations WHERE version BETWEEN 9 AND 19",
+        "DELETE FROM schema_migrations WHERE version BETWEEN 9 AND 28",
     ] {
         sqlx::query(statement)
             .execute(&proxy.key_store.pool)

--- a/src/tests/schema_migrations.rs
+++ b/src/tests/schema_migrations.rs
@@ -32,7 +32,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28,
+            25, 26, 27, 28, 29,
         ]
     );
     let source_revision_triggers: i64 = sqlx::query_scalar(
@@ -61,7 +61,7 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
     )
     .fetch_one(&pool)
     .await
-    .expect("read v28 identity-repair generation column");
+    .expect("read v29 identity-repair generation column");
     assert_eq!(identity_repair_generation_column, 1);
     let identity_repair_index: i64 = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' \
@@ -69,8 +69,8 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
     )
     .fetch_one(&pool)
     .await
-    .expect("check v28 does not add a business-table index");
-    assert_eq!(identity_repair_index, 0);
+    .expect("read v28 identity-repair index");
+    assert_eq!(identity_repair_index, 1);
     let transport_observation_column: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pragma_table_info('upstream_reconciliation_run_observation') WHERE name = 'last_transport_kind'",
     )
@@ -208,6 +208,70 @@ async fn versioned_schema_migrations_are_idempotent_and_fail_closed_on_drift() {
 }
 
 #[tokio::test]
+async fn reconciliation_identity_fence_migration_preserves_v28_ledger_identity() {
+    let db_path = temp_db_path("reconciliation-identity-fence-v28-upgrade");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-identity-fence-v28-upgrade".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("create current database");
+    drop(proxy);
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    sqlx::query("DELETE FROM schema_migrations WHERE version = 29")
+        .execute(&pool)
+        .await
+        .expect("restore the v28 migration ledger");
+    sqlx::query(
+        "ALTER TABLE upstream_reconciliation_projection_state \
+         DROP COLUMN identity_repair_generation",
+    )
+    .execute(&pool)
+    .await
+    .expect("restore the v28 projection state");
+    pool.close().await;
+
+    let reopened = TavilyProxy::with_endpoint(
+        vec!["tvly-reconciliation-identity-fence-v28-upgrade".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("upgrade an existing v28 database");
+    let v28_checksum: String =
+        sqlx::query_scalar("SELECT checksum FROM schema_migrations WHERE version = 28")
+            .fetch_one(&reopened.key_store.pool)
+            .await
+            .expect("read preserved v28 checksum");
+    assert_eq!(
+        v28_checksum,
+        "sha256:ab30da1112183f3ea75cde687ab08e1685588e3885e5183c6ffb5f788f49b0af"
+    );
+    let v29_recorded: i64 =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = 29)")
+            .fetch_one(&reopened.key_store.pool)
+            .await
+            .expect("read v29 ledger record");
+    assert_eq!(v29_recorded, 1);
+    let fence_generation: i64 = sqlx::query_scalar(
+        "SELECT identity_repair_generation FROM upstream_reconciliation_projection_state \
+         WHERE id = 'local'",
+    )
+    .fetch_one(&reopened.key_store.pool)
+    .await
+    .expect("read v29 repair generation");
+    assert_eq!(fence_generation, 1);
+
+    drop(reopened);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+}
+
+#[tokio::test]
 async fn reconciliation_transport_observation_migration_is_additive_and_warm_safe() {
     let db_path = temp_db_path("reconciliation-transport-observation-migration");
     let db_str = db_path.to_string_lossy().to_string();
@@ -298,10 +362,10 @@ async fn reconciliation_transport_observation_migration_is_additive_and_warm_saf
 
 #[tokio::test]
 async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v26_work() {
-    let db_path = temp_db_path("reconciliation-current-source-identity-repair-v28");
+    let db_path = temp_db_path("reconciliation-current-source-identity-repair-v29");
     let db_str = db_path.to_string_lossy().to_string();
     let proxy = TavilyProxy::with_endpoint(
-        vec!["tvly-reconciliation-current-source-identity-repair-v28".to_string()],
+        vec!["tvly-reconciliation-current-source-identity-repair-v29".to_string()],
         DEFAULT_UPSTREAM,
         &db_str,
     )
@@ -314,17 +378,21 @@ async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v
         .begin()
         .await
         .expect("begin v26 migration fixture");
-    sqlx::query("DELETE FROM schema_migrations WHERE version IN (27, 28)")
+    sqlx::query("DELETE FROM schema_migrations WHERE version IN (27, 28, 29)")
         .execute(&mut *transaction)
         .await
         .expect("simulate an existing v26 ledger");
+    sqlx::query("DROP INDEX idx_upstream_reconciliation_usage_identity_repair")
+        .execute(&mut *transaction)
+        .await
+        .expect("remove v28 identity-repair index");
     sqlx::query(
         "ALTER TABLE upstream_reconciliation_projection_state \
          DROP COLUMN identity_repair_generation",
     )
     .execute(&mut *transaction)
     .await
-    .expect("remove v28 identity-repair generation");
+    .expect("remove v29 identity-repair generation");
     sqlx::query("DROP TRIGGER trg_upstream_reconciliation_usage_work_update")
         .execute(&mut *transaction)
         .await
@@ -460,7 +528,7 @@ async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v
             .key_store
             .prepare_versioned_schema()
             .await
-            .expect("upgrade a v26 database to v28"),
+            .expect("upgrade a v26 database to v29"),
         "an existing v26 database must not request full bootstrap"
     );
     let v28_recorded: i64 =
@@ -469,6 +537,12 @@ async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v
             .await
             .expect("read v28 ledger record");
     assert_eq!(v28_recorded, 1);
+    let v29_recorded: i64 =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = 29)")
+            .fetch_one(&proxy.key_store.pool)
+            .await
+            .expect("read v29 ledger record");
+    assert_eq!(v29_recorded, 1);
     let repair_state: (String, String, String, i64, Option<String>) = sqlx::query_as(
         "SELECT cursor_token_id, cursor_key_id, cursor_period_code, completed, last_defer_reason \
          FROM upstream_reconciliation_projection_state WHERE id = 'local'",
@@ -586,7 +660,7 @@ async fn reconciliation_current_source_identity_repair_migration_resumes_stale_v
 
     drop(proxy);
     let reopened = TavilyProxy::with_endpoint(
-        vec!["tvly-reconciliation-current-source-identity-repair-v28".to_string()],
+        vec!["tvly-reconciliation-current-source-identity-repair-v29".to_string()],
         DEFAULT_UPSTREAM,
         &db_str,
     )
@@ -654,7 +728,7 @@ async fn reconciliation_engine_state_migration_resumes_an_incomplete_legacy_proj
         // a later migration recorded while its prerequisite object is intentionally dropped would
         // correctly trigger warm-start drift rejection before the missing migrations
         // can be replayed.
-        "DELETE FROM schema_migrations WHERE version BETWEEN 9 AND 28",
+        "DELETE FROM schema_migrations WHERE version BETWEEN 9 AND 29",
     ] {
         sqlx::query(statement)
             .execute(&proxy.key_store.pool)
@@ -1340,7 +1414,7 @@ async fn baseline_adoption_records_compatible_existing_schema_without_full_boots
         versions,
         vec![
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28,
+            25, 26, 27, 28, 29,
         ]
     );
 

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -2851,3 +2851,119 @@ async fn reconciliation_source_revisions_ignore_storage_refresh_and_retain_obser
     drop(proxy);
     let _ = std::fs::remove_file(db_path);
 }
+
+#[tokio::test]
+async fn reconciliation_source_updates_rederive_current_group_identity() {
+    let db_path = reconciliation_test_db_path();
+    let db_string = db_path.to_string_lossy().to_string();
+    let (backend_time, _) = BackendTime::manual_from_ts(local_ts(2026, 9, 2, 12, 0));
+    let proxy = TavilyProxy::with_options_and_time(
+        vec!["tvly-reconciliation-source-identity"],
+        DEFAULT_UPSTREAM,
+        &db_string,
+        TavilyProxyOptions::from_database_path(&db_string),
+        backend_time,
+    )
+    .await
+    .expect("create proxy");
+    let first_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-source-identity-a")
+        .await
+        .expect("create first upstream key");
+    let second_key_id = proxy
+        .add_or_undelete_key("tvly-reconciliation-source-identity-b")
+        .await
+        .expect("create second upstream key");
+    let token_id = "source-identity-token";
+    let period_code = "2026-09-02/S1";
+    let insert_usage = r#"INSERT INTO upstream_reconciliation_usage (
+            token_id, key_id, period_code, project_id, billing_subject, settlement_mode,
+            period_start, period_end, request_count, first_used_at, last_used_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, 'shadow', ?, ?, 1, 1, 2, 3)"#;
+    for (key_id, project_id, billing_subject, period_start, period_end) in [
+        (
+            &first_key_id,
+            "identity-a",
+            "token:identity-a",
+            100_i64,
+            400_i64,
+        ),
+        (
+            &second_key_id,
+            "identity-m",
+            "token:identity-m",
+            200_i64,
+            500_i64,
+        ),
+    ] {
+        sqlx::query(insert_usage)
+            .bind(token_id)
+            .bind(key_id)
+            .bind(period_code)
+            .bind(project_id)
+            .bind(billing_subject)
+            .bind(period_start)
+            .bind(period_end)
+            .execute(&proxy.key_store.pool)
+            .await
+            .expect("insert reconciliation source row");
+    }
+
+    sqlx::query(
+        "UPDATE upstream_reconciliation_usage SET token_id = 'source-identity-next-token' \
+         WHERE token_id = ? AND key_id = ? AND period_code = ?",
+    )
+    .bind(token_id)
+    .bind(&first_key_id)
+    .bind(period_code)
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("move lexically first source row into a new token group");
+
+    let old_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
+        "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
+         scheduling_key_id, work_generation FROM upstream_reconciliation_work \
+         WHERE token_id = ? AND period_code = ?",
+    )
+    .bind(token_id)
+    .bind(period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read rederived old source group");
+    assert_eq!(
+        old_group,
+        (
+            "identity-m".to_string(),
+            "token:identity-m".to_string(),
+            "shadow".to_string(),
+            200,
+            500,
+            second_key_id,
+            3,
+        )
+    );
+    let new_group: (String, String, String, i64, i64, String, i64) = sqlx::query_as(
+        "SELECT project_id, billing_subject, settlement_mode, period_start, period_end, \
+         scheduling_key_id, work_generation FROM upstream_reconciliation_work \
+         WHERE token_id = 'source-identity-next-token' AND period_code = ?",
+    )
+    .bind(period_code)
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read rederived new source group");
+    assert_eq!(
+        new_group,
+        (
+            "identity-a".to_string(),
+            "token:identity-a".to_string(),
+            "shadow".to_string(),
+            100,
+            400,
+            first_key_id,
+            1,
+        )
+    );
+
+    drop(proxy);
+    let _ = std::fs::remove_file(db_path);
+}

--- a/src/tests/upstream_reconciliation_engine.rs
+++ b/src/tests/upstream_reconciliation_engine.rs
@@ -1908,6 +1908,28 @@ async fn reconciliation_projection_rejects_stale_claim() {
     .await
     .expect("create proxy");
     sqlx::query(
+        r#"INSERT INTO upstream_reconciliation_usage (
+             token_id, key_id, period_code, project_id, billing_subject,
+             settlement_mode, period_start, period_end, request_count,
+             first_used_at, last_used_at, updated_at
+           ) VALUES ('stale-claim-identity-token', 'stale-claim-identity-key',
+                     '2026-07-15/S1', 'identity-current', 'token:identity-current',
+                     'shadow', 100, 400, 1, 100, 200, 300)"#,
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("insert pending stale-claim identity source");
+    sqlx::query(
+        r#"UPDATE upstream_reconciliation_work
+           SET project_id = 'identity-stale', billing_subject = 'token:identity-stale',
+               period_start = 1, period_end = 2, scheduling_key_id = 'stale-key',
+               work_generation = 3
+           WHERE token_id = 'stale-claim-identity-token' AND period_code = '2026-07-15/S1'"#,
+    )
+    .execute(&proxy.key_store.pool)
+    .await
+    .expect("seed stale work identity for stale claim");
+    sqlx::query(
         "UPDATE upstream_reconciliation_projection_state SET completed = 0 WHERE id = 'local'",
     )
     .execute(&proxy.key_store.pool)
@@ -1935,6 +1957,19 @@ async fn reconciliation_projection_rejects_stale_claim() {
             .await
             .expect("reject stale projection claim"),
         ReconciliationProjectionSliceOutcome::StaleClaim
+    );
+    let unchanged: (String, String, i64) = sqlx::query_as(
+        "SELECT project_id, scheduling_key_id, work_generation \
+         FROM upstream_reconciliation_work \
+         WHERE token_id = 'stale-claim-identity-token' AND period_code = '2026-07-15/S1'",
+    )
+    .fetch_one(&proxy.key_store.pool)
+    .await
+    .expect("read stale-claim fenced work");
+    assert_eq!(
+        unchanged,
+        ("identity-stale".to_string(), "stale-key".to_string(), 3),
+        "a stale claim must not repair or advance the durable work identity"
     );
 
     drop(proxy);


### PR DESCRIPTION
## Summary

- repair durable reconciliation work identities that were already stale before the v27 source trigger upgrade through bounded, resumable projection slices
- retain the immutable v28 migration identity and add v29 for the source/HA snapshot fence
- fence projection writes by source work generation and repair epoch while preserving partial-observation generations
- re-arm the reconciliation representative after Runtime HA baseline import

## Delivery Metadata

- Delivery role: direct
- Spec: docs/specs/upstream-privacy-period-reconciliation/SPEC.md
- Spec disposition: implementation repair; no spec change required
- Solutions: none
- Project docs: none

## Validation

- cargo fmt --check
- cargo clippy --locked -j 2 --lib -- -D warnings
- cargo check --locked
- schema migrations serially: 20 passed
- HA baseline streaming and sessions serially: 7 passed
- reconciliation projection paths serially: 12 passed