### PR TITLE
fix(sqlite): scope dashboard quota reads

### DIFF
--- a/src/store/key_store_dashboard_quota_recovery_tests.rs
+++ b/src/store/key_store_dashboard_quota_recovery_tests.rs
@@ -110,7 +110,7 @@ async fn dashboard_quota_recovery_discards_a_multi_page_draft_on_native_deadline
         matches!(
             result,
             Err(ProxyError::Deferred { operation, ref reason })
-                if operation == "admin_alerts_read" && reason == "read_budget"
+                if operation == "dashboard_quota_read" && reason == "read_budget"
         ),
         "recovery must discard its draft when a bounded source page reaches the native deadline: {result:?}"
     );
@@ -142,7 +142,7 @@ async fn dashboard_quota_source_probe_defers_after_future_page_budget() {
         matches!(
             result,
             Err(ProxyError::Deferred { operation, ref reason })
-                if operation == "admin_alerts_read" && reason == "read_budget"
+                if operation == "dashboard_quota_read" && reason == "read_budget"
         ),
         "future samples spanning multiple keyset pages must defer instead of extending the probe: {result:?}"
     );
@@ -241,7 +241,7 @@ async fn dashboard_quota_recovery_defers_when_source_changes_on_every_staged_pag
         matches!(
             result,
             Err(ProxyError::Deferred { operation, ref reason })
-                if operation == "admin_alerts_read" && reason == "read_budget"
+                if operation == "dashboard_quota_read" && reason == "read_budget"
         ),
         "recovery must defer rather than restart forever when every staged page changes source: {result:?}"
     );

