### PR TITLE
fix(alerts): bound canonical Events reads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,6 +53,10 @@ Tavily Hikari is a single-product service with one owner-facing admin surface, o
   entry within five minutes is stale, and a cold/expired entry returns `503 Retry-After: 1`.
   These cache-only payload responses do not count as synthetic SQLite foreground activity. A configured
   passkey session lookup and a noncanonical bounded-read fallback are each real foreground work.
+  The default Events `1/20` warm slice reads count and page rows directly through the projection
+  time index and decodes materialized payloads in Rust; filtered/noncanonical reads keep their existing
+  JSON CTE semantics. A production-shaped statement that still exceeds the native deadline requires
+  query-plan evidence and a separate projection/index task, never a larger read budget or raw fallback.
 
 ## Reconciliation Terms
 

--- a/docs/adr/0002-scoped-sqlite-and-remote-admission.md
+++ b/docs/adr/0002-scoped-sqlite-and-remote-admission.md
@@ -117,3 +117,7 @@ cgroup. They cannot attribute write amplification to one SQLite statement.
   all three values behind one projection-generation fence and publishes them together. A deferred
   warm retries at `5s`, `5s`, then `30s`; a generation change re-arms one warm without allowing
   HTTP to trigger a rebuild.
+- The canonical Events page is the bounded exception to the general filtered read builder: it uses
+  the projection table's time index for `COUNT(*)` and the first twenty rows, then decodes the stored
+  event payload in Rust. Any remaining >250ms source-read evidence must be presented as a query plan
+  before a later projection/index change; this ADR does not authorize a larger deadline or raw fallback.

--- a/docs/adr/0004-reconciliation-research-drain.md
+++ b/docs/adr/0004-reconciliation-research-drain.md
@@ -45,6 +45,9 @@ stable cursor, so tying its liveness to the main run is unnecessary.
   resumed run actually begins HTTP, so ordinary automatic jobs cannot take the released lease first,
   although their local preparation may still proceed. The reservation ID, owner kind, and resumable
   flag form one synchronized lifecycle, so clearing an old turn cannot corrupt a newer reservation.
+- The administrator Alerts canonical warm path is independent of this drain. Its indexed Events read
+  and cache publication do not consume the Research request turn, alter drain fairness, or change any
+  reconciliation outcome.
 
 ## Consequences
 

--- a/docs/solutions/operations/sqlite-admin-read-containment.md
+++ b/docs/solutions/operations/sqlite-admin-read-containment.md
@@ -81,6 +81,11 @@ reads:
   foreground SQLite activity, or client retries can indefinitely defer the background owner. A configured
   passkey session lookup and a noncanonical exact-key bounded-read fallback each record their real
   foreground SQLite work.
+- The default Events `1/20` warm slice reads `COUNT(*)` and the indexed page directly from
+  `dashboard_alert_projection_events` and decodes its materialized `payload_json` in Rust. Filtered
+  reads retain the JSON CTE contract. A statement that still misses the 250ms native deadline must be
+  handled by a separate query-plan-driven projection/index change; increasing the deadline or restoring
+  a raw fallback is not an admissible containment.
 - Treat every durable alert projection advance, including history-only slices, as a canonical cache
   generation change. The scheduler must fence the three staged values against that generation so a
   partial or cancelled warm never replaces the prior exact-key last-good set.

--- a/docs/specs/admin-alert-center-24h-summary/SPEC.md
+++ b/docs/specs/admin-alert-center-24h-summary/SPEC.md
@@ -35,6 +35,11 @@
   惰性建立连接；HTTP 对 canonical key 只读 exact-key
   cache：同 generation 为 fresh，generation 落后但未过期为 stale，cold/过期为
   `503 Retry-After: 1`，绝不触发重建。
