### PR TITLE
fix(alerts): fence durable canonical warm generation

### DIFF
--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -89,7 +89,9 @@ struct DashboardOverviewCacheState {
     admin_alerts_prewarm_not_before: Option<tokio::time::Instant>,
     admin_alerts_prewarm_defers: u8,
     #[cfg(test)]
-    admin_alerts_warm_after_catalog_pause: Option<AdminAlertsWarmAfterCatalogPause>,
+    admin_alerts_warm_after_catalog_pause: Option<AdminAlertsWarmPause>,
+    #[cfg(test)]
+    admin_alerts_warm_before_projection_fence_pause: Option<AdminAlertsWarmPause>,
     admin_privacy_status: AdminPrivacyStatusController,
     #[cfg(test)]
     build_count: usize,
@@ -119,6 +121,8 @@ impl Default for DashboardOverviewCacheState {
             admin_alerts_prewarm_defers: 0,
             #[cfg(test)]
             admin_alerts_warm_after_catalog_pause: None,
+            #[cfg(test)]
+            admin_alerts_warm_before_projection_fence_pause: None,
             admin_privacy_status: AdminPrivacyStatusController::default(),
             #[cfg(test)]
             build_count: 0,
@@ -158,7 +162,7 @@ fn admin_alerts_warm_error_reason(error: &tavily_hikari::ProxyError) -> &'static
 
 #[cfg(test)]
 #[derive(Debug, Clone)]
-pub(crate) struct AdminAlertsWarmAfterCatalogPause {
+pub(crate) struct AdminAlertsWarmPause {
     arrived: Arc<std::sync::atomic::AtomicBool>,
     arrived_notify: Arc<Notify>,
     released: Arc<std::sync::atomic::AtomicBool>,
@@ -166,7 +170,7 @@ pub(crate) struct AdminAlertsWarmAfterCatalogPause {
 }
 
 #[cfg(test)]
-impl AdminAlertsWarmAfterCatalogPause {
+impl AdminAlertsWarmPause {
     fn new() -> Self {
         Self {
             arrived: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -532,6 +536,11 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
                     .proxy
                     .admin_alert_groups_page_for_cache_warm(1, 20)
                     .await?;
+                #[cfg(test)]
+                pause_admin_alerts_warm_before_projection_fence_for_test(state.as_ref()).await;
+                if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
+                    return Err(admin_alerts_warm_deferred(reason));
+                }
                 if state
                     .proxy
                     .admin_alerts_canonical_warm_projection_fence()
@@ -616,12 +625,24 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
 #[cfg(test)]
 pub(crate) async fn install_admin_alerts_warm_after_catalog_pause_for_test(
     state: &AppState,
-) -> AdminAlertsWarmAfterCatalogPause {
-    let pause = AdminAlertsWarmAfterCatalogPause::new();
+) -> AdminAlertsWarmPause {
+    let pause = AdminAlertsWarmPause::new();
     dashboard_overview_cache_for_state(state)
         .lock()
         .await
         .admin_alerts_warm_after_catalog_pause = Some(pause.clone());
+    pause
+}
+
+#[cfg(test)]
+pub(crate) async fn install_admin_alerts_warm_before_projection_fence_pause_for_test(
+    state: &AppState,
+) -> AdminAlertsWarmPause {
+    let pause = AdminAlertsWarmPause::new();
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_alerts_warm_before_projection_fence_pause = Some(pause.clone());
     pause
 }
 
@@ -643,6 +664,24 @@ async fn pause_admin_alerts_warm_after_catalog_for_test(state: &AppState) {
     let Some(pause) = pause else {
         return;
     };
+    pause_admin_alerts_warm_for_test(pause).await;
+}
+
+#[cfg(test)]
+async fn pause_admin_alerts_warm_before_projection_fence_for_test(state: &AppState) {
+    let pause = dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_alerts_warm_before_projection_fence_pause
+        .take();
+    let Some(pause) = pause else {
+        return;
+    };
+    pause_admin_alerts_warm_for_test(pause).await;
+}
+
+#[cfg(test)]
+async fn pause_admin_alerts_warm_for_test(pause: AdminAlertsWarmPause) {
     pause
         .arrived
         .store(true, std::sync::atomic::Ordering::Release);

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -88,6 +88,8 @@ struct DashboardOverviewCacheState {
     admin_alerts_prewarm_in_flight: bool,
     admin_alerts_prewarm_not_before: Option<tokio::time::Instant>,
     admin_alerts_prewarm_defers: u8,
+    #[cfg(test)]
+    admin_alerts_warm_after_catalog_pause: Option<AdminAlertsWarmAfterCatalogPause>,
     admin_privacy_status: AdminPrivacyStatusController,
     #[cfg(test)]
     build_count: usize,
@@ -115,6 +117,8 @@ impl Default for DashboardOverviewCacheState {
             admin_alerts_prewarm_in_flight: false,
             admin_alerts_prewarm_not_before: None,
             admin_alerts_prewarm_defers: 0,
+            #[cfg(test)]
+            admin_alerts_warm_after_catalog_pause: None,
             admin_privacy_status: AdminPrivacyStatusController::default(),
             #[cfg(test)]
             build_count: 0,
@@ -145,9 +149,50 @@ fn admin_alerts_warm_error_reason(error: &tavily_hikari::ProxyError) -> &'static
         "foreground_pressure" => "foreground_pressure",
         "pool_pressure" => "pool_pressure",
         "recent_contention" => "recent_contention",
+        "projection_fence_changed" => "projection_fence_changed",
         "projection_generation_changed" => "projection_generation_changed",
         "read_budget" => "read_budget",
         _ => "deferred",
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub(crate) struct AdminAlertsWarmAfterCatalogPause {
+    arrived: Arc<std::sync::atomic::AtomicBool>,
+    arrived_notify: Arc<Notify>,
+    released: Arc<std::sync::atomic::AtomicBool>,
+    release: Arc<Notify>,
+}
+
+#[cfg(test)]
+impl AdminAlertsWarmAfterCatalogPause {
+    fn new() -> Self {
+        Self {
+            arrived: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            arrived_notify: Arc::new(Notify::new()),
+            released: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            release: Arc::new(Notify::new()),
+        }
+    }
+
+    pub(crate) async fn wait_until_arrived(&self) {
+        loop {
+            if self.arrived.load(std::sync::atomic::Ordering::Acquire) {
+                return;
+            }
+            let notified = self.arrived_notify.notified();
+            if self.arrived.load(std::sync::atomic::Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub(crate) fn release(&self) {
+        self.released
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.release.notify_waiters();
     }
 }
 
@@ -459,12 +504,18 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
             }
             let generation = current_admin_alerts_generation(state.as_ref()).await;
             let result = async {
+                let durable_projection_fence = state
+                    .proxy
+                    .admin_alerts_canonical_warm_projection_fence()
+                    .await?;
                 state.proxy.prepare_admin_alerts_canonical_warm().await?;
                 if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
                     return Err(admin_alerts_warm_deferred(reason));
                 }
                 state.proxy.record_admin_alerts_warm_slice();
                 let catalog = state.proxy.admin_alert_catalog_for_cache_warm().await?;
+                #[cfg(test)]
+                pause_admin_alerts_warm_after_catalog_for_test(state.as_ref()).await;
                 if let Some(reason) = state.proxy.admin_alerts_cache_warm_defer_reason() {
                     return Err(admin_alerts_warm_deferred(reason));
                 }
@@ -481,6 +532,18 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
                     .proxy
                     .admin_alert_groups_page_for_cache_warm(1, 20)
                     .await?;
+                if state
+                    .proxy
+                    .admin_alerts_canonical_warm_projection_fence()
+                    .await?
+                    != durable_projection_fence
+                {
+                    state.proxy.record_admin_alerts_warm_generation_discard();
+                    return Err(tavily_hikari::ProxyError::Deferred {
+                        operation: "admin_alerts_warm",
+                        reason: "projection_fence_changed".to_string(),
+                    });
+                }
                 if !publish_admin_alerts_canonical(
                     state.as_ref(),
                     generation,
@@ -548,6 +611,52 @@ pub(crate) async fn prewarm_admin_alerts(state: Arc<AppState>) {
             }
         }
     });
+}
+
+#[cfg(test)]
+pub(crate) async fn install_admin_alerts_warm_after_catalog_pause_for_test(
+    state: &AppState,
+) -> AdminAlertsWarmAfterCatalogPause {
+    let pause = AdminAlertsWarmAfterCatalogPause::new();
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_alerts_warm_after_catalog_pause = Some(pause.clone());
+    pause
+}
+
+#[cfg(test)]
+pub(crate) async fn rearm_admin_alerts_prewarm_for_test(state: &AppState) {
+    dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_alerts_prewarm_not_before = None;
+}
+
+#[cfg(test)]
+async fn pause_admin_alerts_warm_after_catalog_for_test(state: &AppState) {
+    let pause = dashboard_overview_cache_for_state(state)
+        .lock()
+        .await
+        .admin_alerts_warm_after_catalog_pause
+        .take();
+    let Some(pause) = pause else {
+        return;
+    };
+    pause
+        .arrived
+        .store(true, std::sync::atomic::Ordering::Release);
+    pause.arrived_notify.notify_waiters();
+    loop {
+        if pause.released.load(std::sync::atomic::Ordering::Acquire) {
+            return;
+        }
+        let notified = pause.release.notified();
+        if pause.released.load(std::sync::atomic::Ordering::Acquire) {
+            return;
+        }
+        notified.await;
+    }
 }
 
 #[cfg(test)]

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -1005,6 +1005,86 @@ async fn admin_alerts_warm_discards_durable_projection_fence_change_between_slic
 }
 
 #[tokio::test]
+async fn admin_alerts_warm_defers_before_final_fence_when_pressure_arrives_between_slices() {
+    let db_path = temp_db_path("admin-alerts-final-fence-pressure");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-admin-alerts-final-fence-pressure".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let (_, state) = spawn_builtin_keys_admin_server_with_state(
+        proxy,
+        "admin-alerts-final-fence-pressure-password",
+    )
+    .await;
+
+    let mut projection_ready = false;
+    for _ in 0..64 {
+        state
+            .proxy
+            .advance_dashboard_alert_projection_scheduler_step()
+            .await
+            .expect("complete the empty alert projection before warming the admin cache");
+        if state.proxy.admin_alert_catalog().await.is_ok() {
+            projection_ready = true;
+            break;
+        }
+    }
+    assert!(projection_ready, "empty projection must complete before warming admin cache");
+
+    super::super::rearm_admin_alerts_prewarm_for_test(state.as_ref()).await;
+    let pause = super::super::install_admin_alerts_warm_before_projection_fence_pause_for_test(
+        state.as_ref(),
+    )
+    .await;
+    super::super::prewarm_admin_alerts(state.clone()).await;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        pause.wait_until_arrived(),
+    )
+    .await
+    .expect("the retry reaches the groups-to-fence pause");
+
+    state.proxy.force_next_admin_alert_read_deadline_for_test();
+    for _ in 0..6 {
+        state.proxy.record_foreground_activity();
+    }
+    assert!(
+        state.proxy.foreground_activity_rps() > 5,
+        "fixture establishes pressure after the groups slice"
+    );
+    pause.release();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            if cache.admin_alerts_prewarm_defers > 0 {
+                break;
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("pressure before the final fence defers the canonical warm");
+
+    assert!(
+        state
+            .proxy
+            .admin_alerts_canonical_warm_projection_fence()
+            .await
+            .is_err(),
+        "the deferred warmer must not consume the final fence read budget"
+    );
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn admin_alerts_canonical_read_waits_for_history_projection_coverage() {
     let db_path = temp_db_path("admin-alerts-history-coverage");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -894,6 +894,117 @@ async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses()
 }
 
 #[tokio::test]
+async fn admin_alerts_warm_discards_durable_projection_fence_change_between_slices() {
+    let db_path = temp_db_path("admin-alerts-durable-warm-fence");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-admin-alerts-durable-warm-fence".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+    let (_, state) = spawn_builtin_keys_admin_server_with_state(
+        proxy,
+        "admin-alerts-durable-warm-fence-password",
+    )
+    .await;
+
+    let mut projection_ready = false;
+    for _ in 0..64 {
+        state
+            .proxy
+            .advance_dashboard_alert_projection_scheduler_step()
+            .await
+            .expect("complete the empty alert projection before warming the admin cache");
+        if state.proxy.admin_alert_catalog().await.is_ok() {
+            projection_ready = true;
+            break;
+        }
+    }
+    assert!(projection_ready, "empty projection must complete before warming admin cache");
+
+    super::super::prewarm_admin_alerts(state.clone()).await;
+    let initial_last_good = tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            let canonical = cache
+                .admin_alerts
+                .entries
+                .iter()
+                .filter(|entry| entry.canonical)
+                .map(|entry| (entry.key.clone(), entry.generation, entry.stored_at))
+                .collect::<Vec<_>>();
+            if canonical.len() == 3 && !cache.admin_alerts_prewarm_in_flight {
+                break (cache.alert_projection_generation, canonical);
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("initial background warmer publishes canonical last-good values");
+
+    super::super::rearm_admin_alerts_prewarm_for_test(state.as_ref()).await;
+    let pause = super::super::install_admin_alerts_warm_after_catalog_pause_for_test(state.as_ref())
+        .await;
+    super::super::prewarm_admin_alerts(state.clone()).await;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        pause.wait_until_arrived(),
+    )
+    .await
+    .expect("the retry reaches the catalog-to-events pause");
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let changed = sqlx::query(
+        "UPDATE observability.dashboard_alert_projection_history_state SET generation = generation + 1",
+    )
+    .execute(&pool)
+    .await
+    .expect("commit a durable history projection generation between warm slices");
+    assert_eq!(changed.rows_affected(), 3);
+    {
+        let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+        let cache = cache_handle.lock().await;
+        assert_eq!(
+            cache.alert_projection_generation, initial_last_good.0,
+            "the scheduler has not yet propagated the durable projection commit into memory"
+        );
+    }
+    pause.release();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let cache_handle = super::super::dashboard_overview_cache_for_state(state.as_ref());
+            let cache = cache_handle.lock().await;
+            if cache.admin_alerts_prewarm_defers > 0 {
+                let canonical = cache
+                    .admin_alerts
+                    .entries
+                    .iter()
+                    .filter(|entry| entry.canonical)
+                    .map(|entry| (entry.key.clone(), entry.generation, entry.stored_at))
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    canonical, initial_last_good.1,
+                    "a durable generation change must discard staged values and retain last-good"
+                );
+                assert_eq!(cache.alert_projection_generation, initial_last_good.0);
+                break;
+            }
+            drop(cache);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the durable fence mismatch defers the canonical warm");
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn admin_alerts_canonical_read_waits_for_history_projection_coverage() {
     let db_path = temp_db_path("admin-alerts-history-coverage");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -896,6 +896,33 @@ impl KeyStore {
         self.ensure_admin_alert_projection_coverage_for_warm().await
     }
 
+    pub(crate) async fn admin_alerts_canonical_warm_projection_fence(
+        &self,
+    ) -> Result<(i64, i64), ProxyError> {
+        // The canonical values use separate bounded snapshots. Capture both
+        // durable projection lanes before staging and again before publish so
+        // an intervening projection commit cannot mix their generations.
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .await?;
+        let result = async {
+            let query_result = sqlx::query_as::<_, (i64, i64)>(
+                r#"SELECT
+                       (SELECT COALESCE(SUM(generation), 0)
+                          FROM observability.dashboard_alert_projection_state),
+                       (SELECT COALESCE(SUM(generation), 0)
+                          FROM observability.dashboard_alert_projection_history_state)"#,
+            )
+            .fetch_one(&mut *session)
+            .await;
+            session.query(query_result).await
+        }
+        .await;
+        let finish = session.finish().await;
+        finish?;
+        result
+    }
+
     async fn effective_auth_token_log_retention_days_in_admin_session(
         &self,
         session: &mut AdminAlertsReadSession,

--- a/src/tavily_proxy/proxy_alerts.rs
+++ b/src/tavily_proxy/proxy_alerts.rs
@@ -70,6 +70,15 @@ impl TavilyProxy {
     }
 
     #[doc(hidden)]
+    pub async fn admin_alerts_canonical_warm_projection_fence(
+        &self,
+    ) -> Result<(i64, i64), ProxyError> {
+        self.key_store
+            .admin_alerts_canonical_warm_projection_fence()
+            .await
+    }
+
+    #[doc(hidden)]
     pub async fn prewarm_admin_alerts_cache_capacity(&self) -> Result<(), ProxyError> {
         self.key_store
             .sqlite_runtime


### PR DESCRIPTION
Delivery role: child
Parent Tracking Issue: #600
Ticket: #601
Integration base: prd/sqlite-dashboard-quota-recovery-repair-v4-scopefix2
Wave: 1 repair
Spec baseline: docs/specs/performance-architecture-hardening/SPEC.md@9e2f79ce5160ecdf19dd3fca44eae972daa86649

Fixes the aggregate-review P1 for canonical Alerts warm publication. A bounded AdminAlertsCacheWarm durable projection fence is captured before staging catalog/events page 1/20/groups page 1/20 and checked again immediately before the existing in-memory generation-fenced publish. A mismatch defers and retains exact-key pinned last-good values.

Validation on head 76d991097a82c6b1e2262a98d5af90b8177d0782:
- exact durable-fence cross-slice regression
- exact existing Alerts pressure regression
- bin-admin-api-lifecycle manifest shard
- cargo fmt, clippy, commitlint
- two-axis staged diff review; one test-gate lost-wakeup finding fixed and revalidated

Refs #601