### PR TITLE
test(ci): stabilize SQLite integration fixtures

### DIFF
--- a/src/tests/dashboard_rollup_integrity.rs
+++ b/src/tests/dashboard_rollup_integrity.rs
@@ -584,6 +584,12 @@ async fn rebalance_rollup_recovery_is_fenced_and_resumable() {
     .await
     .expect("count matching recovery source logs");
     assert_eq!(matched, 501);
+    // Start from the legacy source fixture, not any checkpoint that startup
+    // may have initialized before the legacy rows were inserted.
+    sqlx::query("DELETE FROM dashboard_rollup_rebalance_recovery WHERE id = 1")
+        .execute(&proxy.key_store.pool)
+        .await
+        .expect("clear recovery checkpoint for legacy fixture");
 
     let first = proxy
         .run_dashboard_rollup_integrity_slice()

--- a/src/tests/jobs_and_request_log_retention.rs
+++ b/src/tests/jobs_and_request_log_retention.rs
@@ -626,10 +626,18 @@ async fn scheduled_job_claim_serializes_concurrent_duplicate_triggers() {
             .map(|_| proxy.scheduled_job_claim("db_compaction", "manual", None, 1)),
     )
     .await;
-    let claimed: Vec<i64> = results
-        .into_iter()
-        .filter_map(|result| result.expect("claim should not error"))
-        .collect();
+    let mut claimed = Vec::new();
+    for result in results {
+        match result {
+            Ok(Some(job_id)) => claimed.push(job_id),
+            Ok(None) => {}
+            // A concurrent control claim must yield rather than wait past its
+            // foreground-protection budget. Its caller can retry the trigger;
+            // the durable uniqueness constraint remains the invariant here.
+            Err(error) if crate::store::is_transient_sqlite_write_error(&error) => {}
+            Err(error) => panic!("claim returned a non-transient error: {error}"),
+        }
+    }
     assert_eq!(claimed.len(), 1);
 
     let running_count: i64 =


### PR DESCRIPTION
## Summary

- preserve the bounded control-transaction contract in the concurrent scheduled-job claim test
- reset the legacy rebalance-recovery checkpoint inside its fixture so the test deterministically exercises bootstrap

## Delivery metadata

- Delivery role: direct integration repair
- Base: `prd/sqlite-dashboard-quota-recovery-repair-v4-scopefix2` at `a22191c4e132dbaa3c556847c8fa913f176b57c2`
- Head: `11158786`
- Spec: - (test-only CI repair)
- Solutions: -
- Project Docs: -

## Validation

- `cargo fmt --check`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-scheduled-request-maintenance-claim --diagnostic`
- `python3 scripts/ci_backend_tests.py run-shard --id lib-request-rollup-integrity --diagnostic`
- both affected shards repeated with default resource limits

<!-- CUSTOM_NOTES_START -->
<!-- CUSTOM_NOTES_END -->