+  默认 Events `1/20` 的 canonical slice 直接从投影表的
+  `(occurred_at DESC, row_sort_id DESC)` 索引读取计数和页面，并在 Rust 解码已物化的
+  `payload_json`；只有带筛选的非 canonical 查询才保留 JSON CTE 语义。若该直接页在生产形状
+  快照上仍超过 `250ms`，必须先提交 `EXPLAIN QUERY PLAN` 证据再另立投影/索引任务，不能提高
+  读预算或恢复 raw fallback。
   Canonical HTTP 的 fresh、stale 与 cold payload 响应不计入 synthetic SQLite 前台活动；已配置
   passkey 的 session lookup 与实际进入 bounded database fallback 的 noncanonical 读取仍计量；
   前者在开始获取 SQLite 连接之前计量，避免 cache-only 重试自行阻止 warm admission，同时不隐藏

--- a/docs/specs/performance-architecture-hardening/SPEC.md
+++ b/docs/specs/performance-architecture-hardening/SPEC.md
@@ -115,6 +115,11 @@
 - Dashboard 的 recent alert summary 只由 projection worker 在独立的 60 秒窗口内物化。若 source
   generation 在窗口内前进，已有 summary 必须标记 stale，Dashboard HTTP/SSE 继续服务 last-good，而非
   在读取路径执行 sidecar 聚合。
+- The canonical Events `1/20` page is read directly from the projection table's time index: its
+  count and ordered page do not evaluate the JSON CTE, and Rust decodes the already-materialized
+  payload. This optimization is limited to the unfiltered canonical key; a filtered read keeps the
+  existing CTE semantics. A production-shaped statement that misses the native deadline requires
+  query-plan evidence before any separate projection/index change.
 - 历史 lane 的 fence 必须与 recent tail 的起点同秒衔接：tail 拥有起点秒内的记录，history 包含严格更早
   的记录，运行时始终使用复合 cursor；仅 v17 对旧的“同秒 + 空 id”历史 fence 做一次性上一秒迁移，
   以恢复该低 sentinel 的边界所有权。空闲 source probe 不得写 cursor/generation；覆盖观察只能由

--- a/docs/specs/runtime-performance-observability/SPEC.md
+++ b/docs/specs/runtime-performance-observability/SPEC.md
@@ -171,6 +171,10 @@
 - `component=admin_read event=alerts_canonical_warm_published|alerts_canonical_warm_deferred`
   Warm diagnostics report only the defer category, retry delay, projection generation outcome, and
   aggregate slice counts. They never include SQL, filters, users, tokens, keys, or response bodies.
+- The canonical Events warm slice reports the bounded indexed projection phase separately from
+  filtered CTE reads. Its metrics cover only statement elapsed/defer and decoded row count; no SQL,
+  payload, or filter value is recorded. A future query-plan change must retain the same operation
+  boundary and native deadline.
 - `component=startup event=admin_privacy_status_prewarm_started|admin_privacy_status_prewarm_deferred`
   - `component=admin_read event=low_memory_protection_decision`
 - `sqlite_workload_window` aggregates `observability_deferred_write` alongside other operation

--- a/docs/specs/sqlite-write-lock-hardening/SPEC.md
+++ b/docs/specs/sqlite-write-lock-hardening/SPEC.md
@@ -521,6 +521,10 @@ source when a usable persisted runtime already exists.
   most 80 due rows. The exact processed `(next_poll_at, key_id, request_id)` cursor, Research outcome,
   and optional Key cooldown commit in one claim-fenced transaction. A read deadline, cancellation,
   or stale claim leaves all three unchanged.
+- The unfiltered administrator Events canonical page is a bounded read-only exception to the
+  filtered JSON projection builder: it uses the projection time index and decodes materialized
+  payloads after the query. Its `100ms` acquire and `250ms` native statement deadline remain fixed;
+  a missed deadline is evidence for a separate query-plan task, not a reason to relax this contract.
 
 ## Related ADRs
 

--- a/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
+++ b/docs/specs/upstream-privacy-period-reconciliation/SPEC.md
@@ -119,6 +119,9 @@
   return; uncertainty closes the physical connection. Billed-credit hydrate is the pre-request
   source-read gate; after an observation, settlement reads current ledger state through a bounded
   finalization connection so charges recorded during HTTP are not missed.