--- a/src/store/key_store_request_logs_and_dashboard.rs
+++ b/src/store/key_store_request_logs_and_dashboard.rs
@@ -2240,11 +2240,11 @@ impl KeyStore {
 
     fn dashboard_quota_read_budget_deferred(&self) -> ProxyError {
         self.sqlite_runtime.record_deferred(
-            SqliteOperation::AdminAlertsCacheWarm,
+            SqliteOperation::DashboardQuotaRead,
             SqliteAdmissionDeferReason::QueryDeadline,
         );
         ProxyError::Deferred {
-            operation: "admin_alerts_read",
+            operation: "dashboard_quota_read",
             reason: "read_budget".to_string(),
         }
     }
@@ -2253,7 +2253,7 @@ impl KeyStore {
         let mut before_id = None;
         for _ in 0..DASHBOARD_QUOTA_SOURCE_MAX_PAGES {
             let mut session = self
-                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::DashboardQuotaRead)
                 .await?;
             let query_result = match before_id {
                 Some(before_id) => sqlx::query(
@@ -2313,7 +2313,7 @@ impl KeyStore {
         today_end: i64,
     ) -> Result<i64, ProxyError> {
         let mut session = self
-            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::DashboardQuotaRead)
             .await?;
         let query_result = sqlx::query_scalar::<_, i64>(
             r#"
@@ -2403,7 +2403,7 @@ impl KeyStore {
         }
 
         let mut session = self
-            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::DashboardQuotaRead)
             .await?;
         let query_result = sqlx::query(
             r#"
@@ -2468,7 +2468,7 @@ impl KeyStore {
         page_size: i64,
     ) -> Result<Vec<DashboardQuotaSample>, ProxyError> {
         let mut session = self
-            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::DashboardQuotaRead)
             .await?;
         let page_size = page_size.max(1);
         let query_result = match cursor {
@@ -2622,7 +2622,7 @@ impl KeyStore {
         lower_bound: i64,
     ) -> Result<Option<DashboardQuotaSample>, ProxyError> {
         let mut session = self
-            .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+            .begin_admin_alerts_read_session_for_operation(SqliteOperation::DashboardQuotaRead)
             .await?;
         let query_result = sqlx::query_scalar::<_, i64>(
             r#"
@@ -2654,7 +2654,7 @@ impl KeyStore {
         let mut baseline = None;
         loop {
             let mut session = self
-                .begin_admin_alerts_read_session_for_operation(SqliteOperation::AdminAlertsCacheWarm)
+                .begin_admin_alerts_read_session_for_operation(SqliteOperation::DashboardQuotaRead)
                 .await?;
             let query_result = sqlx::query(
                 r#"

--- a/src/store/sqlite_runtime.rs
+++ b/src/store/sqlite_runtime.rs
@@ -125,6 +125,7 @@ pub(crate) enum SqliteOperation {
     AdminMutation,
     AdminAlertsRead,
     AdminAlertsCacheWarm,
+    DashboardQuotaRead,
     AdminPrivacyRead,
     AdminRead,
     AlertProjection,
@@ -183,6 +184,7 @@ impl SqliteOperation {
             Self::AdminMutation => "admin_mutation",
             Self::AdminAlertsRead => "admin_alerts_read",
             Self::AdminAlertsCacheWarm => "admin_alerts_cache_warm",
+            Self::DashboardQuotaRead => "dashboard_quota_read",
             Self::AdminPrivacyRead => "admin_privacy_read",
             Self::AdminRead => "admin_read",
             Self::AlertProjection => "alert_projection",
@@ -208,6 +210,7 @@ impl SqliteOperation {
             Self::AdminMutation | Self::ForegroundJobTrigger => "foreground_work",
             Self::AdminAlertsRead
             | Self::AdminAlertsCacheWarm
+            | Self::DashboardQuotaRead
             | Self::AdminPrivacyRead
             | Self::BillingLedgerAuditRead
             | Self::HaBaselineRead
@@ -231,6 +234,7 @@ impl SqliteOperation {
             Self::AdminMutation => Duration::from_millis(100),
             Self::AdminAlertsRead
             | Self::AdminAlertsCacheWarm
+            | Self::DashboardQuotaRead
             | Self::AdminPrivacyRead
             | Self::AdminRead
             | Self::AlertProjection
@@ -254,6 +258,7 @@ impl SqliteOperation {
             Self::AdminMutation => Duration::from_millis(100),
             Self::AdminAlertsRead
             | Self::AdminAlertsCacheWarm
+            | Self::DashboardQuotaRead
             | Self::AdminPrivacyRead
             | Self::AdminRead
             | Self::AlertProjection
@@ -280,6 +285,7 @@ impl SqliteOperation {
             // a future that still owns the physical connection.
             Self::AdminAlertsRead
             | Self::AdminAlertsCacheWarm
+            | Self::DashboardQuotaRead
             | Self::AdminPrivacyRead
             | Self::AdminRead
             | Self::AdminMutation
@@ -1112,7 +1118,9 @@ impl SqliteRuntime {
             };
         let cooperative_run_deadline = if matches!(
             operation,
-            SqliteOperation::AdminAlertsRead | SqliteOperation::AdminAlertsCacheWarm
+            SqliteOperation::AdminAlertsRead
+                | SqliteOperation::AdminAlertsCacheWarm
+                | SqliteOperation::DashboardQuotaRead
         ) {
             let deadline = Instant::now() + ADMIN_ALERTS_READ_RUN_BUDGET;
             let mut handle = conn.lock_handle().await.map_err(ProxyError::Database)?;
@@ -1171,6 +1179,7 @@ impl SqliteRuntime {
             SqliteOperation::AdminPrivacyRead
                 | SqliteOperation::AdminAlertsRead
                 | SqliteOperation::AdminAlertsCacheWarm
+                | SqliteOperation::DashboardQuotaRead
         ) {
             // Admin privacy refreshes are detached from the HTTP budget. Its
             // connection-local busy timeout is the bounded defer mechanism;
@@ -1226,6 +1235,10 @@ impl SqliteRuntime {
                 ADMIN_ALERTS_READ_PROGRESS_HANDLER_OPS,
             )),
             SqliteOperation::AdminAlertsCacheWarm => Some((
+                ADMIN_ALERTS_READ_RUN_BUDGET,
+                ADMIN_ALERTS_READ_PROGRESS_HANDLER_OPS,
+            )),
+            SqliteOperation::DashboardQuotaRead => Some((
                 ADMIN_ALERTS_READ_RUN_BUDGET,
                 ADMIN_ALERTS_READ_PROGRESS_HANDLER_OPS,
             )),
@@ -1923,6 +1936,7 @@ impl KeyStore {
     ) -> Result<AdminAlertsReadSession, ProxyError> {
         Ok(AdminAlertsReadSession {
             snapshot: Some(self.sqlite_runtime.begin_read_snapshot(operation).await?),
+            operation,
         })
     }
 
@@ -1970,6 +1984,7 @@ pub(crate) struct ReconciliationReadSession {
 #[derive(Debug)]
 pub(crate) struct AdminAlertsReadSession {
     snapshot: Option<SqliteReadSnapshot>,
+    operation: SqliteOperation,
 }
 
 #[derive(Debug)]
@@ -2018,7 +2033,7 @@ impl SqliteOperationConnection {
                 .record_deferred(self.operation, SqliteAdmissionDeferReason::QueryDeadline);
             return match restore_result {
                 Ok(()) => Err(ProxyError::Deferred {
-                    operation: "admin_alerts_read",
+                    operation: self.operation.as_str(),
                     reason: "read_budget".to_string(),
                 }),
                 Err(restore_err) => Err(ProxyError::Database(restore_err)),
@@ -2521,7 +2536,7 @@ impl AdminAlertsReadSession {
     /// use the same close path as the native read deadline.
     pub(crate) async fn defer<T>(&mut self, reason: impl Into<String>) -> Result<T, ProxyError> {
         let error = ProxyError::Deferred {
-            operation: "admin_alerts_read",
+            operation: self.operation.as_str(),
             reason: reason.into(),
         };
         match self

--- a/src/store/sqlite_runtime_metrics_tests.rs
+++ b/src/store/sqlite_runtime_metrics_tests.rs
@@ -47,6 +47,33 @@ async fn deferred_read_close_is_not_reported_as_a_database_error() {
 }
 
 #[tokio::test]
+async fn workload_window_keeps_dashboard_quota_read_defers_out_of_alerts_warm_metrics() {
+    let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
+    let error = ProxyError::Deferred {
+        operation: "dashboard_quota_read",
+        reason: "read_budget".to_string(),
+    };
+
+    runtime.record_deferred_error(SqliteOperation::DashboardQuotaRead, &error);
+
+    let window = runtime.inner.workload.lock().unwrap();
+    let quota_metrics = &window.operations[&SqliteOperation::DashboardQuotaRead];
+    assert_eq!(quota_metrics.deferred, 1);
+    assert_eq!(
+        quota_metrics
+            .deferred_by_reason
+            .get(&SqliteAdmissionDeferReason::QueryDeadline),
+        Some(&1)
+    );
+    assert!(
+        !window
+            .operations
+            .contains_key(&SqliteOperation::AdminAlertsCacheWarm),
+        "Dashboard quota timeouts must not be attributed to canonical Alerts warming"
+    );
+}
+
+#[tokio::test]
 async fn workload_window_reports_canonical_alerts_warm_events_without_sensitive_fields() {
     let runtime = SqliteRuntime::new(SqlitePool::connect_lazy("sqlite::memory:").unwrap());
     runtime.record_admin_alerts_warm_slice();


### PR DESCRIPTION
## Summary

- Add a dedicated DashboardQuotaRead SQLite operation.
- Preserve the requested operation through bounded read-session deadline and defer errors.
- Keep Dashboard quota defers and workload-window counters out of Alerts warm metrics.

## Validation

- cargo fmt --check
- cargo clippy --locked -j 2 -- -D warnings
- dashboard_quota_source_probe_defers_after_future_page_budget
- workload_window_keeps_dashboard_quota_read_defers_out_of_alerts_warm_metrics

Closes #602 repair follow-up.