+- Administrator Alerts canonical Events reads are outside this reconciliation source contract: they
+  use the independent `AdminAlertsCacheWarm` snapshot and projection time index, while reconciliation
+  source reads retain their own preparation deadline and claim-fenced continuation.
 - The global remote-attempt limit is one actual outbound HTTP request. Candidate selection,
   projection, hydrate, finalization, and Research bookkeeping do not hold that request lease.
   Manual work keeps priority; automatic main reconciliation and Research drain representatives

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -2,7 +2,55 @@ use super::*;
 use super::core_support_and_parsing::*;
 use super::linuxdo_oauth_and_admin_keys::*;
 use super::upstream_support_and_manual_jobs::*;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
 use tavily_hikari::SqliteAdmissionOutcome;
+use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
+
+#[derive(Clone)]
+struct AlertPerfLogWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl AlertPerfLogWriter {
+    fn new() -> (Self, Arc<Mutex<Vec<u8>>>) {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                buffer: Arc::clone(&buffer),
+            },
+            buffer,
+        )
+    }
+}
+
+struct AlertPerfLogWriterGuard {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl<'a> MakeWriter<'a> for AlertPerfLogWriter {
+    type Writer = AlertPerfLogWriterGuard;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        AlertPerfLogWriterGuard {
+            buffer: Arc::clone(&self.buffer),
+        }
+    }
+}
+
+impl Write for AlertPerfLogWriterGuard {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer
+            .lock()
+            .expect("alert perf log buffer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 #[tokio::test]
 async fn alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_stays_24h() {
@@ -797,14 +845,37 @@ async fn admin_alerts_canonical_events_use_bounded_projection_reads() {
         "canonical Events count must use a covering time index: {count_plan}"
     );
 
+    let (writer, log_buffer) = AlertPerfLogWriter::new();
+    let dispatch = tracing::Dispatch::new(
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::new("info"))
+            .with_writer(writer)
+            .json()
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_target(true)
+            .finish(),
+    );
+    let log_guard = tracing::dispatcher::set_default(&dispatch);
     let events = proxy
         .admin_alert_events_page_for_cache_warm(1, 20)
         .await
         .expect("indexed canonical event page");
+    drop(log_guard);
     assert_eq!(events.total, 1);
     assert_eq!(events.items.len(), 1);
     assert_eq!(events.items[0].id, "auth_token_log:alert-source-1");
     assert_eq!(events.items[0].alert_type, "upstream_rate_limited_429");
+    let logs = String::from_utf8(log_buffer.lock().expect("alert perf log buffer lock").clone())
+        .expect("utf8 alert perf logs");
+    assert!(
+        logs.lines().any(|line| {
+            line.contains("\"event\":\"alerts_projection_indexed\"")
+                && line.contains("\"phase\":\"canonical_events_indexed\"")
+        }),
+        "canonical warm call must emit its indexed execution phase: {logs}"
+    );
 
     let _ = std::fs::remove_file(db_path);
 }

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -701,6 +701,115 @@ async fn alerts_endpoints_default_to_all_history_while_dashboard_recent_alerts_s
 }
 
 #[tokio::test]
+async fn admin_alerts_canonical_events_use_bounded_projection_reads() {
+    let db_path = temp_db_path("admin-alerts-indexed-events");
+    let db_str = db_path.to_string_lossy().to_string();
+    let proxy = TavilyProxy::with_endpoint(
+        vec!["tvly-admin-alerts-indexed-events".to_string()],
+        DEFAULT_UPSTREAM,
+        &db_str,
+    )
+    .await
+    .expect("proxy created");
+
+    let pool = connect_sqlite_test_pool(&db_str).await;
+    let payload = serde_json::json!({
+        "source_kind": "auth_token_log",
+        "source_id": "alert-source-1",
+        "row_sort_id": "alert-sort-1",
+        "alert_type": "upstream_rate_limited_429",
+        "occurred_at": 1_700_000_000_i64,
+        "token_id": "token-1",
+        "key_id": "key-1",
+        "request_log_id": null,
+        "method": "POST",
+        "path": "/mcp",
+        "query": null,
+        "request_kind_key": "tavily_search",
+        "request_kind_label": "Tavily Search",
+        "request_kind_detail": "POST /mcp",
+        "result_status": "error",
+        "failure_kind": "upstream_rate_limited_429",
+        "error_message": "HTTP 429",
+        "counts_business_quota": true,
+        "user_id": "user-1",
+        "user_display_name": "Test User",
+        "user_username": "tester",
+        "reason_code": null,
+        "reason_summary": null,
+        "reason_detail": null,
+        "job_id": null,
+        "job_type": null,
+        "job_trigger_source": null,
+        "job_status": null,
+        "job_attempt": null,
+        "job_message": null,
+        "job_queued_at": null,
+        "job_started_at": null,
+        "job_finished_at": null
+    })
+    .to_string();
+    sqlx::query(
+        r#"INSERT INTO observability.dashboard_alert_projection_events
+               (source_kind, source_id, occurred_at, row_sort_id, payload_json, projected_at)
+           VALUES ('auth_token_log', 'alert-source-1', 1700000000, 'alert-sort-1', ?, 1700000000)"#,
+    )
+    .bind(payload)
+    .execute(&pool)
+    .await
+    .expect("seed projected alert event");
+
+    let plan_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+             SELECT source_kind, source_id, occurred_at, row_sort_id, payload_json
+               FROM observability.dashboard_alert_projection_events
+              ORDER BY occurred_at DESC, row_sort_id DESC
+              LIMIT 20 OFFSET 0"#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("explain canonical event page");
+    let plan = plan_rows
+        .iter()
+        .filter_map(|row| row.try_get::<String, _>("detail").ok())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        plan.contains("idx_dashboard_alert_projection_events_time"),
+        "canonical Events page must use its time index: {plan}"
+    );
+
+    let count_plan_rows = sqlx::query(
+        r#"EXPLAIN QUERY PLAN
+             SELECT COUNT(*)
+               FROM observability.dashboard_alert_projection_events"#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("explain canonical event count");
+    let count_plan = count_plan_rows
+        .iter()
+        .filter_map(|row| row.try_get::<String, _>("detail").ok())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        count_plan.contains("idx_dashboard_alert_projection_events_time"),
+        "canonical Events count must use a covering time index: {count_plan}"
+    );
+
+    let events = proxy
+        .admin_alert_events_page_for_cache_warm(1, 20)
+        .await
+        .expect("indexed canonical event page");
+    assert_eq!(events.total, 1);
+    assert_eq!(events.items.len(), 1);
+    assert_eq!(events.items[0].id, "auth_token_log:alert-source-1");
+    assert_eq!(events.items[0].alert_type, "upstream_rate_limited_429");
+
+    let _ = std::fs::remove_file(db_path);
+}
+
+#[tokio::test]
 async fn admin_alerts_pressure_uses_same_key_last_good_and_reports_cold_misses() {
     let db_path = temp_db_path("admin-alerts-last-good");
     let db_str = db_path.to_string_lossy().to_string();

--- a/src/server/tests/alerts_and_ha_dashboard_defaults.rs
+++ b/src/server/tests/alerts_and_ha_dashboard_defaults.rs
@@ -2,53 +2,55 @@ use super::*;
 use super::core_support_and_parsing::*;
 use super::linuxdo_oauth_and_admin_keys::*;
 use super::upstream_support_and_manual_jobs::*;
-use std::io::Write;
 use std::sync::{Arc, Mutex};
 use tavily_hikari::SqliteAdmissionOutcome;
-use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
+use tracing::{Event, Subscriber, field};
+use tracing_subscriber::{layer::{Context, Layer, SubscriberExt}, registry::LookupSpan};
 
 #[derive(Clone)]
-struct AlertPerfLogWriter {
-    buffer: Arc<Mutex<Vec<u8>>>,
+struct AlertPerfEventLayer {
+    events: Arc<Mutex<Vec<(String, String)>>>,
 }
 
-impl AlertPerfLogWriter {
-    fn new() -> (Self, Arc<Mutex<Vec<u8>>>) {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        (
-            Self {
-                buffer: Arc::clone(&buffer),
-            },
-            buffer,
-        )
-    }
-}
-
-struct AlertPerfLogWriterGuard {
-    buffer: Arc<Mutex<Vec<u8>>>,
-}
-
-impl<'a> MakeWriter<'a> for AlertPerfLogWriter {
-    type Writer = AlertPerfLogWriterGuard;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        AlertPerfLogWriterGuard {
-            buffer: Arc::clone(&self.buffer),
+impl<S> Layer<S> for AlertPerfEventLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = AlertPerfEventVisitor::default();
+        event.record(&mut visitor);
+        if let (Some(event_name), Some(phase)) = (visitor.event, visitor.phase) {
+            self.events
+                .lock()
+                .expect("alert perf event lock")
+                .push((event_name, phase));
         }
     }
 }
 
-impl Write for AlertPerfLogWriterGuard {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buffer
-            .lock()
-            .expect("alert perf log buffer lock")
-            .extend_from_slice(buf);
-        Ok(buf.len())
+#[derive(Default)]
+struct AlertPerfEventVisitor {
+    event: Option<String>,
+    phase: Option<String>,
+}
+
+impl field::Visit for AlertPerfEventVisitor {
+    fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
+        self.record(field, format!("{value:?}").trim_matches('"').to_string());
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+    fn record_str(&mut self, field: &field::Field, value: &str) {
+        self.record(field, value.to_string());
+    }
+}
+
+impl AlertPerfEventVisitor {
+    fn record(&mut self, field: &field::Field, value: String) {
+        match field.name() {
+            "event" => self.event = Some(value),
+            "phase" => self.phase = Some(value),
+            _ => {}
+        }
     }
 }
 
@@ -845,19 +847,11 @@ async fn admin_alerts_canonical_events_use_bounded_projection_reads() {
         "canonical Events count must use a covering time index: {count_plan}"
     );
 
-    let (writer, log_buffer) = AlertPerfLogWriter::new();
-    let dispatch = tracing::Dispatch::new(
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::new("info"))
-            .with_writer(writer)
-            .json()
-            .flatten_event(true)
-            .with_current_span(false)
-            .with_span_list(false)
-            .with_target(true)
-            .finish(),
-    );
-    let log_guard = tracing::dispatcher::set_default(&dispatch);
+    let log_events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(AlertPerfEventLayer {
+        events: Arc::clone(&log_events),
+    });
+    let log_guard = tracing::subscriber::set_default(subscriber);
     let events = proxy
         .admin_alert_events_page_for_cache_warm(1, 20)
         .await
@@ -867,14 +861,12 @@ async fn admin_alerts_canonical_events_use_bounded_projection_reads() {
     assert_eq!(events.items.len(), 1);
     assert_eq!(events.items[0].id, "auth_token_log:alert-source-1");
     assert_eq!(events.items[0].alert_type, "upstream_rate_limited_429");
-    let logs = String::from_utf8(log_buffer.lock().expect("alert perf log buffer lock").clone())
-        .expect("utf8 alert perf logs");
+    let logs = log_events.lock().expect("alert perf event lock");
     assert!(
-        logs.lines().any(|line| {
-            line.contains("\"event\":\"alerts_projection_indexed\"")
-                && line.contains("\"phase\":\"canonical_events_indexed\"")
+        logs.iter().any(|(event, phase)| {
+            event == "alerts_projection_indexed" && phase == "canonical_events_indexed"
         }),
-        "canonical warm call must emit its indexed execution phase: {logs}"
+        "canonical warm call must emit its indexed execution phase: {logs:?}"
     );
 
     let _ = std::fs::remove_file(db_path);

--- a/src/store/key_store_alert_models.rs
+++ b/src/store/key_store_alert_models.rs
@@ -9,6 +9,18 @@ struct AlertEventFilters<'a> {
     request_kinds: &'a [String],
 }
 
+impl AlertEventFilters<'_> {
+    fn is_unfiltered(self) -> bool {
+        self.alert_type.is_none()
+            && self.since.is_none()
+            && self.until.is_none()
+            && self.user_id.is_none()
+            && self.token_id.is_none()
+            && self.key_id.is_none()
+            && self.request_kinds.is_empty()
+    }
+}
+
 #[derive(Clone, Copy)]
 enum AlertReadSource {
     Raw,

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -1170,13 +1170,11 @@ impl KeyStore {
         let rows = self
             .fetch_alert_query_rows_for_operation(query, AlertReadSource::Projected, operation)
             .await?;
-        let items = rows
-            .into_iter()
-            .map(Self::decode_alert_event_projection_row)
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .filter_map(Self::build_alert_event_from_projection)
-            .collect::<Vec<_>>();
+        let items = Self::build_alert_event_items(
+            rows.into_iter()
+                .map(Self::decode_alert_event_projection_row)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
         emit_perf_log(
             DbLogStatus::Info,
             "admin_read",
@@ -1230,13 +1228,11 @@ impl KeyStore {
             .fetch_all(&mut *session)
             .await;
             let rows = session.query(rows_result).await?;
-            let items = rows
-                .into_iter()
-                .map(Self::decode_default_alert_event_projection_row)
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .filter_map(Self::build_alert_event_from_projection)
-                .collect::<Vec<_>>();
+            let items = Self::build_alert_event_items(
+                rows.into_iter()
+                    .map(Self::decode_default_alert_event_projection_row)
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
             Ok::<_, ProxyError>(PaginatedAlertEvents {
                 items,
                 total,
@@ -2385,6 +2381,14 @@ impl KeyStore {
         };
         event.semantic_window = event_semantic_window(&event);
         Some(event)
+    }
+
+    fn build_alert_event_items(
+        rows: impl IntoIterator<Item = AlertEventProjectionRow>,
+    ) -> Vec<AlertEventRecord> {
+        rows.into_iter()
+            .filter_map(Self::build_alert_event_from_projection)
+            .collect()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/store/key_store_alerts.rs
+++ b/src/store/key_store_alerts.rs
@@ -1127,6 +1127,17 @@ impl KeyStore {
         per_page: i64,
         operation: SqliteOperation,
     ) -> Result<PaginatedAlertEvents, ProxyError> {
+        // The canonical warm key has no filters and always requests the first
+        // twenty rows. Keep that hot path on the projection table's time
+        // index. Filtered administrator reads still use the CTE because their
+        // join semantics are part of the public API contract.
+        if operation == SqliteOperation::AdminAlertsCacheWarm
+            && page == 1
+            && per_page == 20
+            && filters.is_unfiltered()
+        {
+            return self.fetch_default_projected_alert_events_page().await;
+        }
         let started = Instant::now();
         let page = page.max(1);
         let per_page = per_page.clamp(1, 100);
@@ -1186,6 +1197,72 @@ impl KeyStore {
             page,
             per_page,
         })
+    }
+
+    async fn fetch_default_projected_alert_events_page(
+        &self,
+    ) -> Result<PaginatedAlertEvents, ProxyError> {
+        let started = Instant::now();
+        let operation = SqliteOperation::AdminAlertsCacheWarm;
+        let mut session = self
+            .begin_admin_alerts_read_session_for_operation(operation)
+            .await?;
+        let result = async {
+            // COUNT(*) is deliberately independent from payload decoding. It
+            // can use the projection table without evaluating JSON for every
+            // historical row.
+            let total_result = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM observability.dashboard_alert_projection_events",
+            )
+            .fetch_one(&mut *session)
+            .await;
+            let total = session.query(total_result).await?;
+
+            // occurred_at/row_sort_id is the projection's covering order for
+            // the canonical page. Only the compact identity columns and the
+            // already-materialized payload are read from SQLite.
+            let rows_result = sqlx::query(
+                r#"SELECT source_kind, source_id, occurred_at, row_sort_id, payload_json
+                     FROM observability.dashboard_alert_projection_events
+                    ORDER BY occurred_at DESC, row_sort_id DESC
+                    LIMIT 20 OFFSET 0"#,
+            )
+            .fetch_all(&mut *session)
+            .await;
+            let rows = session.query(rows_result).await?;
+            let items = rows
+                .into_iter()
+                .map(Self::decode_default_alert_event_projection_row)
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .filter_map(Self::build_alert_event_from_projection)
+                .collect::<Vec<_>>();
+            Ok::<_, ProxyError>(PaginatedAlertEvents {
+                items,
+                total,
+                page: 1,
+                per_page: 20,
+            })
+        }
+        .await;
+        let finish_result = session.finish().await;
+        finish_result?;
+        let value = result?;
+        emit_perf_log(
+            DbLogStatus::Info,
+            "admin_read",
+            "alerts_projection_indexed",
+            started.elapsed(),
+            PerfLogScope {
+                route: Some("/api/alerts/events"),
+                scope: Some("alerts"),
+                phase: Some("canonical_events_indexed"),
+                page_size: Some(20),
+                row_count: Some(value.items.len()),
+                ..Default::default()
+            },
+        );
+        Ok(value)
     }
 
     async fn fetch_alert_event_projection_page(
@@ -2161,6 +2238,23 @@ impl KeyStore {
             job_started_at: row.try_get("job_started_at")?,
             job_finished_at: row.try_get("job_finished_at")?,
         })
+    }
+
+    fn decode_default_alert_event_projection_row(
+        row: sqlx::sqlite::SqliteRow,
+    ) -> Result<AlertEventProjectionRow, ProxyError> {
+        let payload_json = row.try_get::<String, _>("payload_json")?;
+        let mut projection = serde_json::from_str::<AlertEventProjectionRow>(&payload_json)
+            .map_err(|_| ProxyError::Other("invalid alert projection payload".to_string()))?;
+
+        // The ordering and source identity columns are authoritative for the
+        // indexed read. Reapply them so a stale payload cannot alter paging
+        // identity or the event's source reference.
+        projection.source_kind = row.try_get("source_kind")?;
+        projection.source_id = row.try_get("source_id")?;
+        projection.row_sort_id = row.try_get("row_sort_id")?;
+        projection.occurred_at = row.try_get("occurred_at")?;
+        Ok(projection)
     }
 
     fn build_alert_event_from_projection(row: AlertEventProjectionRow) -> Option<AlertEventRecord> {


### PR DESCRIPTION
## Summary
- Route the unfiltered canonical admin Alerts Events page (page 1, 20 rows) through direct projected-table reads.
- Keep count/page work inside the existing bounded AdminAlertsReadSession and decode materialized payloads in Rust.
- Preserve filtered Events and Groups semantics; no raw fallback, SQLite tuning, schema change, or Research behavior change.

## Evidence
- `cargo test --locked admin_alerts -- --nocapture` (9 passed)
- `cargo test --locked admin_alerts_canonical_events_use_bounded_projection_reads -- --nocapture` (passed; page and count plans use `idx_dashboard_alert_projection_events_time`; the real warm call emitted `alerts_projection_indexed/canonical_events_indexed`)
- `cargo clippy --locked -j 2 -- -D warnings`
- `python3 scripts/ci_backend_tests.py verify`
- `cargo test --locked --test rust_source_line_budgets -- --nocapture`
- `bunx --bun dprint check`
- Read-only 101 dual-DB testbox comparison `alerts_canonical_20260907_c06eb1_r2` passed and cleaned all temporary resources: candidate `terminalDelta=2`, `researchTerminalDelta=25`, `researchPendingDelta=-24`, `dashboardHttp5xx=0`, `foregroundHttp5xx=0`, `maintenanceHttp5xx=0`, `projectionDiscarded=0`, `nestedTransactionErrors=0`, `sqliteFinalLockErrors=0`, billing adjustment delta `0`.

## Scope
- No public/admin JSON shape changes.
- No UI changes or visual evidence required.
- The plan requires Research PR-B to start only after this PR is merged and `origin/main` is re-locked.

Stop condition: merge-ready / Step 5C Ready.